### PR TITLE
Fix creation of /etc/sysconfig/bootloader for ISOs

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -200,11 +200,11 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 self.cmdline_failsafe
             )
 
-        log.info('Writing sysconfig bootloader file')
         sysconfig_bootloader_location = ''.join(
             [self.root_dir, '/etc/sysconfig/']
         )
         if os.path.exists(sysconfig_bootloader_location):
+            log.info('Writing sysconfig bootloader file')
             sysconfig_bootloader_file = ''.join(
                 [sysconfig_bootloader_location, 'bootloader']
             )

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -139,6 +139,16 @@ class LiveImageBuilder(object):
             }
         }
 
+        # create /etc/sysconfig/bootloader if needed
+        if self.firmware.efi_mode():
+            bootloader_sysconfig = BootLoaderConfig(
+                'grub2', self.xml_state, self.root_dir, {
+                    'grub_directory_name':
+                        Defaults.get_grub_boot_directory_name(self.root_dir)
+                }
+            )
+            bootloader_sysconfig.setup_sysconfig_bootloader()
+
         # pack system into live boot structure as expected by dracut
         log.info(
             'Packing system into dracut live ISO type: {0}'.format(
@@ -211,6 +221,7 @@ class LiveImageBuilder(object):
             bootloader_config.setup_live_boot_images(
                 mbrid=self.mbrid, lookup_path=self.root_dir
             )
+            # TODO clean sysconfig/bootloader ?
         else:
             # setup bootloader config to boot the ISO via isolinux.
             # This allows for booting on x86 platforms in BIOS mode

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -221,10 +221,16 @@ class TestLiveImageBuilder(object):
             call('dracut_rescue_image="no"\n')
         ]
 
-        kiwi.builder.live.BootLoaderConfig.assert_called_once_with(
-            'grub2', self.xml_state, 'temp_media_dir',
-            {'grub_directory_name': 'grub2'}
-        )
+        kiwi.builder.live.BootLoaderConfig.call_args_list == [
+            call(
+                'grub2', self.xml_state, 'root_dir',
+                {'grub_directory_name': 'grub2'}
+            ),
+            call(
+                'grub2', self.xml_state, 'temp_media_dir',
+                {'grub_directory_name': 'grub2'}
+            )
+        ]
         self.bootloader.setup_live_boot_images.assert_called_once_with(
             lookup_path='root_dir', mbrid=self.mbrid
         )


### PR DESCRIPTION
This commit forces the creation of /etc/sysconfig/bootloader
before building the squashfs container. Since bootloader configuration
was generally prepared in a different area of the root-tree after
the creation of the squashfs container this sysconfig file was never
included into the image.

Fixes #1112