### PR TITLE
Make extended attribute check an on demand feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ version := $(shell \
 
 .PHONY: test
 test:
-	tox -e unit_py3_6
+	tox -e unit_py3_6 "-n 5"
 
 flake:
 	tox -e check

--- a/kiwi/utils/sync.py
+++ b/kiwi/utils/sync.py
@@ -16,8 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import importlib
 from stat import ST_MODE
-import xattr
 
 # project
 from kiwi.logger import log
@@ -94,6 +94,13 @@ class DataSync(object):
 
         :rtype: bool
         """
+        try:
+            xattr = importlib.import_module('xattr')
+        except Exception as issue:
+            log.warning(
+                'Could not load xattr module: {0}'.format(issue)
+            )
+            return False
         try:
             xattr.getxattr(self.target_dir, 'user.mime_type')
         except Exception as e:

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -83,6 +83,12 @@ Group:          Development/Languages/Python
 %if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?suse_version} || 0%{?debian} || 0%{?ubuntu}
 Recommends:     jing
 %endif
+%if 0%{?fedora} || 0%{?rhel} >= 8
+Recommends:     python%{python3_pkgversion}-pyxattr
+%endif
+%if 0%{?suse_version} || 0%{?debian} || 0%{?ubuntu}
+Recommends:     python%{python3_pkgversion}-xattr
+%endif
 %if 0%{?ubuntu} || 0%{?debian}
 Requires:       python%{python3_pkgversion}-yaml
 %else
@@ -92,7 +98,6 @@ Requires:       python%{python3_pkgversion}-docopt
 Requires:       python%{python3_pkgversion}-lxml
 Requires:       python%{python3_pkgversion}-requests
 Requires:       python%{python3_pkgversion}-setuptools
-Requires:       python%{python3_pkgversion}-xattr
 # tools used by kiwi
 %if 0%{?suse_version}
 %ifarch x86_64


### PR DESCRIPTION
Support for the xattr module is handled differently at the side
of the distribution vendors. There is xattr(GPL) and pyxattr(MIT)
and both might exist or not depending on the version of the desired
distribution. To deal better with this we made the strict requirement
in kiwi for xattr a distribution specific recommendation in the spec
file and changed the code to load the xattr module as an on demand
plugin. If no xattr module support exists the method
target_supports_extended_attributes() will return False which
effectively result in a warning message and rsync operations to run
without the -X and -A options.

