### PR TITLE
Do not create a new machine-id file

### DIFF
--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -238,8 +238,10 @@ class SystemSetup(object):
         machine_id = os.sep.join(
             [self.root_dir, 'etc', 'machine-id']
         )
-        with open(machine_id, 'w'):
-            pass
+
+        if os.path.exists(machine_id):
+            with open(machine_id, 'w'):
+                pass
 
     def setup_permissions(self):
         """

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -847,8 +847,12 @@ class TestSystemSetup(object):
             ]
         )
 
+    @patch('kiwi.system.setup.os.path.exists')
     @patch_open
-    def test_setup_machine_id(self, mock_open):
+    def test_setup_machine_id(self, mock_open, mock_path_exists):
+        mock_path_exists.return_value = True
+        self.setup.setup_machine_id()
+        mock_path_exists.return_value = False
         self.setup.setup_machine_id()
         mock_open.assert_called_once_with(
             'root_dir/etc/machine-id', 'w'


### PR DESCRIPTION
This commit ensures KIWI is not creating a new machine-id empty file
in case it was not provided during the system installation.

Fixes bsc#1141168
