### PR TITLE
Fixed setup of bootloader files

### DIFF
--- a/kiwi/bootloader/config/__init__.py
+++ b/kiwi/bootloader/config/__init__.py
@@ -34,18 +34,20 @@ class BootLoaderConfig(object):
     :param string root_dir: root directory path name
     :param dict custom_args: custom bootloader config arguments dictionary
     """
-    def __new__(self, name, xml_state, root_dir, custom_args=None):
+    def __new__(
+        self, name, xml_state, root_dir, boot_dir=None, custom_args=None
+    ):
         if name == 'grub2':
             return BootLoaderConfigGrub2(
-                xml_state, root_dir, custom_args
+                xml_state, root_dir, boot_dir, custom_args
             )
         elif name == 'grub2_s390x_emu':
             return BootLoaderConfigZipl(
-                xml_state, root_dir, custom_args
+                xml_state, root_dir, boot_dir, custom_args
             )
         elif name == 'isolinux':
             return BootLoaderConfigIsoLinux(
-                xml_state, root_dir, custom_args
+                xml_state, root_dir, boot_dir, custom_args
             )
         else:
             raise KiwiBootLoaderConfigSetupError(

--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -38,8 +38,9 @@ class BootLoaderConfigBase(object):
     :param string root_dir: root directory path name
     :param dict custom_args: custom bootloader arguments dictionary
     """
-    def __init__(self, xml_state, root_dir, custom_args=None):
+    def __init__(self, xml_state, root_dir, boot_dir=None, custom_args=None):
         self.root_dir = root_dir
+        self.boot_dir = boot_dir or root_dir
         self.xml_state = xml_state
         self.arch = platform.machine()
 
@@ -167,7 +168,7 @@ class BootLoaderConfigBase(object):
         :rtype: str
         """
         efi_boot_path = os.path.normpath(
-            os.sep.join([self.root_dir, in_sub_dir, 'EFI/BOOT'])
+            os.sep.join([self.boot_dir, in_sub_dir, 'EFI/BOOT'])
         )
         Path.create(efi_boot_path)
         return efi_boot_path
@@ -326,7 +327,7 @@ class BootLoaderConfigBase(object):
         bootpath = '/boot'
         need_boot_partition = False
         if target == 'disk':
-            disk_setup = DiskSetup(self.xml_state, self.root_dir)
+            disk_setup = DiskSetup(self.xml_state, self.boot_dir)
             need_boot_partition = disk_setup.need_boot_partition()
             if need_boot_partition:
                 # if an extra boot partition is used we will find the

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -151,7 +151,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             if self.firmware.efi_mode():
                 if self.iso_boot or self.shim_fallback_setup:
                     efi_vendor_boot_path = Defaults.get_shim_vendor_directory(
-                        self.root_dir
+                        self.boot_dir
                     )
                     if efi_vendor_boot_path:
                         grub_config_file_for_efi_boot = os.sep.join(
@@ -200,11 +200,11 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 self.cmdline_failsafe
             )
 
-        log.info('Writing sysconfig bootloader file')
         sysconfig_bootloader_location = ''.join(
             [self.root_dir, '/etc/sysconfig/']
         )
         if os.path.exists(sysconfig_bootloader_location):
+            log.info('Writing sysconfig bootloader file')
             sysconfig_bootloader_file = ''.join(
                 [sysconfig_bootloader_location, 'bootloader']
             )
@@ -405,10 +405,10 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             self._get_grub2_boot_path()
         )
         mbrid.write(
-            self.root_dir + '/boot/' + mbrid.get_id()
+            self.boot_dir + '/boot/' + mbrid.get_id()
         )
         mbrid.write(
-            self.root_dir + '/boot/mbrid'
+            self.boot_dir + '/boot/mbrid'
         )
 
         self._copy_theme_data_to_boot_directory(lookup_path, 'iso')
@@ -553,7 +553,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             '--> Running fallback setup for shim secure boot efi image'
         )
         if not lookup_path:
-            lookup_path = self.root_dir
+            lookup_path = self.boot_dir
         grub_image = Defaults.get_signed_grub_loader(lookup_path)
         if not grub_image:
             raise KiwiBootLoaderGrubSecureBootError(
@@ -588,7 +588,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         grub modules
         """
         if not lookup_path:
-            lookup_path = self.root_dir
+            lookup_path = self.boot_dir
         grub_image = Defaults.get_unsigned_grub_loader(lookup_path)
         if grub_image:
             log.info('--> Using prebuilt unsigned efi image')
@@ -607,7 +607,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         Provide bios grub image
         """
         if not lookup_path:
-            lookup_path = self.root_dir
+            lookup_path = self.boot_dir
         grub_image = Defaults.get_grub_bios_core_loader(lookup_path)
         if grub_image:
             log.info('--> Using prebuilt bios image')
@@ -635,9 +635,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         )
 
     def _create_embedded_fat_efi_image(self):
-        Path.create(self.root_dir + '/boot/' + self.arch)
+        Path.create(self.boot_dir + '/boot/' + self.arch)
         efi_fat_image = ''.join(
-            [self.root_dir + '/boot/', self.arch, '/efi']
+            [self.boot_dir + '/boot/', self.arch, '/efi']
         )
         Command.run(
             ['qemu-img', 'create', efi_fat_image, '15M']
@@ -648,7 +648,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         Command.run(
             [
                 'mcopy', '-Do', '-s', '-i', efi_fat_image,
-                self.root_dir + '/EFI', '::'
+                self.boot_dir + '/EFI', '::'
             ]
         )
 
@@ -742,7 +742,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 return grub_mkimage_tool
 
     def _get_grub2_boot_path(self):
-        return self.root_dir + '/boot/' + self.boot_directory_name
+        return self.boot_dir + '/boot/' + self.boot_directory_name
 
     def _get_efi_image_name(self):
         return os.sep.join(
@@ -777,7 +777,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
 
     def _get_module_path(self, format_name, lookup_path=None):
         if not lookup_path:
-            lookup_path = self.root_dir
+            lookup_path = self.boot_dir
         return Defaults.get_grub_path(lookup_path, format_name)
 
     def _find_theme_background_file(self, lookup_path):
@@ -792,11 +792,11 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
 
     def _copy_theme_data_to_boot_directory(self, lookup_path, target):
         if not lookup_path:
-            lookup_path = self.root_dir
+            lookup_path = self.boot_dir
         boot_fonts_dir = os.path.normpath(
             os.sep.join(
                 [
-                    self.root_dir,
+                    self.boot_dir,
                     self.get_boot_path(target),
                     self.boot_directory_name,
                     'fonts'
@@ -819,7 +819,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 )
 
         boot_theme_dir = os.sep.join(
-            [self.root_dir, 'boot', self.boot_directory_name, 'themes']
+            [self.boot_dir, 'boot', self.boot_directory_name, 'themes']
         )
         Path.create(boot_theme_dir)
 
@@ -836,7 +836,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                     # file which was created at install time of the theme
                     # package by the activate-theme script
                     boot_theme_background_backup_file = os.sep.join(
-                        [self.root_dir, 'background.png']
+                        [self.boot_dir, 'background.png']
                     )
                     Command.run(
                         [
@@ -876,7 +876,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         if self.theme:
             theme_dir = os.sep.join(
                 [
-                    self.root_dir, 'boot', self.boot_directory_name,
+                    self.boot_dir, 'boot', self.boot_directory_name,
                     'themes', self.theme
                 ]
             )
@@ -890,10 +890,10 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         Copy efi boot data from lookup_path to the root directory
         """
         if not lookup_path:
-            lookup_path = self.root_dir
+            lookup_path = self.boot_dir
         efi_path = lookup_path + '/boot/efi/'
         if os.path.exists(efi_path):
-            efi_data = DataSync(efi_path, self.root_dir)
+            efi_data = DataSync(efi_path, self.boot_dir)
             efi_data.sync_data(options=['-a'])
 
     def _copy_efi_modules_to_boot_directory(self, lookup_path):
@@ -928,7 +928,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
 
     def _get_shim_install(self):
         chroot_env = {
-            'PATH': os.sep.join([self.root_dir, 'usr', 'sbin'])
+            'PATH': os.sep.join([self.boot_dir, 'usr', 'sbin'])
         }
         return Path.which(
             filename='shim-install', custom_env=chroot_env

--- a/kiwi/bootloader/config/isolinux.py
+++ b/kiwi/bootloader/config/isolinux.py
@@ -234,7 +234,7 @@ class BootLoaderConfigIsoLinux(BootLoaderConfigBase):
         pass
 
     def _get_iso_boot_path(self):
-        return self.root_dir + '/boot/' + self.arch + '/loader'
+        return self.boot_dir + '/boot/' + self.arch + '/loader'
 
     def _have_theme(self):
         if os.path.exists(self._get_iso_boot_path() + '/bootlogo'):

--- a/kiwi/bootloader/config/zipl.py
+++ b/kiwi/bootloader/config/zipl.py
@@ -106,14 +106,14 @@ class BootLoaderConfigZipl(BootLoaderConfigBase):
                     'mv',
                     os.sep.join(
                         [
-                            self.root_dir, 'boot',
-                            os.readlink(self.root_dir + '/boot/initrd')
+                            self.boot_dir, 'boot',
+                            os.readlink(self.boot_dir + '/boot/initrd')
                         ]
                     ),
                     os.sep.join(
                         [
-                            self.root_dir, 'boot',
-                            os.readlink(self.root_dir + '/boot/image')
+                            self.boot_dir, 'boot',
+                            os.readlink(self.boot_dir + '/boot/image')
                         ]
                     ),
                     self._get_zipl_boot_path()
@@ -174,7 +174,7 @@ class BootLoaderConfigZipl(BootLoaderConfigBase):
         pass
 
     def _get_zipl_boot_path(self):
-        return self.root_dir + '/boot/zipl'
+        return self.boot_dir + '/boot/zipl'
 
     def _get_target_geometry(self):
         if self.target_table_type == 'dasd':

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -242,7 +242,8 @@ class DiskBuilder(object):
 
         # create the bootloader instance
         self.bootloader_config = BootLoaderConfig(
-            self.bootloader, self.xml_state, self.root_dir, {
+            self.bootloader, self.xml_state, root_dir=self.root_dir,
+            boot_dir=self.root_dir, custom_args={
                 'targetbase':
                     loop_provider.get_device(),
                 'grub_directory_name':

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -188,7 +188,8 @@ class InstallImageBuilder(object):
             # for compat boot. The complete bootloader setup will be
             # based on grub
             bootloader_config = BootLoaderConfig(
-                'grub2', self.xml_state, self.media_dir, {
+                'grub2', self.xml_state, root_dir=self.root_dir,
+                boot_dir=self.media_dir, custom_args={
                     'grub_directory_name':
                         Defaults.get_grub_boot_directory_name(self.root_dir)
                 }
@@ -201,7 +202,8 @@ class InstallImageBuilder(object):
             # This allows for booting on x86 platforms in BIOS mode
             # only.
             bootloader_config = BootLoaderConfig(
-                'isolinux', self.xml_state, self.media_dir
+                'isolinux', self.xml_state, root_dir=self.root_dir,
+                boot_dir=self.media_dir
             )
         IsoToolsBase.setup_media_loader_directory(
             self.boot_image_task.boot_root_directory, self.media_dir,

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -95,7 +95,7 @@ class TestBootLoaderConfigGrub2(object):
             return_value=False
         )
         self.bootloader = BootLoaderConfigGrub2(
-            self.state, 'root_dir', {'grub_directory_name': 'grub2'}
+            self.state, 'root_dir', None, {'grub_directory_name': 'grub2'}
         )
 
     @patch('platform.machine')

--- a/test/unit/bootloader_config_test.py
+++ b/test/unit/bootloader_config_test.py
@@ -17,16 +17,18 @@ class TestBootLoaderConfig(object):
     def test_bootloader_config_grub2(self, mock_grub2):
         xml_state = mock.Mock()
         BootLoaderConfig('grub2', xml_state, 'root_dir')
-        mock_grub2.assert_called_once_with(xml_state, 'root_dir', None)
+        mock_grub2.assert_called_once_with(xml_state, 'root_dir', None, None)
 
     @patch('kiwi.bootloader.config.BootLoaderConfigIsoLinux')
     def test_bootloader_config_isolinux(self, mock_isolinux):
         xml_state = mock.Mock()
-        BootLoaderConfig('isolinux', xml_state, 'root_dir')
-        mock_isolinux.assert_called_once_with(xml_state, 'root_dir', None)
+        BootLoaderConfig('isolinux', xml_state, 'root_dir', 'boot_dir')
+        mock_isolinux.assert_called_once_with(
+            xml_state, 'root_dir', 'boot_dir', None
+        )
 
     @patch('kiwi.bootloader.config.BootLoaderConfigZipl')
     def test_bootloader_config_zipl(self, mock_zipl):
         xml_state = mock.Mock()
         BootLoaderConfig('grub2_s390x_emu', xml_state, 'root_dir')
-        mock_zipl.assert_called_once_with(xml_state, 'root_dir', None)
+        mock_zipl.assert_called_once_with(xml_state, 'root_dir', None, None)

--- a/test/unit/bootloader_config_zipl_test.py
+++ b/test/unit/bootloader_config_zipl_test.py
@@ -70,7 +70,7 @@ class TestBootLoaderConfigZipl(object):
             return_value='oem'
         )
         self.bootloader = BootLoaderConfigZipl(
-            self.xml_state, 'root_dir', {'targetbase': '/dev/loop0'}
+            self.xml_state, 'root_dir', None, {'targetbase': '/dev/loop0'}
         )
 
     @raises(KiwiBootLoaderZiplPlatformError)

--- a/test/unit/builder_install_test.py
+++ b/test/unit/builder_install_test.py
@@ -164,8 +164,10 @@ class TestInstallImageBuilder(object):
             'target_dir/result-image.raw.squashfs'
         )
         mock_BootLoaderConfig.assert_called_once_with(
-            'grub2', self.xml_state, 'temp_media_dir',
-            {'grub_directory_name': mock_grub_dir.return_value}
+            'grub2', self.xml_state, root_dir='root_dir',
+            boot_dir='temp_media_dir', custom_args={
+                'grub_directory_name': mock_grub_dir.return_value
+            }
         )
         bootloader_config.setup_install_boot_images.assert_called_once_with(
             lookup_path='root_dir', mbrid=self.mbrid
@@ -234,7 +236,8 @@ class TestInstallImageBuilder(object):
         self.firmware.efi_mode.return_value = None
         self.install_image.create_install_iso()
         mock_BootLoaderConfig.assert_called_once_with(
-            'isolinux', self.xml_state, 'temp_media_dir'
+            'isolinux', self.xml_state, root_dir='root_dir',
+            boot_dir='temp_media_dir'
         )
 
     @patch('kiwi.builder.install.IsoToolsBase.setup_media_loader_directory')

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -222,8 +222,10 @@ class TestLiveImageBuilder(object):
         ]
 
         kiwi.builder.live.BootLoaderConfig.assert_called_once_with(
-            'grub2', self.xml_state, 'temp_media_dir',
-            {'grub_directory_name': 'grub2'}
+            'grub2', self.xml_state, root_dir='root_dir',
+            boot_dir='temp_media_dir', custom_args={
+                'grub_directory_name': 'grub2'
+            }
         )
         self.bootloader.setup_live_boot_images.assert_called_once_with(
             lookup_path='root_dir', mbrid=self.mbrid
@@ -304,7 +306,8 @@ class TestLiveImageBuilder(object):
         kiwi.builder.live.BootLoaderConfig.reset_mock()
         self.live_image.create()
         kiwi.builder.live.BootLoaderConfig.assert_called_once_with(
-            'isolinux', self.xml_state, 'temp_media_dir'
+            'isolinux', self.xml_state, root_dir='root_dir',
+            boot_dir='temp_media_dir'
         )
 
     @patch('kiwi.builder.live.IsoToolsBase.setup_media_loader_directory')


### PR DESCRIPTION
The BootLoaderConfig class interface writes several files
e.g etc/sysconfig/bootloader, boot/grub2/grub.cfg and more.
Depending on the image type some of those files belongs
into the root directory and some belongs into the boot
directory. For standard images both locations points to
the same master root entry point. However for special
types like live systems the root tree and the boot tree
are different targets. For example live root filesystems
are a squashfs compressed image file whereas the plain
booting information lives outside. Because of that this
patch introduces a refactoring of the BootLoaderConfig
class to allow to distinguish between root_dir and
boot_dir paths. In addition the live image builder makes
use of the new concept and thus Fixes #1112

