### PR TITLE
Fixed ISO creation in EFI mode with cdrtools

### DIFF
--- a/kiwi/filesystem/isofs.py
+++ b/kiwi/filesystem/isofs.py
@@ -15,7 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import os
+from textwrap import dedent
+
 # project
+from kiwi.logger import log
 from kiwi.filesystem.base import FileSystemBase
 from kiwi.iso_tools.iso import Iso
 from kiwi.iso_tools import IsoTools
@@ -54,14 +58,24 @@ class FileSystemIsoFs(FileSystemBase):
         iso_tool.create_iso(filename)
 
         if not iso_tool.has_iso_hybrid_capability():
-            hybrid_offset = iso.create_header_end_block(filename)
-            iso_tool.create_iso(
-                filename, hidden_files=[iso.header_end_name]
-            )
-            iso.relocate_boot_catalog(filename)
-            iso.fix_boot_catalog(filename)
-            mbr_id = meta_data['mbr_id'] if 'mbr_id' in meta_data else \
-                '0xffffffff'
-            iso.create_hybrid(
-                hybrid_offset, mbr_id, filename, bool(efi_mode)
-            )
+            if not efi_mode:
+                hybrid_offset = iso.create_header_end_block(filename)
+                iso_tool.create_iso(
+                    filename, hidden_files=[iso.header_end_name]
+                )
+                iso.relocate_boot_catalog(filename)
+                iso.fix_boot_catalog(filename)
+                mbr_id = meta_data['mbr_id'] if 'mbr_id' in meta_data else \
+                    '0xffffffff'
+                iso.create_hybrid(
+                    hybrid_offset, mbr_id, filename
+                )
+            else:
+                message = dedent('''
+                    Can't create hybrid ISO in EFI mode with cdrtools
+
+                    isohybrid requires isolinux as loader. In EFI mode
+                    the configured bootloader e.g grub is used and no
+                    isolinux signature exists.
+                ''').strip() + os.linesep
+                log.warning(message)

--- a/kiwi/iso_tools/cdrtools.py
+++ b/kiwi/iso_tools/cdrtools.py
@@ -24,6 +24,7 @@ from collections import (
 )
 
 # project
+from kiwi.defaults import Defaults
 from kiwi.iso_tools.base import IsoToolsBase
 from kiwi.utils.command_capabilities import CommandCapabilities
 from kiwi.path import Path
@@ -80,7 +81,10 @@ class IsoToolsCdrTools(IsoToolsBase):
 
         :param list custom_args: custom ISO creation args
         """
+        efi_mode = False
         if custom_args:
+            if custom_args.get('efi_mode'):
+                efi_mode = True
             if 'mbr_id' in custom_args:
                 self.iso_parameters += [
                     '-A', custom_args['mbr_id']
@@ -109,7 +113,15 @@ class IsoToolsCdrTools(IsoToolsBase):
             '-hide', catalog_file,
             '-hide-joliet', catalog_file,
         ]
-        loader_file = self.boot_path + '/loader/isolinux.bin'
+        if efi_mode:
+            loader_file = os.sep.join(
+                [
+                    self.boot_path, 'loader',
+                    Defaults.get_isolinux_bios_grub_loader()
+                ]
+            )
+        else:
+            loader_file = self.boot_path + '/loader/isolinux.bin'
         self.iso_loaders += [
             '-b', loader_file, '-c', catalog_file
         ]

--- a/test/unit/iso_tools_cdrtools_test.py
+++ b/test/unit/iso_tools_cdrtools_test.py
@@ -95,6 +95,23 @@ class TestIsoToolsCdrTools(object):
             '-c', 'boot/x86_64/boot.catalog'
         ]
 
+        self.iso_tool.iso_loaders = []
+        self.file_mock.write.reset_mock()
+        self.iso_tool.init_iso_creation_parameters(
+            {
+                'efi_mode': 'uefi',
+                'mbr_id': 'app_id',
+                'publisher': 'org',
+                'preparer': 'name',
+                'volume_id': 'vol_id',
+                'udf': True
+            }
+        )
+        assert self.iso_tool.iso_loaders == [
+            '-b', 'boot/x86_64/loader/eltorito.img',
+            '-c', 'boot/x86_64/boot.catalog'
+        ]
+
     @patch('os.path.exists')
     @patch('os.path.getsize')
     @patch('kiwi.iso_tools.cdrtools.CommandCapabilities.has_option_in_help')


### PR DESCRIPTION
The changes introduced in #1113 will use the configured bootloader
e.g grub to boot the ISO image in BIOS and EFI mode. The creation
process works flawlessly if xorriso is used. However if cdrtools
are configured the options passed to e.g mkisofs were wrong. In
addition it's not possible to create a hybrid ISO based on
isohybrid if the loader is not isolinux. If cdrtools are in use
the process to make an ISO hybrid bootable is always based on
isohybrid and thus only works with isolinux. This patch also
covers this case with a warning message and the consequence that
we have to skip the hybrid setup in this case.

