### PR TITLE
virtual_size must be an integer in metadata.json for libvirt vagrant boxes

### DIFF
--- a/kiwi/storage/subformat/vagrant_libvirt.py
+++ b/kiwi/storage/subformat/vagrant_libvirt.py
@@ -56,7 +56,7 @@ class DiskFormatVagrantLibVirt(DiskFormatVagrantBase):
         """
         return {
             'format': 'qcow2',
-            'virtual_size': format(self.vagrantconfig.get_virtualsize() or 42)
+            'virtual_size': int(self.vagrantconfig.get_virtualsize() or 42)
         }
 
     def get_additional_vagrant_config_settings(self):

--- a/test/unit/storage_subformat_vagrant_libvirt_test.py
+++ b/test/unit/storage_subformat_vagrant_libvirt_test.py
@@ -55,7 +55,7 @@ class TestDiskFormatVagrantLibVirt(object):
 
     def test_get_additional_metadata(self):
         assert self.disk_format.get_additional_metadata() == {
-            'format': 'qcow2', 'virtual_size': '42'
+            'format': 'qcow2', 'virtual_size': 42
         }
 
     def test_get_additional_vagrant_config_settings(self):


### PR DESCRIPTION
vagrant-libvirt expects that the parameter `virtual_size` from `metadata.json` is an integer and not a string.

Supplying a string results in a backtrace when the user provides a different value for `libvirt.machine_virtual_size` (as the integer is then compared to string, which blows up here: [lib/vagrant-libvirt/action/handle_box_image.rb:47](https://github.com/vagrant-libvirt/vagrant-libvirt/blob/c3af181c83f8da94597e3f0e784508033d774a43/lib/vagrant-libvirt/action/handle_box_image.rb#L47)).
