### PR TITLE
Do not compress the install tarball archive

### DIFF
--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -97,7 +97,7 @@ class InstallImageBuilder(object):
                 xml_state.xml_data.get_name(),
                 '.' + self.arch,
                 '-' + xml_state.get_image_version(),
-                '.install.tar.xz'
+                '.install.tar'
             ]
         )
         self.dracut_config_file = ''.join(
@@ -324,12 +324,9 @@ class InstallImageBuilder(object):
 
         # create pxe install tarball
         log.info('Creating pxe install archive')
-        archive = ArchiveTar(
-            self.pxename.replace('.xz', '')
-        )
-        archive.create_xz_compressed(
-            self.pxe_dir, xz_options=self.xz_options
-        )
+        archive = ArchiveTar(self.pxename)
+
+        archive.create(self.pxe_dir)
 
     def _create_pxe_install_kernel_and_initrd(self):
         kernel = Kernel(self.boot_image_task.boot_root_directory)

--- a/test/unit/builder_install_test.py
+++ b/test/unit/builder_install_test.py
@@ -371,9 +371,7 @@ class TestInstallImageBuilder(object):
         mock_archive.assert_called_once_with(
             'target_dir/result-image.x86_64-1.2.3.install.tar'
         )
-        archive.create_xz_compressed.assert_called_once_with(
-            'tmpdir', xz_options=None
-        )
+        archive.create.assert_called_once_with('tmpdir')
 
         file_mock.write.reset_mock()
         mock_chmod.reset_mock()


### PR DESCRIPTION
Most of the components of the *.install.tar.xz file of a PXE install
image are already compressed, thus it doesn't make much sense to
recompress them again.

Fixes #1032
