### PR TITLE
Added support for fscreateoptions attribute

### DIFF
--- a/doc/source/working_with_kiwi/xml_description.rst
+++ b/doc/source/working_with_kiwi/xml_description.rst
@@ -307,6 +307,25 @@ build types and will be covered here:
   via the `-o` flag to :command:`mount` and are included in
   :file:`/etc/fstab`.
 
+- `fscreateoptions`: Specifies the filesystem options used to create the
+  filesystem. In KIWI the filesystem utility to create a filesystem is
+  called without any custom options. The default options are filesystem
+  specific and are provided along with the package that provides the
+  filesystem utility. For the Linux `ext[234]` filesystem, the default
+  options can be found in the :file:`/etc/mke2fs.conf` file. Other
+  filesystems provides this differently and documents information
+  about options and their defaults in the respective manual page, e.g
+  :command:`man mke2fs`. With the `fscreateoptions` attribute it's possible
+  to directly influence how the filesystem will be created. The options
+  provided as a string are passed to the command that creates the
+  filesystem without any further validation by KIWI. For example, to turn
+  off the journal on creation of an ext4 filesystem the following option
+  would be required:
+
+  .. code:: xml
+
+      <type fscreateoptions="-O ^has_journal"/>
+
 - `kernelcmdline`: Additional kernel parameters passed to the kernel by the
   bootloader.
 

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -80,6 +80,7 @@ class DiskBuilder(object):
         self.persistency_type = xml_state.build_type.get_devicepersistency()
         self.root_filesystem_is_overlay = xml_state.build_type.get_overlayroot()
         self.custom_root_mount_args = xml_state.get_fs_mount_option_list()
+        self.custom_root_creation_args = xml_state.get_fs_create_option_list()
         self.build_type_name = xml_state.get_build_type_name()
         self.image_format = xml_state.build_type.get_format()
         self.install_iso = xml_state.build_type.get_installiso()
@@ -283,6 +284,8 @@ class DiskBuilder(object):
             volume_manager_custom_parameters = {
                 'fs_mount_options':
                     self.custom_root_mount_args,
+                'fs_create_options':
+                    self.custom_root_creation_args,
                 'root_label':
                     self.disk_setup.get_root_label(),
                 'root_is_snapshot':
@@ -318,7 +321,8 @@ class DiskBuilder(object):
                 self.requested_filesystem, device_map['root'].get_device()
             )
             filesystem_custom_parameters = {
-                'mount_options': self.custom_root_mount_args
+                'mount_options': self.custom_root_mount_args,
+                'create_options': self.custom_root_creation_args
             }
             filesystem = FileSystem(
                 self.requested_filesystem, device_map['root'],

--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -68,7 +68,8 @@ class FileSystemBuilder(object):
                 self.requested_image_type
             )
         self.filesystem_custom_parameters = {
-            'mount_options': xml_state.get_fs_mount_option_list()
+            'mount_options': xml_state.get_fs_mount_option_list(),
+            'create_options': xml_state.get_fs_create_option_list()
         }
         self.system_setup = SystemSetup(
             xml_state=xml_state, root_dir=self.root_dir

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -172,7 +172,11 @@ class InstallImageBuilder(object):
             ]
         )
         squashed_image = FileSystemSquashFs(
-            device_provider=None, root_dir=self.squashed_contents
+            device_provider=None,
+            root_dir=self.squashed_contents,
+            custom_args={
+                'create_options': self.xml_state.get_fs_create_option_list()
+            }
         )
         squashed_image.create_on_file(squashed_image_file)
         Command.run(

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -69,9 +69,6 @@ class LiveImageBuilder(object):
             Defaults.get_volume_id()
         self.mbrid = SystemIdentifier()
         self.mbrid.calculate_id()
-        self.filesystem_custom_parameters = {
-            'mount_options': xml_state.get_fs_mount_option_list()
-        }
         self.publisher = xml_state.build_type.get_publisher() or \
             Defaults.get_publisher()
         self.custom_args = custom_args
@@ -205,7 +202,8 @@ class LiveImageBuilder(object):
         )
         root_filesystem = Defaults.get_default_live_iso_root_filesystem()
         filesystem_custom_parameters = {
-            'mount_options': self.xml_state.get_fs_mount_option_list()
+            'mount_options': self.xml_state.get_fs_mount_option_list(),
+            'create_options': self.xml_state.get_fs_create_option_list()
         }
         filesystem_setup = FileSystemSetup(
             self.xml_state, self.root_dir

--- a/kiwi/builder/pxe.py
+++ b/kiwi/builder/pxe.py
@@ -51,8 +51,13 @@ class PxeBuilder(object):
         self.target_dir = target_dir
         self.compressed = xml_state.build_type.get_compressed()
         self.xen_server = xml_state.is_xen_server()
+        self.filesystem_custom_parameters = {
+            'mount_options': xml_state.get_fs_mount_option_list(),
+            'create_options': xml_state.get_fs_create_option_list()
+        }
         self.filesystem = FileSystemBuilder(
-            xml_state, target_dir, root_dir + '/'
+            xml_state, target_dir, root_dir + '/',
+            self.filesystem_custom_parameters
         )
         self.system_setup = SystemSetup(
             xml_state=xml_state, root_dir=root_dir

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1467,6 +1467,9 @@ div {
         ## Specifies the filesystem mount options which also ends up in fstab
         ## The string given here is passed as value to the -o option of mount
         attribute fsmountoptions { text }
+    k.type.fscreateoptions.attribute =
+        ## Specifies options to create the filesystem
+        attribute fscreateoptions { text }
     k.type.hybridpersistent.attribute =
         ## Will trigger the creation of a partition for a COW file
         ## to keep data persistent over a reboot
@@ -1723,6 +1726,7 @@ div {
         k.type.format.attribute? &
         k.type.formatoptions.attribute? &
         k.type.fsmountoptions.attribute? &
+        k.type.fscreateoptions.attribute? &
         k.type.gcelicense.attribute? &
         k.type.hybridpersistent.attribute? &
         k.type.hybridpersistent_filesystem.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2183,6 +2183,11 @@ partitions</a:documentation>
 The string given here is passed as value to the -o option of mount</a:documentation>
       </attribute>
     </define>
+    <define name="k.type.fscreateoptions.attribute">
+      <attribute name="fscreateoptions">
+        <a:documentation>Specifies options to create the filesystem</a:documentation>
+      </attribute>
+    </define>
     <define name="k.type.hybridpersistent.attribute">
       <attribute name="hybridpersistent">
         <a:documentation>Will trigger the creation of a partition for a COW file
@@ -2581,6 +2586,9 @@ default.</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.fsmountoptions.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.fscreateoptions.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.gcelicense.attribute"/>

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -98,6 +98,10 @@ class VolumeManagerBase(DeviceProvider):
             self.custom_filesystem_args['mount_options'] = \
                 custom_args['fs_mount_options']
 
+        if custom_args and 'fs_create_options' in custom_args:
+            self.custom_filesystem_args['create_options'] = \
+                custom_args['fs_create_options']
+
         self.post_init(custom_args)
 
     def post_init(self, custom_args):

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2542,7 +2542,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, boottimeout=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, boottimeout=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2569,6 +2569,7 @@ class type_(GeneratedsSuper):
         self.format = _cast(None, format)
         self.formatoptions = _cast(None, formatoptions)
         self.fsmountoptions = _cast(None, fsmountoptions)
+        self.fscreateoptions = _cast(None, fscreateoptions)
         self.gcelicense = _cast(None, gcelicense)
         self.hybridpersistent = _cast(bool, hybridpersistent)
         self.hybridpersistent_filesystem = _cast(None, hybridpersistent_filesystem)
@@ -2720,6 +2721,8 @@ class type_(GeneratedsSuper):
     def set_formatoptions(self, formatoptions): self.formatoptions = formatoptions
     def get_fsmountoptions(self): return self.fsmountoptions
     def set_fsmountoptions(self, fsmountoptions): self.fsmountoptions = fsmountoptions
+    def get_fscreateoptions(self): return self.fscreateoptions
+    def set_fscreateoptions(self, fscreateoptions): self.fscreateoptions = fscreateoptions
     def get_gcelicense(self): return self.gcelicense
     def set_gcelicense(self, gcelicense): self.gcelicense = gcelicense
     def get_hybridpersistent(self): return self.hybridpersistent
@@ -2922,6 +2925,9 @@ class type_(GeneratedsSuper):
         if self.fsmountoptions is not None and 'fsmountoptions' not in already_processed:
             already_processed.add('fsmountoptions')
             outfile.write(' fsmountoptions=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.fsmountoptions), input_name='fsmountoptions')), ))
+        if self.fscreateoptions is not None and 'fscreateoptions' not in already_processed:
+            already_processed.add('fscreateoptions')
+            outfile.write(' fscreateoptions=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.fscreateoptions), input_name='fscreateoptions')), ))
         if self.gcelicense is not None and 'gcelicense' not in already_processed:
             already_processed.add('gcelicense')
             outfile.write(' gcelicense=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.gcelicense), input_name='gcelicense')), ))
@@ -3205,6 +3211,10 @@ class type_(GeneratedsSuper):
         if value is not None and 'fsmountoptions' not in already_processed:
             already_processed.add('fsmountoptions')
             self.fsmountoptions = value
+        value = find_attr_value_('fscreateoptions', node)
+        if value is not None and 'fscreateoptions' not in already_processed:
+            already_processed.add('fscreateoptions')
+            self.fscreateoptions = value
         value = find_attr_value_('gcelicense', node)
         if value is not None and 'gcelicense' not in already_processed:
             already_processed.add('gcelicense')

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1698,6 +1698,25 @@ class XMLState(object):
 
         return option_list
 
+    def get_fs_create_option_list(self):
+        """
+        List of root filesystem creation options
+
+        The list contains elements with the information from the
+        fscreateoptions attribute string that got split into its
+        substring components
+
+        :return: list with create options
+
+        :rtype: list
+        """
+        option_list = []
+        create_options = self.build_type.get_fscreateoptions()
+        if create_options:
+            option_list = create_options.split()
+
+        return option_list
+
     def get_derived_from_image_uri(self):
         """
         Uri object of derived image if configured

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -40,7 +40,7 @@
         <rpm-locale-filtering>true</rpm-locale-filtering>
     </preferences>
     <preferences>
-        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" btrfs_root_is_snapshot="true" spare_part="200M" xen_server="true" formatoptions="force_size,super=man" filesystem="ext4">
+        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" fscreateoptions="-O ^has_journal" btrfs_root_is_snapshot="true" spare_part="200M" xen_server="true" formatoptions="force_size,super=man" filesystem="ext4">
             <size unit="G" additive="true">1</size>
             <systemdisk name="mydisk"/>
             <machine memory="512" xen_loader="hvmloader">

--- a/test/unit/builder_filesystem_test.py
+++ b/test/unit/builder_filesystem_test.py
@@ -30,7 +30,10 @@ class TestFileSystemBuilder(object):
             return_value=0
         )
         self.xml_state.get_fs_mount_option_list = mock.Mock(
-            return_value='async'
+            return_value=['async']
+        )
+        self.xml_state.get_fs_create_option_list = mock.Mock(
+            return_value=['-O', 'option']
         )
         self.xml_state.get_build_type_name = mock.Mock(
             return_value='ext3'
@@ -97,7 +100,10 @@ class TestFileSystemBuilder(object):
         )
         self.loop_provider.create.assert_called_once_with()
         mock_fs.assert_called_once_with(
-            'ext3', self.loop_provider, 'root_dir/', {'mount_options': 'async'}
+            'ext3', self.loop_provider, 'root_dir/', {
+                'mount_options': ['async'],
+                'create_options': ['-O', 'option']
+            }
         )
         self.filesystem.create_on_device.assert_called_once_with(None)
         self.filesystem.sync_data.assert_called_once_with(
@@ -128,7 +134,10 @@ class TestFileSystemBuilder(object):
         )
         fs.create()
         mock_fs.assert_called_once_with(
-            'squashfs', provider, 'root_dir', {'mount_options': 'async'}
+            'squashfs', provider, 'root_dir', {
+                'mount_options': ['async'],
+                'create_options': ['-O', 'option']
+            }
         )
         self.filesystem.create_on_file.assert_called_once_with(
             'target_dir/myimage.x86_64-1.2.3.squashfs', None,

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -76,7 +76,10 @@ class TestLiveImageBuilder(object):
 
         self.xml_state = mock.Mock()
         self.xml_state.get_fs_mount_option_list = mock.Mock(
-            return_value='async'
+            return_value=['async']
+        )
+        self.xml_state.get_fs_create_option_list = mock.Mock(
+            return_value=['-O', 'option']
         )
         self.xml_state.build_type.get_flags = mock.Mock(
             return_value=None
@@ -181,9 +184,12 @@ class TestLiveImageBuilder(object):
 
         assert kiwi.builder.live.FileSystem.call_args_list == [
             call(
-                custom_args={'mount_options': 'async'},
                 device_provider=self.loop, name='ext4',
-                root_dir='root_dir/'
+                root_dir='root_dir/',
+                custom_args={
+                    'mount_options': ['async'],
+                    'create_options': ['-O', 'option']
+                }
             ),
             call(
                 device_provider=None, name='squashfs',

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -559,6 +559,9 @@ class TestXMLState(object):
     def test_get_fs_mount_option_list(self):
         assert self.state.get_fs_mount_option_list() == ['async']
 
+    def test_get_fs_create_option_list(self):
+        assert self.state.get_fs_create_option_list() == ['-O', '^has_journal']
+
     @raises(KiwiDistributionNameError)
     @patch('kiwi.xml_parse.type_.get_boot')
     def test_get_distribution_name_from_boot_attribute_no_boot(self, mock_boot):


### PR DESCRIPTION
Along with the fsmountoptions attribute there is now also the
fscreateoptions attribute which allows to control the options
used for creating the filesystem. Please note, it's not kiwi's
task to validate that the given option string is supported
by the selected filesystem. This means providing wrong values
here will cause the build to fail at the time the filesystem
gets created. This Fixes #1109


