### PR TITLE
Fixed use of FileSystemBuilder class

### DIFF
--- a/kiwi/builder/pxe.py
+++ b/kiwi/builder/pxe.py
@@ -51,13 +51,8 @@ class PxeBuilder(object):
         self.target_dir = target_dir
         self.compressed = xml_state.build_type.get_compressed()
         self.xen_server = xml_state.is_xen_server()
-        self.filesystem_custom_parameters = {
-            'mount_options': xml_state.get_fs_mount_option_list(),
-            'create_options': xml_state.get_fs_create_option_list()
-        }
         self.filesystem = FileSystemBuilder(
-            xml_state, target_dir, root_dir + '/',
-            self.filesystem_custom_parameters
+            xml_state, target_dir, root_dir + '/'
         )
         self.system_setup = SystemSetup(
             xml_state=xml_state, root_dir=root_dir


### PR DESCRIPTION
This was a broken coding for the construction of a
FileSystemBuilder instance in the PxeBuilder implementation.
The unit testing did not fail due to mocking code.
Integration testing however showed it immediately

