### PR TITLE
Fix the pyxattr dependency to allow kiwi to function

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -92,7 +92,7 @@ Requires:       python%{python3_pkgversion}-docopt
 Requires:       python%{python3_pkgversion}-lxml
 Requires:       python%{python3_pkgversion}-requests
 Requires:       python%{python3_pkgversion}-setuptools
-%if 0%{?suse_version}
+%if (0%{?suse_version} && 0%{?suse_version} < 1550)
 Requires:       python%{python3_pkgversion}-xattr
 %else
 Requires:       python%{python3_pkgversion}-pyxattr
@@ -354,6 +354,11 @@ Provides manual pages to describe the kiwi commands
 # Drop shebang for kiwi/xml_parse.py, as we don't intend to use it
 # as an independent script
 sed -e "s|#!/usr/bin/env python||" -i kiwi/xml_parse.py
+
+%if 0%{?suse_version} && 0%{?suse_version} < 1550
+# For older SUSE distributions, use the other xattr Python module
+sed -e "s|pyxattr|xattr|" -i setup.py
+%endif
 
 %build
 # Build Python 3 version

--- a/setup.py
+++ b/setup.py
@@ -186,7 +186,7 @@ config = {
     'install_requires': [
         'docopt>=0.6.2',
         'lxml',
-        'xattr',
+        'pyxattr',
         'requests',
         'PyYAML'
     ],


### PR DESCRIPTION
Most Linux distributions offer the `pyxattr` module, including openSUSE Tumbleweed. Going forward, we will use the `pyxattr` module by default as a dependency and only switch back to the
other `xattr` module when on older SUSE Linux distributions that lack the `pyxattr` module.

Note that because kiwi uses `setuptools` to create the CLI entry points, kiwi checks the Python dependencies before executing, so we change the dependency in the `setup.py` accordingly so that it will not fail to start.
