### PR TITLE
Fixed use of Command calls in destructors

### DIFF
--- a/kiwi/command.py
+++ b/kiwi/command.py
@@ -28,6 +28,10 @@ from .exceptions import (
     KiwiCommandNotFound
 )
 
+command_type = namedtuple(
+    'command', ['output', 'error', 'returncode']
+)
+
 
 class Command(object):
     """
@@ -70,9 +74,6 @@ class Command(object):
         """
         from .logger import log
         from .path import Path
-        command_type = namedtuple(
-            'command', ['output', 'error', 'returncode']
-        )
         log.debug('EXEC: [%s]', ' '.join(command))
         environment = os.environ
         if custom_env:


### PR DESCRIPTION
The Command class creates namedtuple to store the result
of the call. That tuple is created inside of the Command
namespace. If called inside of a __del__ destructor which
is often the case in kiwi classes I recently observed an
exception from python saying:

```
File "/usr/lib64/python3.6/collections/__init__.py", line 429, in namedtuple
File "<string>", line 1, in <module>
ModuleNotFoundError: import of builtins halted; None in sys.modules
```

I do not understand why this is a problem for python now
and only found the solution in making the command_type variable
a global namedtuple.

