### PR TITLE
Allow multiple values for grub terminal setup

### DIFF
--- a/build-tests/x86/test-image-fedora/appliance.kiwi
+++ b/build-tests/x86/test-image-fedora/appliance.kiwi
@@ -28,7 +28,7 @@
         <type image="iso" flags="overlay" firmware="uefi" hybridpersistent_filesystem="ext4" hybridpersistent="true"/>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="vmx" filesystem="ext4" bootloader="grub2" kernelcmdline="console=ttyS0 splash"/>
+        <type image="vmx" filesystem="ext4" bootloader="grub2" kernelcmdline="console=ttyS0 splash" bootloader_console="serial console"/>
     </preferences>
     <preferences profiles="Disk">
         <type image="oem" initrd_system="dracut" filesystem="ext4" installiso="true" bootloader="grub2" firmware="uefi">

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -253,7 +253,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             'boot_timeout': self.timeout,
             'title': self.get_menu_entry_title(),
             'bootpath': self.get_boot_path('disk'),
-            'boot_directory_name': self.boot_directory_name
+            'boot_directory_name': self.boot_directory_name,
+            'terminal_setup': self.terminal
         }
         if self.multiboot:
             log.info('--> Using multiboot disk template')
@@ -307,7 +308,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             'title': self.get_menu_entry_install_title(),
             'bootpath': self.get_boot_path('iso'),
             'boot_directory_name': self.boot_directory_name,
-            'efi_image_name': Defaults.get_efi_image_name(self.arch)
+            'efi_image_name': Defaults.get_efi_image_name(self.arch),
+            'terminal_setup': self.terminal
         }
         if self.multiboot:
             log.info('--> Using multiboot install template')
@@ -364,7 +366,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             'title': self.get_menu_entry_title(plain=True),
             'bootpath': self.get_boot_path('iso'),
             'boot_directory_name': self.boot_directory_name,
-            'efi_image_name': Defaults.get_efi_image_name(self.arch)
+            'efi_image_name': Defaults.get_efi_image_name(self.arch),
+            'terminal_setup': self.terminal
         }
         if self.multiboot:
             log.info('--> Using multiboot template')
@@ -494,7 +497,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             grub_default_entries['GRUB_CMDLINE_LINUX_DEFAULT'] = '"{0}"'.format(
                 self.cmdline
             )
-        if self.terminal and self.terminal == 'serial':
+        if self.terminal and 'serial' in self.terminal:
             serial_format = '"serial {0} {1} {2} {3} {4}"'
             grub_default_entries['GRUB_SERIAL_COMMAND'] = serial_format.format(
                 '--speed=38400',

--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -58,18 +58,15 @@ class BootLoaderTemplateGrub2(object):
                 echo "Please press 't' to show the boot menu on this console"
             fi
             set gfxmode=${gfxmode}
-            terminal_output gfxterm
         ''').strip() + os.linesep
 
         self.header_serial = dedent('''
             serial --speed=9600 --unit=0 --word=8 --parity=no --stop=1
-            terminal_input serial
-            terminal_output serial
         ''').strip() + os.linesep
 
-        self.header_textconsole = dedent('''
-            terminal_input console
-            terminal_output console
+        self.header_terminal_setup = dedent('''
+            terminal_input ${terminal_setup}
+            terminal_output ${terminal_setup}
         ''').strip() + os.linesep
 
         self.fonts = dedent('''
@@ -322,13 +319,12 @@ class BootLoaderTemplateGrub2(object):
         template_data += self.timeout
         if hybrid:
             template_data += '\n' + self.header_hybrid
-        if terminal == 'gfxterm':
+        if 'gfxterm' in terminal:
             template_data += self.header_gfxterm
             template_data += self.header_theme
-        elif terminal == 'serial':
+        if 'serial' in terminal:
             template_data += self.header_serial
-        else:
-            template_data += self.header_textconsole
+        template_data += self.header_terminal_setup
         if hybrid:
             template_data += self.menu_entry_hybrid
             if failsafe:
@@ -338,7 +334,7 @@ class BootLoaderTemplateGrub2(object):
             if failsafe:
                 template_data += self.menu_entry_failsafe
         template_data += self.menu_entry_boot_snapshots
-        if terminal == 'gfxterm':
+        if 'gfxterm' in terminal:
             template_data += self.menu_entry_console_switch
         return Template(template_data)
 
@@ -358,18 +354,17 @@ class BootLoaderTemplateGrub2(object):
         """
         template_data = self.header
         template_data += self.timeout
-        if terminal == 'gfxterm':
+        if 'gfxterm' in terminal:
             template_data += self.header_gfxterm
             template_data += self.header_theme
-        elif terminal == 'serial':
+        if 'serial' in terminal:
             template_data += self.header_serial
-        else:
-            template_data += self.header_textconsole
+        template_data += self.header_terminal_setup
         template_data += self.menu_entry_multiboot
         if failsafe:
             template_data += self.menu_entry_failsafe_multiboot
         template_data += self.menu_entry_boot_snapshots
-        if terminal == 'gfxterm':
+        if 'gfxterm' in terminal:
             template_data += self.menu_entry_console_switch
         return Template(template_data)
 
@@ -391,13 +386,12 @@ class BootLoaderTemplateGrub2(object):
         template_data += self.timeout
         if hybrid:
             template_data += self.header_hybrid
-        if terminal == 'gfxterm':
+        if 'gfxterm' in terminal:
             template_data += self.header_gfxterm
             template_data += self.header_theme_iso
-        elif terminal == 'serial':
+        if 'serial' in terminal:
             template_data += self.header_serial
-        else:
-            template_data += self.header_textconsole
+        template_data += self.header_terminal_setup
         if hybrid:
             template_data += self.menu_entry_hybrid
             if failsafe:
@@ -412,7 +406,7 @@ class BootLoaderTemplateGrub2(object):
                 template_data += self.menu_mediacheck_entry
         template_data += self.menu_iso_harddisk_entry
         template_data += self.menu_entry_boot_snapshots
-        if terminal == 'gfxterm':
+        if 'gfxterm' in terminal:
             template_data += self.menu_entry_console_switch
         return Template(template_data)
 
@@ -432,13 +426,12 @@ class BootLoaderTemplateGrub2(object):
         """
         template_data = self.header
         template_data += self.timeout
-        if terminal == 'gfxterm':
+        if 'gfxterm' in terminal:
             template_data += self.header_gfxterm
             template_data += self.header_theme_iso
-        elif terminal == 'serial':
+        if 'serial' in terminal:
             template_data += self.header_serial
-        else:
-            template_data += self.header_textconsole
+        template_data += self.header_terminal_setup
         template_data += self.menu_entry_multiboot
         if failsafe:
             template_data += self.menu_entry_failsafe_multiboot
@@ -446,7 +439,7 @@ class BootLoaderTemplateGrub2(object):
             template_data += self.menu_mediacheck_entry_multiboot
         template_data += self.menu_iso_harddisk_entry
         template_data += self.menu_entry_boot_snapshots
-        if terminal == 'gfxterm':
+        if 'gfxterm' in terminal:
             template_data += self.menu_entry_console_switch
         return Template(template_data)
 
@@ -469,13 +462,12 @@ class BootLoaderTemplateGrub2(object):
             template_data += self.timeout
         if hybrid:
             template_data += self.header_hybrid
-        if terminal == 'gfxterm':
+        if 'gfxterm' in terminal:
             template_data += self.header_gfxterm
             template_data += self.header_theme_iso
-        elif terminal == 'serial':
+        if 'serial' in terminal:
             template_data += self.header_serial
-        else:
-            template_data += self.header_textconsole
+        template_data += self.header_terminal_setup
         template_data += self.menu_iso_harddisk_entry
         if hybrid:
             template_data += self.menu_install_entry_hybrid
@@ -486,7 +478,7 @@ class BootLoaderTemplateGrub2(object):
             if failsafe:
                 template_data += self.menu_install_entry_failsafe
         template_data += self.menu_entry_boot_snapshots
-        if terminal == 'gfxterm':
+        if 'gfxterm' in terminal:
             template_data += self.menu_entry_console_switch
         return Template(template_data)
 
@@ -507,18 +499,17 @@ class BootLoaderTemplateGrub2(object):
         template_data = self.header
         if with_timeout:
             template_data += self.timeout
-        if terminal == 'gfxterm':
+        if 'gfxterm' in terminal:
             template_data += self.header_gfxterm
             template_data += self.header_theme_iso
-        elif terminal == 'serial':
+        if 'serial' in terminal:
             template_data += self.header_serial
-        else:
-            template_data += self.header_textconsole
+        template_data += self.header_terminal_setup
         template_data += self.menu_iso_harddisk_entry
         template_data += self.menu_install_entry_multiboot
         if failsafe:
             template_data += self.menu_install_entry_failsafe_multiboot
         template_data += self.menu_entry_boot_snapshots
-        if terminal == 'gfxterm':
+        if 'gfxterm' in terminal:
             template_data += self.menu_entry_console_switch
         return Template(template_data)

--- a/kiwi/bootloader/template/isolinux.py
+++ b/kiwi/bootloader/template/isolinux.py
@@ -175,7 +175,7 @@ class BootLoaderTemplateIsoLinux(object):
         """
         template_data = self.header
         template_data += self.timeout
-        if terminal == 'serial':
+        if terminal and 'serial' in terminal:
             template_data += self.serial
             with_theme = False
         if with_theme:
@@ -206,7 +206,7 @@ class BootLoaderTemplateIsoLinux(object):
         """
         template_data = self.header
         template_data += self.timeout
-        if terminal == 'serial':
+        if terminal and 'serial' in terminal:
             template_data += self.serial
             with_theme = False
         if with_theme:
@@ -237,7 +237,7 @@ class BootLoaderTemplateIsoLinux(object):
         template_data = self.header
         if with_timeout:
             template_data += self.timeout
-        if terminal == 'serial':
+        if terminal and 'serial' in terminal:
             template_data += self.serial
             with_theme = False
         if with_theme:
@@ -267,7 +267,7 @@ class BootLoaderTemplateIsoLinux(object):
         template_data = self.header
         if with_timeout:
             template_data += self.timeout
-        if terminal == 'serial':
+        if terminal and 'serial' in terminal:
             template_data += self.serial
             with_theme = False
         if with_theme:

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -35,6 +35,7 @@ vhd-tag-type = xsd:token {pattern = "[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}"}
 groups-list = xsd:token {pattern = "[a-zA-Z0-9_\-\.]+(,[a-zA-Z0-9_\-\.]+)*"}
 arch-name = xsd:token {pattern = "(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x))*"}
 portnum-type = xsd:token {pattern = "(\d+|\d+/(udp|tcp))"}
+grub_console = xsd:token {pattern = "(console|gfxterm|serial)( (console|gfxterm|serial))*"}
 
 #==========================================
 # start with image description
@@ -1156,9 +1157,7 @@ div {
         ## Specifies the bootloader console.
         ## The value only has an effect for the grub bootloader.
         ## By default a graphics console setup is used
-        attribute bootloader_console {
-            "console" | "gfxterm" | "serial"
-        }
+        attribute bootloader_console { grub_console }
         >> sch:pattern [ id = "bootloader_console" is-a = "image_type"
             sch:param [ name = "attr" value = "bootloader_console" ]
             sch:param [ name = "types" value = "oem vmx iso" ]

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -76,6 +76,11 @@
       <param name="pattern">(\d+|\d+/(udp|tcp))</param>
     </data>
   </define>
+  <define name="grub_console">
+    <data type="token">
+      <param name="pattern">(console|gfxterm|serial)( (console|gfxterm|serial))*</param>
+    </data>
+  </define>
   <!--
     ==========================================
     start with image description
@@ -1749,11 +1754,7 @@ the editbootinstall and editbootconfig custom scripts</a:documentation>
         <a:documentation>Specifies the bootloader console.
 The value only has an effect for the grub bootloader.
 By default a graphics console setup is used</a:documentation>
-        <choice>
-          <value>console</value>
-          <value>gfxterm</value>
-          <value>serial</value>
-        </choice>
+        <ref name="grub_console"/>
       </attribute>
       <sch:pattern id="bootloader_console" is-a="image_type">
         <sch:param name="attr" value="bootloader_console"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2795,6 +2795,13 @@ class type_(GeneratedsSuper):
     def set_publisher(self, publisher): self.publisher = publisher
     def get_disk_start_sector(self): return self.disk_start_sector
     def set_disk_start_sector(self, disk_start_sector): self.disk_start_sector = disk_start_sector
+    def validate_grub_console(self, value):
+        # Validate type grub_console, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_grub_console_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_grub_console_patterns_, ))
+    validate_grub_console_patterns_ = [['^(console$|^gfxterm$|^serial)( (console$|^gfxterm$|^serial))*$']]
     def validate_partition_size_type(self, value):
         # Validate type partition-size-type, a restriction on xs:token.
         if value is not None and Validate_simpletypes_:
@@ -2867,7 +2874,7 @@ class type_(GeneratedsSuper):
             outfile.write(' bootloader=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bootloader), input_name='bootloader')), ))
         if self.bootloader_console is not None and 'bootloader_console' not in already_processed:
             already_processed.add('bootloader_console')
-            outfile.write(' bootloader_console=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bootloader_console), input_name='bootloader_console')), ))
+            outfile.write(' bootloader_console=%s' % (quote_attrib(self.bootloader_console), ))
         if self.zipl_targettype is not None and 'zipl_targettype' not in already_processed:
             already_processed.add('zipl_targettype')
             outfile.write(' zipl_targettype=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.zipl_targettype), input_name='zipl_targettype')), ))
@@ -3089,6 +3096,7 @@ class type_(GeneratedsSuper):
             already_processed.add('bootloader_console')
             self.bootloader_console = value
             self.bootloader_console = ' '.join(self.bootloader_console.split())
+            self.validate_grub_console(self.bootloader_console)    # validate type grub_console
         value = find_attr_value_('zipl_targettype', node)
         if value is not None and 'zipl_targettype' not in already_processed:
             already_processed.add('zipl_targettype')

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -405,7 +405,8 @@ class TestBootLoaderConfigGrub2(object):
                 'bootpath': '/',
                 'search_params': '--fs-uuid --set=root boot_uuid',
                 'initrd_file': 'initrd',
-                'theme': None
+                'theme': None,
+                'terminal_setup': 'gfxterm'
             }
         )
 

--- a/test/unit/bootloader_template_grub2_test.py
+++ b/test/unit/bootloader_template_grub2_test.py
@@ -18,12 +18,13 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot',
-            boot_directory_name='grub2'
+            boot_directory_name='grub2',
+            terminal_setup='console'
         )
 
     def test_get_disk_template_console(self):
         assert self.grub2.get_disk_template(
-            terminal='console'
+            terminal='serial console'
         ).substitute(
             search_params='--fs-uuid --set=root 0815',
             default_boot='0',
@@ -33,7 +34,8 @@ class TestBootLoaderTemplateGrub2(object):
             failsafe_boot_options='splash',
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
-            bootpath='/boot'
+            bootpath='/boot',
+            terminal_setup='serial console'
         )
 
     def test_get_disk_template_serial_no_hybird(self):
@@ -49,7 +51,8 @@ class TestBootLoaderTemplateGrub2(object):
             failsafe_boot_options='splash',
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
-            bootpath='/boot'
+            bootpath='/boot',
+            terminal_setup='serial'
         )
 
     def test_get_multiboot_disk_template(self):
@@ -66,7 +69,8 @@ class TestBootLoaderTemplateGrub2(object):
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot',
             boot_directory_name='grub2',
-            hypervisor='xen.gz'
+            hypervisor='xen.gz',
+            terminal_setup='console'
         )
 
     def test_get_multiboot_disk_template_console(self):
@@ -82,12 +86,13 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot',
-            hypervisor='xen.gz'
+            hypervisor='xen.gz',
+            terminal_setup='console'
         )
 
     def test_get_multiboot_disk_template_serial(self):
         assert self.grub2.get_multiboot_disk_template(
-            terminal='serial'
+            terminal='serial console'
         ).substitute(
             search_params='--fs-uuid --set=root 0815',
             default_boot='0',
@@ -98,7 +103,8 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot',
-            hypervisor='xen.gz'
+            hypervisor='xen.gz',
+            terminal_setup='serial console'
         )
 
     def test_get_multiboot_install_template(self):
@@ -116,7 +122,8 @@ class TestBootLoaderTemplateGrub2(object):
             bootpath='/boot',
             boot_directory_name='grub2',
             hypervisor='xen.gz',
-            efi_image_name='bootx64.efi'
+            efi_image_name='bootx64.efi',
+            terminal_setup='console'
         )
 
     def test_get_multiboot_install_template_console(self):
@@ -133,7 +140,8 @@ class TestBootLoaderTemplateGrub2(object):
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot',
             hypervisor='xen.gz',
-            efi_image_name='bootx64.efi'
+            efi_image_name='bootx64.efi',
+            terminal_setup='console'
         )
 
     def test_get_multiboot_install_template_serial(self):
@@ -150,7 +158,8 @@ class TestBootLoaderTemplateGrub2(object):
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot',
             hypervisor='xen.gz',
-            efi_image_name='bootx64.efi'
+            efi_image_name='bootx64.efi',
+            terminal_setup='serial'
         )
 
     def test_get_install_template(self):
@@ -167,7 +176,8 @@ class TestBootLoaderTemplateGrub2(object):
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot',
             boot_directory_name='grub2',
-            efi_image_name='bootx64.efi'
+            efi_image_name='bootx64.efi',
+            terminal_setup='console'
         )
 
     def test_get_install_template_console_no_hybrid(self):
@@ -184,7 +194,8 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot',
-            efi_image_name='bootx64.efi'
+            efi_image_name='bootx64.efi',
+            terminal_setup='console'
         )
 
     def test_get_install_template_serial_no_hybrid(self):
@@ -201,7 +212,8 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot',
-            efi_image_name='bootx64.efi'
+            efi_image_name='bootx64.efi',
+            terminal_setup='serial'
         )
 
     def test_get_iso_template(self):
@@ -218,7 +230,8 @@ class TestBootLoaderTemplateGrub2(object):
             title='LimeJeOS-SLE12-Community',
             bootpath='/boot',
             boot_directory_name='grub2',
-            efi_image_name='bootx64.efi'
+            efi_image_name='bootx64.efi',
+            terminal_setup='console'
         )
 
     def test_get_iso_template_console_no_hybrid(self):
@@ -235,7 +248,8 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community',
             bootpath='/boot',
-            efi_image_name='bootx64.efi'
+            efi_image_name='bootx64.efi',
+            terminal_setup='console'
         )
 
     def test_get_iso_template_serial_no_hybrid(self):
@@ -252,7 +266,8 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community',
             bootpath='/boot',
-            efi_image_name='bootx64.efi'
+            efi_image_name='bootx64.efi',
+            terminal_setup='serial'
         )
 
     def test_get_iso_template_checkiso_no_hybrid(self):
@@ -271,7 +286,8 @@ class TestBootLoaderTemplateGrub2(object):
             title='LimeJeOS-SLE12-Community',
             bootpath='/boot',
             boot_directory_name='grub2',
-            efi_image_name='bootx64.efi'
+            efi_image_name='bootx64.efi',
+            terminal_setup='console'
         )
 
     def test_get_iso_template_checkiso(self):
@@ -288,7 +304,8 @@ class TestBootLoaderTemplateGrub2(object):
             title='LimeJeOS-SLE12-Community',
             bootpath='/boot',
             boot_directory_name='grub2',
-            efi_image_name='bootx64.efi'
+            efi_image_name='bootx64.efi',
+            terminal_setup='console'
         )
 
     def test_get_multiboot_iso_template(self):
@@ -306,7 +323,8 @@ class TestBootLoaderTemplateGrub2(object):
             bootpath='/boot',
             boot_directory_name='grub2',
             hypervisor='xen.gz',
-            efi_image_name='bootx64.efi'
+            efi_image_name='bootx64.efi',
+            terminal_setup='console'
         )
 
     def test_get_multiboot_iso_template_console(self):
@@ -323,7 +341,8 @@ class TestBootLoaderTemplateGrub2(object):
             title='LimeJeOS-SLE12-Community',
             bootpath='/boot',
             hypervisor='xen.gz',
-            efi_image_name='bootx64.efi'
+            efi_image_name='bootx64.efi',
+            terminal_setup='console'
         )
 
     def test_get_multiboot_iso_template_serial(self):
@@ -340,7 +359,8 @@ class TestBootLoaderTemplateGrub2(object):
             title='LimeJeOS-SLE12-Community',
             bootpath='/boot',
             hypervisor='xen.gz',
-            efi_image_name='bootx64.efi'
+            efi_image_name='bootx64.efi',
+            terminal_setup='serial'
         )
 
     def test_get_multiboot_iso_template_checkiso(self):
@@ -358,5 +378,6 @@ class TestBootLoaderTemplateGrub2(object):
             bootpath='/boot',
             boot_directory_name='grub2',
             hypervisor='xen.gz',
-            efi_image_name='bootx64.efi'
+            efi_image_name='bootx64.efi',
+            terminal_setup='console'
         )


### PR DESCRIPTION
With regards to the grub documentation from
https://www.gnu.org/software/grub/manual/grub/grub.html#terminal_005finput
multiple terminal consoles can be active. This patch allows
to specify terminal collection between serial, console and gfxterm
This Fixes #1123

