### PR TITLE
Fixed left over import of six module

### DIFF
--- a/kiwi/command_process.py
+++ b/kiwi/command_process.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-import six
 from collections import namedtuple
 
 # project
@@ -148,7 +147,7 @@ class CommandProcess(object):
             self.command.kill()
 
 
-class CommandIterator(six.Iterator):
+class CommandIterator(object):
     """
     **Implements an Iterator for Instances of Command**
 


### PR DESCRIPTION
The use of the six compat module was needed to support py2
With the drop of py2 support all of six was no longer needed.
However this one was overlooked.

