### PR TITLE
Pass components to debootstrap call

### DIFF
--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -147,6 +147,12 @@ class PackageManagerApt(PackageManagerBase):
             cmd = ['debootstrap', '--no-check-gpg']
             if self.deboostrap_minbase:
                 cmd.append('--variant=minbase')
+            if self.repository.components:
+                cmd.append(
+                    '--components={0}'.format(
+                        ','.join(self.repository.components)
+                    )
+                )
             cmd.extend([
                 self.distribution, bootstrap_dir, self.distribution_path
             ])

--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -66,6 +66,7 @@ class RepositoryApt(RepositoryBase):
         self.distribution = None
         self.distribution_path = None
         self.repo_names = []
+        self.components = []
 
         # apt-get support is based on creating a sources file which
         # contains path names to the repo and its cache. In order to
@@ -158,6 +159,7 @@ class RepositoryApt(RepositoryBase):
             uri = uri.replace('file://', 'file:/')
         if not components:
             components = 'main'
+        self._add_components(components)
         with open(list_file, 'w') as repo:
             if repo_gpgcheck is False:
                 repo_line = 'deb [trusted=yes check-valid-until=no] {0}'.format(uri)
@@ -251,6 +253,11 @@ class RepositoryApt(RepositoryBase):
         for repo_file in repo_files:
             if repo_file not in self.repo_names:
                 Path.wipe(repos_dir + '/' + repo_file)
+
+    def _add_components(self, components):
+        for component in components.split():
+            if component not in self.components:
+                self.components.append(component)
 
     def _create_apt_get_runtime_environment(self):
         for apt_get_dir in list(self.shared_apt_get_dir.values()):

--- a/test/unit/package_manager_apt_test.py
+++ b/test/unit/package_manager_apt_test.py
@@ -17,6 +17,7 @@ class TestPackageManagerApt(object):
         repository.root_dir = 'root-dir'
         repository.signing_keys = ['key-file.asc']
         repository.unauthenticated = 'false'
+        repository.components = ['main', 'restricted']
 
         root_bind = mock.Mock()
         root_bind.move_to_root = mock.Mock(
@@ -102,19 +103,31 @@ class TestPackageManagerApt(object):
             options=['-a', '-H', '-X', '-A']
         )
         assert mock_run.call_args_list == [
-            call(command=['mountpoint', '-q', 'root-dir/dev'], raise_on_error=False),
-            call([
-                'debootstrap', '--no-check-gpg', '--variant=minbase',
-                'xenial', 'root-dir.debootstrap', 'xenial_path'],
-                ['env']),
-            call([
-                'chroot', 'root-dir', 'apt-key', 'add', 'key-file.asc'
-            ], ['env']),
-            call(['rm', '-r', '-f', 'root-dir.debootstrap']),
-            call([
-                'chroot', 'root-dir', 'apt-get',
-                'root-moved-arguments', 'update'
-            ], ['env'])
+            call(
+                command=['mountpoint', '-q', 'root-dir/dev'],
+                raise_on_error=False
+            ),
+            call(
+                [
+                    'debootstrap', '--no-check-gpg', '--variant=minbase',
+                    '--components=main,restricted', 'xenial',
+                    'root-dir.debootstrap', 'xenial_path'
+                ], ['env']
+            ),
+            call(
+                [
+                    'chroot', 'root-dir', 'apt-key', 'add', 'key-file.asc'
+                ], ['env']
+            ),
+            call(
+                ['rm', '-r', '-f', 'root-dir.debootstrap']
+            ),
+            call(
+                [
+                    'chroot', 'root-dir', 'apt-get',
+                    'root-moved-arguments', 'update'
+                ], ['env']
+            )
         ]
         mock_call.assert_called_once_with([
             'chroot', 'root-dir', 'apt-get',


### PR DESCRIPTION
If repo components are specified the collective list of
component names should be passed to the debootstrap call.
This Fixes #1157

