### PR TITLE
Align setup.py with the correct license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -183,6 +183,7 @@ config = {
     'download_url': 'https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder',
     'author_email': 'ms@suse.com',
     'version': __version__,
+    'license' : 'GPLv3+',
     'install_requires': [
         'docopt>=0.6.2',
         'lxml',
@@ -209,7 +210,7 @@ config = {
        # classifier: http://pypi.python.org/pypi?%3Aaction=list_classifiers
        'Development Status :: 5 - Production/Stable',
        'Intended Audience :: Developers',
-       'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
+       'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
        'Operating System :: POSIX :: Linux',
        'Programming Language :: Python :: 3.6',
        'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
License metadata for the setuptools package was not in line with the real license provided within kiwi. This PR fixes it.