### PR TITLE
Document that grub tweaks may be required for LUKS encryption

### DIFF
--- a/doc/source/working_with_kiwi/xml_description.rst
+++ b/doc/source/working_with_kiwi/xml_description.rst
@@ -332,7 +332,12 @@ build types and will be covered here:
 - `luks`: Supplying a value will trigger the encryption of the partitions
   using the LUKS extension and using the provided string as the
   password. Note that the password must be entered when booting the
-  appliance!
+  appliance!  You may also need to tweak the grub configuration, e.g.
+  by adding something like the following to `config.sh`:
+
+  .. code:: bash
+
+      echo "GRUB_ENABLE_CRYPTODISK=y" >>/etc/default/grub
 
 - `primary`: Boolean option, KIWI will by default build the image which
   `primary` attribute is set to `true`.


### PR DESCRIPTION
At least on SLES (and presumably openSUSE), the grub configuration needs `GRUB_ENABLE_CRYPTODISK=y` adding, so document this caveat and give an example of how to do it.