### PR TITLE
Fix bool value handling

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -48,6 +48,7 @@ function get_disk_list {
     local max_disk
     local kiwi_oem_maxdisk
     local blk_opts="-p -n -r -o NAME,SIZE,TYPE"
+    local message
     if [ -n "${kiwi_devicepersistency}" ];then
         disk_id=${kiwi_devicepersistency}
     fi
@@ -86,9 +87,13 @@ function get_disk_list {
         disk_size=$(echo "${disk_meta}" | cut -f2 -d:)
         if [ ${max_disk} -gt 0 ]; then
             local disk_size_bytes
-            disk_size_bytes=$(binsize_to_bytesize "${disk_size}") || disk_size_bytes=0
+            disk_size_bytes=$(binsize_to_bytesize "${disk_size}") || \
+                disk_size_bytes=0
             if [ "${disk_size_bytes}" -gt "${max_disk}" ]; then
-                info "${disk_device} filtered out by rd.kiwi.oem.maxdisk=${kiwi_oem_maxdisk} (is ${disk_size})" >&2
+                message="${disk_device} filtered out by"
+                message="${message} rd.kiwi.oem.maxdisk=${kiwi_oem_maxdisk}"
+                message="${message} (disk size is: ${disk_size})"
+                info "${message}" >&2
                 continue
             fi
         fi
@@ -106,8 +111,9 @@ function get_disk_list {
         # check for custom filter rule
         if [ -n "${kiwi_oemdevicefilter}" ];then
             if [[ ${disk_device} =~ ${kiwi_oemdevicefilter} ]];then
-                # info is more or less "echo" if debug is on, and it clutters stdout
-                info "${disk_device} filtered out by: ${kiwi_oemdevicefilter}" >&2
+                message="${disk_device} filtered out by rule:"
+                message="${message} ${kiwi_oemdevicefilter}"
+                info "${message}" >&2
                 continue
             fi
         fi

--- a/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
@@ -133,3 +133,17 @@ function binsize_to_bytesize {
     esac
     awk "BEGIN {print int(${bs}*${mult})}"
 }
+
+function bool {
+    # """
+    # provides boolean string true|false for given value.
+    # Only if value matches true return true, in any other
+    # case return false
+    # """
+    local value=$1
+    if [ -n "${value}" ] && [ "${value}" = "true" ] ;then
+        echo "true"
+    else
+        echo "false"
+    fi
+}


### PR DESCRIPTION
__Fixed handling of bool values in initrd code__
    
Some values evaluated in the initrd code are created in
the kiwi builder and passed in as a profile file. bool
values created by kiwi for use in shell scripts takes
the string 'true' or 'false' or are not set at all if not
specified in the kiwi XML description. Some code paths
in the initrd code uses the '-n' switch to check for bool
values, however if the string 'false' is passed '-n' will
do the wrong thing. Therefore a method for the initrd
code has been introduced to clearly handle bool values

