### PR TITLE
Allow dracut initrd to be used with pxe type

### DIFF
--- a/kiwi/boot/image/__init__.py
+++ b/kiwi/boot/image/__init__.py
@@ -39,10 +39,12 @@ class BootImage(object):
         initrd_system = xml_state.get_initrd_system()
         if initrd_system == 'kiwi':
             return BootImageKiwi(
-                xml_state, target_dir, root_dir, signing_keys
+                xml_state, target_dir, None, signing_keys
             )
         elif initrd_system == 'dracut':
-            return BootImageDracut(xml_state, target_dir, root_dir)
+            return BootImageDracut(
+                xml_state, target_dir, root_dir, None
+            )
         else:
             raise KiwiBootImageSetupError(
                 'Support for %s initrd system not implemented' % initrd_system

--- a/kiwi/builder/pxe.py
+++ b/kiwi/builder/pxe.py
@@ -65,7 +65,8 @@ class PxeBuilder(object):
             and 'xz_options' in custom_args else None
 
         self.boot_image_task = BootImage(
-            xml_state, target_dir, signing_keys=self.boot_signing_keys
+            xml_state, target_dir, root_dir,
+            signing_keys=self.boot_signing_keys
         )
         self.image_name = ''.join(
             [

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1505,7 +1505,7 @@ div {
         }
         >> sch:pattern [ id = "initrd_system" is-a = "image_type"
             sch:param [ name = "attr" value = "initrd_system" ]
-            sch:param [ name = "types" value = "oem" ]
+            sch:param [ name = "types" value = "oem pxe" ]
         ]
     k.type.image.attribute =
         ## Specifies the image type

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2238,7 +2238,7 @@ system does not support all features of the kiwi initrd</a:documentation>
       </attribute>
       <sch:pattern id="initrd_system" is-a="image_type">
         <sch:param name="attr" value="initrd_system"/>
-        <sch:param name="types" value="oem"/>
+        <sch:param name="types" value="oem pxe"/>
       </sch:pattern>
     </define>
     <define name="k.type.image.attribute">

--- a/test/unit/boot_image_test.py
+++ b/test/unit/boot_image_test.py
@@ -33,5 +33,5 @@ class TestBootImage(object):
         self.xml_state.get_initrd_system.return_value = 'dracut'
         BootImage(self.xml_state, 'target_dir', 'root_dir')
         mock_dracut.assert_called_once_with(
-            self.xml_state, 'target_dir', 'root_dir'
+            self.xml_state, 'target_dir', 'root_dir', None
         )


### PR DESCRIPTION
The pxe image type builds a simple filesystem image plus a
custom initrd. That initrd is usually build from the kiwi
netboot image descriptions which implements a workflow to
fetch the filesystem image and deploy it as rootfs for a
pxe client. User who wants to implement their own handling
of the rootfs image in e.g a custom dracut module were not
able to build this image type because we did not allow
the initrd_system attribute for the pxe type

