### PR TITLE
remove '-z' option from rsync local copy calls

### DIFF
--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -135,7 +135,7 @@ class BootImageKiwi(BootImageBase):
                 temp_boot_root_directory
             )
             data.sync_data(
-                options=['-z', '-a']
+                options=['-a']
             )
             boot_directory = temp_boot_root_directory + '/boot'
             Path.wipe(boot_directory)

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -852,7 +852,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                     theme_dir, boot_theme_dir
                 )
                 data.sync_data(
-                    options=['-z', '-a']
+                    options=['-a']
                 )
                 if boot_theme_background_file:
                     # Install preserved background file to the theme
@@ -870,7 +870,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                     os.path.dirname(boot_theme_background_file), boot_theme_dir
                 )
                 data.sync_data(
-                    options=['-z', '-a']
+                    options=['-a']
                 )
 
         self._check_boot_theme_exists()
@@ -922,7 +922,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 module_path + '/', boot_module_path
             )
             data.sync_data(
-                options=['-z', '-a'], exclude=['*.module']
+                options=['-a'], exclude=['*.module']
             )
         except Exception as e:
             raise KiwiBootLoaderGrubModulesError(

--- a/kiwi/container/setup/base.py
+++ b/kiwi/container/setup/base.py
@@ -170,7 +170,7 @@ class ContainerSetupBase(object):
         try:
             data = DataSync('/dev/', self.root_dir + '/dev/')
             data.sync_data(
-                options=['-z', '-a', '-x', '--devices', '--specials']
+                options=['-a', '-x', '--devices', '--specials']
             )
         except Exception as e:
             raise KiwiContainerSetupError(

--- a/kiwi/iso_tools/base.py
+++ b/kiwi/iso_tools/base.py
@@ -176,5 +176,5 @@ class IsoToolsBase(object):
             loader_data, media_boot_path
         )
         data.sync_data(
-            options=['-z', '-a']
+            options=['-a']
         )

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -502,7 +502,7 @@ class SystemSetup(object):
                 modprobe_config, target_root_dir + '/etc/'
             )
             data.sync_data(
-                options=['-z', '-a']
+                options=['-a']
             )
 
     def export_package_list(self, target_dir):

--- a/test/unit/boot_image_builtin_kiwi_test.py
+++ b/test/unit/boot_image_builtin_kiwi_test.py
@@ -112,7 +112,7 @@ class TestBootImageKiwi(object):
         mock_sync.assert_called_once_with(
             'boot-root-directory/', 'temp-boot-directory'
         )
-        data.sync_data.assert_called_once_with(options=['-z', '-a'])
+        data.sync_data.assert_called_once_with(options=['-a'])
         mock_cpio.assert_called_once_with(
             ''.join(
                 [

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -631,8 +631,8 @@ class TestBootLoaderConfigGrub2(object):
             )
         ]
         assert data.sync_data.call_args_list == [
-            call(exclude=['*.module'], options=['-z', '-a']),
-            call(exclude=['*.module'], options=['-z', '-a'])
+            call(exclude=['*.module'], options=['-a']),
+            call(exclude=['*.module'], options=['-a'])
         ]
 
         mock_get_unsigned_grub_loader.return_value = 'custom_grub_image'
@@ -758,12 +758,12 @@ class TestBootLoaderConfigGrub2(object):
         self.bootloader.setup_disk_boot_images('uuid')
         assert mock_command.call_args_list == [
             call([
-                'rsync', '-z', '-a', '--exclude', '/*.module',
+                'rsync', '-a', '--exclude', '/*.module',
                 'root_dir/usr/share/grub2/i386-pc/',
                 'root_dir/boot/grub2/i386-pc'
             ]),
             call([
-                'rsync', '-z', '-a', '--exclude', '/*.module',
+                'rsync', '-a', '--exclude', '/*.module',
                 'root_dir/usr/share/grub2/x86_64-efi/',
                 'root_dir/boot/grub2/x86_64-efi']
             )]
@@ -804,12 +804,12 @@ class TestBootLoaderConfigGrub2(object):
         self.bootloader.setup_disk_boot_images('uuid')
         assert mock_command.call_args_list == [
             call([
-                'rsync', '-z', '-a', '--exclude', '/*.module',
+                'rsync', '-a', '--exclude', '/*.module',
                 'root_dir/usr/share/grub2/i386-pc/',
                 'root_dir/boot/grub2/i386-pc'
             ]),
             call([
-                'rsync', '-z', '-a', '--exclude', '/*.module',
+                'rsync', '-a', '--exclude', '/*.module',
                 'root_dir/usr/share/grub2/x86_64-efi/',
                 'root_dir/boot/grub2/x86_64-efi'
             ]),
@@ -861,12 +861,12 @@ class TestBootLoaderConfigGrub2(object):
         self.bootloader.setup_disk_boot_images('uuid')
         assert mock_command.call_args_list == [
             call([
-                'rsync', '-z', '-a', '--exclude', '/*.module',
+                'rsync', '-a', '--exclude', '/*.module',
                 'root_dir/usr/share/grub2/i386-pc/',
                 'root_dir/boot/grub2/i386-pc'
             ]),
             call([
-                'rsync', '-z', '-a', '--exclude', '/*.module',
+                'rsync', '-a', '--exclude', '/*.module',
                 'root_dir/usr/share/grub2/x86_64-efi/',
                 'root_dir/boot/grub2/x86_64-efi'
             ]),
@@ -988,8 +988,8 @@ class TestBootLoaderConfigGrub2(object):
             )
         ]
         assert data.sync_data.call_args_list == [
-            call(exclude=['*.module'], options=['-z', '-a']),
-            call(exclude=['*.module'], options=['-z', '-a'])
+            call(exclude=['*.module'], options=['-a']),
+            call(exclude=['*.module'], options=['-a'])
         ]
 
         mock_get_unsigned_grub_loader.return_value = 'custom_grub_image'
@@ -1068,7 +1068,7 @@ class TestBootLoaderConfigGrub2(object):
             ),
             call(
                 [
-                    'rsync', '-z', '-a', '--exclude', '/*.module',
+                    'rsync', '-a', '--exclude', '/*.module',
                     'root_dir/usr/share/grub2/x86_64-efi/',
                     'root_dir/boot/grub2/x86_64-efi'
                 ]
@@ -1137,7 +1137,7 @@ class TestBootLoaderConfigGrub2(object):
             'root_dir/boot/grub2/themes'
         )
         assert data.sync_data.call_args_list[0] == call(
-            options=['-z', '-a']
+            options=['-a']
         )
 
     @patch('kiwi.bootloader.config.grub2.Command.run')
@@ -1184,7 +1184,7 @@ class TestBootLoaderConfigGrub2(object):
             'root_dir/boot/grub2/themes'
         )
         assert data.sync_data.call_args_list[0] == call(
-            options=['-z', '-a']
+            options=['-a']
         )
 
     @patch('kiwi.bootloader.config.grub2.Command.run')

--- a/test/unit/container_setup_base_test.py
+++ b/test/unit/container_setup_base_test.py
@@ -121,7 +121,7 @@ class TestContainerSetupBase(object):
             '/dev/', 'root_dir/dev/'
         )
         data.sync_data.assert_called_once_with(
-            options=['-z', '-a', '-x', '--devices', '--specials']
+            options=['-a', '-x', '--devices', '--specials']
         )
 
     @patch('kiwi.container.setup.base.Command.run')

--- a/test/unit/iso_tools_base_test.py
+++ b/test/unit/iso_tools_base_test.py
@@ -203,5 +203,5 @@ class TestIsoToolsBase(object):
             'media_dir/boot/x86_64/loader'
         )
         data.sync_data.assert_called_once_with(
-            options=['-z', '-a']
+            options=['-a']
         )

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -803,7 +803,7 @@ class TestSystemSetup(object):
             'root_dir/etc/modprobe.d', 'target_root_dir/etc/'
         )
         data.sync_data.assert_called_once_with(
-            options=['-z', '-a']
+            options=['-a']
         )
 
     @patch('kiwi.system.setup.Command.run')


### PR DESCRIPTION
rsync's "compress" option just does not make any sense when rsync is
used to copy files locally, it only increases CPU usage and slows down
the process ;-)