### PR TITLE
Add /mnt to list of protected paths

### DIFF
--- a/kiwi/path.py
+++ b/kiwi/path.py
@@ -141,7 +141,7 @@ class Path(object):
         )
         path_elements = path.split(os.sep)
         protected_elements = [
-            'boot', 'dev', 'proc', 'run', 'sys', 'tmp', 'home'
+            'boot', 'dev', 'proc', 'run', 'sys', 'tmp', 'home', 'mnt'
         ]
         for path_index in reversed(range(0, len(path_elements))):
             sub_path = os.sep.join(path_elements[0:path_index])


### PR DESCRIPTION
On recursive removal make sure /mnt belong to the protected
elements. This Fixes #1170


