### PR TITLE
Add crypt dependency to kiwi-lib dracut module

### DIFF
--- a/dracut/modules.d/99kiwi-lib/module-setup.sh
+++ b/dracut/modules.d/99kiwi-lib/module-setup.sh
@@ -2,12 +2,12 @@
 
 # called by dracut
 check() {
-    return 0
+    return 255
 }
 
 # called by dracut
 depends() {
-    echo udev-rules
+    echo udev-rules crypt
     return 0
 }
 


### PR DESCRIPTION
This commit fixes the dependencies of the kiwi-lib dracut module to
include crypt module required by kiwi-luks-lib.sh.

In addition it also updates the check() section to return 255 instead of
0. In check section a return code of 0 means install it, 255 install
only if required by another module, anything else, do not install.

Related with bsc#1142899
