### PR TITLE
Stop inheriting from object

### DIFF
--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -283,7 +283,7 @@ syntax as supported by Sphinx, an example class is documented as follows:
 
 .. code:: python
 
-   class Example(object):
+   class Example:
        """
        **Example class**
 

--- a/helper/schema_parser.py
+++ b/helper/schema_parser.py
@@ -19,7 +19,7 @@ import sys
 logging.basicConfig(level=logging.WARNING)
 
 
-class SchemaNode(object):
+class SchemaNode:
 
     Child = namedtuple('Child', ['node', 'properties'])
 
@@ -216,7 +216,7 @@ class Element(SchemaNode):
         return elements
 
 
-class RNGSchemaParser(object):
+class RNGSchemaParser:
 
     def __init__(self, schema):
         self.logger = logging.getLogger(self.__class__.__name__)

--- a/kiwi/app.py
+++ b/kiwi/app.py
@@ -19,7 +19,7 @@
 from .tasks.base import CliTask
 
 
-class App(object):
+class App:
     """
     **Implements creation of task instances**
 

--- a/kiwi/archive/cpio.py
+++ b/kiwi/archive/cpio.py
@@ -19,7 +19,7 @@
 from kiwi.command import Command
 
 
-class ArchiveCpio(object):
+class ArchiveCpio:
     """
     **Extraction/Creation of cpio archives**
 

--- a/kiwi/archive/tar.py
+++ b/kiwi/archive/tar.py
@@ -23,7 +23,7 @@ from kiwi.defaults import Defaults
 from kiwi.utils.command_capabilities import CommandCapabilities
 
 
-class ArchiveTar(object):
+class ArchiveTar:
     """
     **Extraction/Creation of tar archives**
 

--- a/kiwi/boot/image/__init__.py
+++ b/kiwi/boot/image/__init__.py
@@ -24,7 +24,7 @@ from kiwi.exceptions import (
 )
 
 
-class BootImage(object):
+class BootImage:
     """
     **BootImge Factory**
 

--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -33,7 +33,7 @@ from kiwi.exceptions import (
 )
 
 
-class BootImageBase(object):
+class BootImageBase:
     """
     **Base class for boot image(initrd) task**
 

--- a/kiwi/bootloader/config/__init__.py
+++ b/kiwi/bootloader/config/__init__.py
@@ -25,7 +25,7 @@ from kiwi.exceptions import (
 )
 
 
-class BootLoaderConfig(object):
+class BootLoaderConfig:
     """
     **BootLoaderConfig factory**
 

--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -30,7 +30,7 @@ from kiwi.exceptions import (
 )
 
 
-class BootLoaderConfigBase(object):
+class BootLoaderConfigBase:
     """
     **Base class for bootloader configuration**
 

--- a/kiwi/bootloader/install/__init__.py
+++ b/kiwi/bootloader/install/__init__.py
@@ -24,7 +24,7 @@ from ...exceptions import (
 )
 
 
-class BootLoaderInstall(object):
+class BootLoaderInstall:
     """
     **BootLoaderInstall Factory**
 

--- a/kiwi/bootloader/install/base.py
+++ b/kiwi/bootloader/install/base.py
@@ -17,7 +17,7 @@
 #
 
 
-class BootLoaderInstallBase(object):
+class BootLoaderInstallBase:
     """
     **Base class for bootloader installation on device**
 

--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -20,7 +20,7 @@ from string import Template
 from textwrap import dedent
 
 
-class BootLoaderTemplateGrub2(object):
+class BootLoaderTemplateGrub2:
     """
     **grub2 configuraton file templates**
     """

--- a/kiwi/bootloader/template/isolinux.py
+++ b/kiwi/bootloader/template/isolinux.py
@@ -19,7 +19,7 @@ from string import Template
 from textwrap import dedent
 
 
-class BootLoaderTemplateIsoLinux(object):
+class BootLoaderTemplateIsoLinux:
     """
     **isolinux configuraton file templates**
     """

--- a/kiwi/bootloader/template/zipl.py
+++ b/kiwi/bootloader/template/zipl.py
@@ -19,7 +19,7 @@ from string import Template
 from textwrap import dedent
 
 
-class BootLoaderTemplateZipl(object):
+class BootLoaderTemplateZipl:
     """
     **zipl configuraton file templates**
     """

--- a/kiwi/builder/__init__.py
+++ b/kiwi/builder/__init__.py
@@ -29,7 +29,7 @@ from kiwi.exceptions import (
 )
 
 
-class ImageBuilder(object):
+class ImageBuilder:
     """
         image builder factory
     """

--- a/kiwi/builder/archive.py
+++ b/kiwi/builder/archive.py
@@ -31,7 +31,7 @@ from kiwi.exceptions import (
 )
 
 
-class ArchiveBuilder(object):
+class ArchiveBuilder:
     """
     **Root archive image builder**
 

--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -30,7 +30,7 @@ from kiwi.exceptions import KiwiContainerBuilderError
 from kiwi.runtime_config import RuntimeConfig
 
 
-class ContainerBuilder(object):
+class ContainerBuilder:
     """
     **Container image builder**
 

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -54,7 +54,7 @@ from kiwi.exceptions import (
 )
 
 
-class DiskBuilder(object):
+class DiskBuilder:
     """
     **Disk image builder**
 

--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -34,7 +34,7 @@ from kiwi.exceptions import (
 )
 
 
-class FileSystemBuilder(object):
+class FileSystemBuilder:
     """
     **Filesystem image builder**
 

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -42,7 +42,7 @@ from kiwi.exceptions import (
 )
 
 
-class InstallImageBuilder(object):
+class InstallImageBuilder:
     """
     **Installation image builder**
 

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -46,7 +46,7 @@ from kiwi.exceptions import (
 )
 
 
-class LiveImageBuilder(object):
+class LiveImageBuilder:
     """
     **Live image builder**
 

--- a/kiwi/builder/pxe.py
+++ b/kiwi/builder/pxe.py
@@ -36,7 +36,7 @@ from kiwi.exceptions import (
 )
 
 
-class PxeBuilder(object):
+class PxeBuilder:
     """
     **Filesystem based PXE image builder.**
 

--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -86,7 +86,7 @@ from .version import __version__
 from .help import Help
 
 
-class Cli(object):
+class Cli:
     """
     **Implements the main command line interface**
 

--- a/kiwi/command.py
+++ b/kiwi/command.py
@@ -33,7 +33,7 @@ command_type = namedtuple(
 )
 
 
-class Command(object):
+class Command:
     """
     **Implements command invocation**
 

--- a/kiwi/command_process.py
+++ b/kiwi/command_process.py
@@ -26,7 +26,7 @@ from .exceptions import (
 )
 
 
-class CommandProcess(object):
+class CommandProcess:
     """
     **Implements processing of non blocking Command calls**
 
@@ -147,7 +147,7 @@ class CommandProcess(object):
             self.command.kill()
 
 
-class CommandIterator(object):
+class CommandIterator:
     """
     **Implements an Iterator for Instances of Command**
 

--- a/kiwi/container/__init__.py
+++ b/kiwi/container/__init__.py
@@ -23,7 +23,7 @@ from kiwi.exceptions import (
 )
 
 
-class ContainerImage(object):
+class ContainerImage:
     """
     **Container Image factory**
 

--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -25,7 +25,7 @@ from kiwi.oci_tools import OCI
 from kiwi.utils.compress import Compress
 
 
-class ContainerImageOCI(object):
+class ContainerImageOCI:
     """
     Create oci container from a root directory
 

--- a/kiwi/container/setup/__init__.py
+++ b/kiwi/container/setup/__init__.py
@@ -24,7 +24,7 @@ from kiwi.exceptions import (
 )
 
 
-class ContainerSetup(object):
+class ContainerSetup:
     """
         container setup factory
     """

--- a/kiwi/container/setup/base.py
+++ b/kiwi/container/setup/base.py
@@ -27,7 +27,7 @@ from kiwi.exceptions import (
 )
 
 
-class ContainerSetupBase(object):
+class ContainerSetupBase:
     """
     Base class for setting up the root system to create
     a container image from for e.g docker. The methods here

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -31,7 +31,7 @@ from .version import (
 from .exceptions import KiwiBootLoaderGrubDataError
 
 
-class Defaults(object):
+class Defaults:
     """
     **Implements default values**
 

--- a/kiwi/filesystem/__init__.py
+++ b/kiwi/filesystem/__init__.py
@@ -31,7 +31,7 @@ from ..exceptions import (
 )
 
 
-class FileSystem(object):
+class FileSystem:
     """
     **FileSystem factory**
 

--- a/kiwi/filesystem/base.py
+++ b/kiwi/filesystem/base.py
@@ -28,7 +28,7 @@ from kiwi.exceptions import (
 )
 
 
-class FileSystemBase(object):
+class FileSystemBase:
     """
     **Implements base class for filesystem interface**
 

--- a/kiwi/filesystem/setup.py
+++ b/kiwi/filesystem/setup.py
@@ -21,7 +21,7 @@ from kiwi.logger import log
 from kiwi.defaults import Defaults
 
 
-class FileSystemSetup(object):
+class FileSystemSetup:
     """
     **Implement filesystem setup methods**
 

--- a/kiwi/firmware.py
+++ b/kiwi/firmware.py
@@ -26,7 +26,7 @@ from .exceptions import (
 )
 
 
-class FirmWare(object):
+class FirmWare:
     """
     **Implements firmware specific methods**
 

--- a/kiwi/help.py
+++ b/kiwi/help.py
@@ -21,7 +21,7 @@ import subprocess
 from .exceptions import KiwiHelpNoCommandGiven
 
 
-class Help(object):
+class Help:
     """
     **Implements man page help for kiwi commands**
 

--- a/kiwi/iso_tools/__init__.py
+++ b/kiwi/iso_tools/__init__.py
@@ -21,7 +21,7 @@ from kiwi.iso_tools.xorriso import IsoToolsXorrIso
 from kiwi.runtime_config import RuntimeConfig
 
 
-class IsoTools(object):
+class IsoTools:
     """
     **IsoTools factory**
     """

--- a/kiwi/iso_tools/base.py
+++ b/kiwi/iso_tools/base.py
@@ -27,7 +27,7 @@ from kiwi.path import Path
 from kiwi.logger import log
 
 
-class IsoToolsBase(object):
+class IsoToolsBase:
     """
     **Base Class for Parameter API for iso creation tools**
 

--- a/kiwi/iso_tools/iso.py
+++ b/kiwi/iso_tools/iso.py
@@ -32,7 +32,7 @@ from kiwi.exceptions import (
 )
 
 
-class Iso(object):
+class Iso:
     """
     **Implements helper methods around the creation of ISO filesystems**
 

--- a/kiwi/kiwi_compat.py
+++ b/kiwi/kiwi_compat.py
@@ -51,7 +51,7 @@ from docopt import DocoptExit
 from .path import Path
 
 
-class Cli(object):
+class Cli:
     """
         Compatibility class for old style kiwi calls
     """
@@ -82,7 +82,7 @@ class Cli(object):
             )
 
 
-class Translate(object):
+class Translate:
     def __init__(self, arguments):
         self.arguments = arguments
 
@@ -210,7 +210,7 @@ class Translate(object):
         )
 
 
-class Command(object):
+class Command:
     @staticmethod
     def execute(arguments):
         os.execvp(Command.lookup_kiwi(), ['kiwi'] + arguments)

--- a/kiwi/logger.py
+++ b/kiwi/logger.py
@@ -24,7 +24,7 @@ from .exceptions import (
 )
 
 
-class ColorMessage(object):
+class ColorMessage:
     """
     **Implements color messages for Python logging facility**
 

--- a/kiwi/mount_manager.py
+++ b/kiwi/mount_manager.py
@@ -23,7 +23,7 @@ from .command import Command
 from .path import Path
 
 
-class MountManager(object):
+class MountManager:
     """
     **Implements methods for mounting, umounting and mount checking**
 

--- a/kiwi/oci_tools/__init__.py
+++ b/kiwi/oci_tools/__init__.py
@@ -25,7 +25,7 @@ from kiwi.exceptions import (
 )
 
 
-class OCI(object):
+class OCI:
     """
     **OCI Factory**
     """

--- a/kiwi/oci_tools/base.py
+++ b/kiwi/oci_tools/base.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from kiwi.utils.sync import DataSync
 
 
-class OCIBase(object):
+class OCIBase:
     """
     **Base Class for Open Container Interface operations**
 

--- a/kiwi/package_manager/__init__.py
+++ b/kiwi/package_manager/__init__.py
@@ -25,7 +25,7 @@ from kiwi.exceptions import (
 )
 
 
-class PackageManager(object):
+class PackageManager:
     """
     **Package manager factory**
 

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -17,7 +17,7 @@
 #
 
 
-class PackageManagerBase(object):
+class PackageManagerBase:
     """
     **Implements base class for installation/deletion of
     packages and collections using a package manager**

--- a/kiwi/partitioner/__init__.py
+++ b/kiwi/partitioner/__init__.py
@@ -28,7 +28,7 @@ from kiwi.exceptions import (
 )
 
 
-class Partitioner(object):
+class Partitioner:
     """
     **Partitioner factory**
 

--- a/kiwi/partitioner/base.py
+++ b/kiwi/partitioner/base.py
@@ -17,7 +17,7 @@
 #
 
 
-class PartitionerBase(object):
+class PartitionerBase:
     """
     **Base class for partitioners**
 

--- a/kiwi/path.py
+++ b/kiwi/path.py
@@ -24,7 +24,7 @@ from .logger import log
 from .exceptions import KiwiFileAccessError
 
 
-class Path(object):
+class Path:
     """
     **Directory path helpers**
     """

--- a/kiwi/privileges.py
+++ b/kiwi/privileges.py
@@ -23,7 +23,7 @@ from .exceptions import (
 )
 
 
-class Privileges(object):
+class Privileges:
     """
     **Implements check for root privileges**
     """

--- a/kiwi/repository/__init__.py
+++ b/kiwi/repository/__init__.py
@@ -25,7 +25,7 @@ from kiwi.exceptions import (
 )
 
 
-class Repository(object):
+class Repository:
     """
     **Repository factory**
 

--- a/kiwi/repository/base.py
+++ b/kiwi/repository/base.py
@@ -17,7 +17,7 @@
 #
 
 
-class RepositoryBase(object):
+class RepositoryBase:
     """
     Implements base class for package manager repository handling
 

--- a/kiwi/repository/template/apt.py
+++ b/kiwi/repository/template/apt.py
@@ -20,7 +20,7 @@ from string import Template
 from textwrap import dedent
 
 
-class PackageManagerTemplateAptGet(object):
+class PackageManagerTemplateAptGet:
     """
     apt-get configuration file template
     """

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -32,7 +32,7 @@ from .exceptions import (
 )
 
 
-class RuntimeChecker(object):
+class RuntimeChecker:
     """
     **Implements build consistency checks at runtime**
 

--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -27,7 +27,7 @@ from .exceptions import (
 )
 
 
-class RuntimeConfig(object):
+class RuntimeConfig:
     """
     **Implements reading of runtime configuration file:**
 

--- a/kiwi/solver/repository/__init__.py
+++ b/kiwi/solver/repository/__init__.py
@@ -23,7 +23,7 @@ from kiwi.solver.repository.rpm_dir import SolverRepositoryRpmDir
 from kiwi.exceptions import KiwiSolverRepositorySetupError
 
 
-class SolverRepository(object):
+class SolverRepository:
     """
     **Repository factory for creation of SAT solvables**
 

--- a/kiwi/solver/repository/base.py
+++ b/kiwi/solver/repository/base.py
@@ -32,7 +32,7 @@ from kiwi.command import Command
 from kiwi.defaults import Defaults
 
 
-class SolverRepositoryBase(object):
+class SolverRepositoryBase:
     """
     **Base class interface for SAT solvable creation.**
 

--- a/kiwi/solver/sat.py
+++ b/kiwi/solver/sat.py
@@ -30,7 +30,7 @@ from kiwi.exceptions import (
 )
 
 
-class Sat(object):
+class Sat:
     """
     **Sat Solver class to run package solver operations**
 

--- a/kiwi/storage/device_provider.py
+++ b/kiwi/storage/device_provider.py
@@ -22,7 +22,7 @@ from kiwi.exceptions import (
 )
 
 
-class DeviceProvider(object):
+class DeviceProvider:
     """
     **Base class for any class providing storage devices**
     """

--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -25,7 +25,7 @@ from kiwi.defaults import Defaults
 from kiwi.logger import log
 
 
-class DiskSetup(object):
+class DiskSetup:
     """
     **Implements disk setup methods**
 

--- a/kiwi/storage/subformat/__init__.py
+++ b/kiwi/storage/subformat/__init__.py
@@ -33,7 +33,7 @@ from kiwi.exceptions import (
 )
 
 
-class DiskFormat(object):
+class DiskFormat:
     """
     **DiskFormat factory**
 

--- a/kiwi/storage/subformat/base.py
+++ b/kiwi/storage/subformat/base.py
@@ -32,7 +32,7 @@ from kiwi.exceptions import (
 )
 
 
-class DiskFormatBase(object):
+class DiskFormatBase:
     """
     **Base class to create disk formats from a raw disk image**
 

--- a/kiwi/storage/subformat/template/vagrant_config.py
+++ b/kiwi/storage/subformat/template/vagrant_config.py
@@ -20,7 +20,7 @@ import os
 from textwrap import dedent
 
 
-class VagrantConfigTemplate(object):
+class VagrantConfigTemplate:
     """
     **Generate a Vagrantfile configuration template**
 

--- a/kiwi/storage/subformat/template/virtualbox_ovf.py
+++ b/kiwi/storage/subformat/template/virtualbox_ovf.py
@@ -19,7 +19,7 @@
 from string import Template
 
 
-class VirtualboxOvfTemplate(object):
+class VirtualboxOvfTemplate:
     """
     **Generate a OVF file template for a vagrant virtualbox box**
 

--- a/kiwi/storage/subformat/template/vmware_settings.py
+++ b/kiwi/storage/subformat/template/vmware_settings.py
@@ -19,7 +19,7 @@ from string import Template
 from textwrap import dedent
 
 
-class VmwareSettingsTemplate(object):
+class VmwareSettingsTemplate:
     """
     VMware machine settings template
     """

--- a/kiwi/system/identifier.py
+++ b/kiwi/system/identifier.py
@@ -19,7 +19,7 @@ import random
 import struct
 
 
-class SystemIdentifier(object):
+class SystemIdentifier:
     """
     **Create a random ID to identify the system**
 

--- a/kiwi/system/kernel.py
+++ b/kiwi/system/kernel.py
@@ -24,7 +24,7 @@ from kiwi.command import Command
 from kiwi.exceptions import KiwiKernelLookupError
 
 
-class Kernel(object):
+class Kernel:
     """
     **Implementes kernel lookup and extraction from given root tree**
 

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -41,7 +41,7 @@ from kiwi.exceptions import (
 )
 
 
-class SystemPrepare(object):
+class SystemPrepare:
     """
     Implements preparation and installation of a new root system
 

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -23,7 +23,7 @@ from kiwi.system.shell import Shell
 from kiwi.defaults import Defaults
 
 
-class Profile(object):
+class Profile:
     """
     **Create bash readable .profile environment from the XML
     description**

--- a/kiwi/system/result.py
+++ b/kiwi/system/result.py
@@ -32,7 +32,7 @@ result_file_type = namedtuple(
 )
 
 
-class Result(object):
+class Result:
     """
     **Collect image building results**
 

--- a/kiwi/system/root_bind.py
+++ b/kiwi/system/root_bind.py
@@ -34,7 +34,7 @@ from kiwi.exceptions import (
 )
 
 
-class RootBind(object):
+class RootBind:
     """
     **Implements binding/copying of host system paths
     into the new root directory**

--- a/kiwi/system/root_import/__init__.py
+++ b/kiwi/system/root_import/__init__.py
@@ -21,7 +21,7 @@ from kiwi.exceptions import KiwiRootImportError
 from kiwi.logger import log
 
 
-class RootImport(object):
+class RootImport:
     """
     Root import factory
 

--- a/kiwi/system/root_import/base.py
+++ b/kiwi/system/root_import/base.py
@@ -26,7 +26,7 @@ from kiwi.exceptions import (
 )
 
 
-class RootImportBase(object):
+class RootImportBase:
     """
     Imports the root system from an already packed image.
 

--- a/kiwi/system/root_init.py
+++ b/kiwi/system/root_init.py
@@ -33,7 +33,7 @@ from kiwi.exceptions import (
 )
 
 
-class RootInit(object):
+class RootInit:
     """
     **Implements creation of new root directory for a linux system**
 

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -47,7 +47,7 @@ from kiwi.exceptions import (
 )
 
 
-class SystemSetup(object):
+class SystemSetup:
     """
     **Implementation of system setup steps supported by kiwi**
 

--- a/kiwi/system/shell.py
+++ b/kiwi/system/shell.py
@@ -22,7 +22,7 @@ from kiwi.command import Command
 from kiwi.defaults import Defaults
 
 
-class Shell(object):
+class Shell:
     """
     **Special character handling for shell evaluated code**
     """

--- a/kiwi/system/size.py
+++ b/kiwi/system/size.py
@@ -20,7 +20,7 @@ from kiwi.command import Command
 from kiwi.defaults import Defaults
 
 
-class SystemSize(object):
+class SystemSize:
     """
     **Provide source tree size information**
 

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -35,7 +35,7 @@ from kiwi.exceptions import (
 )
 
 
-class Uri(object):
+class Uri:
     """
     **Normalize url types available in a kiwi configuration into
     standard mime types**

--- a/kiwi/system/users.py
+++ b/kiwi/system/users.py
@@ -18,7 +18,7 @@
 from kiwi.command import Command
 
 
-class Users(object):
+class Users:
     """
     **Operations on users and groups in a root directory**
 

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -32,7 +32,7 @@ from kiwi.exceptions import (
 )
 
 
-class CliTask(object):
+class CliTask:
     """
     Base class for all task classes, loads the task and provides
     the interface to the command options and the XML description

--- a/kiwi/utils/block.py
+++ b/kiwi/utils/block.py
@@ -21,7 +21,7 @@ import os
 from kiwi.command import Command
 
 
-class BlockID(object):
+class BlockID:
     """
     **Get information from a block device**
 

--- a/kiwi/utils/checksum.py
+++ b/kiwi/utils/checksum.py
@@ -28,7 +28,7 @@ from kiwi.exceptions import (
 )
 
 
-class Checksum(object):
+class Checksum:
     """
     **Manage checksum creation for files**
 

--- a/kiwi/utils/codec.py
+++ b/kiwi/utils/codec.py
@@ -20,7 +20,7 @@ from kiwi.logger import log
 from kiwi.exceptions import KiwiDecodingError
 
 
-class Codec(object):
+class Codec:
     """
     **Performs conversions of literal byte sequences to strings**
     """

--- a/kiwi/utils/command_capabilities.py
+++ b/kiwi/utils/command_capabilities.py
@@ -23,7 +23,7 @@ from kiwi.logger import log
 from kiwi.exceptions import KiwiCommandCapabilitiesError
 
 
-class CommandCapabilities(object):
+class CommandCapabilities:
     """
     **Validation of command version flags or version**
 

--- a/kiwi/utils/compress.py
+++ b/kiwi/utils/compress.py
@@ -29,7 +29,7 @@ from kiwi.exceptions import (
 )
 
 
-class Compress(object):
+class Compress:
     """
     **File compression / decompression**
 

--- a/kiwi/utils/output.py
+++ b/kiwi/utils/output.py
@@ -24,7 +24,7 @@ from kiwi.path import Path
 from kiwi.logger import log
 
 
-class DataOutput(object):
+class DataOutput:
     """
     **Converts dict or list variables to a print friendly json format**
 

--- a/kiwi/utils/rpm.py
+++ b/kiwi/utils/rpm.py
@@ -24,7 +24,7 @@ from kiwi.defaults import Defaults
 from kiwi.path import Path
 
 
-class Rpm(object):
+class Rpm:
     """
     **Helper methods to handle the rpm database configuration**
     """

--- a/kiwi/utils/rpm_database.py
+++ b/kiwi/utils/rpm_database.py
@@ -24,7 +24,7 @@ from kiwi.path import Path
 from kiwi.utils.rpm import Rpm
 
 
-class RpmDataBase(object):
+class RpmDataBase:
     """
     **Setup RPM database configuration**
     """

--- a/kiwi/utils/size.py
+++ b/kiwi/utils/size.py
@@ -21,7 +21,7 @@ import math
 from kiwi.exceptions import KiwiSizeError
 
 
-class StringToSize(object):
+class StringToSize:
     """
     **Performs size convertions from strings to numbers**
     """

--- a/kiwi/utils/sync.py
+++ b/kiwi/utils/sync.py
@@ -24,7 +24,7 @@ from kiwi.logger import log
 from kiwi.command import Command
 
 
-class DataSync(object):
+class DataSync:
     """
     **Sync data from a source directory to a target directory
     using the rsync protocol**

--- a/kiwi/utils/sysconfig.py
+++ b/kiwi/utils/sysconfig.py
@@ -18,7 +18,7 @@
 import os
 
 
-class SysConfig(object):
+class SysConfig:
     """
     **Read and Write sysconfig style files**
 

--- a/kiwi/volume_manager/__init__.py
+++ b/kiwi/volume_manager/__init__.py
@@ -24,7 +24,7 @@ from kiwi.exceptions import (
 )
 
 
-class VolumeManager(object):
+class VolumeManager:
     """
     **VolumeManager factory**
 

--- a/kiwi/xml_description.py
+++ b/kiwi/xml_description.py
@@ -41,7 +41,7 @@ from .exceptions import (
 )
 
 
-class XMLDescription(object):
+class XMLDescription:
     """
     **Implements data management for the XML description**
 

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -101,7 +101,7 @@ try:
     from generatedssuper import GeneratedsSuper
 except ImportError as exp:
     
-    class GeneratedsSuper(object):
+    class GeneratedsSuper:
         tzoff_pattern = re_.compile(r'(\+|-)((0\d|1[0-3]):[0-5]\d|14:00)$')
         class _FixedOffsetTZ(datetime_.tzinfo):
             def __init__(self, offset, name):
@@ -678,7 +678,7 @@ class MixedContainer:
             outfile.write(')\n')
 
 
-class MemberSpec_(object):
+class MemberSpec_:
     def __init__(self, name='', data_type='', container=0,
             optional=0, child_attrs=None, choice=None):
         self.name = name

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -35,7 +35,7 @@ from .exceptions import (
 )
 
 
-class XMLState(object):
+class XMLState:
     """
     **Implements methods to get stateful information from the XML data**
 

--- a/test/unit/archive_cpio_test.py
+++ b/test/unit/archive_cpio_test.py
@@ -3,7 +3,7 @@ from mock import patch
 from kiwi.archive.cpio import ArchiveCpio
 
 
-class TestArchiveCpio(object):
+class TestArchiveCpio:
     def setup(self):
         self.archive = ArchiveCpio('foo.cpio')
 

--- a/test/unit/archive_tar_test.py
+++ b/test/unit/archive_tar_test.py
@@ -9,7 +9,7 @@ from kiwi.archive.tar import ArchiveTar
 from kiwi.exceptions import KiwiCommandCapabilitiesError
 
 
-class TestArchiveTar(object):
+class TestArchiveTar:
     @patch('kiwi.archive.tar.Command.run')
     def setup(self, mock_command):
         command = mock.Mock()

--- a/test/unit/boot_image_base_test.py
+++ b/test/unit/boot_image_base_test.py
@@ -13,7 +13,7 @@ from kiwi.exceptions import (
 from kiwi.boot.image.base import BootImageBase
 
 
-class TestBootImageBase(object):
+class TestBootImageBase:
     @patch('kiwi.boot.image.base.os.path.exists')
     @patch('platform.machine')
     def setup(self, mock_machine, mock_exists):

--- a/test/unit/boot_image_builtin_kiwi_test.py
+++ b/test/unit/boot_image_builtin_kiwi_test.py
@@ -14,7 +14,7 @@ from kiwi.xml_state import XMLState
 from kiwi.exceptions import KiwiConfigFileNotFound
 
 
-class TestBootImageKiwi(object):
+class TestBootImageKiwi:
     @patch('kiwi.boot.image.builtin_kiwi.mkdtemp')
     @patch('kiwi.boot.image.builtin_kiwi.os.path.exists')
     @patch('platform.machine')

--- a/test/unit/boot_image_dracut_test.py
+++ b/test/unit/boot_image_dracut_test.py
@@ -13,7 +13,7 @@ from kiwi.xml_state import XMLState
 from kiwi.exceptions import KiwiDiskBootImageError
 
 
-class TestBootImageKiwi(object):
+class TestBootImageKiwi:
     @patch('kiwi.boot.image.base.os.path.exists')
     @patch('platform.machine')
     def setup(self, mock_machine, mock_exists):

--- a/test/unit/boot_image_test.py
+++ b/test/unit/boot_image_test.py
@@ -8,7 +8,7 @@ from kiwi.exceptions import KiwiBootImageSetupError
 from kiwi.boot.image import BootImage
 
 
-class TestBootImage(object):
+class TestBootImage:
     def setup(self):
         self.xml_state = mock.Mock()
         self.xml_state.get_initrd_system = mock.Mock(

--- a/test/unit/bootloader_config_base_test.py
+++ b/test/unit/bootloader_config_base_test.py
@@ -10,7 +10,7 @@ from kiwi.exceptions import KiwiBootLoaderTargetError
 from kiwi.bootloader.config.base import BootLoaderConfigBase
 
 
-class TestBootLoaderConfigBase(object):
+class TestBootLoaderConfigBase:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -23,7 +23,7 @@ from kiwi.exceptions import (
 from kiwi.bootloader.config.grub2 import BootLoaderConfigGrub2
 
 
-class TestBootLoaderConfigGrub2(object):
+class TestBootLoaderConfigGrub2:
     @patch('kiwi.bootloader.config.grub2.FirmWare')
     @patch('kiwi.bootloader.config.base.BootLoaderConfigBase.get_boot_theme')
     @patch('platform.machine')

--- a/test/unit/bootloader_config_isolinux_test.py
+++ b/test/unit/bootloader_config_isolinux_test.py
@@ -9,7 +9,7 @@ from kiwi.bootloader.config.isolinux import BootLoaderConfigIsoLinux
 from kiwi.exceptions import KiwiTemplateError
 
 
-class TestBootLoaderConfigIsoLinux(object):
+class TestBootLoaderConfigIsoLinux:
     @patch('os.path.exists')
     @patch('platform.machine')
     def setup(self, mock_machine, mock_exists):

--- a/test/unit/bootloader_config_test.py
+++ b/test/unit/bootloader_config_test.py
@@ -8,7 +8,7 @@ from kiwi.exceptions import KiwiBootLoaderConfigSetupError
 from kiwi.bootloader.config import BootLoaderConfig
 
 
-class TestBootLoaderConfig(object):
+class TestBootLoaderConfig:
     @raises(KiwiBootLoaderConfigSetupError)
     def test_bootloader_config_not_implemented(self):
         BootLoaderConfig('foo', mock.Mock(), 'root_dir')

--- a/test/unit/bootloader_config_zipl_test.py
+++ b/test/unit/bootloader_config_zipl_test.py
@@ -18,7 +18,7 @@ from kiwi.exceptions import (
 from kiwi.bootloader.config.zipl import BootLoaderConfigZipl
 
 
-class TestBootLoaderConfigZipl(object):
+class TestBootLoaderConfigZipl:
     @patch('kiwi.bootloader.config.zipl.FirmWare')
     @patch('platform.machine')
     def setup(self, mock_machine, mock_firmware):

--- a/test/unit/bootloader_install_base_test.py
+++ b/test/unit/bootloader_install_base_test.py
@@ -5,7 +5,7 @@ from .test_helper import raises
 from kiwi.bootloader.install.base import BootLoaderInstallBase
 
 
-class TestBootLoaderInstallBase(object):
+class TestBootLoaderInstallBase:
     def setup(self):
         self.bootloader = BootLoaderInstallBase(
             'root_dir', mock.Mock()

--- a/test/unit/bootloader_install_grub2_test.py
+++ b/test/unit/bootloader_install_grub2_test.py
@@ -16,7 +16,7 @@ from kiwi.bootloader.install.grub2 import BootLoaderInstallGrub2
 from kiwi.defaults import Defaults
 
 
-class TestBootLoaderInstallGrub2(object):
+class TestBootLoaderInstallGrub2:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'

--- a/test/unit/bootloader_install_test.py
+++ b/test/unit/bootloader_install_test.py
@@ -9,7 +9,7 @@ from kiwi.exceptions import KiwiBootLoaderInstallSetupError
 from kiwi.bootloader.install import BootLoaderInstall
 
 
-class TestBootLoaderInstall(object):
+class TestBootLoaderInstall:
     @raises(KiwiBootLoaderInstallSetupError)
     def test_bootloader_install_not_implemented(self):
         BootLoaderInstall('foo', 'root_dir', mock.Mock())

--- a/test/unit/bootloader_install_zipl_test.py
+++ b/test/unit/bootloader_install_zipl_test.py
@@ -10,7 +10,7 @@ from kiwi.exceptions import KiwiBootLoaderZiplInstallError
 from kiwi.bootloader.install.zipl import BootLoaderInstallZipl
 
 
-class TestBootLoaderInstallZipl(object):
+class TestBootLoaderInstallZipl:
     @patch('kiwi.bootloader.install.zipl.MountManager')
     def setup(self, mock_mount):
         custom_args = {

--- a/test/unit/bootloader_template_grub2_test.py
+++ b/test/unit/bootloader_template_grub2_test.py
@@ -1,7 +1,7 @@
 from kiwi.bootloader.template.grub2 import BootLoaderTemplateGrub2
 
 
-class TestBootLoaderTemplateGrub2(object):
+class TestBootLoaderTemplateGrub2:
     def setup(self):
         self.grub2 = BootLoaderTemplateGrub2()
 

--- a/test/unit/bootloader_template_isolinux_test.py
+++ b/test/unit/bootloader_template_isolinux_test.py
@@ -1,7 +1,7 @@
 from kiwi.bootloader.template.isolinux import BootLoaderTemplateIsoLinux
 
 
-class TestBootLoaderTemplateIsoLinux(object):
+class TestBootLoaderTemplateIsoLinux:
     def setup(self):
         self.isolinux = BootLoaderTemplateIsoLinux()
 

--- a/test/unit/bootloader_template_zipl_test.py
+++ b/test/unit/bootloader_template_zipl_test.py
@@ -1,7 +1,7 @@
 from kiwi.bootloader.template.zipl import BootLoaderTemplateZipl
 
 
-class TestBootLoaderTemplateZipl(object):
+class TestBootLoaderTemplateZipl:
     def setup(self):
         self.zipl = BootLoaderTemplateZipl()
 

--- a/test/unit/builder_archive_test.py
+++ b/test/unit/builder_archive_test.py
@@ -9,7 +9,7 @@ from kiwi.exceptions import KiwiArchiveSetupError
 from kiwi.builder.archive import ArchiveBuilder
 
 
-class TestArchiveBuilder(object):
+class TestArchiveBuilder:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'

--- a/test/unit/builder_container_test.py
+++ b/test/unit/builder_container_test.py
@@ -10,7 +10,7 @@ from kiwi.builder.container import ContainerBuilder
 from kiwi.exceptions import KiwiContainerBuilderError
 
 
-class TestContainerBuilder(object):
+class TestContainerBuilder:
     @patch('platform.machine')
     @patch('os.path.exists')
     def setup(self, mock_exists, mock_machine):

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -23,7 +23,7 @@ from kiwi.storage.mapped_device import MappedDevice
 from builtins import bytes
 
 
-class TestDiskBuilder(object):
+class TestDiskBuilder:
     @patch('os.path.exists')
     @patch('platform.machine')
     def setup(self, mock_machine, mock_exists):

--- a/test/unit/builder_filesystem_test.py
+++ b/test/unit/builder_filesystem_test.py
@@ -9,7 +9,7 @@ from kiwi.exceptions import KiwiFileSystemSetupError
 from kiwi.builder.filesystem import FileSystemBuilder
 
 
-class TestFileSystemBuilder(object):
+class TestFileSystemBuilder:
     @patch('kiwi.builder.filesystem.FileSystemSetup')
     @patch('platform.machine')
     def setup(self, mock_machine, mock_fs_setup):

--- a/test/unit/builder_install_test.py
+++ b/test/unit/builder_install_test.py
@@ -13,7 +13,7 @@ from kiwi.exceptions import KiwiInstallBootImageError
 from kiwi.builder.install import InstallImageBuilder
 
 
-class TestInstallImageBuilder(object):
+class TestInstallImageBuilder:
     @patch('platform.machine')
     def setup(self, mock_machine):
         boot_names_type = namedtuple(

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -10,7 +10,7 @@ from kiwi.exceptions import KiwiLiveBootImageError
 from kiwi.builder.live import LiveImageBuilder
 
 
-class TestLiveImageBuilder(object):
+class TestLiveImageBuilder:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'

--- a/test/unit/builder_pxe_test.py
+++ b/test/unit/builder_pxe_test.py
@@ -12,7 +12,7 @@ from kiwi.exceptions import KiwiPxeBootImageError
 from kiwi.builder.pxe import PxeBuilder
 
 
-class TestPxeBuilder(object):
+class TestPxeBuilder:
     @patch('kiwi.builder.pxe.FileSystemBuilder')
     @patch('kiwi.builder.pxe.BootImage')
     def setup(self, mock_boot, mock_filesystem):

--- a/test/unit/builder_test.py
+++ b/test/unit/builder_test.py
@@ -9,7 +9,7 @@ from kiwi.exceptions import KiwiRequestedTypeError
 from kiwi.builder import ImageBuilder
 
 
-class TestImageBuilder(object):
+class TestImageBuilder:
     @patch('kiwi.builder.FileSystemBuilder')
     def test_filesystem_builder(self, mock_builder):
         xml_state = mock.Mock()

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -14,7 +14,7 @@ from kiwi.exceptions import (
 )
 
 
-class TestCli(object):
+class TestCli:
     def setup(self):
         self.help_global_args = {
             'help': False,

--- a/test/unit/command_process_test.py
+++ b/test/unit/command_process_test.py
@@ -11,7 +11,7 @@ from kiwi.command_process import CommandIterator
 from builtins import bytes
 
 
-class TestCommandProcess(object):
+class TestCommandProcess:
     def fake_matcher(self, item, output):
         return True
 

--- a/test/unit/command_test.py
+++ b/test/unit/command_test.py
@@ -14,7 +14,7 @@ from kiwi.exceptions import (
 from kiwi.command import Command
 
 
-class TestCommand(object):
+class TestCommand:
     @raises(KiwiCommandError)
     @patch('kiwi.path.Path.which')
     @patch('subprocess.Popen')

--- a/test/unit/container_image_oci_test.py
+++ b/test/unit/container_image_oci_test.py
@@ -8,7 +8,7 @@ from kiwi.container.oci import ContainerImageOCI
 from kiwi.version import __version__
 
 
-class TestContainerImageOCI(object):
+class TestContainerImageOCI:
     @patch('kiwi.oci_tools.umoci.CommandCapabilities.has_option_in_help')
     @patch('kiwi.container.oci.RuntimeConfig')
     def setup(self, mock_RuntimeConfig, mock_cmd_caps):

--- a/test/unit/container_image_test.py
+++ b/test/unit/container_image_test.py
@@ -7,7 +7,7 @@ from kiwi.exceptions import KiwiContainerImageSetupError
 from kiwi.container import ContainerImage
 
 
-class TestContainerImage(object):
+class TestContainerImage:
     @raises(KiwiContainerImageSetupError)
     def test_container_image_not_implemented(self):
         ContainerImage('foo', 'root_dir')

--- a/test/unit/container_setup_base_test.py
+++ b/test/unit/container_setup_base_test.py
@@ -8,7 +8,7 @@ from kiwi.exceptions import KiwiContainerSetupError
 from kiwi.container.setup.base import ContainerSetupBase
 
 
-class TestContainerSetupBase(object):
+class TestContainerSetupBase:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         mock_exists.return_value = True

--- a/test/unit/container_setup_docker_test.py
+++ b/test/unit/container_setup_docker_test.py
@@ -7,7 +7,7 @@ from .test_helper import patch_open
 from kiwi.container.setup.docker import ContainerSetupDocker
 
 
-class TestContainerSetupDocker(object):
+class TestContainerSetupDocker:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         mock_exists.return_value = True

--- a/test/unit/container_setup_oci_test.py
+++ b/test/unit/container_setup_oci_test.py
@@ -7,7 +7,7 @@ from .test_helper import patch_open
 from kiwi.container.setup.oci import ContainerSetupOCI
 
 
-class TestContainerSetupOCI(object):
+class TestContainerSetupOCI:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         mock_exists.return_value = True

--- a/test/unit/container_setup_test.py
+++ b/test/unit/container_setup_test.py
@@ -7,7 +7,7 @@ from kiwi.exceptions import KiwiContainerSetupError
 from kiwi.container.setup import ContainerSetup
 
 
-class TestContainerSetup(object):
+class TestContainerSetup:
     @raises(KiwiContainerSetupError)
     def test_container_not_implemented(self):
         ContainerSetup('foo', 'root_dir')

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -9,7 +9,7 @@ from .test_helper import argv_kiwi_tests
 from kiwi.defaults import Defaults
 
 
-class TestDefaults(object):
+class TestDefaults:
     def setup(self):
         self.defaults = Defaults()
 

--- a/test/unit/filesystem_base_test.py
+++ b/test/unit/filesystem_base_test.py
@@ -9,7 +9,7 @@ from kiwi.exceptions import KiwiFileSystemSyncError
 from kiwi.filesystem.base import FileSystemBase
 
 
-class TestFileSystemBase(object):
+class TestFileSystemBase:
     def setup(self):
         provider = mock.Mock()
         provider.get_device = mock.Mock(

--- a/test/unit/filesystem_btrfs_test.py
+++ b/test/unit/filesystem_btrfs_test.py
@@ -5,7 +5,7 @@ import mock
 from kiwi.filesystem.btrfs import FileSystemBtrfs
 
 
-class TestFileSystemBtrfs(object):
+class TestFileSystemBtrfs:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         mock_exists.return_value = True

--- a/test/unit/filesystem_clicfs_test.py
+++ b/test/unit/filesystem_clicfs_test.py
@@ -5,7 +5,7 @@ import mock
 from kiwi.filesystem.clicfs import FileSystemClicFs
 
 
-class TestFileSystemClicFs(object):
+class TestFileSystemClicFs:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         mock_exists.return_value = True

--- a/test/unit/filesystem_ext2_test.py
+++ b/test/unit/filesystem_ext2_test.py
@@ -5,7 +5,7 @@ import mock
 from kiwi.filesystem.ext2 import FileSystemExt2
 
 
-class TestFileSystemExt2(object):
+class TestFileSystemExt2:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         mock_exists.return_value = True

--- a/test/unit/filesystem_ext3_test.py
+++ b/test/unit/filesystem_ext3_test.py
@@ -5,7 +5,7 @@ import mock
 from kiwi.filesystem.ext3 import FileSystemExt3
 
 
-class TestFileSystemExt3(object):
+class TestFileSystemExt3:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         mock_exists.return_value = True

--- a/test/unit/filesystem_ext4_test.py
+++ b/test/unit/filesystem_ext4_test.py
@@ -5,7 +5,7 @@ import mock
 from kiwi.filesystem.ext4 import FileSystemExt4
 
 
-class TestFileSystemExt4(object):
+class TestFileSystemExt4:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         mock_exists.return_value = True

--- a/test/unit/filesystem_fat16_test.py
+++ b/test/unit/filesystem_fat16_test.py
@@ -5,7 +5,7 @@ import mock
 from kiwi.filesystem.fat16 import FileSystemFat16
 
 
-class TestFileSystemFat16(object):
+class TestFileSystemFat16:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         mock_exists.return_value = True

--- a/test/unit/filesystem_fat32_test.py
+++ b/test/unit/filesystem_fat32_test.py
@@ -5,7 +5,7 @@ import mock
 from kiwi.filesystem.fat32 import FileSystemFat32
 
 
-class TestFileSystemFat32(object):
+class TestFileSystemFat32:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         mock_exists.return_value = True

--- a/test/unit/filesystem_isofs_test.py
+++ b/test/unit/filesystem_isofs_test.py
@@ -6,7 +6,7 @@ import mock
 from kiwi.filesystem.isofs import FileSystemIsoFs
 
 
-class TestFileSystemIsoFs(object):
+class TestFileSystemIsoFs:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         mock_exists.return_value = True

--- a/test/unit/filesystem_setup_test.py
+++ b/test/unit/filesystem_setup_test.py
@@ -5,7 +5,7 @@ import mock
 from kiwi.filesystem.setup import FileSystemSetup
 
 
-class TestFileSystemSetup(object):
+class TestFileSystemSetup:
     @patch('kiwi.filesystem.setup.SystemSize')
     def setup(self, mock_size):
         size = mock.Mock()

--- a/test/unit/filesystem_squashfs_test.py
+++ b/test/unit/filesystem_squashfs_test.py
@@ -5,7 +5,7 @@ import mock
 from kiwi.filesystem.squashfs import FileSystemSquashFs
 
 
-class TestFileSystemSquashfs(object):
+class TestFileSystemSquashfs:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         mock_exists.return_value = True

--- a/test/unit/filesystem_test.py
+++ b/test/unit/filesystem_test.py
@@ -8,7 +8,7 @@ from kiwi.exceptions import KiwiFileSystemSetupError
 from kiwi.filesystem import FileSystem
 
 
-class TestFileSystem(object):
+class TestFileSystem:
     @raises(KiwiFileSystemSetupError)
     def test_filesystem_not_implemented(self):
         FileSystem('foo', mock.Mock(), 'root_dir')

--- a/test/unit/filesystem_xfs_test.py
+++ b/test/unit/filesystem_xfs_test.py
@@ -5,7 +5,7 @@ import mock
 from kiwi.filesystem.xfs import FileSystemXfs
 
 
-class TestFileSystemXfs(object):
+class TestFileSystemXfs:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         mock_exists.return_value = True

--- a/test/unit/firmware_test.py
+++ b/test/unit/firmware_test.py
@@ -8,7 +8,7 @@ from kiwi.exceptions import KiwiNotImplementedError
 from kiwi.firmware import FirmWare
 
 
-class TestFirmWare(object):
+class TestFirmWare:
     @patch('platform.machine')
     def setup(self, mock_platform):
         mock_platform.return_value = 'x86_64'

--- a/test/unit/help_test.py
+++ b/test/unit/help_test.py
@@ -7,7 +7,7 @@ from kiwi.help import Help
 from kiwi.exceptions import KiwiHelpNoCommandGiven
 
 
-class TestHelp(object):
+class TestHelp:
     def setup(self):
         self.help = Help()
 

--- a/test/unit/iso_tools_base_test.py
+++ b/test/unit/iso_tools_base_test.py
@@ -6,7 +6,7 @@ from .test_helper import raises
 from kiwi.iso_tools.base import IsoToolsBase
 
 
-class TestIsoToolsBase(object):
+class TestIsoToolsBase:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'

--- a/test/unit/iso_tools_cdrtools_test.py
+++ b/test/unit/iso_tools_cdrtools_test.py
@@ -7,7 +7,7 @@ from kiwi.iso_tools.cdrtools import IsoToolsCdrTools
 from kiwi.exceptions import KiwiIsoToolError
 
 
-class TestIsoToolsCdrTools(object):
+class TestIsoToolsCdrTools:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'

--- a/test/unit/iso_tools_iso_test.py
+++ b/test/unit/iso_tools_iso_test.py
@@ -20,7 +20,7 @@ from kiwi.exceptions import (
 )
 
 
-class TestIso(object):
+class TestIso:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'

--- a/test/unit/iso_tools_test.py
+++ b/test/unit/iso_tools_test.py
@@ -4,7 +4,7 @@ import mock
 from kiwi.iso_tools import IsoTools
 
 
-class TestIsoTools(object):
+class TestIsoTools:
     def setup(self):
         self.runtime_config = mock.Mock()
         self.runtime_config.get_iso_tool_category = mock.Mock()

--- a/test/unit/iso_tools_xorriso_test.py
+++ b/test/unit/iso_tools_xorriso_test.py
@@ -5,7 +5,7 @@ from kiwi.iso_tools.xorriso import IsoToolsXorrIso
 from kiwi.exceptions import KiwiIsoToolError
 
 
-class TestIsoToolsXorrIso(object):
+class TestIsoToolsXorrIso:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'

--- a/test/unit/kiwi_compat_test.py
+++ b/test/unit/kiwi_compat_test.py
@@ -7,7 +7,7 @@ from .test_helper import argv_kiwi_tests
 import kiwi.kiwi_compat
 
 
-class TestKiwiCompat(object):
+class TestKiwiCompat:
     def teardown(self):
         sys.argv = argv_kiwi_tests
 

--- a/test/unit/logger_test.py
+++ b/test/unit/logger_test.py
@@ -18,7 +18,7 @@ from kiwi.logger import (
 from kiwi.exceptions import KiwiLogFileSetupFailed
 
 
-class TestLoggerSchedulerFilter(object):
+class TestLoggerSchedulerFilter:
     def setup(self):
         self.scheduler_filter = LoggerSchedulerFilter()
 
@@ -36,7 +36,7 @@ class TestLoggerSchedulerFilter(object):
             assert self.scheduler_filter.filter(record) is False
 
 
-class TestColorFormatter(object):
+class TestColorFormatter:
     def setup(self):
         self.color_formatter = ColorFormatter('%(levelname)s: %(message)s')
 
@@ -52,7 +52,7 @@ class TestColorFormatter(object):
         assert 'message' in self.color_formatter.format(record)
 
 
-class TestInfoFilter(object):
+class TestInfoFilter:
     def setup(self):
         self.info_filter = InfoFilter()
 
@@ -65,7 +65,7 @@ class TestInfoFilter(object):
         assert self.info_filter.filter(record) is True
 
 
-class TestDebugFilter(object):
+class TestDebugFilter:
     def setup(self):
         self.debug_filter = DebugFilter()
 
@@ -78,7 +78,7 @@ class TestDebugFilter(object):
         assert self.debug_filter.filter(record) is True
 
 
-class TestErrorFilter(object):
+class TestErrorFilter:
     def setup(self):
         self.error_filter = ErrorFilter()
 
@@ -91,7 +91,7 @@ class TestErrorFilter(object):
         assert self.error_filter.filter(record) is True
 
 
-class TestWarningFilter(object):
+class TestWarningFilter:
     def setup(self):
         self.error_filter = WarningFilter()
 
@@ -104,7 +104,7 @@ class TestWarningFilter(object):
         assert self.error_filter.filter(record) is True
 
 
-class TestLogger(object):
+class TestLogger:
     @patch('sys.stdout')
     def test_progress(self, mock_stdout):
         log.progress(50, 100, 'foo')

--- a/test/unit/mount_manager_test.py
+++ b/test/unit/mount_manager_test.py
@@ -5,7 +5,7 @@ import mock
 from kiwi.mount_manager import MountManager
 
 
-class TestMountManager(object):
+class TestMountManager:
     def setup(self):
         self.mount_manager = MountManager(
             '/dev/some-device', '/some/mountpoint'

--- a/test/unit/oci_tools_base_test.py
+++ b/test/unit/oci_tools_base_test.py
@@ -3,7 +3,7 @@ from pytest import raises
 from kiwi.oci_tools.base import OCIBase
 
 
-class TestOCIBase(object):
+class TestOCIBase:
     def setup(self):
         self.oci = OCIBase()
 

--- a/test/unit/oci_tools_buildah_test.py
+++ b/test/unit/oci_tools_buildah_test.py
@@ -8,7 +8,7 @@ from kiwi.oci_tools.buildah import OCIBuildah
 from kiwi.exceptions import KiwiBuildahError
 
 
-class TestOCIBuildah(object):
+class TestOCIBuildah:
     @patch('kiwi.oci_tools.base.datetime')
     def setup(self, mock_datetime):
         strftime = Mock()

--- a/test/unit/oci_tools_test.py
+++ b/test/unit/oci_tools_test.py
@@ -10,7 +10,7 @@ from kiwi.exceptions import (
 )
 
 
-class TestOCI(object):
+class TestOCI:
     def setup(self):
         self.runtime_config = Mock()
         self.runtime_config.get_oci_archive_tool = Mock()

--- a/test/unit/oci_tools_umoci_test.py
+++ b/test/unit/oci_tools_umoci_test.py
@@ -5,7 +5,7 @@ from mock import (
 from kiwi.oci_tools.umoci import OCIUmoci
 
 
-class TestOCIUmoci(object):
+class TestOCIUmoci:
     @patch('kiwi.oci_tools.umoci.CommandCapabilities.has_option_in_help')
     @patch('kiwi.oci_tools.base.datetime')
     @patch('kiwi.oci_tools.umoci.mkdtemp')

--- a/test/unit/package_manager_apt_test.py
+++ b/test/unit/package_manager_apt_test.py
@@ -11,7 +11,7 @@ from kiwi.exceptions import (
 )
 
 
-class TestPackageManagerApt(object):
+class TestPackageManagerApt:
     def setup(self):
         repository = mock.Mock()
         repository.root_dir = 'root-dir'

--- a/test/unit/package_manager_base_test.py
+++ b/test/unit/package_manager_base_test.py
@@ -6,7 +6,7 @@ from .test_helper import raises
 from kiwi.package_manager.base import PackageManagerBase
 
 
-class TestPackageManagerBase(object):
+class TestPackageManagerBase:
     def setup(self):
         repository = mock.Mock()
         repository.root_dir = 'root-dir'

--- a/test/unit/package_manager_dnf_test.py
+++ b/test/unit/package_manager_dnf_test.py
@@ -7,7 +7,7 @@ from kiwi.package_manager.dnf import PackageManagerDnf
 from kiwi.exceptions import KiwiRequestError
 
 
-class TestPackageManagerDnf(object):
+class TestPackageManagerDnf:
     def setup(self):
         repository = mock.Mock()
         repository.root_dir = 'root-dir'

--- a/test/unit/package_manager_test.py
+++ b/test/unit/package_manager_test.py
@@ -9,7 +9,7 @@ from kiwi.package_manager import PackageManager
 from kiwi.exceptions import KiwiPackageManagerSetupError
 
 
-class TestPackageManager(object):
+class TestPackageManager:
     @raises(KiwiPackageManagerSetupError)
     def test_package_manager_not_implemented(self):
         PackageManager('repository', 'ms-manager')

--- a/test/unit/package_manager_zypper_test.py
+++ b/test/unit/package_manager_zypper_test.py
@@ -7,7 +7,7 @@ from kiwi.package_manager.zypper import PackageManagerZypper
 from kiwi.exceptions import KiwiRequestError
 
 
-class TestPackageManagerZypper(object):
+class TestPackageManagerZypper:
     def setup(self):
         repository = mock.Mock()
         repository.root_dir = 'root-dir'

--- a/test/unit/partitioner_base_test.py
+++ b/test/unit/partitioner_base_test.py
@@ -5,7 +5,7 @@ from .test_helper import raises
 from kiwi.partitioner.base import PartitionerBase
 
 
-class TestPartitionerBase(object):
+class TestPartitionerBase:
     def setup(self):
         disk_provider = mock.Mock()
         disk_provider.get_device = mock.Mock(

--- a/test/unit/partitioner_dasd_test.py
+++ b/test/unit/partitioner_dasd_test.py
@@ -7,7 +7,7 @@ from .test_helper import patch_open
 from kiwi.partitioner.dasd import PartitionerDasd
 
 
-class TestPartitionerDasd(object):
+class TestPartitionerDasd:
     @patch('kiwi.partitioner.dasd.Command.run')
     @patch('kiwi.partitioner.dasd.NamedTemporaryFile')
     @patch_open

--- a/test/unit/partitioner_gpt_test.py
+++ b/test/unit/partitioner_gpt_test.py
@@ -8,7 +8,7 @@ from kiwi.partitioner.gpt import PartitionerGpt
 from kiwi.exceptions import KiwiPartitionerGptFlagError
 
 
-class TestPartitionerGpt(object):
+class TestPartitionerGpt:
     def setup(self):
         disk_provider = mock.Mock()
         disk_provider.get_device = mock.Mock(

--- a/test/unit/partitioner_msdos_test.py
+++ b/test/unit/partitioner_msdos_test.py
@@ -11,7 +11,7 @@ from kiwi.partitioner.msdos import PartitionerMsDos
 from kiwi.exceptions import KiwiPartitionerMsDosFlagError
 
 
-class TestPartitionerMsDos(object):
+class TestPartitionerMsDos:
     def setup(self):
         disk_provider = mock.Mock()
         disk_provider.get_device = mock.Mock(

--- a/test/unit/partitioner_test.py
+++ b/test/unit/partitioner_test.py
@@ -9,7 +9,7 @@ from kiwi.partitioner import Partitioner
 from kiwi.exceptions import KiwiPartitionerSetupError
 
 
-class TestPartitioner(object):
+class TestPartitioner:
     @patch('platform.machine')
     @raises(KiwiPartitionerSetupError)
     def test_partitioner_not_implemented(self, mock_machine):

--- a/test/unit/path_test.py
+++ b/test/unit/path_test.py
@@ -7,7 +7,7 @@ from kiwi.path import Path
 from kiwi.exceptions import KiwiFileAccessError
 
 
-class TestPath(object):
+class TestPath:
     def test_sort_by_hierarchy(self):
         ordered = Path.sort_by_hierarchy(
             ['usr', 'usr/bin', 'etc', 'usr/lib']

--- a/test/unit/privileges_test.py
+++ b/test/unit/privileges_test.py
@@ -6,7 +6,7 @@ from kiwi.exceptions import KiwiPrivilegesError
 from kiwi.privileges import Privileges
 
 
-class TestPrivileges(object):
+class TestPrivileges:
     @raises(KiwiPrivilegesError)
     @patch('os.geteuid')
     def test_check_for_root_permiossion_false(self, mock_euid):

--- a/test/unit/repository_apt_test.py
+++ b/test/unit/repository_apt_test.py
@@ -7,7 +7,7 @@ from .test_helper import patch_open
 from kiwi.repository.apt import RepositoryApt
 
 
-class TestRepositoryApt(object):
+class TestRepositoryApt:
     @patch('kiwi.repository.apt.NamedTemporaryFile')
     @patch_open
     @patch('kiwi.repository.apt.PackageManagerTemplateAptGet')

--- a/test/unit/repository_base_test.py
+++ b/test/unit/repository_base_test.py
@@ -5,7 +5,7 @@ from .test_helper import raises
 from kiwi.repository.base import RepositoryBase
 
 
-class TestRepositoryBase(object):
+class TestRepositoryBase:
     def setup(self):
         root_bind = mock.Mock()
         self.repo = RepositoryBase(root_bind)

--- a/test/unit/repository_dnf_test.py
+++ b/test/unit/repository_dnf_test.py
@@ -9,7 +9,7 @@ import mock
 from kiwi.repository.dnf import RepositoryDnf
 
 
-class TestRepositoryDnf(object):
+class TestRepositoryDnf:
     @patch('kiwi.repository.dnf.NamedTemporaryFile')
     @patch_open
     @patch('kiwi.repository.dnf.ConfigParser')

--- a/test/unit/repository_template_apt_test.py
+++ b/test/unit/repository_template_apt_test.py
@@ -1,7 +1,7 @@
 from kiwi.repository.template.apt import PackageManagerTemplateAptGet
 
 
-class TestPackageManagerTemplateAptGet(object):
+class TestPackageManagerTemplateAptGet:
     def setup(self):
         self.apt = PackageManagerTemplateAptGet()
 

--- a/test/unit/repository_test.py
+++ b/test/unit/repository_test.py
@@ -9,7 +9,7 @@ from kiwi.repository import Repository
 from kiwi.exceptions import KiwiRepositorySetupError
 
 
-class TestRepository(object):
+class TestRepository:
     @raises(KiwiRepositorySetupError)
     def test_repository_manager_not_implemented(self):
         Repository('root_bind', 'ms-manager')

--- a/test/unit/repository_zypper_test.py
+++ b/test/unit/repository_zypper_test.py
@@ -10,7 +10,7 @@ from kiwi.repository.zypper import RepositoryZypper
 from kiwi.exceptions import KiwiCommandError
 
 
-class TestRepositoryZypper(object):
+class TestRepositoryZypper:
     @patch('kiwi.command.Command.run')
     @patch('kiwi.repository.zypper.NamedTemporaryFile')
     @patch_open

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -16,7 +16,7 @@ sys.argv = [
 argv_kiwi_tests = sys.argv
 
 
-class TestRuntimeChecker(object):
+class TestRuntimeChecker:
     def setup(self):
         self.description = XMLDescription(
             '../data/example_runtime_checker_config.xml'

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -9,7 +9,7 @@ from kiwi.exceptions import KiwiRuntimeConfigFormatError
 from kiwi.defaults import Defaults
 
 
-class TestRuntimeConfig(object):
+class TestRuntimeConfig:
     def setup(self):
         with patch.dict('os.environ', {'HOME': '../data'}):
             self.runtime_config = RuntimeConfig()

--- a/test/unit/shell_test.py
+++ b/test/unit/shell_test.py
@@ -5,7 +5,7 @@ from kiwi.system.shell import Shell
 from kiwi.defaults import Defaults
 
 
-class TestShell(object):
+class TestShell:
     def test_quote(self):
         assert Shell.quote('aa\!') == 'aa\\\\\\!'
 

--- a/test/unit/solver_repository_base_test.py
+++ b/test/unit/solver_repository_base_test.py
@@ -10,7 +10,7 @@ from kiwi.solver.repository.base import SolverRepositoryBase
 from kiwi.exceptions import KiwiUriOpenError
 
 
-class TestSolverRepositoryBase(object):
+class TestSolverRepositoryBase:
     def setup(self):
         self.context_manager_mock = mock.Mock()
         self.file_mock = mock.Mock()

--- a/test/unit/solver_repository_rpm_dir_test.py
+++ b/test/unit/solver_repository_rpm_dir_test.py
@@ -9,7 +9,7 @@ from kiwi.solver.repository.base import SolverRepositoryBase
 from kiwi.exceptions import KiwiRpmDirNotRemoteError
 
 
-class TestSolverRepositoryRpmDir(object):
+class TestSolverRepositoryRpmDir:
     def setup(self):
         self.uri = mock.Mock()
         self.solver = SolverRepositoryRpmDir(self.uri)

--- a/test/unit/solver_repository_rpm_md_test.py
+++ b/test/unit/solver_repository_rpm_md_test.py
@@ -8,7 +8,7 @@ from kiwi.solver.repository.rpm_md import SolverRepositoryRpmMd
 from kiwi.solver.repository.base import SolverRepositoryBase
 
 
-class TestSolverRepositoryRpmMd(object):
+class TestSolverRepositoryRpmMd:
     def setup(self):
         self.xml_data = etree.parse('../data/repomd.xml')
         self.uri = mock.Mock()

--- a/test/unit/solver_repository_suse_test.py
+++ b/test/unit/solver_repository_suse_test.py
@@ -8,7 +8,7 @@ from kiwi.solver.repository.suse import SolverRepositorySUSE
 from kiwi.solver.repository.base import SolverRepositoryBase
 
 
-class TestSolverRepositorySUSE(object):
+class TestSolverRepositorySUSE:
     def setup(self):
         self.xml_data = etree.parse('../data/repomd.xml')
         self.uri = mock.Mock()

--- a/test/unit/solver_repository_test.py
+++ b/test/unit/solver_repository_test.py
@@ -8,7 +8,7 @@ from kiwi.solver.repository import SolverRepository
 from kiwi.exceptions import KiwiSolverRepositorySetupError
 
 
-class TestSolverRepository(object):
+class TestSolverRepository:
     def setup(self):
         self.uri = mock.Mock()
         self.uri.repo_type = 'some-unknown-type'

--- a/test/unit/solver_sat_test.py
+++ b/test/unit/solver_sat_test.py
@@ -11,7 +11,7 @@ from kiwi.exceptions import (
 )
 
 
-class TestSat(object):
+class TestSat:
     @patch('importlib.import_module')
     def setup(self, mock_import_module):
         self.sat = Sat()

--- a/test/unit/storage_device_provider_test.py
+++ b/test/unit/storage_device_provider_test.py
@@ -9,7 +9,7 @@ from kiwi.exceptions import KiwiDeviceProviderError
 from kiwi.storage.device_provider import DeviceProvider
 
 
-class TestDeviceProvider(object):
+class TestDeviceProvider:
     def setup(self):
         self.provider = DeviceProvider()
 

--- a/test/unit/storage_disk_test.py
+++ b/test/unit/storage_disk_test.py
@@ -7,7 +7,7 @@ from .test_helper import patch_open
 from kiwi.storage.disk import Disk
 
 
-class TestDisk(object):
+class TestDisk:
     @patch('kiwi.storage.disk.Partitioner')
     @patch_open
     def setup(self, mock_open, mock_partitioner):

--- a/test/unit/storage_loop_device_test.py
+++ b/test/unit/storage_loop_device_test.py
@@ -7,7 +7,7 @@ from kiwi.exceptions import KiwiLoopSetupError
 from kiwi.storage.loop_device import LoopDevice
 
 
-class TestLoopDevice(object):
+class TestLoopDevice:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         mock_exists.return_value = False

--- a/test/unit/storage_luks_device_test.py
+++ b/test/unit/storage_luks_device_test.py
@@ -8,7 +8,7 @@ from kiwi.exceptions import KiwiLuksSetupError
 from kiwi.storage.luks_device import LuksDevice
 
 
-class TestLuksDevice(object):
+class TestLuksDevice:
     def setup(self):
         storage_device = Mock()
         storage_device.get_byte_size = Mock(

--- a/test/unit/storage_mapped_device_test.py
+++ b/test/unit/storage_mapped_device_test.py
@@ -9,7 +9,7 @@ from kiwi.exceptions import KiwiMappedDeviceError
 from kiwi.storage.mapped_device import MappedDevice
 
 
-class TestMappedDevice(object):
+class TestMappedDevice:
     @patch('os.path.exists')
     def setup(self, mock_path):
         mock_path.return_value = True

--- a/test/unit/storage_raid_device_test.py
+++ b/test/unit/storage_raid_device_test.py
@@ -8,7 +8,7 @@ from kiwi.exceptions import KiwiRaidSetupError
 from kiwi.storage.raid_device import RaidDevice
 
 
-class TestRaidDevice(object):
+class TestRaidDevice:
     def setup(self):
         storage_device = mock.Mock()
         storage_device.get_device = mock.Mock(

--- a/test/unit/storage_setup_test.py
+++ b/test/unit/storage_setup_test.py
@@ -10,7 +10,7 @@ from kiwi.xml_description import XMLDescription
 from kiwi.defaults import Defaults
 
 
-class TestDiskSetup(object):
+class TestDiskSetup:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'

--- a/test/unit/storage_subformat_base_test.py
+++ b/test/unit/storage_subformat_base_test.py
@@ -12,7 +12,7 @@ from kiwi.exceptions import (
 from kiwi.storage.subformat.base import DiskFormatBase
 
 
-class TestDiskFormatBase(object):
+class TestDiskFormatBase:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'

--- a/test/unit/storage_subformat_gce_test.py
+++ b/test/unit/storage_subformat_gce_test.py
@@ -7,7 +7,7 @@ from .test_helper import patch_open
 from kiwi.storage.subformat.gce import DiskFormatGce
 
 
-class TestDiskFormatGce(object):
+class TestDiskFormatGce:
     def setup(self):
         xml_data = mock.Mock()
         xml_data.get_name = mock.Mock(

--- a/test/unit/storage_subformat_ova_test.py
+++ b/test/unit/storage_subformat_ova_test.py
@@ -12,7 +12,7 @@ from kiwi.exceptions import (
 from kiwi.storage.subformat.ova import DiskFormatOva
 
 
-class TestDiskFormatOva(object):
+class TestDiskFormatOva:
     @patch('platform.machine')
     def setup(self, mock_machine):
         self.context_manager_mock = mock.Mock()

--- a/test/unit/storage_subformat_qcow2_test.py
+++ b/test/unit/storage_subformat_qcow2_test.py
@@ -5,7 +5,7 @@ import mock
 from kiwi.storage.subformat.qcow2 import DiskFormatQcow2
 
 
-class TestDiskFormatQcow2(object):
+class TestDiskFormatQcow2:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'

--- a/test/unit/storage_subformat_template_vagrant_config_test.py
+++ b/test/unit/storage_subformat_template_vagrant_config_test.py
@@ -5,7 +5,7 @@ from kiwi.storage.subformat.template.vagrant_config import (
 from textwrap import dedent
 
 
-class TestVagrantConfigTemplate(object):
+class TestVagrantConfigTemplate:
 
     def setup(self):
         self.vagrant_config = VagrantConfigTemplate()

--- a/test/unit/storage_subformat_template_virtualbox_ovf_test.py
+++ b/test/unit/storage_subformat_template_virtualbox_ovf_test.py
@@ -5,7 +5,7 @@ from kiwi.storage.subformat.template.virtualbox_ovf import (
 )
 
 
-class TestVirtualboxOvfTemplate(object):
+class TestVirtualboxOvfTemplate:
 
     def setup(self):
         self.ovf_template = VirtualboxOvfTemplate()

--- a/test/unit/storage_subformat_template_vmware_settings_test.py
+++ b/test/unit/storage_subformat_template_vmware_settings_test.py
@@ -3,7 +3,7 @@ from kiwi.storage.subformat.template.vmware_settings import (
 )
 
 
-class TestVmwareSettingsTempla(object):
+class TestVmwareSettingsTempla:
     def setup(self):
         self.vmware = VmwareSettingsTemplate()
 

--- a/test/unit/storage_subformat_test.py
+++ b/test/unit/storage_subformat_test.py
@@ -9,7 +9,7 @@ from kiwi.exceptions import KiwiDiskFormatSetupError
 from kiwi.storage.subformat import DiskFormat
 
 
-class TestDiskFormat(object):
+class TestDiskFormat:
     def setup(self):
         self.xml_state = mock.Mock()
         self.xml_state.get_build_type_format_options.return_value = {}

--- a/test/unit/storage_subformat_vagrant_base_test.py
+++ b/test/unit/storage_subformat_vagrant_base_test.py
@@ -13,7 +13,7 @@ from kiwi.storage.subformat.vagrant_base import DiskFormatVagrantBase
 from textwrap import dedent
 
 
-class TestDiskFormatVagrantBase(object):
+class TestDiskFormatVagrantBase:
     def setup(self):
         xml_data = Mock()
         xml_data.get_name = Mock(

--- a/test/unit/storage_subformat_vagrant_libvirt_test.py
+++ b/test/unit/storage_subformat_vagrant_libvirt_test.py
@@ -9,7 +9,7 @@ from .test_helper import patch_open
 from kiwi.storage.subformat.vagrant_libvirt import DiskFormatVagrantLibVirt
 
 
-class TestDiskFormatVagrantLibVirt(object):
+class TestDiskFormatVagrantLibVirt:
     def setup(self):
         xml_data = Mock()
         xml_data.get_name = Mock(

--- a/test/unit/storage_subformat_vagrant_virtualbox_test.py
+++ b/test/unit/storage_subformat_vagrant_virtualbox_test.py
@@ -14,7 +14,7 @@ from kiwi.storage.subformat.vagrant_virtualbox import (
 from kiwi.defaults import Defaults
 
 
-class TestDiskFormatVagrantVirtualBox(object):
+class TestDiskFormatVagrantVirtualBox:
     def setup(self):
         with open("../data/vagrant_virtualbox.ovf", "r") as ovf_file:
             self.Leap_15_ovf = ovf_file.read(-1)

--- a/test/unit/storage_subformat_vdi_test.py
+++ b/test/unit/storage_subformat_vdi_test.py
@@ -5,7 +5,7 @@ import mock
 from kiwi.storage.subformat.vdi import DiskFormatVdi
 
 
-class TestDiskFormatVdi(object):
+class TestDiskFormatVdi:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'

--- a/test/unit/storage_subformat_vhd_test.py
+++ b/test/unit/storage_subformat_vhd_test.py
@@ -5,7 +5,7 @@ import mock
 from kiwi.storage.subformat.vhd import DiskFormatVhd
 
 
-class TestDiskFormatVhd(object):
+class TestDiskFormatVhd:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'

--- a/test/unit/storage_subformat_vhdfixed_test.py
+++ b/test/unit/storage_subformat_vhdfixed_test.py
@@ -14,7 +14,7 @@ from kiwi.storage.subformat.vhdfixed import DiskFormatVhdFixed
 from builtins import bytes
 
 
-class TestDiskFormatVhdFixed(object):
+class TestDiskFormatVhdFixed:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'

--- a/test/unit/storage_subformat_vhdx_test.py
+++ b/test/unit/storage_subformat_vhdx_test.py
@@ -5,7 +5,7 @@ import mock
 from kiwi.storage.subformat.vhdx import DiskFormatVhdx
 
 
-class TestDiskFormatVhdx(object):
+class TestDiskFormatVhdx:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'

--- a/test/unit/storage_subformat_vmdk_test.py
+++ b/test/unit/storage_subformat_vmdk_test.py
@@ -12,7 +12,7 @@ from kiwi.exceptions import (
 from kiwi.storage.subformat.vmdk import DiskFormatVmdk
 
 
-class TestDiskFormatVmdk(object):
+class TestDiskFormatVmdk:
     @patch('platform.machine')
     def setup(self, mock_machine):
         self.context_manager_mock = mock.Mock()

--- a/test/unit/system_identifier_test.py
+++ b/test/unit/system_identifier_test.py
@@ -7,7 +7,7 @@ from .test_helper import patch_open
 from kiwi.system.identifier import SystemIdentifier
 
 
-class TestSystemIdentifier(object):
+class TestSystemIdentifier:
     def setup(self):
         self.identifier = SystemIdentifier()
 

--- a/test/unit/system_kernel_test.py
+++ b/test/unit/system_kernel_test.py
@@ -11,7 +11,7 @@ from kiwi.exceptions import KiwiKernelLookupError
 from kiwi.system.kernel import Kernel
 
 
-class TestKernel(object):
+class TestKernel:
     @patch('os.listdir')
     def setup(self, mock_listdir):
         mock_listdir.return_value = ['1.2.3-default']

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -18,7 +18,7 @@ from kiwi.xml_description import XMLDescription
 from kiwi.xml_state import XMLState
 
 
-class TestSystemPrepare(object):
+class TestSystemPrepare:
     @patch('kiwi.system.prepare.RootInit')
     @patch('kiwi.system.prepare.RootBind')
     @patch('kiwi.logger.log.get_logfile')

--- a/test/unit/system_profile_test.py
+++ b/test/unit/system_profile_test.py
@@ -9,7 +9,7 @@ from kiwi.xml_state import XMLState
 from kiwi.xml_description import XMLDescription
 
 
-class TestProfile(object):
+class TestProfile:
     def setup(self):
         self.tmpfile = mock.Mock()
         self.tmpfile.name = 'tmpfile'

--- a/test/unit/system_result_test.py
+++ b/test/unit/system_result_test.py
@@ -8,7 +8,7 @@ from kiwi.system.result import Result
 from kiwi.exceptions import KiwiResultError
 
 
-class TestResult(object):
+class TestResult:
     def setup(self):
         self.context_manager_mock = mock.MagicMock()
         self.file_mock = mock.MagicMock()

--- a/test/unit/system_root_bind_test.py
+++ b/test/unit/system_root_bind_test.py
@@ -16,7 +16,7 @@ from kiwi.exceptions import (
 from kiwi.system.root_bind import RootBind
 
 
-class TestRootBind(object):
+class TestRootBind:
     def setup(self):
         root = mock.Mock()
         root.root_dir = 'root-dir'

--- a/test/unit/system_root_import_base_test.py
+++ b/test/unit/system_root_import_base_test.py
@@ -7,7 +7,7 @@ from kiwi.system.root_import.base import RootImportBase
 from kiwi.exceptions import KiwiRootImportError
 
 
-class TestRootImportBase(object):
+class TestRootImportBase:
     @patch('os.path.exists')
     @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
     def test_init(self, mock_buildservice, mock_path):

--- a/test/unit/system_root_import_oci_test.py
+++ b/test/unit/system_root_import_oci_test.py
@@ -9,7 +9,7 @@ from kiwi.system.root_import.oci import RootImportOCI
 from kiwi.exceptions import KiwiRootImportError
 
 
-class TestRootImportOCI(object):
+class TestRootImportOCI:
     @patch('os.path.exists')
     def setup(self, mock_path):
         mock_path.return_value = True

--- a/test/unit/system_root_import_test.py
+++ b/test/unit/system_root_import_test.py
@@ -6,7 +6,7 @@ from kiwi.system.root_import import RootImport
 from kiwi.exceptions import KiwiRootImportError
 
 
-class TestRootImport(object):
+class TestRootImport:
     @patch('kiwi.system.root_import.RootImportOCI')
     def test_docker_import(self, mock_docker_import):
         RootImport('root_dir', 'file:///image.tar.xz', 'docker')

--- a/test/unit/system_root_init_test.py
+++ b/test/unit/system_root_init_test.py
@@ -12,7 +12,7 @@ from kiwi.exceptions import (
 from kiwi.system.root_init import RootInit
 
 
-class TestRootInit(object):
+class TestRootInit:
     @raises(KiwiRootDirExists)
     @patch('os.path.exists')
     def test_init_raises_error(self, mock_path):

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -17,7 +17,7 @@ from kiwi.exceptions import (
 from kiwi.defaults import Defaults
 
 
-class TestSystemSetup(object):
+class TestSystemSetup:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'

--- a/test/unit/system_size_test.py
+++ b/test/unit/system_size_test.py
@@ -5,7 +5,7 @@ import mock
 from kiwi.system.size import SystemSize
 
 
-class TestSystemSize(object):
+class TestSystemSize:
     def setup(self):
         self.size = SystemSize('directory')
 

--- a/test/unit/system_uri_test.py
+++ b/test/unit/system_uri_test.py
@@ -15,7 +15,7 @@ from kiwi.system.uri import Uri
 import hashlib
 
 
-class TestUri(object):
+class TestUri:
     def setup(self):
         self.mock_mkdtemp = mock.Mock()
         self.mock_manager = mock.Mock()

--- a/test/unit/tasks_base_test.py
+++ b/test/unit/tasks_base_test.py
@@ -9,7 +9,7 @@ from kiwi.exceptions import KiwiConfigFileNotFound
 import kiwi.xml_parse
 
 
-class TestCliTask(object):
+class TestCliTask:
     @patch('kiwi.logger.log.setLogLevel')
     @patch('kiwi.logger.log.set_logfile')
     @patch('kiwi.logger.log.set_color_format')

--- a/test/unit/tasks_image_info_test.py
+++ b/test/unit/tasks_image_info_test.py
@@ -12,7 +12,7 @@ from kiwi.tasks.image_info import ImageInfoTask
 from collections import namedtuple
 
 
-class TestImageInfoTask(object):
+class TestImageInfoTask:
     def setup(self):
         sys.argv = [
             sys.argv[0], '--profile', 'vmxFlavour', 'image', 'info',

--- a/test/unit/tasks_image_resize_test.py
+++ b/test/unit/tasks_image_resize_test.py
@@ -16,7 +16,7 @@ from kiwi.exceptions import (
 from kiwi.tasks.image_resize import ImageResizeTask
 
 
-class TestImageResizeTask(object):
+class TestImageResizeTask:
     def setup(self):
         sys.argv = [
             sys.argv[0], '--type', 'vmx', 'image', 'resize',

--- a/test/unit/tasks_result_bundle_test.py
+++ b/test/unit/tasks_result_bundle_test.py
@@ -12,7 +12,7 @@ from kiwi.tasks.result_bundle import ResultBundleTask
 from kiwi.system.result import Result
 
 
-class TestResultBundleTask(object):
+class TestResultBundleTask:
     def setup(self):
         sys.argv = [
             sys.argv[0], 'result', 'bundle', '--target-dir', 'target_dir',

--- a/test/unit/tasks_result_list_test.py
+++ b/test/unit/tasks_result_list_test.py
@@ -10,7 +10,7 @@ from .test_helper import argv_kiwi_tests
 from kiwi.tasks.result_list import ResultListTask
 
 
-class TestResultListTask(object):
+class TestResultListTask:
     def setup(self):
         sys.argv = [
             sys.argv[0], 'result', 'list', '--target-dir', 'directory'

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -11,7 +11,7 @@ from .test_helper import argv_kiwi_tests
 from kiwi.tasks.system_build import SystemBuildTask
 
 
-class TestSystemBuildTask(object):
+class TestSystemBuildTask:
     def setup(self):
         sys.argv = [
             sys.argv[0], '--profile', 'vmxFlavour', 'system', 'build',

--- a/test/unit/tasks_system_create_test.py
+++ b/test/unit/tasks_system_create_test.py
@@ -9,7 +9,7 @@ from .test_helper import argv_kiwi_tests
 from kiwi.tasks.system_create import SystemCreateTask
 
 
-class TestSystemCreateTask(object):
+class TestSystemCreateTask:
     def setup(self):
         sys.argv = [
             sys.argv[0], '--profile', 'vmxFlavour', 'system', 'create',

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -11,7 +11,7 @@ from .test_helper import argv_kiwi_tests
 from kiwi.tasks.system_prepare import SystemPrepareTask
 
 
-class TestSystemPrepareTask(object):
+class TestSystemPrepareTask:
     def setup(self):
         sys.argv = [
             sys.argv[0], '--profile', 'vmxFlavour', 'system', 'prepare',

--- a/test/unit/tasks_system_update_test.py
+++ b/test/unit/tasks_system_update_test.py
@@ -8,7 +8,7 @@ from .test_helper import argv_kiwi_tests
 from kiwi.tasks.system_update import SystemUpdateTask
 
 
-class TestSystemUpdateTask(object):
+class TestSystemUpdateTask:
     def setup(self):
         sys.argv = [
             sys.argv[0], '--profile', 'vmxFlavour', 'system', 'update',

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -20,7 +20,7 @@ argv_kiwi_tests = sys.argv
 patch_open = patch('builtins.open')
 
 
-class raises(object):
+class raises:
     """
     exception decorator as used in nose, tools/nontrivial.py
     """

--- a/test/unit/users_test.py
+++ b/test/unit/users_test.py
@@ -3,7 +3,7 @@ from mock import patch
 from kiwi.system.users import Users
 
 
-class TestUsers(object):
+class TestUsers:
     def setup(self):
         self.users = Users('root_dir')
 

--- a/test/unit/utils_block_test.py
+++ b/test/unit/utils_block_test.py
@@ -3,7 +3,7 @@ from mock import patch
 from kiwi.utils.block import BlockID
 
 
-class TestBlockID(object):
+class TestBlockID:
     def setup(self):
         self.blkid = BlockID('device')
 

--- a/test/unit/utils_checksum_test.py
+++ b/test/unit/utils_checksum_test.py
@@ -10,7 +10,7 @@ from kiwi.utils.checksum import Checksum
 from builtins import bytes
 
 
-class TestChecksum(object):
+class TestChecksum:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         self.context_manager_mock = mock.Mock()

--- a/test/unit/utils_codec_test.py
+++ b/test/unit/utils_codec_test.py
@@ -6,7 +6,7 @@ from kiwi.utils.codec import Codec
 from kiwi.exceptions import KiwiDecodingError
 
 
-class TestCodec(object):
+class TestCodec:
 
     def setup(self):
         self.literal = bytes(b'\xc3\xbc')

--- a/test/unit/utils_command_capabilities_test.py
+++ b/test/unit/utils_command_capabilities_test.py
@@ -8,7 +8,7 @@ from kiwi.utils.command_capabilities import CommandCapabilities
 from kiwi.exceptions import KiwiCommandCapabilitiesError
 
 
-class TestCommandCapabilities(object):
+class TestCommandCapabilities:
     @patch('kiwi.command.Command.run')
     def test_has_option_in_help(self, mock_run):
         command_type = namedtuple('command', ['output', 'error'])

--- a/test/unit/utils_compress_test.py
+++ b/test/unit/utils_compress_test.py
@@ -11,7 +11,7 @@ from kiwi.exceptions import (
 )
 
 
-class TestCompress(object):
+class TestCompress:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         mock_exists.return_value = True

--- a/test/unit/utils_rpm_database_test.py
+++ b/test/unit/utils_rpm_database_test.py
@@ -5,7 +5,7 @@ from mock import (
 from kiwi.utils.rpm_database import RpmDataBase
 
 
-class TestRpmDataBase(object):
+class TestRpmDataBase:
     def setup(self):
         self.rpmdb = RpmDataBase('root_dir')
         self.rpmdb.rpmdb_host = Mock()

--- a/test/unit/utils_rpm_test.py
+++ b/test/unit/utils_rpm_test.py
@@ -9,7 +9,7 @@ from kiwi.utils.rpm import Rpm
 from kiwi.defaults import Defaults
 
 
-class TestRpm(object):
+class TestRpm:
     def setup(self):
         self.rpm_host = Rpm()
         self.rpm_image = Rpm('root_dir')

--- a/test/unit/utils_size_test.py
+++ b/test/unit/utils_size_test.py
@@ -4,7 +4,7 @@ from kiwi.utils.size import StringToSize
 from kiwi.exceptions import KiwiSizeError
 
 
-class TestStringToSize(object):
+class TestStringToSize:
 
     def test_to_bytes(self):
         assert StringToSize.to_bytes('1m') == 1048576

--- a/test/unit/utils_sync_test.py
+++ b/test/unit/utils_sync_test.py
@@ -5,7 +5,7 @@ from mock import patch
 from kiwi.utils.sync import DataSync
 
 
-class TestDataSync(object):
+class TestDataSync:
     def setup(self):
         self.sync = DataSync('source_dir', 'target_dir')
 

--- a/test/unit/utils_sysconfig_test.py
+++ b/test/unit/utils_sysconfig_test.py
@@ -7,7 +7,7 @@ from .test_helper import patch_open
 from kiwi.utils.sysconfig import SysConfig
 
 
-class TestSysConfig(object):
+class TestSysConfig:
     def setup(self):
         self.context_manager_mock = mock.Mock()
         self.file_mock = mock.Mock()

--- a/test/unit/volume_manager_base_test.py
+++ b/test/unit/volume_manager_base_test.py
@@ -9,7 +9,7 @@ from kiwi.exceptions import KiwiVolumeManagerSetupError
 from kiwi.volume_manager.base import VolumeManagerBase
 
 
-class TestVolumeManagerBase(object):
+class TestVolumeManagerBase:
     @patch('os.path.exists')
     def setup(self, mock_path):
         self.volume_type = namedtuple(

--- a/test/unit/volume_manager_btrfs_test.py
+++ b/test/unit/volume_manager_btrfs_test.py
@@ -16,7 +16,7 @@ from kiwi.exceptions import (
 from kiwi.volume_manager.btrfs import VolumeManagerBtrfs
 
 
-class TestVolumeManagerBtrfs(object):
+class TestVolumeManagerBtrfs:
     @patch('os.path.exists')
     def setup(self, mock_path):
         self.context_manager_mock = mock.Mock()

--- a/test/unit/volume_manager_lvm_test.py
+++ b/test/unit/volume_manager_lvm_test.py
@@ -12,7 +12,7 @@ from kiwi.volume_manager.lvm import VolumeManagerLVM
 from kiwi.defaults import Defaults
 
 
-class TestVolumeManagerLVM(object):
+class TestVolumeManagerLVM:
     @patch('os.path.exists')
     def setup(self, mock_path):
         self.volume_type = namedtuple(

--- a/test/unit/volume_manager_test.py
+++ b/test/unit/volume_manager_test.py
@@ -9,7 +9,7 @@ from kiwi.exceptions import KiwiVolumeManagerSetupError
 from kiwi.volume_manager import VolumeManager
 
 
-class TestVolumeManager(object):
+class TestVolumeManager:
     @raises(KiwiVolumeManagerSetupError)
     def test_volume_manager_not_implemented(self):
         VolumeManager('foo', mock.Mock(), 'root_dir', mock.Mock())

--- a/test/unit/xml_description_test.py
+++ b/test/unit/xml_description_test.py
@@ -18,7 +18,7 @@ from kiwi.exceptions import (
 from kiwi.xml_description import XMLDescription
 
 
-class TestSchema(object):
+class TestSchema:
     def setup(self):
         test_xml = bytes(
             b"""<?xml version="1.0" encoding="utf-8"?>

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -12,7 +12,7 @@ from kiwi.exceptions import (
 from collections import namedtuple
 
 
-class TestXMLState(object):
+class TestXMLState:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'


### PR DESCRIPTION
Mass change of `class Foo(object):` to `class Foo:` as you no longer have to inherit from `object` in Python3.