### PR TITLE
Update live iso integration test build

### DIFF
--- a/build-tests/x86/test-image-iso/appliance.kiwi
+++ b/build-tests/x86/test-image-iso/appliance.kiwi
@@ -54,7 +54,6 @@
         <package name="which"/>
         <package name="kernel-default"/>
         <package name="shim"/>
-        <package name="gfxboot-branding-openSUSE"/>
         <package name="timezone"/>
         <package name="dracut-kiwi-live"/>
     </packages>


### PR DESCRIPTION
Our live iso test is setup for EFI. Since the switch to grub
no isolinux will be used with the test. Thus there is no need
to install the gfxboot branding package anymore

