### PR TITLE
Add support for custom fstab script extension

### DIFF
--- a/build-tests/x86/test-image-MicroOS/appliance.kiwi
+++ b/build-tests/x86/test-image-MicroOS/appliance.kiwi
@@ -84,6 +84,7 @@
         <package name="kernel-default"/>
         <package name="shim"/>
         <package name="timezone"/>
+        <package name="read-only-root-fs"/>
     </packages>
     <packages type="bootstrap">
         <package name="udev"/>

--- a/build-tests/x86/test-image-MicroOS/config.sh
+++ b/build-tests/x86/test-image-MicroOS/config.sh
@@ -32,9 +32,9 @@ echo "Configure image: [$kiwi_iname]..."
 suseSetupProduct
 
 #======================================
-# Create Host Keys
+# Install overlay systemd mount props
 #--------------------------------------
-/usr/sbin/sshd-gen-keys-start
+cp /usr/sbin/setup-fstab-for-overlayfs /etc/fstab.script
 
 #======================================
 # Activate services

--- a/doc/source/building/working_with_images/custom_fstab_extension.rst
+++ b/doc/source/building/working_with_images/custom_fstab_extension.rst
@@ -42,25 +42,31 @@ The optimal way to provide custom fstab information is through a
 package. If this can't be done the files can also be provided via
 the overlay file tree of the image description.
 
-KIWI supports two ways to modify the contents of the `/etc/fstab`
+KIWI supports three ways to modify the contents of the `/etc/fstab`
 file:
 
-1. Providing an `/etc/fstab.append` file
+Providing an `/etc/fstab.append` file
+  If that file exists in the image root tree, KIWI will take its
+  contents and append it to the existing `/etc/fstab` file. The
+  provided `/etc/fstab.append` file will be deleted after successful
+  modification.
 
-   If that file exists in the image root tree, KIWI will take its
-   contents and append it to the existing `/etc/fstab` file. The
-   provided `/etc/fstab.append` file will be deleted after successful
-   modification.
+Providing an `/etc/fstab.patch` file
+  The `/etc/fstab.patch` represents a patch file that will be
+  applied to `/etc/fstab` using the `patch` program. This method
+  also allows to change the existing contents of `/etc/fstab`.
+  On success `/etc/fstab.patch` will be deleted.
 
-2. Providing an `/etc/fstab.patch` file
-
-   The `/etc/fstab.patch` represents a patch file that will be
-   applied to `/etc/fstab` using the `patch` program. This method
-   also allows to change the existing contents of `/etc/fstab`.
-   On success `/etc/fstab.patch` will be deleted.
+Providing an `/etc/fstab.script` file
+  The `/etc/fstab.script` represents an executable which is called
+  as chrooted process. This method is the most flexible one and
+  allows to apply any change. On success `/etc/fstab.script` will be
+  deleted.
 
 .. note::
 
-   `/etc/fstab.append` and `/etc/fstab.patch` can be used together.
-   If both files are provided, appending happens first and patching
-   afterwards.
+   All three variants to handle the fstab file can be used together.
+   Appending happens first, patching afterwards and the script call
+   is last. When using the script call, there is no validation that
+   checks if the script actually handles fstab or any other
+   file in the image rootfs.

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -703,12 +703,14 @@ class TestSystemSetup:
             call('fstab_entry\n'),
             call('append_entry')
         ]
-        mock_command.assert_called_once_with(
-            ['patch', 'root_dir/etc/fstab', 'root_dir/etc/fstab.patch']
-        )
+        assert mock_command.call_args_list == [
+            call(['patch', 'root_dir/etc/fstab', 'root_dir/etc/fstab.patch']),
+            call(['chroot', 'root_dir', '/etc/fstab.script'])
+        ]
         assert mock_wipe.call_args_list == [
             call('root_dir/etc/fstab.append'),
-            call('root_dir/etc/fstab.patch')
+            call('root_dir/etc/fstab.patch'),
+            call('root_dir/etc/fstab.script')
         ]
 
     @patch('kiwi.command.Command.run')


### PR DESCRIPTION
In addition to fstab append and patch features we also allow
an fstab.script file that is called chrooted. The change is
needed to support overlay mounting of filesystems as part
of the initrd. If system filesystems needs to be changed in
a way that they can be used in an overlay mount, the standard
mount entry has to take the x-initrd.mount capability which
requires a modification of the fstab which is cumbersome to
handle as a patch file. This concept is currently used as
part of the MicroOS project in SUSE and is applied in the
integration test build maintained for this target. This
Fixes bsc#1129566

