### PR TITLE
Fix return value of is_prepared method

### DIFF
--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -158,7 +158,7 @@ class BootImageBase:
 
         :rtype: bool
         """
-        return os.listdir(self.boot_root_directory)
+        return bool(os.listdir(self.boot_root_directory))
 
     def load_boot_xml_description(self):
         """

--- a/test/unit/boot_image_base_test.py
+++ b/test/unit/boot_image_base_test.py
@@ -82,8 +82,10 @@ class TestBootImageBase:
 
     @patch('os.listdir')
     def test_is_prepared(self, mock_listdir):
-        mock_listdir.return_value = True
-        assert self.boot_image.is_prepared() == mock_listdir.return_value
+        mock_listdir.return_value = []
+        assert self.boot_image.is_prepared() is False
+        mock_listdir.return_value = ['a', 'b', 'c']
+        assert self.boot_image.is_prepared() is True
 
     @patch('kiwi.boot.image.base.XMLState.copy_strip_sections')
     def test_import_system_description_elements(self, mock_strip):


### PR DESCRIPTION
The method is expected to return a bool value. In fact it
returned a list. An empty list is evalutated as False in
python, a list with content as True. So the way the method
is used is correct but the return value should be a real
bool value to match the docs and expectations. Also the
unit test for this code was wrong. This Fixes #1175

