### PR TITLE
Detect raid disks in oem dump module

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -75,7 +75,7 @@ function get_disk_list {
         scan_multipath_devices
     fi
     for disk_meta in $(
-        eval lsblk "${blk_opts}" | grep disk | tr ' ' ":"
+        eval lsblk "${blk_opts}" | grep -E "disk|raid" | tr ' ' ":"
     );do
         disk_device="$(echo "${disk_meta}" | cut -f1 -d:)"
         if [ "$(blkid "${disk_device}" -s LABEL -o value)" = \


### PR DESCRIPTION
The current disk detection only takes lsblk entries into
account that marks the device as 'disk'. However on raid
disks like fake raid controllers the disk is mapped via
dmraid and marked as 'raidX' device. This commit also takes
those devices into account for deployment. Issue #1181

