### PR TITLE
Add --add-bootstrap-packages option

### DIFF
--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -17,6 +17,7 @@ SYNOPSIS
        [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>]
        [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>...]
        [--add-package=<name>...]
+       [--add-bootstrap-package=<name>...]
        [--delete-package=<name>...]
        [--signing-key=<key-file>...]
    kiwi system build help
@@ -33,6 +34,11 @@ are created in the specified target-dir.
 
 OPTIONS
 -------
+
+--add-bootstrap-package=<name>
+
+  specify package to install as part of the early kiwi bootstrap phase.
+  The option can be specified multiple times
 
 --add-package=<name>
 

--- a/doc/source/commands/system_prepare.rst
+++ b/doc/source/commands/system_prepare.rst
@@ -17,6 +17,7 @@ SYNOPSIS
        [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>]
        [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>...]
        [--add-package=<name>...]
+       [--add-bootstrap-package=<name>...]
        [--delete-package=<name>...]
        [--signing-key=<key-file>...]
    kiwi system prepare help
@@ -35,6 +36,11 @@ As the root user you can enter this system via chroot as follows:
 
 OPTIONS
 -------
+
+--add-bootstrap-package=<name>
+
+  specify package to install as part of the early kiwi bootstrap phase.
+  The option can be specified multiple times
 
 --add-package=<name>
 

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -177,23 +177,27 @@ class SystemPrepare:
             repo, package_manager
         )
 
-    def install_bootstrap(self, manager):
+    def install_bootstrap(self, manager, plus_packages=None):
         """
         Install system software using the package manager
         from the host, also known as bootstrapping
 
         :param object manager: instance of a :class:`PackageManager` subclass
+        :param list plus_packages: list of additional packages
 
         :raises KiwiBootStrapPhaseFailed: if the bootstrapping process fails
             either installing packages or including bootstrap archives
         """
-        if not self.xml_state.get_bootstrap_packages_sections():
+        if not self.xml_state.get_bootstrap_packages_sections() \
+           and not plus_packages:
             log.warning('No <packages> sections marked as "bootstrap" found')
             log.info('Processing of bootstrap stage skipped')
             return
 
         log.info('Installing bootstrap packages')
-        bootstrap_packages = self.xml_state.get_bootstrap_packages()
+        bootstrap_packages = self.xml_state.get_bootstrap_packages(
+            plus_packages
+        )
         collection_type = self.xml_state.get_bootstrap_collection_type()
         log.info('--> collection type: %s', collection_type)
         bootstrap_collections = self.xml_state.get_bootstrap_collections()

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -25,6 +25,7 @@ usage: kiwi system build -h | --help
            [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>]
            [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>...]
            [--add-package=<name>...]
+           [--add-bootstrap-package=<name>...]
            [--delete-package=<name>...]
            [--set-container-derived-from=<uri>]
            [--set-container-tag=<name>]
@@ -40,6 +41,8 @@ commands:
         show manual page for build command
 
 options:
+    --add-bootstrap-package=<name>
+        install the given package name as part of the early bootstrap process
     --add-package=<name>
         install the given package name
     --add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>
@@ -194,7 +197,9 @@ class SystemBuildTask(CliTask):
             self.command_args['--clear-cache'],
             self.command_args['--signing-key']
         )
-        system.install_bootstrap(manager)
+        system.install_bootstrap(
+            manager, self.command_args['--add-bootstrap-package']
+        )
         system.install_system(
             manager
         )

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -25,6 +25,7 @@ usage: kiwi system prepare -h | --help
            [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>]
            [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>...]
            [--add-package=<name>...]
+           [--add-bootstrap-package=<name>...]
            [--delete-package=<name>...]
            [--set-container-derived-from=<uri>]
            [--set-container-tag=<name>]
@@ -39,6 +40,8 @@ commands:
         show manual page for prepare command
 
 options:
+    --add-bootstrap-package=<name>
+        install the given package name as part of the early bootstrap process
     --add-package=<name>
         install the given package name
     --add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>
@@ -178,7 +181,9 @@ class SystemPrepareTask(CliTask):
             self.command_args['--clear-cache'],
             self.command_args['--signing-key']
         )
-        system.install_bootstrap(manager)
+        system.install_bootstrap(
+            manager, self.command_args['--add-bootstrap-package']
+        )
         system.install_system(
             manager
         )

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -370,13 +370,15 @@ class XMLState:
         """
         return self.get_packages_sections(['image'])
 
-    def get_bootstrap_packages(self):
+    def get_bootstrap_packages(self, plus_packages=None):
         """
         List of package names from the type="bootstrap" packages section(s)
 
         The list gets the selected package manager appended
         if there is a request to install packages inside of
         the image via a chroot operation
+
+        :param list plus_packages: list of additional packages
 
         :return: package names
 
@@ -392,6 +394,8 @@ class XMLState:
                 result.append(package.package_section.get_name())
             if self.get_system_packages():
                 result.append(self.get_package_manager())
+        if plus_packages:
+            result += plus_packages
         return sorted(list(set(result)))
 
     def get_system_packages(self):

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -45,6 +45,7 @@ class TestCli:
             '--root': 'directory',
             '--set-repo': None,
             '--add-package': [],
+            '--add-bootstrap-package': [],
             '--delete-package': [],
             '--set-container-derived-from': None,
             '--set-container-tag': None,

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -88,6 +88,7 @@ class TestSystemBuildTask:
         self.task.command_args['--set-repo'] = None
         self.task.command_args['--add-repo'] = []
         self.task.command_args['--add-package'] = []
+        self.task.command_args['--add-bootstrap-package'] = []
         self.task.command_args['--delete-package'] = []
         self.task.command_args['--ignore-repos'] = False
         self.task.command_args['--ignore-repos-used-for-build'] = False
@@ -149,7 +150,7 @@ class TestSystemBuildTask:
             False, None
         )
         self.system_prepare.install_bootstrap.assert_called_once_with(
-            self.manager
+            self.manager, []
         )
         self.system_prepare.install_system.assert_called_once_with(
             self.manager

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -78,6 +78,7 @@ class TestSystemPrepareTask:
         self.task.command_args['--set-repo'] = None
         self.task.command_args['--add-repo'] = []
         self.task.command_args['--add-package'] = []
+        self.task.command_args['--add-bootstrap-package'] = []
         self.task.command_args['--delete-package'] = []
         self.task.command_args['--ignore-repos'] = False
         self.task.command_args['--ignore-repos-used-for-build'] = False
@@ -139,7 +140,7 @@ class TestSystemPrepareTask:
             True, None
         )
         self.system_prepare.install_bootstrap.assert_called_once_with(
-            self.manager
+            self.manager, []
         )
         self.system_prepare.install_system.assert_called_once_with(
             self.manager

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -77,6 +77,9 @@ class TestXMLState:
         assert self.state.get_bootstrap_packages() == [
             'filesystem', 'zypper'
         ]
+        assert self.state.get_bootstrap_packages(plus_packages=['vim']) == [
+            'filesystem', 'vim', 'zypper'
+        ]
         assert self.no_image_packages_boot_state.get_bootstrap_packages() == [
             'patterns-openSUSE-base'
         ]


### PR DESCRIPTION
The prepare and build commands now allows to specify additional
packages to be installed as part of the early bootstrap phase
This Fixes #1151

