### PR TITLE
Add the `-wildcards` flag in mksqashfs call

### DIFF
--- a/kiwi/filesystem/squashfs.py
+++ b/kiwi/filesystem/squashfs.py
@@ -52,7 +52,7 @@ class FileSystemSquashFs(FileSystemBase):
                 self.custom_args['create_options'].append('powerpc')
 
         if exclude:
-            exclude_options.append('-e')
+            exclude_options.extend(['-wildcards', '-e'])
             for item in exclude:
                 exclude_options.append(item)
 

--- a/test/unit/filesystem_squashfs_test.py
+++ b/test/unit/filesystem_squashfs_test.py
@@ -30,8 +30,8 @@ class TestFileSystemSquashfs:
         self.squashfs.create_on_file('myimage', 'label', ['foo'])
         mock_command.assert_called_once_with(
             [
-                'mksquashfs', 'root_dir', 'myimage', '-noappend',
-                '-b', '1M', '-comp', 'xz', '-Xbcj', 'powerpc', '-e', 'foo'
+                'mksquashfs', 'root_dir', 'myimage', '-noappend', '-b', '1M',
+                '-comp', 'xz', '-Xbcj', 'powerpc', '-wildcards', '-e', 'foo'
             ]
         )
 


### PR DESCRIPTION
This commit ensures the `-wildcards` flag of mksquashfs is being used.

This is related to #1184