### PR TITLE
Fixed user permission fix

### DIFF
--- a/doc/source/working_with_kiwi/shell_scripts.rst
+++ b/doc/source/working_with_kiwi/shell_scripts.rst
@@ -200,8 +200,8 @@ The following list describes all functions provided by :file:`.kconfig`:
   Set the default run level.
 
 ``baseSetupUserPermissions``
-  Search all home directories of all users listed in :file:`/etc/passwd` and
-  change the ownership of all files to belong to the correct user and group.
+  Set the ownership of all home directories and their content to the correct
+  users and groups listed in :file:`/etc/passwd`.
 
 ``baseStripAndKeep {list of info-files to keep}``
   Helper function for the ``baseStrip*`` functions, reads the list of files

--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -263,7 +263,7 @@ function baseSetupUserPermissions {
         fi
         if [[ ! "${shell}" =~ nologin|true|false ]];then
             group=$(grep "${group}" /etc/group | cut -f1 -d:)
-            chown -c -R "${usern}:${group} ${dir}/*"
+            chown -c -R ${usern}:${group} ${dir}/*
         fi
     done < /etc/passwd
 }

--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -263,7 +263,7 @@ function baseSetupUserPermissions {
         fi
         if [[ ! "${shell}" =~ nologin|true|false ]];then
             group=$(grep "${group}" /etc/group | cut -f1 -d:)
-            chown -c -R ${usern}:${group} ${dir}/*
+            chown -c -R "${usern}":"${group}" "${dir}"/*
         fi
     done < /etc/passwd
 }

--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -263,7 +263,7 @@ function baseSetupUserPermissions {
         fi
         if [[ ! "${shell}" =~ nologin|true|false ]];then
             group=$(grep "${group}" /etc/group | cut -f1 -d:)
-            chown -c -R "${usern}":"${group}" "${dir}"/*
+            chown -c -R "${usern}":"${group}" "${dir}"
         fi
     done < /etc/passwd
 }


### PR DESCRIPTION
The comand was evaluated as chmod -c -R '...' . This is not the correct
syntax. Removing quotation marks solved problem.

Fixes #1190  .


