### PR TITLE
Do not require multipath in dracut-kiwi-oem-dump

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -271,12 +271,6 @@ BuildRequires:  dracut
 %endif
 Requires:       dracut-kiwi-lib
 Requires:       kexec-tools
-%if 0%{?suse_version} || 0%{?debian} || 0%{?ubuntu}
-Requires:       multipath-tools
-%endif
-%if 0%{?fedora} || 0%{?rhel}
-Requires:       device-mapper-multipath
-%endif
 Requires:       gawk
 License:        GPL-3.0-or-later
 Group:          %{sysgroup}


### PR DESCRIPTION
Installation of multipath tools triggers storage devices
to be handled as multipath maps in dracut. If the deployment
happens in a non multipath system those devices do not exist
and the system later hangs in the dracut initqueue waiting
for mapper devices that never appears

