### PR TITLE
Fix GPT to MBR convertion

### DIFF
--- a/kiwi/partitioner/gpt.py
+++ b/kiwi/partitioner/gpt.py
@@ -138,12 +138,12 @@ class PartitionerGpt(PartitionerBase):
             if '(EFI System)' in partition_info.output:
                 efi_partition_number = number
             partition_ids.append(format(number))
-        Command.run(
-            ['sgdisk', '-m', ':'.join(partition_ids), self.disk_device]
-        )
         if efi_partition_number:
             # turn former EFI partition into standard linux partition
             self.set_flag(efi_partition_number, 't.linux')
+        Command.run(
+            ['sgdisk', '-m', ':'.join(partition_ids), self.disk_device]
+        )
 
     def resize_table(self, entries=128):
         """

--- a/test/unit/partitioner_gpt_test.py
+++ b/test/unit/partitioner_gpt_test.py
@@ -97,8 +97,8 @@ class TestPartitionerGpt:
             call(['sgdisk', '-i=2', '/dev/loop0']),
             call(['sgdisk', '-i=3', '/dev/loop0']),
             call(['sgdisk', '-i=4', '/dev/loop0']),
-            call(['sgdisk', '-m', '1:2:3:4', '/dev/loop0']),
-            call(['sgdisk', '-t', '4:8300', '/dev/loop0'])
+            call(['sgdisk', '-t', '4:8300', '/dev/loop0']),
+            call(['sgdisk', '-m', '1:2:3:4', '/dev/loop0'])
         ]
 
     @patch('kiwi.partitioner.gpt.Command.run')


### PR DESCRIPTION
This commit swaps the order of the command in gpt to mbr convertion
in partitioner.gpt.set_mbr method.

sgdisk by default converts the partition table from MBR to GPT in memory.
The change is never applied unless you provide the -g option forcing to
overwrite the partition table format. If sgdisk does the convertion in
memory and the user does not provide the -g flag it returns an error
code.

The solution applied in this commit is to just run the GPT to MBR
convertion as the last sgdisk command and change partition type before
running the convertion.

Fixes #1169
