### PR TITLE
Fix modules omission for dracut based initrds

### DIFF
--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -166,7 +166,7 @@ class BootImageDracut(BootImageBase):
                 ] if self.modules else []
                 omit_modules_args = [
                     '--omit', ' {0} '.format(' '.join(self.omit_modules))
-                ] if self.omit_install_modules else []
+                ] if self.omit_modules else []
             dracut_initrd_basename += '.xz'
             options = self.dracut_options + modules_args +\
                 omit_modules_args + included_files

--- a/test/unit/boot_image_dracut_test.py
+++ b/test/unit/boot_image_dracut_test.py
@@ -125,12 +125,15 @@ class TestBootImageKiwi:
         self.boot_image.include_file(
             '/system-directory/var/lib/bar', install_media=True
         )
+        self.boot_image.include_module('foo')
+        self.boot_image.omit_module('bar')
         self.boot_image.create_initrd()
         assert mock_command.call_args_list == [
             call([
                 'chroot', 'system-directory',
                 'dracut', '--force', '--no-hostonly',
                 '--no-hostonly-cmdline', '--xz',
+                '--add', ' foo ', '--omit', ' bar ',
                 '--install', 'system-directory/etc/foo',
                 '--install', '/system-directory/var/lib/bar',
                 'LimeJeOS-openSUSE-13.2.x86_64-1.13.2.initrd.xz', '1.2.3'


### PR DESCRIPTION
This commit fixes a regression introduced in 07ea23a4. In OEM images
the dracut modules were not properly omitted as the code was evaluating
the wrong variable.

Fixes #1201
