### PR TITLE
Add information in PXE install files

### DIFF
--- a/doc/source/building/build_oem_disk.rst
+++ b/doc/source/building/build_oem_disk.rst
@@ -177,8 +177,8 @@ target system:
 
       .. code:: bash
 
-          scp pxeboot.initrd.xz PXE_SERVER_IP:/srv/tftpboot/boot/initrd
-          scp pxeboot.kernel PXE_SERVER_IP:/srv/tftpboot/boot/linux
+          scp pxeboot.{exc_image_base_name}.x86_64-{exc_image_version}.initrd.xz PXE_SERVER_IP:/srv/tftpboot/boot/initrd
+          scp pxeboot.{exc_image_base_name}.x86_64-{exc_image_version}.kernel PXE_SERVER_IP:/srv/tftpboot/boot/linux
 
 3. Copy the OEM disk image, MD5 file, system kernel and initrd to
    the PXE boot server:
@@ -190,15 +190,15 @@ target system:
 
       .. code:: bash
 
-          scp {exc_image_base_name}.xz PXE_SERVER_IP:/srv/tftpboot/image/
-          scp {exc_image_base_name}.md5 PXE_SERVER_IP:/srv/tftpboot/image/
+          scp {exc_image_base_name}.x86_64-{exc_image_version}.xz PXE_SERVER_IP:/srv/tftpboot/image/
+          scp {exc_image_base_name}.x86_64-{exc_image_version}.md5 PXE_SERVER_IP:/srv/tftpboot/image/
 
    b) Copy kernel and initrd used for booting the system via kexec
 
       .. code:: bash
 
-          scp {exc_image_base_name}.initrd PXE_SERVER_IP:/srv/tftpboot/image/
-          scp {exc_image_base_name}.kernel PXE_SERVER_IP:/srv/tftpboot/image/
+          scp {exc_image_base_name}.x86_64-{exc_image_version}.initrd PXE_SERVER_IP:/srv/tftpboot/image/
+          scp {exc_image_base_name}.x86_64-{exc_image_version}.kernel PXE_SERVER_IP:/srv/tftpboot/image/
 
 4. Add/Update the kernel command line parameters
 
@@ -208,7 +208,7 @@ target system:
 
    .. code:: bash
 
-       append initrd=boot/initrd rd.kiwi.install.pxe rd.kiwi.install.image=tftp://192.168.100.16/image/{exc_image_base_name}.xz
+       append initrd=boot/initrd rd.kiwi.install.pxe rd.kiwi.install.image=tftp://192.168.100.16/image/{exc_image_base_name}.x86_64-{exc_image_version}.xz
 
    The location of the image is specified as a source URI which can point
    to any location supported by the `curl` command. KIWI calls `curl` to fetch

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -93,11 +93,14 @@ class InstallImageBuilder:
         )
         self.pxename = ''.join(
             [
-                target_dir, '/',
                 xml_state.xml_data.get_name(),
                 '.' + self.arch,
-                '-' + xml_state.get_image_version(),
-                '.install.tar'
+                '-' + xml_state.get_image_version()
+            ]
+        )
+        self.pxetarball = ''.join(
+            [
+                target_dir, '/', self.pxename, '.install.tar'
             ]
         )
         self.dracut_config_file = ''.join(
@@ -258,7 +261,7 @@ class InstallImageBuilder:
         pxe_image_filename = ''.join(
             [
                 self.pxe_dir, '/',
-                self.xml_state.xml_data.get_name(), '.xz'
+                self.pxename, '.xz'
             ]
         )
         compress = Compress(
@@ -275,7 +278,7 @@ class InstallImageBuilder:
         pxe_md5_filename = ''.join(
             [
                 self.pxe_dir, '/',
-                self.xml_state.xml_data.get_name(), '.md5'
+                self.pxename, '.md5'
             ]
         )
         checksum = Checksum(self.diskname)
@@ -292,7 +295,7 @@ class InstallImageBuilder:
                 [self.root_dir, 'boot', boot_names.initrd_name]
             )
             target_initrd_name = '{0}/{1}.initrd'.format(
-                self.pxe_dir, self.xml_state.xml_data.get_name()
+                self.pxe_dir, self.pxename
             )
             shutil.copy(
                 system_image_initrd, target_initrd_name
@@ -303,8 +306,7 @@ class InstallImageBuilder:
         # this information helps to configure the boot server correctly
         append_filename = ''.join(
             [
-                self.pxe_dir, '/',
-                self.xml_state.xml_data.get_name(), '.append'
+                self.pxe_dir, '/', self.pxename, '.append'
             ]
         )
         if self.initrd_system == 'kiwi':
@@ -328,19 +330,21 @@ class InstallImageBuilder:
 
         # create pxe install tarball
         log.info('Creating pxe install archive')
-        archive = ArchiveTar(self.pxename)
+        archive = ArchiveTar(self.pxetarball)
 
         archive.create(self.pxe_dir)
 
     def _create_pxe_install_kernel_and_initrd(self):
+        kernelname = 'pxeboot.{0}.kernel'.format(self.pxename)
+        initrdname = 'pxeboot.{0}.initrd.xz'.format(self.pxename)
         kernel = Kernel(self.boot_image_task.boot_root_directory)
         if kernel.get_kernel():
-            kernel.copy_kernel(self.pxe_dir, '/pxeboot.kernel')
+            kernel.copy_kernel(self.pxe_dir, kernelname)
             os.symlink(
-                'pxeboot.kernel', ''.join(
+                kernelname, ''.join(
                     [
                         self.pxe_dir, '/',
-                        self.xml_state.xml_data.get_name(), '.kernel'
+                        self.pxename, '.kernel'
                     ]
                 )
             )
@@ -351,7 +355,9 @@ class InstallImageBuilder:
             )
         if self.xml_state.is_xen_server():
             if kernel.get_xen_hypervisor():
-                kernel.copy_xen_hypervisor(self.pxe_dir, '/pxeboot.xen.gz')
+                kernel.copy_xen_hypervisor(
+                    self.pxe_dir, '/pxeboot.{0}.xen.gz'.format(self.pxename)
+                )
             else:
                 raise KiwiInstallBootImageError(
                     'No hypervisor in boot image tree %s found' %
@@ -373,10 +379,10 @@ class InstallImageBuilder:
         Command.run(
             [
                 'mv', self.boot_image_task.initrd_filename,
-                self.pxe_dir + '/pxeboot.initrd.xz'
+                self.pxe_dir + '/{0}'.format(initrdname)
             ]
         )
-        os.chmod(self.pxe_dir + '/pxeboot.initrd.xz', 420)
+        os.chmod(self.pxe_dir + '/{0}'.format(initrdname), 420)
 
     def _create_iso_install_kernel_and_initrd(self):
         boot_path = self.media_dir + '/boot/' + self.arch + '/loader'

--- a/test/unit/builder_install_test.py
+++ b/test/unit/builder_install_test.py
@@ -333,39 +333,46 @@ class TestInstallImageBuilder:
         )
         compress.xz.assert_called_once_with(None)
         assert mock_command.call_args_list[0] == call(
-            ['mv', compress.compressed_filename, 'tmpdir/result-image.xz']
+            [
+                'mv', compress.compressed_filename,
+                'tmpdir/result-image.x86_64-1.2.3.xz'
+            ]
         )
         mock_md5.assert_called_once_with(
             'target_dir/result-image.x86_64-1.2.3.raw'
         )
         checksum.md5.assert_called_once_with(
-            'tmpdir/result-image.md5'
+            'tmpdir/result-image.x86_64-1.2.3.md5'
         )
         assert mock_open.call_args_list == [
             call('initrd_dir/config.vmxsystem', 'w'),
-            call('tmpdir/result-image.append', 'w')
+            call('tmpdir/result-image.x86_64-1.2.3.append', 'w')
         ]
         assert file_mock.write.call_args_list == [
             call('IMAGE="result-image.raw"\n'),
             call('pxe=1 custom_kernel_options\n')
         ]
         self.kernel.copy_kernel.assert_called_once_with(
-            'tmpdir', '/pxeboot.kernel'
+            'tmpdir', 'pxeboot.result-image.x86_64-1.2.3.kernel'
         )
         mock_symlink.assert_called_once_with(
-            'pxeboot.kernel', 'tmpdir/result-image.kernel'
+            'pxeboot.result-image.x86_64-1.2.3.kernel',
+            'tmpdir/result-image.x86_64-1.2.3.kernel'
         )
         self.kernel.copy_xen_hypervisor.assert_called_once_with(
-            'tmpdir', '/pxeboot.xen.gz'
+            'tmpdir', '/pxeboot.result-image.x86_64-1.2.3.xen.gz'
         )
         self.boot_image_task.create_initrd.assert_called_once_with(
             self.mbrid, 'initrd_kiwi_install', install_initrd=True
         )
         assert mock_command.call_args_list[1] == call(
-            ['mv', 'initrd', 'tmpdir/pxeboot.initrd.xz']
+            [
+                'mv', 'initrd',
+                'tmpdir/pxeboot.result-image.x86_64-1.2.3.initrd.xz'
+            ]
         )
         mock_chmod.assert_called_once_with(
-            'tmpdir/pxeboot.initrd.xz', 420
+            'tmpdir/pxeboot.result-image.x86_64-1.2.3.initrd.xz', 420
         )
         mock_archive.assert_called_once_with(
             'target_dir/result-image.x86_64-1.2.3.install.tar'
@@ -383,14 +390,15 @@ class TestInstallImageBuilder:
             '/config.bootoptions', install_media=True
         )
         mock_copy.assert_called_once_with(
-            'root_dir/boot/initrd-kernel_version', 'tmpdir/result-image.initrd'
+            'root_dir/boot/initrd-kernel_version',
+            'tmpdir/result-image.x86_64-1.2.3.initrd'
         )
         assert mock_chmod.call_args_list == [
-            call('tmpdir/result-image.initrd', 420),
-            call('tmpdir/pxeboot.initrd.xz', 420)
+            call('tmpdir/result-image.x86_64-1.2.3.initrd', 420),
+            call('tmpdir/pxeboot.result-image.x86_64-1.2.3.initrd.xz', 420)
         ]
         assert mock_open.call_args_list == [
-            call('tmpdir/result-image.append', 'w'),
+            call('tmpdir/result-image.x86_64-1.2.3.append', 'w'),
         ]
         assert file_mock.write.call_args_list == [
             call(


### PR DESCRIPTION
This commmit adds additional information for the image and pxeboot files
that are part of the install tarball in OEM PXE deployments. This way all
files inside the install tarball include the following pattern

`<image-name>.<arch>-<version>`

at the same time anyfile prefix and suffix remains unchanged.

Fixes #1147
