### PR TITLE
Fixed kiwi-live module setup

### DIFF
--- a/dracut/modules.d/90kiwi-live/kiwi-live-checkmedia.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-checkmedia.sh
@@ -2,7 +2,7 @@
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 type runMediaCheck >/dev/null 2>&1 || . /lib/kiwi-live-lib.sh
 
-if getargbool 0 mediacheck; then
+if getargbool 0 mediacheck || getargbool 0 rd.live.check; then
     declare root=${root}
     initGlobalDevices "${root#live:}"
     runMediaCheck

--- a/dracut/modules.d/90kiwi-live/module-setup.sh
+++ b/dracut/modules.d/90kiwi-live/module-setup.sh
@@ -25,10 +25,11 @@ install() {
     declare systemdutildir=${systemdutildir}
     declare dracutbasedir=${dracutbasedir}
     local dmsquashdir=
+    inst_multiple -o checkmedia
     inst_multiple \
         umount dmsetup blockdev blkid lsblk dd losetup \
         grep cut partprobe find wc fdisk tail mkfs.ext4 mkfs.xfs \
-        checkmedia dialog cat
+        dialog cat
 
     dmsquashdir=$(find "${dracutbasedir}/modules.d" -name "*dmsquash-live")
     if [ -n "${dmsquashdir}" ] && \

--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -173,7 +173,7 @@ class BootImageDracut(BootImageBase):
             dracut_call = Command.run(
                 [
                     'chroot', self.boot_root_directory,
-                    'dracut', '--force',
+                    'dracut', '--verbose',
                     '--no-hostonly',
                     '--no-hostonly-cmdline',
                     '--xz'

--- a/test/unit/boot_image_dracut_test.py
+++ b/test/unit/boot_image_dracut_test.py
@@ -131,7 +131,7 @@ class TestBootImageKiwi:
         assert mock_command.call_args_list == [
             call([
                 'chroot', 'system-directory',
-                'dracut', '--force', '--no-hostonly',
+                'dracut', '--verbose', '--no-hostonly',
                 '--no-hostonly-cmdline', '--xz',
                 '--add', ' foo ', '--omit', ' bar ',
                 '--install', 'system-directory/etc/foo',
@@ -149,7 +149,7 @@ class TestBootImageKiwi:
         assert mock_command.call_args_list == [
             call([
                 'chroot', 'system-directory',
-                'dracut', '--force', '--no-hostonly',
+                'dracut', '--verbose', '--no-hostonly',
                 '--no-hostonly-cmdline', '--xz',
                 '--install', '/system-directory/var/lib/bar',
                 'foo.xz', '1.2.3'


### PR DESCRIPTION
The installation of the checkmedia tool is optional and
and not mandatory. In addition activate the media check
verification also through the upstream used rd.live.check
kernel parameter. This is related to Issue #1158


