### PR TITLE
Refactor use of raises in unit tests

### DIFF
--- a/test/unit/archive_tar_test.py
+++ b/test/unit/archive_tar_test.py
@@ -1,8 +1,8 @@
-from mock import patch, call
-
+from mock import (
+    patch, call
+)
+from pytest import raises
 import mock
-
-from .test_helper import raises
 
 from kiwi.archive.tar import ArchiveTar
 
@@ -17,13 +17,13 @@ class TestArchiveTar:
         mock_command.return_value = command
         self.archive = ArchiveTar('foo.tar')
 
-    @raises(KiwiCommandCapabilitiesError)
     @patch('kiwi.archive.tar.Command.run')
     def test_invalid_tar_command_version(self, mock_command):
         command = mock.Mock()
         command.output = 'version cannot be parsed'
         mock_command.return_value = command
-        self.archive = ArchiveTar('foo.tar')
+        with raises(KiwiCommandCapabilitiesError):
+            self.archive = ArchiveTar('foo.tar')
 
     @patch('kiwi.archive.tar.Command.run')
     def test_extract(self, mock_command):

--- a/test/unit/boot_image_base_test.py
+++ b/test/unit/boot_image_base_test.py
@@ -1,8 +1,8 @@
 from mock import patch
-
+from pytest import raises
 import mock
 
-from .test_helper import raises, patch_open
+from .test_helper import patch_open
 
 from kiwi.exceptions import (
     KiwiTargetDirectoryNotFound,
@@ -34,26 +34,26 @@ class TestBootImageBase:
             self.xml_state, 'some-target-dir'
         )
 
-    @raises(KiwiTargetDirectoryNotFound)
     def test_boot_image_raises(self):
-        BootImageBase(
-            self.xml_state, 'target-dir-does-not-exist', 'some-root-dir'
-        )
+        with raises(KiwiTargetDirectoryNotFound):
+            BootImageBase(
+                self.xml_state, 'target-dir-does-not-exist', 'some-root-dir'
+            )
 
-    @raises(NotImplementedError)
     def test_prepare(self):
-        self.boot_image.prepare()
+        with raises(NotImplementedError):
+            self.boot_image.prepare()
 
-    @raises(NotImplementedError)
     def test_create_initrd(self):
-        self.boot_image.create_initrd()
+        with raises(NotImplementedError):
+            self.boot_image.create_initrd()
 
-    @raises(KiwiBootImageDumpError)
     @patch_open
     @patch('pickle.dump')
     def test_dump_error(self, mock_dump, mock_open):
         mock_dump.side_effect = Exception
-        self.boot_image.dump('filename')
+        with raises(KiwiBootImageDumpError):
+            self.boot_image.dump('filename')
 
     @patch_open
     @patch('pickle.dump')
@@ -109,15 +109,15 @@ class TestBootImageBase:
         assert self.boot_image.get_boot_description_directory() == \
             '/usr/share/kiwi/custom_boot/oemboot/suse-13.2'
 
-    @raises(KiwiConfigFileNotFound)
     @patch('kiwi.boot.image.base.BootImageBase.get_boot_description_directory')
     def test_load_boot_xml_description(self, mock_boot_dir):
         mock_boot_dir.return_value = None
-        self.boot_image.load_boot_xml_description()
+        with raises(KiwiConfigFileNotFound):
+            self.boot_image.load_boot_xml_description()
 
-    @raises(NotImplementedError)
     def test_get_boot_names(self):
-        self.boot_image.get_boot_names()
+        with raises(NotImplementedError):
+            self.boot_image.get_boot_names()
 
     def test_noop_methods(self):
         self.boot_image.include_module('module')

--- a/test/unit/boot_image_builtin_kiwi_test.py
+++ b/test/unit/boot_image_builtin_kiwi_test.py
@@ -1,12 +1,13 @@
+import sys
 import mock
-
 from mock import patch
 from mock import call
 from collections import namedtuple
+from pytest import raises
 
 import kiwi
 
-from .test_helper import raises
+from .test_helper import argv_kiwi_tests
 
 from kiwi.boot.image.builtin_kiwi import BootImageKiwi
 from kiwi.xml_description import XMLDescription
@@ -81,11 +82,11 @@ class TestBootImageKiwi:
         )
         self.setup.call_image_script.assert_called_once_with()
 
-    @raises(KiwiConfigFileNotFound)
     @patch('os.path.exists')
     def test_prepare_no_boot_description_found(self, mock_os_path):
         mock_os_path.return_value = False
-        self.boot_image.prepare()
+        with raises(KiwiConfigFileNotFound):
+            self.boot_image.prepare()
 
     @patch('kiwi.boot.image.builtin_kiwi.ArchiveCpio')
     @patch('kiwi.boot.image.builtin_kiwi.Compress')
@@ -172,3 +173,6 @@ class TestBootImageKiwi:
         assert self.boot_image.get_boot_names() == boot_names_type(
             kernel_name='linux.vmx', initrd_name='initrd.vmx'
         )
+
+    def teardown(self):
+        sys.argv = argv_kiwi_tests

--- a/test/unit/boot_image_dracut_test.py
+++ b/test/unit/boot_image_dracut_test.py
@@ -3,8 +3,9 @@ import mock
 from mock import patch
 from mock import call
 from collections import namedtuple
+from pytest import raises
 
-from .test_helper import patch_open, raises
+from .test_helper import patch_open
 
 from kiwi.boot.image.dracut import BootImageDracut
 from kiwi.xml_description import XMLDescription
@@ -161,13 +162,13 @@ class TestBootImageKiwi:
             ])
         ]
 
-    @raises(KiwiDiskBootImageError)
     @patch('kiwi.boot.image.dracut.Kernel')
     def test_get_boot_names_raises(self, mock_Kernel):
         kernel = mock.Mock()
         mock_Kernel.return_value = kernel
         kernel.get_kernel.return_value = None
-        self.boot_image.get_boot_names()
+        with raises(KiwiDiskBootImageError):
+            self.boot_image.get_boot_names()
 
     @patch_open
     @patch('kiwi.boot.image.dracut.Kernel')

--- a/test/unit/boot_image_test.py
+++ b/test/unit/boot_image_test.py
@@ -1,8 +1,7 @@
-from mock import patch
-
-import mock
-
-from .test_helper import raises
+from mock import (
+    Mock, patch
+)
+from pytest import raises
 
 from kiwi.exceptions import KiwiBootImageSetupError
 from kiwi.boot.image import BootImage
@@ -10,15 +9,15 @@ from kiwi.boot.image import BootImage
 
 class TestBootImage:
     def setup(self):
-        self.xml_state = mock.Mock()
-        self.xml_state.get_initrd_system = mock.Mock(
+        self.xml_state = Mock()
+        self.xml_state.get_initrd_system = Mock(
             return_value='kiwi'
         )
 
-    @raises(KiwiBootImageSetupError)
     def test_boot_image_not_implemented(self):
         self.xml_state.get_initrd_system.return_value = 'foo'
-        BootImage(self.xml_state, 'target_dir')
+        with raises(KiwiBootImageSetupError):
+            BootImage(self.xml_state, 'target_dir')
 
     @patch('kiwi.boot.image.BootImageKiwi')
     def test_boot_image_task_kiwi(self, mock_kiwi):

--- a/test/unit/bootloader_config_base_test.py
+++ b/test/unit/bootloader_config_base_test.py
@@ -1,8 +1,8 @@
-from mock import patch
-from mock import call
+from mock import (
+    patch, call
+)
+from pytest import raises
 import mock
-
-from .test_helper import raises
 
 from kiwi.xml_state import XMLState
 from kiwi.xml_description import XMLDescription
@@ -24,44 +24,44 @@ class TestBootLoaderConfigBase:
             self.state, 'root_dir'
         )
 
-    @raises(NotImplementedError)
     def test_write(self):
-        self.bootloader.write()
+        with raises(NotImplementedError):
+            self.bootloader.write()
 
-    @raises(NotImplementedError)
     def test_setup_disk_image_config(self):
-        self.bootloader.setup_disk_image_config(
-            'boot_uuid', 'root_uuid', 'hypervisor',
-            'kernel', 'initrd', 'options'
-        )
+        with raises(NotImplementedError):
+            self.bootloader.setup_disk_image_config(
+                'boot_uuid', 'root_uuid', 'hypervisor',
+                'kernel', 'initrd', 'options'
+            )
 
-    @raises(NotImplementedError)
     def test_setup_install_image_config(self):
-        self.bootloader.setup_install_image_config(
-            'mbrid', 'hypervisor', 'kernel', 'initrd'
-        )
+        with raises(NotImplementedError):
+            self.bootloader.setup_install_image_config(
+                'mbrid', 'hypervisor', 'kernel', 'initrd'
+            )
 
-    @raises(NotImplementedError)
     def test_setup_live_image_config(self):
-        self.bootloader.setup_live_image_config(
-            'mbrid', 'hypervisor', 'kernel', 'initrd'
-        )
+        with raises(NotImplementedError):
+            self.bootloader.setup_live_image_config(
+                'mbrid', 'hypervisor', 'kernel', 'initrd'
+            )
 
-    @raises(NotImplementedError)
     def test_setup_disk_boot_images(self):
-        self.bootloader.setup_disk_boot_images('uuid')
+        with raises(NotImplementedError):
+            self.bootloader.setup_disk_boot_images('uuid')
 
-    @raises(NotImplementedError)
     def test_setup_install_boot_images(self):
-        self.bootloader.setup_install_boot_images('mbrid')
+        with raises(NotImplementedError):
+            self.bootloader.setup_install_boot_images('mbrid')
 
-    @raises(NotImplementedError)
     def test_setup_live_boot_images(self):
-        self.bootloader.setup_live_boot_images('mbrid')
+        with raises(NotImplementedError):
+            self.bootloader.setup_live_boot_images('mbrid')
 
-    @raises(NotImplementedError)
     def test_setup_sysconfig_bootloader(self):
-        self.bootloader.setup_sysconfig_bootloader()
+        with raises(NotImplementedError):
+            self.bootloader.setup_sysconfig_bootloader()
 
     @patch('kiwi.path.Path.create')
     def test_create_efi_path(self, mock_path):
@@ -164,11 +164,10 @@ class TestBootLoaderConfigBase:
             call('Switching to standard install')
         ]
 
-    @raises(KiwiBootLoaderTargetError)
     def test_get_boot_path_raises(self):
-        self.bootloader.get_boot_path('foo')
+        with raises(KiwiBootLoaderTargetError):
+            self.bootloader.get_boot_path('foo')
 
-    @raises(KiwiBootLoaderTargetError)
     @patch('kiwi.bootloader.config.base.DiskSetup')
     @patch('kiwi.xml_parse.type_.get_filesystem')
     @patch('kiwi.xml_state.XMLState.get_volumes')
@@ -184,7 +183,8 @@ class TestBootLoaderConfigBase:
             return_value=False
         )
         mock_disk_setup.return_value = disk_setup
-        self.bootloader.get_boot_path()
+        with raises(KiwiBootLoaderTargetError):
+            self.bootloader.get_boot_path()
 
     @patch('kiwi.bootloader.config.base.DiskSetup')
     @patch('kiwi.xml_parse.type_.get_filesystem')

--- a/test/unit/bootloader_config_isolinux_test.py
+++ b/test/unit/bootloader_config_isolinux_test.py
@@ -3,7 +3,8 @@ import mock
 from mock import (
     patch, call
 )
-from .test_helper import raises, patch_open
+from pytest import raises
+from .test_helper import patch_open
 from kiwi.bootloader.config.isolinux import BootLoaderConfigIsoLinux
 
 from kiwi.exceptions import KiwiTemplateError
@@ -160,10 +161,10 @@ class TestBootLoaderConfigIsoLinux:
             True, True, None, True
         )
 
-    @raises(KiwiTemplateError)
     def test_setup_install_image_config_invalid_template(self):
         self.isolinux.get_install_message_template.side_effect = Exception
-        self.bootloader.setup_install_image_config(mbrid=None)
+        with raises(KiwiTemplateError):
+            self.bootloader.setup_install_image_config(mbrid=None)
 
     def test_setup_install_boot_images(self):
         assert self.bootloader.setup_install_boot_images(mbrid=None) is None
@@ -171,10 +172,10 @@ class TestBootLoaderConfigIsoLinux:
     def test_setup_live_boot_images(self):
         assert self.bootloader.setup_live_boot_images(mbrid=None) is None
 
-    @raises(KiwiTemplateError)
     def test_setup_live_image_config_invalid_template(self):
         self.isolinux.get_message_template.side_effect = Exception
-        self.bootloader.setup_live_image_config(mbrid=None)
+        with raises(KiwiTemplateError):
+            self.bootloader.setup_live_image_config(mbrid=None)
 
     def test_setup_live_image_config(self):
         template_parameters = {

--- a/test/unit/bootloader_config_test.py
+++ b/test/unit/bootloader_config_test.py
@@ -1,27 +1,26 @@
-from mock import patch
-
-import mock
-
-from .test_helper import raises
+from mock import (
+    patch, Mock
+)
+from pytest import raises
 
 from kiwi.exceptions import KiwiBootLoaderConfigSetupError
 from kiwi.bootloader.config import BootLoaderConfig
 
 
 class TestBootLoaderConfig:
-    @raises(KiwiBootLoaderConfigSetupError)
     def test_bootloader_config_not_implemented(self):
-        BootLoaderConfig('foo', mock.Mock(), 'root_dir')
+        with raises(KiwiBootLoaderConfigSetupError):
+            BootLoaderConfig('foo', Mock(), 'root_dir')
 
     @patch('kiwi.bootloader.config.BootLoaderConfigGrub2')
     def test_bootloader_config_grub2(self, mock_grub2):
-        xml_state = mock.Mock()
+        xml_state = Mock()
         BootLoaderConfig('grub2', xml_state, 'root_dir')
         mock_grub2.assert_called_once_with(xml_state, 'root_dir', None, None)
 
     @patch('kiwi.bootloader.config.BootLoaderConfigIsoLinux')
     def test_bootloader_config_isolinux(self, mock_isolinux):
-        xml_state = mock.Mock()
+        xml_state = Mock()
         BootLoaderConfig('isolinux', xml_state, 'root_dir', 'boot_dir')
         mock_isolinux.assert_called_once_with(
             xml_state, 'root_dir', 'boot_dir', None
@@ -29,6 +28,6 @@ class TestBootLoaderConfig:
 
     @patch('kiwi.bootloader.config.BootLoaderConfigZipl')
     def test_bootloader_config_zipl(self, mock_zipl):
-        xml_state = mock.Mock()
+        xml_state = Mock()
         BootLoaderConfig('grub2_s390x_emu', xml_state, 'root_dir')
         mock_zipl.assert_called_once_with(xml_state, 'root_dir', None, None)

--- a/test/unit/bootloader_install_base_test.py
+++ b/test/unit/bootloader_install_base_test.py
@@ -1,6 +1,5 @@
-import mock
-
-from .test_helper import raises
+from mock import Mock
+from pytest import raises
 
 from kiwi.bootloader.install.base import BootLoaderInstallBase
 
@@ -8,13 +7,13 @@ from kiwi.bootloader.install.base import BootLoaderInstallBase
 class TestBootLoaderInstallBase:
     def setup(self):
         self.bootloader = BootLoaderInstallBase(
-            'root_dir', mock.Mock()
+            'root_dir', Mock()
         )
 
-    @raises(NotImplementedError)
     def test_install(self):
-        self.bootloader.install()
+        with raises(NotImplementedError):
+            self.bootloader.install()
 
-    @raises(NotImplementedError)
     def test_install_required(self):
-        self.bootloader.install_required()
+        with raises(NotImplementedError):
+            self.bootloader.install_required()

--- a/test/unit/bootloader_install_grub2_test.py
+++ b/test/unit/bootloader_install_grub2_test.py
@@ -1,19 +1,17 @@
-from mock import patch
-from mock import call
-
+from mock import (
+    patch, call
+)
+from pytest import raises
 import mock
 
-from .test_helper import raises
+from kiwi.bootloader.install.grub2 import BootLoaderInstallGrub2
+from kiwi.defaults import Defaults
 
 from kiwi.exceptions import (
     KiwiBootLoaderGrubInstallError,
     KiwiBootLoaderGrubDataError,
     KiwiBootLoaderGrubPlatformError
 )
-
-from kiwi.bootloader.install.grub2 import BootLoaderInstallGrub2
-
-from kiwi.defaults import Defaults
 
 
 class TestBootLoaderInstallGrub2:
@@ -88,42 +86,42 @@ class TestBootLoaderInstallGrub2:
         )
 
     @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
-    @raises(KiwiBootLoaderGrubInstallError)
     def test_post_init_ppc_no_prep_device(self, mock_grub_path):
         self.bootloader.arch = 'ppc64'
         del self.custom_args['prep_device']
-        self.bootloader.install()
+        with raises(KiwiBootLoaderGrubInstallError):
+            self.bootloader.install()
 
     @patch('kiwi.bootloader.install.grub2.Command.run')
     @patch('kiwi.bootloader.install.grub2.MountManager')
     @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
-    @raises(KiwiBootLoaderGrubDataError)
     def test_grub2_bootloader_not_installed(
         self, mock_grub_path, mock_mount_manager, mock_command
     ):
         mock_grub_path.return_value = None
         self.bootloader.arch = 'x86_64'
-        self.bootloader.install()
+        with raises(KiwiBootLoaderGrubDataError):
+            self.bootloader.install()
 
     @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
-    @raises(KiwiBootLoaderGrubPlatformError)
     def test_unsupported_platform(self, mock_grub_path):
         self.bootloader.arch = 'unsupported'
-        self.bootloader.install()
+        with raises(KiwiBootLoaderGrubPlatformError):
+            self.bootloader.install()
 
-    @raises(KiwiBootLoaderGrubInstallError)
     def test_post_init_no_boot_device(self):
-        self.bootloader.post_init({})
+        with raises(KiwiBootLoaderGrubInstallError):
+            self.bootloader.post_init({})
 
-    @raises(KiwiBootLoaderGrubInstallError)
     def test_post_init_no_root_device(self):
-        self.bootloader.post_init({'boot_device': 'a'})
+        with raises(KiwiBootLoaderGrubInstallError):
+            self.bootloader.post_init({'boot_device': 'a'})
 
-    @raises(KiwiBootLoaderGrubInstallError)
     def test_post_init_secure_boot_no_efi_device(self):
         self.firmware.efi_mode.return_value = 'uefi'
         del self.custom_args['efi_device']
-        self.bootloader.post_init(self.custom_args)
+        with raises(KiwiBootLoaderGrubInstallError):
+            self.bootloader.post_init(self.custom_args)
 
     def test_install_required(self):
         assert self.bootloader.install_required() is True

--- a/test/unit/bootloader_install_test.py
+++ b/test/unit/bootloader_install_test.py
@@ -1,27 +1,25 @@
-
-from mock import patch
-
-import mock
-
-from .test_helper import raises
+from mock import (
+    patch, Mock
+)
+from pytest import raises
 
 from kiwi.exceptions import KiwiBootLoaderInstallSetupError
 from kiwi.bootloader.install import BootLoaderInstall
 
 
 class TestBootLoaderInstall:
-    @raises(KiwiBootLoaderInstallSetupError)
     def test_bootloader_install_not_implemented(self):
-        BootLoaderInstall('foo', 'root_dir', mock.Mock())
+        with raises(KiwiBootLoaderInstallSetupError):
+            BootLoaderInstall('foo', 'root_dir', Mock())
 
     @patch('kiwi.bootloader.install.BootLoaderInstallGrub2')
     def test_bootloader_install_grub2(self, mock_grub2):
-        device_provider = mock.Mock()
+        device_provider = Mock()
         BootLoaderInstall('grub2', 'root_dir', device_provider)
         mock_grub2.assert_called_once_with('root_dir', device_provider, None)
 
     @patch('kiwi.bootloader.install.BootLoaderInstallZipl')
     def test_bootloader_install_zipl(self, mock_zipl):
-        device_provider = mock.Mock()
+        device_provider = Mock()
         BootLoaderInstall('grub2_s390x_emu', 'root_dir', device_provider)
         mock_zipl.assert_called_once_with('root_dir', device_provider, None)

--- a/test/unit/bootloader_install_zipl_test.py
+++ b/test/unit/bootloader_install_zipl_test.py
@@ -1,12 +1,9 @@
-from mock import patch
-from mock import call
-
-import mock
-
-from .test_helper import raises
+from mock import (
+    patch, call, Mock
+)
+from pytest import raises
 
 from kiwi.exceptions import KiwiBootLoaderZiplInstallError
-
 from kiwi.bootloader.install.zipl import BootLoaderInstallZipl
 
 
@@ -16,23 +13,23 @@ class TestBootLoaderInstallZipl:
         custom_args = {
             'boot_device': '/dev/mapper/loop0p1'
         }
-        boot_mount = mock.Mock()
+        boot_mount = Mock()
         boot_mount.device = custom_args['boot_device']
         boot_mount.mountpoint = 'tmp_boot'
 
         mock_mount.return_value = boot_mount
 
-        device_provider = mock.Mock()
-        device_provider.get_device = mock.Mock(
+        device_provider = Mock()
+        device_provider.get_device = Mock(
             return_value='/dev/some-device'
         )
         self.bootloader = BootLoaderInstallZipl(
             'root_dir', device_provider, custom_args
         )
 
-    @raises(KiwiBootLoaderZiplInstallError)
     def test_post_init_missing_boot_mount_path(self):
-        self.bootloader.post_init(None)
+        with raises(KiwiBootLoaderZiplInstallError):
+            self.bootloader.post_init(None)
 
     def test_install_required(self):
         assert self.bootloader.install_required() is True

--- a/test/unit/builder_archive_test.py
+++ b/test/unit/builder_archive_test.py
@@ -1,9 +1,10 @@
 from mock import patch
-
+from pytest import raises
+import sys
 import mock
 import kiwi
 
-from .test_helper import raises
+from .test_helper import argv_kiwi_tests
 
 from kiwi.exceptions import KiwiArchiveSetupError
 from kiwi.builder.archive import ArchiveBuilder
@@ -31,7 +32,6 @@ class TestArchiveBuilder:
             self.xml_state, 'target_dir', 'root_dir'
         )
 
-    @raises(KiwiArchiveSetupError)
     def test_create_unknown_archive_type(self):
         xml_state = mock.Mock()
         xml_state.get_build_type_name = mock.Mock(
@@ -46,7 +46,8 @@ class TestArchiveBuilder:
         archive = ArchiveBuilder(
             xml_state, 'target_dir', 'root_dir'
         )
-        archive.create()
+        with raises(KiwiArchiveSetupError):
+            archive.create()
 
     @patch('kiwi.builder.archive.ArchiveTar')
     @patch('kiwi.builder.archive.Checksum')
@@ -78,3 +79,6 @@ class TestArchiveBuilder:
         self.setup.export_package_list.assert_called_once_with(
             'target_dir'
         )
+
+    def teardown(self):
+        sys.argv = argv_kiwi_tests

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -1,26 +1,26 @@
 import mock
-from mock import call
-from mock import patch
-
+from mock import (
+    call, patch
+)
+from pytest import raises
 import kiwi
 
-from .test_helper import raises, patch_open
+from .test_helper import patch_open
 
 from collections import OrderedDict
 from collections import namedtuple
-
-from kiwi.exceptions import (
-    KiwiDiskBootImageError,
-    KiwiInstallMediaError,
-    KiwiVolumeManagerSetupError
-)
+from builtins import bytes
 
 from kiwi.xml_description import XMLDescription
 from kiwi.xml_state import XMLState
 from kiwi.builder.disk import DiskBuilder
 from kiwi.storage.mapped_device import MappedDevice
 
-from builtins import bytes
+from kiwi.exceptions import (
+    KiwiDiskBootImageError,
+    KiwiInstallMediaError,
+    KiwiVolumeManagerSetupError
+)
 
 
 class TestDiskBuilder:
@@ -212,7 +212,6 @@ class TestDiskBuilder:
         )
         assert disk_builder.arch == 'ix86'
 
-    @raises(KiwiInstallMediaError)
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
@@ -220,13 +219,14 @@ class TestDiskBuilder:
         self, mock_cmd, mock_open, mock_fs
     ):
         self.disk_builder.build_type_name = 'vmx'
-        self.disk_builder.create_disk()
+        with raises(KiwiInstallMediaError):
+            self.disk_builder.create_disk()
 
-    @raises(KiwiVolumeManagerSetupError)
     def test_create_disk_overlay_with_volume_setup_not_supported(self):
         self.disk_builder.root_filesystem_is_overlay = True
         self.disk_builder.volume_manager_name = 'lvm'
-        self.disk_builder.create_disk()
+        with raises(KiwiVolumeManagerSetupError):
+            self.disk_builder.create_disk()
 
     @patch_open
     @patch('os.path.exists')
@@ -245,22 +245,22 @@ class TestDiskBuilder:
         mock_wipe.assert_called_once_with('target_dir/boot_image.pickledump')
 
     @patch('os.path.exists')
-    @raises(KiwiInstallMediaError)
     def test_create_install_media_no_boot_instance_found(self, mock_path):
         result_instance = mock.Mock()
         mock_path.return_value = False
         self.disk_builder.install_iso = True
-        self.disk_builder.create_install_media(result_instance)
+        with raises(KiwiInstallMediaError):
+            self.disk_builder.create_install_media(result_instance)
 
     @patch('os.path.exists')
     @patch('pickle.load')
-    @raises(KiwiInstallMediaError)
     def test_create_install_media_pickle_load_error(self, mock_load, mock_path):
         result_instance = mock.Mock()
         mock_load.side_effect = Exception
         mock_path.return_value = True
         self.disk_builder.install_iso = True
-        self.disk_builder.create_install_media(result_instance)
+        with raises(KiwiInstallMediaError):
+            self.disk_builder.create_install_media(result_instance)
 
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open
@@ -574,14 +574,14 @@ class TestDiskBuilder:
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
-    @raises(KiwiDiskBootImageError)
     def test_create_disk_standard_root_no_hypervisor_found(
         self, mock_command, mock_open, mock_fs
     ):
         self.kernel.get_xen_hypervisor.return_value = False
         self.disk_builder.volume_manager_name = None
         self.disk_builder.xen_server = True
-        self.disk_builder.create_disk()
+        with raises(KiwiDiskBootImageError):
+            self.disk_builder.create_disk()
 
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open

--- a/test/unit/builder_install_test.py
+++ b/test/unit/builder_install_test.py
@@ -1,16 +1,16 @@
-from mock import patch
-from mock import call
-
+from mock import (
+    patch, call
+)
+from pytest import raises
 import mock
 import kiwi
 
 from collections import namedtuple
 
-from .test_helper import raises, patch_open
-
-from kiwi.exceptions import KiwiInstallBootImageError
+from .test_helper import patch_open
 
 from kiwi.builder.install import InstallImageBuilder
+from kiwi.exceptions import KiwiInstallBootImageError
 
 
 class TestInstallImageBuilder:
@@ -243,38 +243,38 @@ class TestInstallImageBuilder:
     @patch('kiwi.builder.install.mkdtemp')
     @patch_open
     @patch('kiwi.builder.install.Command.run')
-    @raises(KiwiInstallBootImageError)
     def test_create_install_iso_no_kernel_found(
         self, mock_command, mock_open, mock_dtemp,
         mock_setup_media_loader_directory
     ):
         self.kernel.get_kernel.return_value = False
-        self.install_image.create_install_iso()
+        with raises(KiwiInstallBootImageError):
+            self.install_image.create_install_iso()
 
     @patch('kiwi.builder.install.IsoToolsBase.setup_media_loader_directory')
     @patch('kiwi.builder.install.mkdtemp')
     @patch_open
     @patch('kiwi.builder.install.Command.run')
-    @raises(KiwiInstallBootImageError)
     def test_create_install_iso_no_hypervisor_found(
         self, mock_command, mock_open, mock_dtemp,
         mock_setup_media_loader_directory
     ):
         self.kernel.get_xen_hypervisor.return_value = False
-        self.install_image.create_install_iso()
+        with raises(KiwiInstallBootImageError):
+            self.install_image.create_install_iso()
 
     @patch('kiwi.builder.install.mkdtemp')
     @patch_open
     @patch('kiwi.builder.install.Command.run')
     @patch('kiwi.builder.install.Checksum')
     @patch('kiwi.builder.install.Compress')
-    @raises(KiwiInstallBootImageError)
     def test_create_install_pxe_no_kernel_found(
         self, mock_compress, mock_md5, mock_command, mock_open, mock_dtemp
     ):
         mock_dtemp.return_value = 'tmpdir'
         self.kernel.get_kernel.return_value = False
-        self.install_image.create_install_pxe_archive()
+        with raises(KiwiInstallBootImageError):
+            self.install_image.create_install_pxe_archive()
 
     @patch('kiwi.builder.install.mkdtemp')
     @patch_open
@@ -282,14 +282,14 @@ class TestInstallImageBuilder:
     @patch('kiwi.builder.install.Checksum')
     @patch('kiwi.builder.install.Compress')
     @patch('kiwi.builder.install.os.symlink')
-    @raises(KiwiInstallBootImageError)
     def test_create_install_pxe_no_hypervisor_found(
         self, mock_symlink, mock_compress, mock_md5, mock_command,
         mock_open, mock_dtemp
     ):
         mock_dtemp.return_value = 'tmpdir'
         self.kernel.get_xen_hypervisor.return_value = False
-        self.install_image.create_install_pxe_archive()
+        with raises(KiwiInstallBootImageError):
+            self.install_image.create_install_pxe_archive()
 
     @patch('kiwi.builder.install.mkdtemp')
     @patch_open

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -1,13 +1,14 @@
-from mock import patch
-from mock import call
+from mock import (
+    patch, call
+)
+from pytest import raises
 import mock
 import kiwi
 
-from .test_helper import raises, patch_open
-
-from kiwi.exceptions import KiwiLiveBootImageError
+from .test_helper import patch_open
 
 from kiwi.builder.live import LiveImageBuilder
+from kiwi.exceptions import KiwiLiveBootImageError
 
 
 class TestLiveImageBuilder:
@@ -318,41 +319,41 @@ class TestLiveImageBuilder:
     @patch('kiwi.builder.live.mkdtemp')
     @patch('kiwi.builder.live.shutil')
     @patch_open
-    @raises(KiwiLiveBootImageError)
     def test_create_no_kernel_found(
         self, mock_open, mock_shutil, mock_dtemp,
         mock_setup_media_loader_directory
     ):
         mock_dtemp.return_value = 'tmpdir'
         self.kernel.get_kernel.return_value = False
-        self.live_image.create()
+        with raises(KiwiLiveBootImageError):
+            self.live_image.create()
 
     @patch('kiwi.builder.live.IsoToolsBase.setup_media_loader_directory')
     @patch('kiwi.builder.live.mkdtemp')
     @patch('kiwi.builder.live.shutil')
     @patch_open
-    @raises(KiwiLiveBootImageError)
     def test_create_no_hypervisor_found(
         self, mock_open, mock_shutil, mock_dtemp,
         mock_setup_media_loader_directory
     ):
         mock_dtemp.return_value = 'tmpdir'
         self.kernel.get_xen_hypervisor.return_value = False
-        self.live_image.create()
+        with raises(KiwiLiveBootImageError):
+            self.live_image.create()
 
     @patch('kiwi.builder.live.IsoToolsBase.setup_media_loader_directory')
     @patch('kiwi.builder.live.mkdtemp')
     @patch('kiwi.builder.live.shutil')
     @patch('os.path.exists')
     @patch_open
-    @raises(KiwiLiveBootImageError)
     def test_create_no_initrd_found(
         self, mock_open, mock_exists, mock_shutil, mock_dtemp,
         mock_setup_media_loader_directory
     ):
         mock_dtemp.return_value = 'tmpdir'
         mock_exists.return_value = False
-        self.live_image.create()
+        with raises(KiwiLiveBootImageError):
+            self.live_image.create()
 
     @patch('kiwi.builder.live.Path.wipe')
     def test_destructor(self, mock_wipe):

--- a/test/unit/builder_test.py
+++ b/test/unit/builder_test.py
@@ -1,19 +1,17 @@
-from mock import patch
-
-import mock
-
-from .test_helper import raises
-
-from kiwi.exceptions import KiwiRequestedTypeError
+from mock import (
+    patch, Mock
+)
+from pytest import raises
 
 from kiwi.builder import ImageBuilder
+from kiwi.exceptions import KiwiRequestedTypeError
 
 
 class TestImageBuilder:
     @patch('kiwi.builder.FileSystemBuilder')
     def test_filesystem_builder(self, mock_builder):
-        xml_state = mock.Mock()
-        xml_state.get_build_type_name = mock.Mock(
+        xml_state = Mock()
+        xml_state.get_build_type_name = Mock(
             return_value='ext4'
         )
         ImageBuilder(xml_state, 'target_dir', 'root_dir')
@@ -23,8 +21,8 @@ class TestImageBuilder:
 
     @patch('kiwi.builder.DiskBuilder')
     def test_disk_builder(self, mock_builder):
-        xml_state = mock.Mock()
-        xml_state.get_build_type_name = mock.Mock(
+        xml_state = Mock()
+        xml_state.get_build_type_name = Mock(
             return_value='vmx'
         )
         ImageBuilder(xml_state, 'target_dir', 'root_dir')
@@ -34,8 +32,8 @@ class TestImageBuilder:
 
     @patch('kiwi.builder.LiveImageBuilder')
     def test_live_builder(self, mock_builder):
-        xml_state = mock.Mock()
-        xml_state.get_build_type_name = mock.Mock(
+        xml_state = Mock()
+        xml_state.get_build_type_name = Mock(
             return_value='iso'
         )
         ImageBuilder(xml_state, 'target_dir', 'root_dir')
@@ -45,8 +43,8 @@ class TestImageBuilder:
 
     @patch('kiwi.builder.PxeBuilder')
     def test_pxe_builder(self, mock_builder):
-        xml_state = mock.Mock()
-        xml_state.get_build_type_name = mock.Mock(
+        xml_state = Mock()
+        xml_state.get_build_type_name = Mock(
             return_value='pxe'
         )
         ImageBuilder(xml_state, 'target_dir', 'root_dir')
@@ -56,8 +54,8 @@ class TestImageBuilder:
 
     @patch('kiwi.builder.ArchiveBuilder')
     def test_archive_builder(self, mock_builder):
-        xml_state = mock.Mock()
-        xml_state.get_build_type_name = mock.Mock(
+        xml_state = Mock()
+        xml_state.get_build_type_name = Mock(
             return_value='tbz'
         )
         ImageBuilder(xml_state, 'target_dir', 'root_dir')
@@ -67,8 +65,8 @@ class TestImageBuilder:
 
     @patch('kiwi.builder.ContainerBuilder')
     def test_container_builder(self, mock_builder):
-        xml_state = mock.Mock()
-        xml_state.get_build_type_name = mock.Mock(
+        xml_state = Mock()
+        xml_state.get_build_type_name = Mock(
             return_value='docker'
         )
         ImageBuilder(xml_state, 'target_dir', 'root_dir')
@@ -76,10 +74,10 @@ class TestImageBuilder:
             xml_state, 'target_dir', 'root_dir', None
         )
 
-    @raises(KiwiRequestedTypeError)
     def test_unsupported_build_type(self):
-        xml_state = mock.Mock()
-        xml_state.get_build_type_name = mock.Mock(
+        xml_state = Mock()
+        xml_state.get_build_type_name = Mock(
             return_value='bogus'
         )
-        ImageBuilder(xml_state, 'target_dir', 'root_dir')
+        with raises(KiwiRequestedTypeError):
+            ImageBuilder(xml_state, 'target_dir', 'root_dir')

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -1,8 +1,9 @@
 import sys
 
 from mock import patch
+from pytest import raises
 
-from .test_helper import argv_kiwi_tests, raises
+from .test_helper import argv_kiwi_tests
 
 from kiwi.cli import Cli
 from kiwi.exceptions import (
@@ -62,11 +63,11 @@ class TestCli:
     def teardown(self):
         sys.argv = argv_kiwi_tests
 
-    @raises(SystemExit)
     @patch('kiwi.cli.Help.show')
     def test_show_and_exit_on_help_request(self, help_show):
         self.cli.all_args['help'] = True
-        self.cli.show_and_exit_on_help_request()
+        with raises(SystemExit):
+            self.cli.show_and_exit_on_help_request()
         help_show.assert_called_once_with('kiwi')
 
     def test_get_servicename_system(self):
@@ -118,7 +119,6 @@ class TestCli:
         assert self.cli.get_command() == 'prepare'
 
     def test_get_command_args(self):
-        print(self.cli.get_command_args())
         assert self.cli.get_command_args() == self.command_args
 
     def test_get_global_args(self):
@@ -142,42 +142,42 @@ class TestCli:
             ['--build', 'description', '--type', 'vmx', '-d', 'destination']
         )
 
-    @raises(KiwiCompatError)
     @patch('kiwi.cli.Path.which')
     @patch('os.execvp')
     def test_invoke_kiwicompat_exec_failed(self, mock_exec, mock_which):
         mock_which.return_value = 'kiwicompat'
         mock_exec.side_effect = Exception
-        self.cli.invoke_kiwicompat([])
+        with raises(KiwiCompatError):
+            self.cli.invoke_kiwicompat([])
 
-    @raises(KiwiCommandNotFound)
     @patch('kiwi.cli.Path.which')
     def test_invoke_kiwicompat_not_found(self, mock_which):
         mock_which.return_value = None
-        self.cli.invoke_kiwicompat([])
+        with raises(KiwiCommandNotFound):
+            self.cli.invoke_kiwicompat([])
 
-    @raises(SystemExit)
     def test_load_command_unknown(self):
         self.cli.loaded = False
         self.cli.all_args['<command>'] = 'foo'
-        self.cli.load_command()
+        with raises(SystemExit):
+            self.cli.load_command()
 
-    @raises(KiwiLoadCommandUndefined)
     def test_load_command_undefined(self):
         self.cli.loaded = False
         self.cli.all_args['<command>'] = None
-        self.cli.load_command()
+        with raises(KiwiLoadCommandUndefined):
+            self.cli.load_command()
 
-    @raises(KiwiCommandNotLoaded)
     def test_get_command_args_not_loaded(self):
         sys.argv = [
             sys.argv[0], 'system', 'command-not-implemented'
         ]
         cli = Cli()
-        cli.get_command_args()
+        with raises(KiwiCommandNotLoaded):
+            cli.get_command_args()
 
-    @raises(KiwiUnknownServiceName)
     def test_get_servicename_unknown(self):
         self.cli.all_args['system'] = False
         self.cli.all_args['foo'] = False
-        self.cli.get_servicename()
+        with raises(KiwiUnknownServiceName):
+            self.cli.get_servicename()

--- a/test/unit/command_process_test.py
+++ b/test/unit/command_process_test.py
@@ -1,14 +1,14 @@
-from mock import call
-from mock import patch
 import mock
+from mock import (
+    call, patch
+)
+from pytest import raises
+from builtins import bytes
 
-from .test_helper import raises
-
-from kiwi.exceptions import KiwiCommandError
 from kiwi.command_process import CommandProcess
 from kiwi.command_process import CommandIterator
 
-from builtins import bytes
+from kiwi.exceptions import KiwiCommandError
 
 
 class TestCommandProcess:
@@ -76,7 +76,6 @@ class TestCommandProcess:
             call('%s: %s', 'system', 'data')
         ]
 
-    @raises(KiwiCommandError)
     @patch('kiwi.command.Command')
     def test_poll_show_progress_raises(self, mock_command):
         match_method = CommandProcess(mock_command).create_match_method(
@@ -89,7 +88,8 @@ class TestCommandProcess:
         process.command.command.output.read = self.flow_out
         process.command.command.error.read = self.flow_err
         process.command.command.process.returncode = 1
-        process.poll_show_progress(['a', 'b'], match_method)
+        with raises(KiwiCommandError):
+            process.poll_show_progress(['a', 'b'], match_method)
 
     @patch('kiwi.command.Command')
     @patch('kiwi.logger.log.debug')
@@ -106,7 +106,6 @@ class TestCommandProcess:
             call('%s: %s', 'system', 'data')
         ]
 
-    @raises(KiwiCommandError)
     @patch('kiwi.command.Command')
     def test_poll_raises(self, mock_command):
         process = CommandProcess(mock_command)
@@ -117,7 +116,8 @@ class TestCommandProcess:
         process.command.command.error.read = self.flow_err
         process.command.command.output.read.return_value = 'data'
         process.command.command.process.returncode = 1
-        process.poll()
+        with raises(KiwiCommandError):
+            process.poll()
 
     @patch('kiwi.command.Command')
     @patch('kiwi.logger.log.debug')

--- a/test/unit/command_test.py
+++ b/test/unit/command_test.py
@@ -1,21 +1,18 @@
 from mock import patch
 from collections import namedtuple
-
+from pytest import raises
 import mock
-
 import os
 
-from .test_helper import raises
+from kiwi.command import Command
 
 from kiwi.exceptions import (
     KiwiCommandError,
     KiwiCommandNotFound
 )
-from kiwi.command import Command
 
 
 class TestCommand:
-    @raises(KiwiCommandError)
     @patch('kiwi.path.Path.which')
     @patch('subprocess.Popen')
     def test_run_raises_error(self, mock_popen, mock_which):
@@ -26,19 +23,20 @@ class TestCommand:
         )
         mock_process.returncode = 1
         mock_popen.return_value = mock_process
-        Command.run(['command', 'args'])
+        with raises(KiwiCommandError):
+            Command.run(['command', 'args'])
 
-    @raises(KiwiCommandError)
     @patch('kiwi.path.Path.which')
     @patch('subprocess.Popen')
     def test_run_failure(self, mock_popen, mock_which):
         mock_which.return_value = 'command'
         mock_popen.side_effect = KiwiCommandError('Run failure')
-        Command.run(['command', 'args'])
+        with raises(KiwiCommandError):
+            Command.run(['command', 'args'])
 
-    @raises(KiwiCommandError)
     def test_run_invalid_environment(self):
-        Command.run(['command', 'args'], {'HOME': '/root'})
+        with raises(KiwiCommandError):
+            Command.run(['command', 'args'], {'HOME': '/root'})
 
     @patch('kiwi.path.Path.which')
     @patch('subprocess.Popen')
@@ -84,13 +82,13 @@ class TestCommand:
         mock_access.return_value = True
         assert Command.run(['command', 'args']) == run_result
 
-    @raises(KiwiCommandNotFound)
     def test_run_command_does_not_exist(self):
-        Command.run(['does-not-exist'])
+        with raises(KiwiCommandNotFound):
+            Command.run(['does-not-exist'])
 
-    @raises(KiwiCommandNotFound)
     def test_call_command_does_not_exist(self):
-        Command.call(['does-not-exist'], os.environ)
+        with raises(KiwiCommandNotFound):
+            Command.call(['does-not-exist'], os.environ)
 
     @patch('kiwi.path.Path.which')
     @patch('subprocess.Popen')
@@ -107,10 +105,10 @@ class TestCommand:
         assert call.error == mock_process.stderr
         assert call.process == mock_process
 
-    @raises(KiwiCommandError)
     @patch('kiwi.path.Path.which')
     @patch('subprocess.Popen')
     def test_call_failure(self, mock_popen, mock_which):
         mock_which.return_value = 'command'
         mock_popen.side_effect = KiwiCommandError('Call failure')
-        Command.call(['command', 'args'])
+        with raises(KiwiCommandError):
+            Command.call(['command', 'args'])

--- a/test/unit/container_image_test.py
+++ b/test/unit/container_image_test.py
@@ -1,16 +1,15 @@
 from mock import patch
-
-from .test_helper import raises
-
-from kiwi.exceptions import KiwiContainerImageSetupError
+from pytest import raises
 
 from kiwi.container import ContainerImage
 
+from kiwi.exceptions import KiwiContainerImageSetupError
+
 
 class TestContainerImage:
-    @raises(KiwiContainerImageSetupError)
     def test_container_image_not_implemented(self):
-        ContainerImage('foo', 'root_dir')
+        with raises(KiwiContainerImageSetupError):
+            ContainerImage('foo', 'root_dir')
 
     @patch('kiwi.container.ContainerImageOCI')
     def test_container_image_docker(self, mock_docker):

--- a/test/unit/container_setup_base_test.py
+++ b/test/unit/container_setup_base_test.py
@@ -1,11 +1,14 @@
-from mock import patch
-from mock import call
+from mock import (
+    patch, call
+)
+from pytest import raises
 import mock
 
-from .test_helper import raises, patch_open
+from .test_helper import patch_open
+
+from kiwi.container.setup.base import ContainerSetupBase
 
 from kiwi.exceptions import KiwiContainerSetupError
-from kiwi.container.setup.base import ContainerSetupBase
 
 
 class TestContainerSetupBase:
@@ -23,14 +26,14 @@ class TestContainerSetupBase:
         self.container = ContainerSetupBase('root_dir')
 
     @patch('os.path.exists')
-    @raises(KiwiContainerSetupError)
     def test_container_root_dir_does_not_exist(self, mock_exists):
         mock_exists.return_value = False
-        ContainerSetupBase('root_dir')
+        with raises(KiwiContainerSetupError):
+            ContainerSetupBase('root_dir')
 
-    @raises(NotImplementedError)
     def test_setup(self):
-        self.container.setup()
+        with raises(NotImplementedError):
+            self.container.setup()
 
     def test_post_init(self):
         self.container.custom_args == {}
@@ -89,11 +92,11 @@ class TestContainerSetupBase:
 
     @patch('os.path.exists')
     @patch('kiwi.container.setup.base.Command.run')
-    @raises(KiwiContainerSetupError)
     def test_deactivate_systemd_service_failed(self, mock_command, mock_exists):
         mock_exists.return_value = True
         mock_command.side_effect = Exception
-        self.container.deactivate_systemd_service('my.service')
+        with raises(KiwiContainerSetupError):
+            self.container.deactivate_systemd_service('my.service')
 
     @patch_open
     @patch('os.path.exists')
@@ -125,7 +128,7 @@ class TestContainerSetupBase:
         )
 
     @patch('kiwi.container.setup.base.Command.run')
-    @raises(KiwiContainerSetupError)
     def test_setup_static_device_nodes_failed(self, mock_command):
         mock_command.side_effect = Exception
-        self.container.setup_static_device_nodes()
+        with raises(KiwiContainerSetupError):
+            self.container.setup_static_device_nodes()

--- a/test/unit/container_setup_test.py
+++ b/test/unit/container_setup_test.py
@@ -1,16 +1,15 @@
 from mock import patch
-
-from .test_helper import raises
-
-from kiwi.exceptions import KiwiContainerSetupError
+from pytest import raises
 
 from kiwi.container.setup import ContainerSetup
 
+from kiwi.exceptions import KiwiContainerSetupError
+
 
 class TestContainerSetup:
-    @raises(KiwiContainerSetupError)
     def test_container_not_implemented(self):
-        ContainerSetup('foo', 'root_dir')
+        with raises(KiwiContainerSetupError):
+            ContainerSetup('foo', 'root_dir')
 
     @patch('kiwi.container.setup.ContainerSetupDocker')
     def test_container_docker(self, mock_docker):

--- a/test/unit/filesystem_base_test.py
+++ b/test/unit/filesystem_base_test.py
@@ -1,12 +1,10 @@
-
 from mock import patch
-
+from pytest import raises
 import mock
 
-from .test_helper import raises
+from kiwi.filesystem.base import FileSystemBase
 
 from kiwi.exceptions import KiwiFileSystemSyncError
-from kiwi.filesystem.base import FileSystemBase
 
 
 class TestFileSystemBase:
@@ -17,23 +15,23 @@ class TestFileSystemBase:
         )
         self.fsbase = FileSystemBase(provider, 'root_dir')
 
-    @raises(KiwiFileSystemSyncError)
     def test_root_dir_does_not_exist(self):
         fsbase = FileSystemBase(mock.Mock(), 'root_dir_not_existing')
-        fsbase.sync_data()
+        with raises(KiwiFileSystemSyncError):
+            fsbase.sync_data()
 
-    @raises(KiwiFileSystemSyncError)
     def test_root_dir_not_defined(self):
         fsbase = FileSystemBase(mock.Mock())
-        fsbase.sync_data()
+        with raises(KiwiFileSystemSyncError):
+            fsbase.sync_data()
 
-    @raises(NotImplementedError)
     def test_create_on_device(self):
-        self.fsbase.create_on_device('/dev/foo')
+        with raises(NotImplementedError):
+            self.fsbase.create_on_device('/dev/foo')
 
-    @raises(NotImplementedError)
     def test_create_on_file(self):
-        self.fsbase.create_on_file('myimage')
+        with raises(NotImplementedError):
+            self.fsbase.create_on_file('myimage')
 
     @patch('kiwi.filesystem.base.MountManager')
     @patch('kiwi.filesystem.base.DataSync')

--- a/test/unit/filesystem_test.py
+++ b/test/unit/filesystem_test.py
@@ -1,17 +1,16 @@
 from mock import patch
-
+from pytest import raises
 import mock
 
-from .test_helper import raises
+from kiwi.filesystem import FileSystem
 
 from kiwi.exceptions import KiwiFileSystemSetupError
-from kiwi.filesystem import FileSystem
 
 
 class TestFileSystem:
-    @raises(KiwiFileSystemSetupError)
     def test_filesystem_not_implemented(self):
-        FileSystem('foo', mock.Mock(), 'root_dir')
+        with raises(KiwiFileSystemSetupError):
+            FileSystem('foo', mock.Mock(), 'root_dir')
 
     @patch('kiwi.filesystem.FileSystemExt2')
     def test_filesystem_ext2(self, mock_ext2):

--- a/test/unit/firmware_test.py
+++ b/test/unit/firmware_test.py
@@ -1,11 +1,10 @@
 from mock import patch
-
+from pytest import raises
 import mock
 
-from .test_helper import raises
+from kiwi.firmware import FirmWare
 
 from kiwi.exceptions import KiwiNotImplementedError
-from kiwi.firmware import FirmWare
 
 
 class TestFirmWare:
@@ -54,13 +53,13 @@ class TestFirmWare:
 
         mock_platform.return_value = 'arm64'
 
-    @raises(KiwiNotImplementedError)
     def test_firmware_unsupported(self):
         xml_state = mock.Mock()
         xml_state.build_type.get_firmware = mock.Mock(
             return_value='bogus'
         )
-        FirmWare(xml_state)
+        with raises(KiwiNotImplementedError):
+            FirmWare(xml_state)
 
     def test_get_partition_table_type(self):
         assert self.firmware_bios.get_partition_table_type() == 'msdos'

--- a/test/unit/help_test.py
+++ b/test/unit/help_test.py
@@ -1,6 +1,5 @@
 from mock import patch
-
-from .test_helper import raises
+from pytest import raises
 
 from kiwi.help import Help
 
@@ -11,9 +10,9 @@ class TestHelp:
     def setup(self):
         self.help = Help()
 
-    @raises(KiwiHelpNoCommandGiven)
     def test_show(self):
-        self.help.show(None)
+        with raises(KiwiHelpNoCommandGiven):
+            self.help.show(None)
 
     @patch('subprocess.call')
     def test_show_command(self, mock_process):

--- a/test/unit/iso_tools_base_test.py
+++ b/test/unit/iso_tools_base_test.py
@@ -1,7 +1,7 @@
 from mock import (
     patch, Mock, call
 )
-from .test_helper import raises
+from pytest import raises
 
 from kiwi.iso_tools.base import IsoToolsBase
 
@@ -12,29 +12,29 @@ class TestIsoToolsBase:
         mock_machine.return_value = 'x86_64'
         self.iso_tool = IsoToolsBase('source-dir')
 
-    @raises(NotImplementedError)
     def test_create_iso(self):
-        self.iso_tool.create_iso('filename')
+        with raises(NotImplementedError):
+            self.iso_tool.create_iso('filename')
 
-    @raises(NotImplementedError)
     def test_list_iso(self):
-        self.iso_tool.list_iso('isofile')
+        with raises(NotImplementedError):
+            self.iso_tool.list_iso('isofile')
 
-    @raises(NotImplementedError)
     def test_get_tool_name(self):
-        self.iso_tool.get_tool_name()
+        with raises(NotImplementedError):
+            self.iso_tool.get_tool_name()
 
-    @raises(NotImplementedError)
     def test_init_iso_creation_parameters(self):
-        self.iso_tool.init_iso_creation_parameters()
+        with raises(NotImplementedError):
+            self.iso_tool.init_iso_creation_parameters()
 
-    @raises(NotImplementedError)
     def test_add_efi_loader_parameters(self):
-        self.iso_tool.add_efi_loader_parameters()
+        with raises(NotImplementedError):
+            self.iso_tool.add_efi_loader_parameters()
 
-    @raises(NotImplementedError)
     def test_has_iso_hybrid_capability(self):
-        self.iso_tool.has_iso_hybrid_capability()
+        with raises(NotImplementedError):
+            self.iso_tool.has_iso_hybrid_capability()
 
     @patch('kiwi.iso_tools.base.DataSync')
     @patch('kiwi.iso_tools.base.shutil')

--- a/test/unit/iso_tools_cdrtools_test.py
+++ b/test/unit/iso_tools_cdrtools_test.py
@@ -1,9 +1,14 @@
-from mock import patch, call
+from mock import (
+    patch, call
+)
+from pytest import raises
 import mock
 from collections import namedtuple
-from .test_helper import raises, patch_open
+
+from .test_helper import patch_open
 
 from kiwi.iso_tools.cdrtools import IsoToolsCdrTools
+
 from kiwi.exceptions import KiwiIsoToolError
 
 
@@ -34,11 +39,11 @@ class TestIsoToolsCdrTools:
             call('mkisofs'), call('genisoimage')
         ]
 
-    @raises(KiwiIsoToolError)
     @patch('os.path.exists')
     def test_get_tool_name_raises(self, mock_exists):
         mock_exists.return_value = False
-        self.iso_tool.get_tool_name()
+        with raises(KiwiIsoToolError):
+            self.iso_tool.get_tool_name()
 
     @patch_open
     @patch('os.walk')
@@ -168,11 +173,11 @@ class TestIsoToolsCdrTools:
         result = self.iso_tool.list_iso('some-iso')
         assert result[2158].name == 'header_end'
 
-    @raises(KiwiIsoToolError)
     @patch('os.path.exists')
     def test_list_iso_no_tool_found(self, mock_exists):
         mock_exists.return_value = False
-        self.iso_tool.list_iso('some-iso')
+        with raises(KiwiIsoToolError):
+            self.iso_tool.list_iso('some-iso')
 
     def test_has_iso_hybrid_capability(self):
         assert self.iso_tool.has_iso_hybrid_capability() is False

--- a/test/unit/iso_tools_xorriso_test.py
+++ b/test/unit/iso_tools_xorriso_test.py
@@ -1,7 +1,8 @@
 from mock import patch
-from .test_helper import raises
+from pytest import raises
 
 from kiwi.iso_tools.xorriso import IsoToolsXorrIso
+
 from kiwi.exceptions import KiwiIsoToolError
 
 
@@ -16,11 +17,11 @@ class TestIsoToolsXorrIso:
         mock_which.return_value = 'tool_found'
         assert self.iso_tool.get_tool_name() == 'tool_found'
 
-    @raises(KiwiIsoToolError)
     @patch('os.path.exists')
     def test_get_tool_name_raises(self, mock_exists):
         mock_exists.return_value = False
-        self.iso_tool.get_tool_name()
+        with raises(KiwiIsoToolError):
+            self.iso_tool.get_tool_name()
 
     @patch('kiwi.iso_tools.xorriso.Path.which')
     def test_init_iso_creation_parameters_isolinux(self, mock_which):

--- a/test/unit/logger_test.py
+++ b/test/unit/logger_test.py
@@ -1,8 +1,9 @@
-from mock import patch
-from mock import call
+from mock import (
+    patch, call
+)
+from pytest import raises
 from collections import namedtuple
 
-from .test_helper import raises
 import logging
 
 from kiwi.logger import (
@@ -142,11 +143,11 @@ class TestLogger:
             )
         ]
 
-    @raises(KiwiLogFileSetupFailed)
     @patch('logging.FileHandler')
     def test_set_logfile_raise(self, mock_file_handler):
         mock_file_handler.side_effect = KiwiLogFileSetupFailed
-        log.set_logfile('logfile')
+        with raises(KiwiLogFileSetupFailed):
+            log.set_logfile('logfile')
 
     def test_getLogLevel(self):
         log.setLogLevel(42)

--- a/test/unit/package_manager_apt_test.py
+++ b/test/unit/package_manager_apt_test.py
@@ -1,10 +1,11 @@
-from mock import patch
-from mock import call
+from mock import (
+    patch, call
+)
+from pytest import raises
 import mock
 
-from .test_helper import raises
-
 from kiwi.package_manager.apt import PackageManagerApt
+
 from kiwi.exceptions import (
     KiwiDebootstrapError,
     KiwiRequestError
@@ -57,30 +58,30 @@ class TestPackageManagerApt:
         assert self.manager.exclude_requests == []
         assert mock_log_warn.called
 
-    @raises(KiwiDebootstrapError)
     def test_process_install_requests_bootstrap_no_dist(self):
         self.manager.distribution = None
-        self.manager.process_install_requests_bootstrap()
+        with raises(KiwiDebootstrapError):
+            self.manager.process_install_requests_bootstrap()
 
     @patch('os.path.exists')
-    @raises(KiwiDebootstrapError)
     def test_process_install_requests_bootstrap_no_debootstrap_script(
         self, mock_exists
     ):
         mock_exists.return_value = False
-        self.manager.process_install_requests_bootstrap()
+        with raises(KiwiDebootstrapError):
+            self.manager.process_install_requests_bootstrap()
 
     @patch('kiwi.command.Command.run')
     @patch('os.path.exists')
     @patch('kiwi.package_manager.apt.Path.wipe')
-    @raises(KiwiDebootstrapError)
     def test_process_install_requests_bootstrap_failed_debootstrap(
         self, mock_wipe, mock_exists, mock_run
     ):
         self.manager.request_package('apt-get')
         mock_run.side_effect = Exception
         mock_exists.return_value = True
-        self.manager.process_install_requests_bootstrap()
+        with raises(KiwiDebootstrapError):
+            self.manager.process_install_requests_bootstrap()
 
     @patch('kiwi.logger.log.warning')
     @patch('kiwi.command.Command.call')
@@ -173,11 +174,11 @@ class TestPackageManagerApt:
         )
 
     @patch('kiwi.command.Command.run')
-    @raises(KiwiRequestError)
     def test_process_delete_requests_package_missing(self, mock_run):
         mock_run.side_effect = Exception
         self.manager.request_package('vim')
-        self.manager.process_delete_requests()
+        with raises(KiwiRequestError):
+            self.manager.process_delete_requests()
 
     @patch('kiwi.command.Command.call')
     def test_update(self, mock_call):

--- a/test/unit/package_manager_base_test.py
+++ b/test/unit/package_manager_base_test.py
@@ -1,7 +1,6 @@
 import mock
 from mock import patch
-
-from .test_helper import raises
+from pytest import raises
 
 from kiwi.package_manager.base import PackageManagerBase
 
@@ -12,61 +11,61 @@ class TestPackageManagerBase:
         repository.root_dir = 'root-dir'
         self.manager = PackageManagerBase(repository)
 
-    @raises(NotImplementedError)
     def test_request_package(self):
-        self.manager.request_package('name')
+        with raises(NotImplementedError):
+            self.manager.request_package('name')
 
-    @raises(NotImplementedError)
     def test_request_collection(self):
-        self.manager.request_collection('name')
+        with raises(NotImplementedError):
+            self.manager.request_collection('name')
 
-    @raises(NotImplementedError)
     def test_request_product(self):
-        self.manager.request_product('name')
+        with raises(NotImplementedError):
+            self.manager.request_product('name')
 
     @patch.object(PackageManagerBase, 'request_package_exclusion')
     def test_request_package_lock(self, mock_exclude):
         self.manager.request_package_lock('name')
         mock_exclude.assert_called_once_with('name')
 
-    @raises(NotImplementedError)
     def test_request_package_exclusion(self):
-        self.manager.request_package_exclusion('name')
+        with raises(NotImplementedError):
+            self.manager.request_package_exclusion('name')
 
-    @raises(NotImplementedError)
     def test_process_install_requests_bootstrap(self):
-        self.manager.process_install_requests_bootstrap()
+        with raises(NotImplementedError):
+            self.manager.process_install_requests_bootstrap()
 
     def test_post_process_install_requests_bootstrap(self):
         self.manager.post_process_install_requests_bootstrap()
 
-    @raises(NotImplementedError)
     def test_process_install_requests(self):
-        self.manager.process_install_requests()
+        with raises(NotImplementedError):
+            self.manager.process_install_requests()
 
-    @raises(NotImplementedError)
     def test_process_delete_requests(self):
-        self.manager.process_delete_requests()
+        with raises(NotImplementedError):
+            self.manager.process_delete_requests()
 
-    @raises(NotImplementedError)
     def test_update(self):
-        self.manager.update()
+        with raises(NotImplementedError):
+            self.manager.update()
 
-    @raises(NotImplementedError)
     def test_process_only_required(self):
-        self.manager.process_only_required()
+        with raises(NotImplementedError):
+            self.manager.process_only_required()
 
-    @raises(NotImplementedError)
     def test_process_plus_recommended(self):
-        self.manager.process_plus_recommended()
+        with raises(NotImplementedError):
+            self.manager.process_plus_recommended()
 
-    @raises(NotImplementedError)
     def test_match_package_installed(self):
-        self.manager.match_package_installed('package_name', 'log')
+        with raises(NotImplementedError):
+            self.manager.match_package_installed('package_name', 'log')
 
-    @raises(NotImplementedError)
     def test_match_package_deleted(self):
-        self.manager.match_package_deleted('package_name', 'log')
+        with raises(NotImplementedError):
+            self.manager.match_package_deleted('package_name', 'log')
 
     def test_database_consistent(self):
         self.manager.database_consistent()

--- a/test/unit/package_manager_dnf_test.py
+++ b/test/unit/package_manager_dnf_test.py
@@ -1,9 +1,9 @@
 from mock import patch
+from pytest import raises
 import mock
 
-from .test_helper import raises
-
 from kiwi.package_manager.dnf import PackageManagerDnf
+
 from kiwi.exceptions import KiwiRequestError
 
 
@@ -110,13 +110,13 @@ class TestPackageManagerDnf:
 
     @patch('kiwi.command.Command.run')
     @patch('kiwi.command.Command.call')
-    @raises(KiwiRequestError)
     def test_process_delete_requests_package_missing(
         self, mock_call, mock_run
     ):
         mock_run.side_effect = Exception
         self.manager.request_package('vim')
-        self.manager.process_delete_requests()
+        with raises(KiwiRequestError):
+            self.manager.process_delete_requests()
         mock_run.assert_called_once_with(
             ['chroot', 'root-dir', 'rpm', '-q', 'vim']
         )

--- a/test/unit/package_manager_test.py
+++ b/test/unit/package_manager_test.py
@@ -1,8 +1,7 @@
-from mock import patch
-
-import mock
-
-from .test_helper import raises
+from mock import (
+    patch, Mock
+)
+from pytest import raises
 
 from kiwi.package_manager import PackageManager
 
@@ -10,30 +9,30 @@ from kiwi.exceptions import KiwiPackageManagerSetupError
 
 
 class TestPackageManager:
-    @raises(KiwiPackageManagerSetupError)
     def test_package_manager_not_implemented(self):
-        PackageManager('repository', 'ms-manager')
+        with raises(KiwiPackageManagerSetupError):
+            PackageManager('repository', 'ms-manager')
 
     @patch('kiwi.package_manager.PackageManagerZypper')
     def test_manager_zypper(self, mock_manager):
-        repository = mock.Mock()
+        repository = Mock()
         PackageManager(repository, 'zypper')
         mock_manager.assert_called_once_with(repository, None)
 
     @patch('kiwi.package_manager.PackageManagerDnf')
     def test_manager_dnf(self, mock_manager):
-        repository = mock.Mock()
+        repository = Mock()
         PackageManager(repository, 'dnf')
         mock_manager.assert_called_once_with(repository, None)
 
     @patch('kiwi.package_manager.PackageManagerDnf')
     def test_manager_yum(self, mock_manager):
-        repository = mock.Mock()
+        repository = Mock()
         PackageManager(repository, 'yum')
         mock_manager.assert_called_once_with(repository, None)
 
     @patch('kiwi.package_manager.PackageManagerApt')
     def test_manager_apt(self, mock_manager):
-        repository = mock.Mock()
+        repository = Mock()
         PackageManager(repository, 'apt-get')
         mock_manager.assert_called_once_with(repository, None)

--- a/test/unit/package_manager_zypper_test.py
+++ b/test/unit/package_manager_zypper_test.py
@@ -1,9 +1,9 @@
 from mock import patch
+from pytest import raises
 import mock
 
-from .test_helper import raises
-
 from kiwi.package_manager.zypper import PackageManagerZypper
+
 from kiwi.exceptions import KiwiRequestError
 
 
@@ -113,11 +113,11 @@ class TestPackageManagerZypper:
 
     @patch('kiwi.command.Command.run')
     @patch('kiwi.command.Command.call')
-    @raises(KiwiRequestError)
     def test_process_delete_requests_package_missing(self, mock_call, mock_run):
         mock_run.side_effect = Exception
         self.manager.request_package('vim')
-        self.manager.process_delete_requests()
+        with raises(KiwiRequestError):
+            self.manager.process_delete_requests()
         mock_run.assert_called_once_with(
             ['chroot', 'root-dir', 'rpm', '-q', 'vim']
         )

--- a/test/unit/partitioner_base_test.py
+++ b/test/unit/partitioner_base_test.py
@@ -1,14 +1,13 @@
-import mock
-
-from .test_helper import raises
+from mock import Mock
+from pytest import raises
 
 from kiwi.partitioner.base import PartitionerBase
 
 
 class TestPartitionerBase:
     def setup(self):
-        disk_provider = mock.Mock()
-        disk_provider.get_device = mock.Mock(
+        disk_provider = Mock()
+        disk_provider.get_device = Mock(
             return_value='/dev/loop0'
         )
         self.partitioner = PartitionerBase(disk_provider)
@@ -16,22 +15,22 @@ class TestPartitionerBase:
     def test_get_id(self):
         assert self.partitioner.get_id() == 0
 
-    @raises(NotImplementedError)
     def test_create(self):
-        self.partitioner.create('name', 100, 'type', ['flag'])
+        with raises(NotImplementedError):
+            self.partitioner.create('name', 100, 'type', ['flag'])
 
-    @raises(NotImplementedError)
     def test_set_flag(self):
-        self.partitioner.set_flag(1, 'flag')
+        with raises(NotImplementedError):
+            self.partitioner.set_flag(1, 'flag')
 
-    @raises(NotImplementedError)
     def test_set_hybrid_mbr(self):
-        self.partitioner.set_hybrid_mbr()
+        with raises(NotImplementedError):
+            self.partitioner.set_hybrid_mbr()
 
-    @raises(NotImplementedError)
     def test_set_mbr(self):
-        self.partitioner.set_mbr()
+        with raises(NotImplementedError):
+            self.partitioner.set_mbr()
 
-    @raises(NotImplementedError)
     def test_resize_table(self):
-        self.partitioner.resize_table()
+        with raises(NotImplementedError):
+            self.partitioner.resize_table()

--- a/test/unit/partitioner_gpt_test.py
+++ b/test/unit/partitioner_gpt_test.py
@@ -1,17 +1,17 @@
-from mock import patch, call
-
-import mock
-
-from .test_helper import raises
+from mock import (
+    patch, call, Mock
+)
+from pytest import raises
 
 from kiwi.partitioner.gpt import PartitionerGpt
+
 from kiwi.exceptions import KiwiPartitionerGptFlagError
 
 
 class TestPartitionerGpt:
     def setup(self):
-        disk_provider = mock.Mock()
-        disk_provider.get_device = mock.Mock(
+        disk_provider = Mock()
+        disk_provider.get_device = Mock(
             return_value='/dev/loop0'
         )
         self.partitioner = PartitionerGpt(disk_provider)
@@ -33,8 +33,8 @@ class TestPartitionerGpt:
     @patch('kiwi.partitioner.gpt.Command.run')
     @patch('kiwi.partitioner.gpt.PartitionerGpt.set_flag')
     def test_create_custom_start_sector(self, mock_flag, mock_command):
-        disk_provider = mock.Mock()
-        disk_provider.get_device = mock.Mock(
+        disk_provider = Mock()
+        disk_provider.get_device = Mock(
             return_value='/dev/loop0'
         )
         partitioner = PartitionerGpt(disk_provider, 4096)
@@ -61,9 +61,9 @@ class TestPartitionerGpt:
             ['sgdisk', '-n', '1:0:0', '-c', '1:name', '/dev/loop0']
         )
 
-    @raises(KiwiPartitionerGptFlagError)
     def test_set_flag_invalid(self):
-        self.partitioner.set_flag(1, 'foo')
+        with raises(KiwiPartitionerGptFlagError):
+            self.partitioner.set_flag(1, 'foo')
 
     @patch('kiwi.partitioner.gpt.Command.run')
     def test_set_flag(self, mock_command):
@@ -87,7 +87,7 @@ class TestPartitionerGpt:
 
     @patch('kiwi.partitioner.gpt.Command.run')
     def test_set_mbr(self, mock_command):
-        command_output = mock.Mock()
+        command_output = Mock()
         command_output.output = '...(EFI System)'
         self.partitioner.partition_id = 4
         mock_command.return_value = command_output

--- a/test/unit/partitioner_msdos_test.py
+++ b/test/unit/partitioner_msdos_test.py
@@ -1,10 +1,10 @@
-from mock import patch, call
-
-import mock
-
-from .test_helper import patch_open, raises
-
+from mock import (
+    patch, call, Mock
+)
+from pytest import raises
 from collections import namedtuple
+
+from .test_helper import patch_open
 
 from kiwi.partitioner.msdos import PartitionerMsDos
 
@@ -13,8 +13,8 @@ from kiwi.exceptions import KiwiPartitionerMsDosFlagError
 
 class TestPartitionerMsDos:
     def setup(self):
-        disk_provider = mock.Mock()
-        disk_provider.get_device = mock.Mock(
+        disk_provider = Mock()
+        disk_provider.get_device = Mock(
             return_value='/dev/loop0'
         )
         self.partitioner = PartitionerMsDos(disk_provider)
@@ -31,11 +31,11 @@ class TestPartitionerMsDos:
         mock_temp.return_value = temp_type(
             name='tempfile'
         )
-        context_manager_mock = mock.Mock()
+        context_manager_mock = Mock()
         mock_open.return_value = context_manager_mock
-        file_mock = mock.Mock()
-        enter_mock = mock.Mock()
-        exit_mock = mock.Mock()
+        file_mock = Mock()
+        enter_mock = Mock()
+        exit_mock = Mock()
         enter_mock.return_value = file_mock
         setattr(context_manager_mock, '__enter__', enter_mock)
         setattr(context_manager_mock, '__exit__', exit_mock)
@@ -62,8 +62,8 @@ class TestPartitionerMsDos:
     def test_create_custom_start_sector(
         self, mock_open, mock_temp, mock_flag, mock_command
     ):
-        disk_provider = mock.Mock()
-        disk_provider.get_device = mock.Mock(
+        disk_provider = Mock()
+        disk_provider.get_device = Mock(
             return_value='/dev/loop0'
         )
         partitioner = PartitionerMsDos(disk_provider, 4096)
@@ -74,11 +74,11 @@ class TestPartitionerMsDos:
         mock_temp.return_value = temp_type(
             name='tempfile'
         )
-        context_manager_mock = mock.Mock()
+        context_manager_mock = Mock()
         mock_open.return_value = context_manager_mock
-        file_mock = mock.Mock()
-        enter_mock = mock.Mock()
-        exit_mock = mock.Mock()
+        file_mock = Mock()
+        enter_mock = Mock()
+        exit_mock = Mock()
         enter_mock.return_value = file_mock
         setattr(context_manager_mock, '__enter__', enter_mock)
         setattr(context_manager_mock, '__exit__', exit_mock)
@@ -114,11 +114,11 @@ class TestPartitionerMsDos:
         mock_temp.return_value = temp_type(
             name='tempfile'
         )
-        context_manager_mock = mock.Mock()
+        context_manager_mock = Mock()
         mock_open.return_value = context_manager_mock
-        file_mock = mock.Mock()
-        enter_mock = mock.Mock()
-        exit_mock = mock.Mock()
+        file_mock = Mock()
+        enter_mock = Mock()
+        exit_mock = Mock()
         enter_mock.return_value = file_mock
         setattr(context_manager_mock, '__enter__', enter_mock)
         setattr(context_manager_mock, '__exit__', exit_mock)
@@ -129,9 +129,9 @@ class TestPartitionerMsDos:
             'n\np\n1\n\n\nw\nq\n'
         )
 
-    @raises(KiwiPartitionerMsDosFlagError)
     def test_set_flag_invalid(self):
-        self.partitioner.set_flag(1, 'foo')
+        with raises(KiwiPartitionerMsDosFlagError):
+            self.partitioner.set_flag(1, 'foo')
 
     @patch('kiwi.partitioner.msdos.Command.run')
     def test_set_flag(self, mock_command):

--- a/test/unit/partitioner_test.py
+++ b/test/unit/partitioner_test.py
@@ -1,8 +1,7 @@
-from mock import patch
-
-import mock
-
-from .test_helper import raises
+from mock import (
+    patch, Mock
+)
+from pytest import raises
 
 from kiwi.partitioner import Partitioner
 
@@ -11,22 +10,22 @@ from kiwi.exceptions import KiwiPartitionerSetupError
 
 class TestPartitioner:
     @patch('platform.machine')
-    @raises(KiwiPartitionerSetupError)
     def test_partitioner_not_implemented(self, mock_machine):
         mock_machine.return_value = 'x86_64'
-        Partitioner('foo', mock.Mock())
+        with raises(KiwiPartitionerSetupError):
+            Partitioner('foo', Mock())
 
     @patch('platform.machine')
-    @raises(KiwiPartitionerSetupError)
     def test_partitioner_for_arch_not_implemented(self, mock_machine):
         mock_machine.return_value = 'some-arch'
-        Partitioner('foo', mock.Mock())
+        with raises(KiwiPartitionerSetupError):
+            Partitioner('foo', Mock())
 
     @patch('kiwi.partitioner.PartitionerGpt')
     @patch('platform.machine')
     def test_partitioner_x86_64_gpt(self, mock_machine, mock_gpt):
         mock_machine.return_value = 'x86_64'
-        storage_provider = mock.Mock()
+        storage_provider = Mock()
         Partitioner('gpt', storage_provider)
         mock_gpt.assert_called_once_with(storage_provider, None)
 
@@ -34,7 +33,7 @@ class TestPartitioner:
     @patch('platform.machine')
     def test_partitioner_x86_64_msdos(self, mock_machine, mock_dos):
         mock_machine.return_value = 'x86_64'
-        storage_provider = mock.Mock()
+        storage_provider = Mock()
         Partitioner('msdos', storage_provider)
         mock_dos.assert_called_once_with(storage_provider, None)
 
@@ -42,7 +41,7 @@ class TestPartitioner:
     @patch('platform.machine')
     def test_partitioner_i686_msdos(self, mock_machine, mock_dos):
         mock_machine.return_value = 'i686'
-        storage_provider = mock.Mock()
+        storage_provider = Mock()
         Partitioner('msdos', storage_provider)
         mock_dos.assert_called_once_with(storage_provider, None)
 
@@ -50,7 +49,7 @@ class TestPartitioner:
     @patch('platform.machine')
     def test_partitioner_i586_msdos(self, mock_machine, mock_dos):
         mock_machine.return_value = 'i586'
-        storage_provider = mock.Mock()
+        storage_provider = Mock()
         Partitioner('msdos', storage_provider)
         mock_dos.assert_called_once_with(storage_provider, None)
 
@@ -58,7 +57,7 @@ class TestPartitioner:
     @patch('platform.machine')
     def test_partitioner_s390_dasd(self, mock_machine, mock_dasd):
         mock_machine.return_value = 's390'
-        storage_provider = mock.Mock()
+        storage_provider = Mock()
         Partitioner('dasd', storage_provider)
         mock_dasd.assert_called_once_with(storage_provider)
 
@@ -69,7 +68,7 @@ class TestPartitioner:
         self, mock_machine, mock_dasd, mock_warning
     ):
         mock_machine.return_value = 's390'
-        storage_provider = mock.Mock()
+        storage_provider = Mock()
         Partitioner('dasd', storage_provider, 4096)
         mock_dasd.assert_called_once_with(storage_provider)
         assert mock_warning.called
@@ -78,7 +77,7 @@ class TestPartitioner:
     @patch('platform.machine')
     def test_partitioner_s390_msdos(self, mock_machine, mock_dos):
         mock_machine.return_value = 's390'
-        storage_provider = mock.Mock()
+        storage_provider = Mock()
         Partitioner('msdos', storage_provider)
         mock_dos.assert_called_once_with(storage_provider, None)
 
@@ -86,7 +85,7 @@ class TestPartitioner:
     @patch('platform.machine')
     def test_partitioner_ppc_msdos(self, mock_machine, mock_dos):
         mock_machine.return_value = 'ppc64'
-        storage_provider = mock.Mock()
+        storage_provider = Mock()
         Partitioner('msdos', storage_provider)
         mock_dos.assert_called_once_with(storage_provider, None)
 
@@ -94,7 +93,7 @@ class TestPartitioner:
     @patch('platform.machine')
     def test_partitioner_ppc_gpt(self, mock_machine, mock_gpt):
         mock_machine.return_value = 'ppc64'
-        storage_provider = mock.Mock()
+        storage_provider = Mock()
         Partitioner('gpt', storage_provider)
         mock_gpt.assert_called_once_with(storage_provider, None)
 
@@ -102,7 +101,7 @@ class TestPartitioner:
     @patch('platform.machine')
     def test_partitioner_arm_gpt(self, mock_machine, mock_gpt):
         mock_machine.return_value = 'aarch64'
-        storage_provider = mock.Mock()
+        storage_provider = Mock()
         Partitioner('gpt', storage_provider)
         mock_gpt.assert_called_once_with(storage_provider, None)
 
@@ -110,6 +109,6 @@ class TestPartitioner:
     @patch('platform.machine')
     def test_partitioner_arm_msdos(self, mock_machine, mock_dos):
         mock_machine.return_value = 'armv7l'
-        storage_provider = mock.Mock()
+        storage_provider = Mock()
         Partitioner('msdos', storage_provider)
         mock_dos.assert_called_once_with(storage_provider, None)

--- a/test/unit/privileges_test.py
+++ b/test/unit/privileges_test.py
@@ -1,17 +1,17 @@
 from mock import patch
+from pytest import raises
 
-from .test_helper import raises
+from kiwi.privileges import Privileges
 
 from kiwi.exceptions import KiwiPrivilegesError
-from kiwi.privileges import Privileges
 
 
 class TestPrivileges:
-    @raises(KiwiPrivilegesError)
     @patch('os.geteuid')
     def test_check_for_root_permiossion_false(self, mock_euid):
         mock_euid.return_value = 1
-        Privileges.check_for_root_permissions()
+        with raises(KiwiPrivilegesError):
+            Privileges.check_for_root_permissions()
 
     @patch('os.geteuid')
     def test_check_for_root_permiossion_true(self, mock_euid):

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -3,17 +3,12 @@ from mock import patch
 import mock
 from pytest import raises
 
+from .test_helper import argv_kiwi_tests
+
 from kiwi.xml_state import XMLState
 from kiwi.xml_description import XMLDescription
 from kiwi.runtime_checker import RuntimeChecker
 from kiwi.exceptions import KiwiRuntimeError
-
-# default commandline used for any test, overwrite when needed
-sys.argv = [
-    sys.argv[0], 'system', 'prepare',
-    '--description', 'description', '--root', 'directory'
-]
-argv_kiwi_tests = sys.argv
 
 
 class TestRuntimeChecker:
@@ -301,3 +296,6 @@ class TestRuntimeChecker:
         runtime_checker = RuntimeChecker(xml_state)
         with raises(KiwiRuntimeError):
             runtime_checker.check_architecture_supports_iso_firmware_setup()
+
+    def teardown(self):
+        sys.argv = argv_kiwi_tests

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -1,12 +1,12 @@
 from mock import patch
+from pytest import raises
 
-from .test_helper import (
-    raises, patch_open
-)
+from .test_helper import patch_open
 
 from kiwi.runtime_config import RuntimeConfig
-from kiwi.exceptions import KiwiRuntimeConfigFormatError
 from kiwi.defaults import Defaults
+
+from kiwi.exceptions import KiwiRuntimeConfigFormatError
 
 
 class TestRuntimeConfig:
@@ -33,10 +33,10 @@ class TestRuntimeConfig:
             self.runtime_config = RuntimeConfig()
             mock_open.assert_called_once_with('/etc/kiwi.yml', 'r')
 
-    @raises(KiwiRuntimeConfigFormatError)
     def test_invalid_yaml_format(self):
         self.runtime_config.config_data = {'xz': None}
-        self.runtime_config.get_xz_options()
+        with raises(KiwiRuntimeConfigFormatError):
+            self.runtime_config.get_xz_options()
 
     def test_get_xz_options(self):
         assert self.runtime_config.get_xz_options() == ['-a', '-b', 'xxx']
@@ -48,8 +48,12 @@ class TestRuntimeConfig:
         assert self.runtime_config.get_bundle_compression() is True
 
     def test_get_bundle_compression_default(self):
-        assert self.default_runtime_config.get_bundle_compression(default=True) is True
-        assert self.default_runtime_config.get_bundle_compression(default=False) is False
+        assert self.default_runtime_config.get_bundle_compression(
+            default=True
+        ) is True
+        assert self.default_runtime_config.get_bundle_compression(
+            default=False
+        ) is False
 
     def test_is_obs_public_default(self):
         assert self.default_runtime_config.is_obs_public() is True

--- a/test/unit/solver_repository_base_test.py
+++ b/test/unit/solver_repository_base_test.py
@@ -1,12 +1,14 @@
 from mock import patch, call
+from pytest import raises
 import os
 import mock
 
 from lxml import etree
 
-from .test_helper import raises, patch_open
+from .test_helper import patch_open
 
 from kiwi.solver.repository.base import SolverRepositoryBase
+
 from kiwi.exceptions import KiwiUriOpenError
 
 
@@ -24,9 +26,9 @@ class TestSolverRepositoryBase:
 
         self.solver = SolverRepositoryBase(self.uri)
 
-    @raises(NotImplementedError)
     def test__setup_repository_metadata(self):
-        self.solver._setup_repository_metadata()
+        with raises(NotImplementedError):
+            self.solver._setup_repository_metadata()
 
     def test__get_repomd_xpath(self):
         xml_data = etree.parse('../data/repomd.xml')
@@ -173,12 +175,12 @@ class TestSolverRepositoryBase:
         )
 
     @patch('kiwi.solver.repository.base.urlopen')
-    @raises(KiwiUriOpenError)
     def test_download_from_repository_raises(self, mock_urlopen):
         self.uri.is_remote.return_value = False
         self.uri.translate.return_value = '/my_local_repo/file'
         mock_urlopen.side_effect = Exception
-        self.solver.download_from_repository('repodata/file', 'target-file')
+        with raises(KiwiUriOpenError):
+            self.solver.download_from_repository('repodata/file', 'target-file')
 
     @patch('kiwi.solver.repository.base.mkdtemp')
     @patch('kiwi.solver.repository.base.random.randrange')

--- a/test/unit/solver_repository_rpm_dir_test.py
+++ b/test/unit/solver_repository_rpm_dir_test.py
@@ -1,22 +1,22 @@
-from mock import patch
-
-import mock
-
-from .test_helper import raises
+from mock import (
+    patch, Mock
+)
+from pytest import raises
 
 from kiwi.solver.repository.rpm_dir import SolverRepositoryRpmDir
 from kiwi.solver.repository.base import SolverRepositoryBase
+
 from kiwi.exceptions import KiwiRpmDirNotRemoteError
 
 
 class TestSolverRepositoryRpmDir:
     def setup(self):
-        self.uri = mock.Mock()
+        self.uri = Mock()
         self.solver = SolverRepositoryRpmDir(self.uri)
 
-    @raises(KiwiRpmDirNotRemoteError)
     def test__setup_repository_metadata_raises(self):
-        self.solver._setup_repository_metadata()
+        with raises(KiwiRpmDirNotRemoteError):
+            self.solver._setup_repository_metadata()
 
     @patch.object(SolverRepositoryBase, 'download_from_repository')
     @patch.object(SolverRepositoryBase, '_create_solvables')

--- a/test/unit/solver_repository_test.py
+++ b/test/unit/solver_repository_test.py
@@ -1,21 +1,21 @@
-from mock import patch
-
-import mock
-
-from .test_helper import raises
+from mock import (
+    patch, Mock
+)
+from pytest import raises
 
 from kiwi.solver.repository import SolverRepository
+
 from kiwi.exceptions import KiwiSolverRepositorySetupError
 
 
 class TestSolverRepository:
     def setup(self):
-        self.uri = mock.Mock()
+        self.uri = Mock()
         self.uri.repo_type = 'some-unknown-type'
 
-    @raises(KiwiSolverRepositorySetupError)
     def test_solver_repository_type_not_implemented(self):
-        SolverRepository(self.uri)
+        with raises(KiwiSolverRepositorySetupError):
+            SolverRepository(self.uri)
 
     @patch('kiwi.solver.repository.SolverRepositorySUSE')
     def test_solver_repository_suse(self, mock_suse):

--- a/test/unit/storage_device_provider_test.py
+++ b/test/unit/storage_device_provider_test.py
@@ -1,25 +1,24 @@
-from mock import patch
-
-import mock
-
-from .test_helper import raises
-
-from kiwi.exceptions import KiwiDeviceProviderError
+from mock import (
+    patch, Mock
+)
+from pytest import raises
 
 from kiwi.storage.device_provider import DeviceProvider
+
+from kiwi.exceptions import KiwiDeviceProviderError
 
 
 class TestDeviceProvider:
     def setup(self):
         self.provider = DeviceProvider()
 
-    @raises(KiwiDeviceProviderError)
     def test_get_device(self):
-        self.provider.get_device()
+        with raises(KiwiDeviceProviderError):
+            self.provider.get_device()
 
     @patch('kiwi.storage.device_provider.Command.run')
     def test_get_uuid(self, mock_command):
-        uuid_call = mock.Mock()
+        uuid_call = Mock()
         uuid_call.output = '0815\n'
         mock_command.return_value = uuid_call
         assert self.provider.get_uuid('/dev/some-device') == '0815'
@@ -29,7 +28,7 @@ class TestDeviceProvider:
 
     @patch('kiwi.storage.device_provider.Command.run')
     def test_get_byte_size(self, mock_command):
-        blockdev_call = mock.Mock()
+        blockdev_call = Mock()
         blockdev_call.output = '1024\n'
         mock_command.return_value = blockdev_call
         assert self.provider.get_byte_size('/dev/some-device') == 1024

--- a/test/unit/storage_loop_device_test.py
+++ b/test/unit/storage_loop_device_test.py
@@ -1,10 +1,9 @@
 from mock import patch
-
-from .test_helper import raises
-
-from kiwi.exceptions import KiwiLoopSetupError
+from pytest import raises
 
 from kiwi.storage.loop_device import LoopDevice
+
+from kiwi.exceptions import KiwiLoopSetupError
 
 
 class TestLoopDevice:
@@ -13,9 +12,9 @@ class TestLoopDevice:
         mock_exists.return_value = False
         self.loop = LoopDevice('loop-file', 20, 4096)
 
-    @raises(KiwiLoopSetupError)
     def test_loop_setup_invalid(self):
-        LoopDevice('loop-file-does-not-exist-and-no-size-given')
+        with raises(KiwiLoopSetupError):
+            LoopDevice('loop-file-does-not-exist-and-no-size-given')
 
     def test_get_device(self):
         assert self.loop.get_device() is None

--- a/test/unit/storage_mapped_device_test.py
+++ b/test/unit/storage_mapped_device_test.py
@@ -1,29 +1,28 @@
+from mock import (
+    patch, Mock
+)
+from pytest import raises
 
-from mock import patch
-
-import mock
-
-from .test_helper import raises
+from kiwi.storage.mapped_device import MappedDevice
 
 from kiwi.exceptions import KiwiMappedDeviceError
-from kiwi.storage.mapped_device import MappedDevice
 
 
 class TestMappedDevice:
     @patch('os.path.exists')
     def setup(self, mock_path):
         mock_path.return_value = True
-        self.device_provider = mock.Mock()
-        self.device_provider.is_loop = mock.Mock()
+        self.device_provider = Mock()
+        self.device_provider.is_loop = Mock()
         self.device = MappedDevice(
             '/dev/foo', self.device_provider
         )
 
     @patch('os.path.exists')
-    @raises(KiwiMappedDeviceError)
     def test_device_not_existingr(self, mock_path):
         mock_path.return_value = False
-        MappedDevice('/dev/foo', mock.Mock())
+        with raises(KiwiMappedDeviceError):
+            MappedDevice('/dev/foo', Mock())
 
     def test_get_device(self):
         assert self.device.get_device() == '/dev/foo'

--- a/test/unit/storage_raid_device_test.py
+++ b/test/unit/storage_raid_device_test.py
@@ -1,33 +1,35 @@
-from mock import patch
+from mock import (
+    patch, Mock
+)
+from pytest import raises
 
-import mock
+from .test_helper import patch_open
 
-from .test_helper import raises, patch_open
+from kiwi.storage.raid_device import RaidDevice
 
 from kiwi.exceptions import KiwiRaidSetupError
-from kiwi.storage.raid_device import RaidDevice
 
 
 class TestRaidDevice:
     def setup(self):
-        storage_device = mock.Mock()
-        storage_device.get_device = mock.Mock(
+        storage_device = Mock()
+        storage_device.get_device = Mock(
             return_value='/dev/some-device'
         )
-        storage_device.is_loop = mock.Mock(
+        storage_device.is_loop = Mock(
             return_value=True
         )
         self.raid = RaidDevice(storage_device)
 
-    @raises(KiwiRaidSetupError)
     def test_create_degraded_raid_invalid_level(self):
-        self.raid.create_degraded_raid('bogus-level')
+        with raises(KiwiRaidSetupError):
+            self.raid.create_degraded_raid('bogus-level')
 
-    @raises(KiwiRaidSetupError)
     @patch('os.path.exists')
     def test_create_degraded_raid_no_free_device(self, mock_path):
         mock_path.return_value = True
-        self.raid.create_degraded_raid('mirroring')
+        with raises(KiwiRaidSetupError):
+            self.raid.create_degraded_raid('mirroring')
 
     @patch('os.path.exists')
     def test_get_device(self, mock_path):
@@ -54,14 +56,14 @@ class TestRaidDevice:
     @patch_open
     def test_create_raid_config(self, mock_open, mock_command):
         self.raid.raid_device = '/dev/md0'
-        command_call = mock.Mock()
+        command_call = Mock()
         command_call.output = 'data'
         mock_command.return_value = command_call
-        context_manager_mock = mock.Mock()
+        context_manager_mock = Mock()
         mock_open.return_value = context_manager_mock
-        file_mock = mock.Mock()
-        enter_mock = mock.Mock()
-        exit_mock = mock.Mock()
+        file_mock = Mock()
+        enter_mock = Mock()
+        exit_mock = Mock()
         enter_mock.return_value = file_mock
         setattr(context_manager_mock, '__enter__', enter_mock)
         setattr(context_manager_mock, '__exit__', exit_mock)

--- a/test/unit/storage_subformat_base_test.py
+++ b/test/unit/storage_subformat_base_test.py
@@ -1,41 +1,40 @@
-from mock import patch
+from mock import (
+    patch, Mock
+)
+from pytest import raises
 
-import mock
-
-from .test_helper import raises
+from kiwi.storage.subformat.base import DiskFormatBase
 
 from kiwi.exceptions import (
     KiwiFormatSetupError,
     KiwiResizeRawDiskError
 )
 
-from kiwi.storage.subformat.base import DiskFormatBase
-
 
 class TestDiskFormatBase:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'
-        xml_data = mock.Mock()
-        xml_data.get_name = mock.Mock(
+        xml_data = Mock()
+        xml_data.get_name = Mock(
             return_value='some-disk-image'
         )
-        self.xml_state = mock.Mock()
+        self.xml_state = Mock()
         self.xml_state.xml_data = xml_data
-        self.xml_state.get_image_version = mock.Mock(
+        self.xml_state.get_image_version = Mock(
             return_value='1.2.3'
         )
         self.disk_format = DiskFormatBase(
             self.xml_state, 'root_dir', 'target_dir'
         )
 
-    @raises(NotImplementedError)
     def test_create_image_format(self):
-        self.disk_format.create_image_format()
+        with raises(NotImplementedError):
+            self.disk_format.create_image_format()
 
-    @raises(KiwiFormatSetupError)
     def test_get_target_file_path_for_format_invalid_format(self):
-        self.disk_format.get_target_file_path_for_format('foo')
+        with raises(KiwiFormatSetupError):
+            self.disk_format.get_target_file_path_for_format('foo')
 
     def test_post_init(self):
         self.disk_format.post_init({'option': 'unhandled'})
@@ -55,7 +54,7 @@ class TestDiskFormatBase:
             'target_dir/some-disk-image.x86_64-1.2.3.vhd'
 
     def test_store_to_result(self):
-        result = mock.Mock()
+        result = Mock()
         self.disk_format.image_format = 'qcow2'
         self.disk_format.store_to_result(result)
         result.add.assert_called_once_with(
@@ -66,11 +65,11 @@ class TestDiskFormatBase:
             use_for_bundle=True
         )
 
-    @raises(KiwiResizeRawDiskError)
     @patch('os.path.getsize')
     def test_resize_raw_disk_raises_on_shrink_disk(self, mock_getsize):
         mock_getsize.return_value = 42
-        self.disk_format.resize_raw_disk(10)
+        with raises(KiwiResizeRawDiskError):
+            self.disk_format.resize_raw_disk(10)
 
     @patch('os.path.getsize')
     @patch('kiwi.storage.subformat.base.Command.run')

--- a/test/unit/storage_subformat_ova_test.py
+++ b/test/unit/storage_subformat_ova_test.py
@@ -1,59 +1,58 @@
-from mock import patch
-from mock import call
-import mock
+from mock import (
+    patch, call, Mock
+)
+from pytest import raises
 
-from .test_helper import raises
+from kiwi.storage.subformat.ova import DiskFormatOva
 
 from kiwi.exceptions import (
     KiwiCommandNotFound,
     KiwiFormatSetupError
 )
 
-from kiwi.storage.subformat.ova import DiskFormatOva
-
 
 class TestDiskFormatOva:
     @patch('platform.machine')
     def setup(self, mock_machine):
-        self.context_manager_mock = mock.Mock()
-        self.file_mock = mock.Mock()
-        self.enter_mock = mock.Mock()
-        self.exit_mock = mock.Mock()
+        self.context_manager_mock = Mock()
+        self.file_mock = Mock()
+        self.enter_mock = Mock()
+        self.exit_mock = Mock()
         self.enter_mock.return_value = self.file_mock
         setattr(self.context_manager_mock, '__enter__', self.enter_mock)
         setattr(self.context_manager_mock, '__exit__', self.exit_mock)
         mock_machine.return_value = 'x86_64'
-        xml_data = mock.Mock()
-        xml_data.get_name = mock.Mock(
+        xml_data = Mock()
+        xml_data.get_name = Mock(
             return_value='some-disk-image'
         )
-        xml_data.get_displayname = mock.Mock(
+        xml_data.get_displayname = Mock(
             return_value=None
         )
-        self.xml_state = mock.Mock()
+        self.xml_state = Mock()
         self.xml_state.xml_data = xml_data
-        self.xml_state.get_image_version = mock.Mock(
+        self.xml_state.get_image_version = Mock(
             return_value='1.2.3'
         )
 
-        self.machine_setup = mock.Mock()
-        self.xml_state.get_build_type_machine_section = mock.Mock(
+        self.machine_setup = Mock()
+        self.xml_state.get_build_type_machine_section = Mock(
             return_value=self.machine_setup
         )
-        self.machine_setup.get_HWversion = mock.Mock(
+        self.machine_setup.get_HWversion = Mock(
             return_value='42'
         )
-        self.machine_setup.get_guestOS = mock.Mock(
+        self.machine_setup.get_guestOS = Mock(
             return_value='suse'
         )
-        self.machine_setup.get_memory = mock.Mock(
+        self.machine_setup.get_memory = Mock(
             return_value='4096'
         )
-        self.machine_setup.get_ncpus = mock.Mock(
+        self.machine_setup.get_ncpus = Mock(
             return_value='2'
         )
 
-        self.machine_setup.get_ovftype = mock.Mock(
+        self.machine_setup.get_ovftype = Mock(
             return_value='vmware'
         )
 
@@ -64,13 +63,13 @@ class TestDiskFormatOva:
     def test_post_init(self):
         self.disk_format.post_init({})
 
-    @raises(KiwiFormatSetupError)
     def test_post_init_bad_ovftype(self):
         self.machine_setup.get_ovftype.return_value = 'foobar'
-        self.disk_format.post_init({})
+        with raises(KiwiFormatSetupError):
+            self.disk_format.post_init({})
 
     def test_store_to_result(self):
-        result = mock.Mock()
+        result = Mock()
         self.disk_format.store_to_result(result)
         assert result.add.call_args_list == [
             call(
@@ -94,7 +93,7 @@ class TestDiskFormatOva:
     ):
         mock_has_option_in_help.return_value = True
         mock_which.return_value = 'ovftool'
-        mock_stat.return_value = mock.Mock(st_mode=0o644)
+        mock_stat.return_value = Mock(st_mode=0o644)
         self.disk_format.create_image_format()
         mock_command.assert_called_once_with(
             [
@@ -105,7 +104,7 @@ class TestDiskFormatOva:
         )
 
     @patch('kiwi.storage.subformat.ova.Path.which')
-    @raises(KiwiCommandNotFound)
     def test_create_image_format_no_ovftool(self, mock_which):
         mock_which.return_value = None
-        self.disk_format.create_image_format()
+        with raises(KiwiCommandNotFound):
+            self.disk_format.create_image_format()

--- a/test/unit/storage_subformat_test.py
+++ b/test/unit/storage_subformat_test.py
@@ -1,31 +1,30 @@
-from mock import patch
-
-import mock
-
-from .test_helper import raises
-
-from kiwi.exceptions import KiwiDiskFormatSetupError
+from mock import (
+    patch, Mock
+)
+from pytest import raises
 
 from kiwi.storage.subformat import DiskFormat
+
+from kiwi.exceptions import KiwiDiskFormatSetupError
 
 
 class TestDiskFormat:
     def setup(self):
-        self.xml_state = mock.Mock()
+        self.xml_state = Mock()
         self.xml_state.get_build_type_format_options.return_value = {}
 
-    @raises(KiwiDiskFormatSetupError)
     def test_format_not_implemented(self):
-        DiskFormat('foo', self.xml_state, 'root_dir', 'target_dir')
+        with raises(KiwiDiskFormatSetupError):
+            DiskFormat('foo', self.xml_state, 'root_dir', 'target_dir')
 
-    @raises(KiwiDiskFormatSetupError)
     def test_disk_format_vagrant_not_implemented(self):
-        self.xml_state.get_build_type_vagrant_config_section = mock.Mock(
+        self.xml_state.get_build_type_vagrant_config_section = Mock(
             return_value=None
         )
-        DiskFormat(
-            'vagrant', self.xml_state, 'root_dir', 'target_dir'
-        )
+        with raises(KiwiDiskFormatSetupError):
+            DiskFormat(
+                'vagrant', self.xml_state, 'root_dir', 'target_dir'
+            )
 
     @patch('kiwi.storage.subformat.DiskFormatQcow2')
     def test_disk_format_qcow2(self, mock_qcow2):
@@ -57,7 +56,7 @@ class TestDiskFormat:
 
     @patch('kiwi.storage.subformat.DiskFormatVhdFixed')
     def test_disk_format_vhdfixed(self, mock_vhdfixed):
-        self.xml_state.build_type.get_vhdfixedtag = mock.Mock(
+        self.xml_state.build_type.get_vhdfixedtag = Mock(
             return_value='disk-tag'
         )
         DiskFormat('vhd-fixed', self.xml_state, 'root_dir', 'target_dir')
@@ -67,7 +66,7 @@ class TestDiskFormat:
 
     @patch('kiwi.storage.subformat.DiskFormatGce')
     def test_disk_format_gce(self, mock_gce):
-        self.xml_state.build_type.get_gcelicense = mock.Mock(
+        self.xml_state.build_type.get_gcelicense = Mock(
             return_value='gce_license_tag'
         )
         DiskFormat('gce', self.xml_state, 'root_dir', 'target_dir')
@@ -78,14 +77,14 @@ class TestDiskFormat:
 
     @patch('kiwi.storage.subformat.DiskFormatVmdk')
     def test_disk_format_vmdk(self, mock_vmdk):
-        vmdisk = mock.Mock()
-        vmdisk.get_controller = mock.Mock(
+        vmdisk = Mock()
+        vmdisk.get_controller = Mock(
             return_value='controller'
         )
-        vmdisk.get_diskmode = mock.Mock(
+        vmdisk.get_diskmode = Mock(
             return_value='disk-mode'
         )
-        self.xml_state.get_build_type_vmdisk_section = mock.Mock(
+        self.xml_state.get_build_type_vmdisk_section = Mock(
             return_value=vmdisk
         )
         DiskFormat('vmdk', self.xml_state, 'root_dir', 'target_dir')
@@ -96,14 +95,14 @@ class TestDiskFormat:
 
     @patch('kiwi.storage.subformat.DiskFormatOva')
     def test_disk_format_ova(self, mock_ova):
-        vmdisk = mock.Mock()
-        vmdisk.get_controller = mock.Mock(
+        vmdisk = Mock()
+        vmdisk.get_controller = Mock(
             return_value='controller'
         )
-        vmdisk.get_diskmode = mock.Mock(
+        vmdisk.get_diskmode = Mock(
             return_value='disk-mode'
         )
-        self.xml_state.get_build_type_vmdisk_section = mock.Mock(
+        self.xml_state.get_build_type_vmdisk_section = Mock(
             return_value=vmdisk
         )
         DiskFormat('ova', self.xml_state, 'root_dir', 'target_dir')
@@ -121,11 +120,11 @@ class TestDiskFormat:
                 ('libvirt', mock_vagrant_libvirt),
                 ('virtualbox', mock_vagrant_virt_box)
         ):
-            vagrant_config = mock.Mock()
-            vagrant_config.get_provider = mock.Mock(
+            vagrant_config = Mock()
+            vagrant_config.get_provider = Mock(
                 return_value=provider_name
             )
-            self.xml_state.get_build_type_vagrant_config_section = mock.Mock(
+            self.xml_state.get_build_type_vagrant_config_section = Mock(
                 return_value=vagrant_config
             )
             DiskFormat(

--- a/test/unit/storage_subformat_vhdfixed_test.py
+++ b/test/unit/storage_subformat_vhdfixed_test.py
@@ -1,30 +1,28 @@
 import sys
+from builtins import bytes
+from mock import (
+    call, patch, Mock
+)
+from pytest import raises
 
-from mock import call
-from mock import patch
-
-import mock
-
-from .test_helper import raises, patch_open
-
-from kiwi.exceptions import KiwiVhdTagError
+from .test_helper import patch_open
 
 from kiwi.storage.subformat.vhdfixed import DiskFormatVhdFixed
 
-from builtins import bytes
+from kiwi.exceptions import KiwiVhdTagError
 
 
 class TestDiskFormatVhdFixed:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'
-        xml_data = mock.Mock()
-        xml_data.get_name = mock.Mock(
+        xml_data = Mock()
+        xml_data.get_name = Mock(
             return_value='some-disk-image'
         )
-        self.xml_state = mock.Mock()
+        self.xml_state = Mock()
         self.xml_state.xml_data = xml_data
-        self.xml_state.get_image_version = mock.Mock(
+        self.xml_state.get_image_version = Mock(
             return_value='1.2.3'
         )
         self.disk_format = DiskFormatVhdFixed(
@@ -38,21 +36,21 @@ class TestDiskFormatVhdFixed:
         ]
         assert self.disk_format.tag == 'tag'
 
-    @raises(KiwiVhdTagError)
     @patch('kiwi.storage.subformat.vhdfixed.Command.run')
     def test_create_image_format_invalid_tag(self, mock_command):
         self.disk_format.tag = 'invalid'
-        self.disk_format.create_image_format()
+        with raises(KiwiVhdTagError):
+            self.disk_format.create_image_format()
 
     @patch('kiwi.storage.subformat.vhdfixed.Command.run')
     @patch_open
     def test_create_image_format(self, mock_open, mock_command):
         self.disk_format.tag = '12345678-1234-1234-1234-123456789999'
-        context_manager_mock = mock.Mock()
+        context_manager_mock = Mock()
         mock_open.return_value = context_manager_mock
-        file_mock = mock.Mock()
-        enter_mock = mock.Mock()
-        exit_mock = mock.Mock()
+        file_mock = Mock()
+        enter_mock = Mock()
+        exit_mock = Mock()
         enter_mock.return_value = file_mock
         setattr(context_manager_mock, '__enter__', enter_mock)
         setattr(context_manager_mock, '__exit__', exit_mock)
@@ -92,7 +90,7 @@ class TestDiskFormatVhdFixed:
         ]
 
     def test_store_to_result(self):
-        result = mock.Mock()
+        result = Mock()
         self.disk_format.store_to_result(result)
         result.add.assert_called_once_with(
             compress=True,

--- a/test/unit/storage_subformat_vmdk_test.py
+++ b/test/unit/storage_subformat_vmdk_test.py
@@ -1,98 +1,97 @@
-from mock import patch
-from mock import call
-import mock
 import os
-
-from .test_helper import raises, patch_open
-
-from kiwi.exceptions import (
-    KiwiTemplateError
+from mock import (
+    patch, call, Mock
 )
+from pytest import raises
+
+from .test_helper import patch_open
 
 from kiwi.storage.subformat.vmdk import DiskFormatVmdk
+
+from kiwi.exceptions import KiwiTemplateError
 
 
 class TestDiskFormatVmdk:
     @patch('platform.machine')
     def setup(self, mock_machine):
-        self.context_manager_mock = mock.Mock()
-        self.file_mock = mock.Mock()
-        self.enter_mock = mock.Mock()
-        self.exit_mock = mock.Mock()
+        self.context_manager_mock = Mock()
+        self.file_mock = Mock()
+        self.enter_mock = Mock()
+        self.exit_mock = Mock()
         self.enter_mock.return_value = self.file_mock
         setattr(self.context_manager_mock, '__enter__', self.enter_mock)
         setattr(self.context_manager_mock, '__exit__', self.exit_mock)
         mock_machine.return_value = 'x86_64'
-        xml_data = mock.Mock()
-        xml_data.get_name = mock.Mock(
+        xml_data = Mock()
+        xml_data.get_name = Mock(
             return_value='some-disk-image'
         )
-        xml_data.get_displayname = mock.Mock(
+        xml_data.get_displayname = Mock(
             return_value=None
         )
-        self.xml_state = mock.Mock()
+        self.xml_state = Mock()
         self.xml_state.xml_data = xml_data
-        self.xml_state.get_image_version = mock.Mock(
+        self.xml_state.get_image_version = Mock(
             return_value='1.2.3'
         )
 
-        self.xml_state.get_build_type_vmconfig_entries = mock.Mock(
+        self.xml_state.get_build_type_vmconfig_entries = Mock(
             return_value=['custom entry 1', 'custom entry 2']
         )
 
-        self.machine_setup = mock.Mock()
-        self.xml_state.get_build_type_machine_section = mock.Mock(
+        self.machine_setup = Mock()
+        self.xml_state.get_build_type_machine_section = Mock(
             return_value=self.machine_setup
         )
-        self.machine_setup.get_HWversion = mock.Mock(
+        self.machine_setup.get_HWversion = Mock(
             return_value='42'
         )
-        self.machine_setup.get_guestOS = mock.Mock(
+        self.machine_setup.get_guestOS = Mock(
             return_value='suse'
         )
-        self.machine_setup.get_memory = mock.Mock(
+        self.machine_setup.get_memory = Mock(
             return_value='4096'
         )
-        self.machine_setup.get_ncpus = mock.Mock(
+        self.machine_setup.get_ncpus = Mock(
             return_value='2'
         )
 
-        self.iso_setup = mock.Mock()
-        self.xml_state.get_build_type_vmdvd_section = mock.Mock(
+        self.iso_setup = Mock()
+        self.xml_state.get_build_type_vmdvd_section = Mock(
             return_value=self.iso_setup
         )
-        self.iso_setup.get_controller = mock.Mock(
+        self.iso_setup.get_controller = Mock(
             return_value='ide'
         )
-        self.iso_setup.get_id = mock.Mock(
+        self.iso_setup.get_id = Mock(
             return_value='0'
         )
 
-        self.network_setup = [mock.Mock()]
-        self.xml_state.get_build_type_vmnic_entries = mock.Mock(
+        self.network_setup = [Mock()]
+        self.xml_state.get_build_type_vmnic_entries = Mock(
             return_value=self.network_setup
         )
-        self.network_setup[0].get_interface = mock.Mock(
+        self.network_setup[0].get_interface = Mock(
             return_value='0'
         )
-        self.network_setup[0].get_mac = mock.Mock(
+        self.network_setup[0].get_mac = Mock(
             return_value='98:90:96:a0:3c:58'
         )
-        self.network_setup[0].get_mode = mock.Mock(
+        self.network_setup[0].get_mode = Mock(
             return_value='bridged'
         )
-        self.network_setup[0].get_driver = mock.Mock(
+        self.network_setup[0].get_driver = Mock(
             return_value='e1000'
         )
 
-        self.disk_setup = mock.Mock()
-        self.xml_state.get_build_type_vmdisk_section = mock.Mock(
+        self.disk_setup = Mock()
+        self.xml_state.get_build_type_vmdisk_section = Mock(
             return_value=self.disk_setup
         )
-        self.disk_setup.get_controller = mock.Mock(
+        self.disk_setup.get_controller = Mock(
             return_value='lsilogic'
         )
-        self.disk_setup.get_id = mock.Mock(
+        self.disk_setup.get_id = Mock(
             return_value='0'
         )
 
@@ -110,7 +109,7 @@ class TestDiskFormatVmdk:
         assert self.disk_format.patch_header_for_pvscsi is True
 
     def test_store_to_result(self):
-        result = mock.Mock()
+        result = Mock()
         self.disk_format.store_to_result(result)
         assert result.add.call_args_list == [
             call(
@@ -129,7 +128,6 @@ class TestDiskFormatVmdk:
             )
         ]
 
-    @raises(KiwiTemplateError)
     @patch('kiwi.storage.subformat.vmdk.VmwareSettingsTemplate.get_template')
     @patch('kiwi.storage.subformat.vmdk.Command.run')
     @patch('os.path.exists')
@@ -137,10 +135,11 @@ class TestDiskFormatVmdk:
     def test_create_image_format_template_error(
         self, mock_open, mock_exists, mock_command, mock_get_template
     ):
-        template = mock.Mock()
+        template = Mock()
         mock_get_template.return_value = template
         template.substitute.side_effect = Exception
-        self.disk_format.create_image_format()
+        with raises(KiwiTemplateError):
+            self.disk_format.create_image_format()
 
     @patch('kiwi.storage.subformat.vmdk.Command.run')
     @patch('os.path.exists')

--- a/test/unit/system_kernel_test.py
+++ b/test/unit/system_kernel_test.py
@@ -1,14 +1,11 @@
-
-from mock import patch
-
 import mock
-
-from .test_helper import raises
-
+from mock import patch
+from pytest import raises
 from collections import namedtuple
 
-from kiwi.exceptions import KiwiKernelLookupError
 from kiwi.system.kernel import Kernel
+
+from kiwi.exceptions import KiwiKernelLookupError
 
 
 class TestKernel:
@@ -27,10 +24,10 @@ class TestKernel:
             'image-1.2.3-default'
         ]
 
-    @raises(KiwiKernelLookupError)
     def test_get_kernel_raises_if_no_kernel_found(self):
         self.kernel.kernel_names = []
-        self.kernel.get_kernel(raise_on_not_found=True)
+        with raises(KiwiKernelLookupError):
+            self.kernel.get_kernel(raise_on_not_found=True)
 
     @patch('os.path.exists')
     @patch('os.path.realpath')

--- a/test/unit/system_result_test.py
+++ b/test/unit/system_result_test.py
@@ -1,24 +1,26 @@
-from mock import patch
+from mock import (
+    patch, Mock, MagicMock
+)
+from pytest import raises
 
-import mock
-
-from .test_helper import patch_open, raises
+from .test_helper import patch_open
 
 from kiwi.system.result import Result
+
 from kiwi.exceptions import KiwiResultError
 
 
 class TestResult:
     def setup(self):
-        self.context_manager_mock = mock.MagicMock()
-        self.file_mock = mock.MagicMock()
-        self.enter_mock = mock.MagicMock()
-        self.exit_mock = mock.MagicMock()
+        self.context_manager_mock = MagicMock()
+        self.file_mock = MagicMock()
+        self.enter_mock = MagicMock()
+        self.exit_mock = MagicMock()
         self.enter_mock.return_value = self.file_mock
         setattr(self.context_manager_mock, '__enter__', self.enter_mock)
         setattr(self.context_manager_mock, '__exit__', self.exit_mock)
 
-        self.xml_state = mock.Mock()
+        self.xml_state = Mock()
 
         self.result = Result(self.xml_state)
 
@@ -54,10 +56,10 @@ class TestResult:
 
     @patch('pickle.dump')
     @patch_open
-    @raises(KiwiResultError)
     def test_dump_failed(self, mock_open, mock_pickle_dump):
         mock_pickle_dump.side_effect = Exception
-        self.result.dump('kiwi.result')
+        with raises(KiwiResultError):
+            self.result.dump('kiwi.result')
 
     @patch('pickle.load')
     @patch('os.path.exists')
@@ -74,18 +76,18 @@ class TestResult:
         )
 
     @patch('os.path.exists')
-    @raises(KiwiResultError)
     def test_load_result_not_present(self, mock_exists):
         mock_exists.return_value = False
-        Result.load('kiwi.result')
+        with raises(KiwiResultError):
+            Result.load('kiwi.result')
 
     @patch('pickle.load')
     @patch('os.path.exists')
-    @raises(KiwiResultError)
     def test_load_failed(self, mock_exists, mock_pickle_load):
         mock_exists.return_value = True
         mock_pickle_load.side_effect = Exception
-        Result.load('kiwi.result')
+        with raises(KiwiResultError):
+            Result.load('kiwi.result')
 
     @patch('os.path.getsize')
     def test_build_constraint(self, mock_getsize):
@@ -93,7 +95,7 @@ class TestResult:
         self.result.verify_image_size(524288000, 'foo')
 
     @patch('os.path.getsize')
-    @raises(KiwiResultError)
     def test_build_constraint_failure(self, mock_getsize):
         mock_getsize.return_value = 524288000
-        self.result.verify_image_size(524287999, 'foo')
+        with raises(KiwiResultError):
+            self.result.verify_image_size(524287999, 'foo')

--- a/test/unit/system_root_import_base_test.py
+++ b/test/unit/system_root_import_base_test.py
@@ -1,9 +1,11 @@
-from mock import patch, call
-
-from .test_helper import raises
+from mock import (
+    patch, call
+)
+from pytest import raises
 
 from kiwi.system.uri import Uri
 from kiwi.system.root_import.base import RootImportBase
+
 from kiwi.exceptions import KiwiRootImportError
 
 
@@ -17,9 +19,9 @@ class TestRootImportBase:
             RootImportBase('root_dir', Uri('file:///image.tar.xz'))
         assert call('/image.tar.xz') in mock_path.call_args_list
 
-    @raises(KiwiRootImportError)
     def test_init_remote_uri(self):
-        RootImportBase('root_dir', Uri('http://example.com/image.tar.xz'))
+        with raises(KiwiRootImportError):
+            RootImportBase('root_dir', Uri('http://example.com/image.tar.xz'))
 
     @patch('kiwi.system.root_import.base.log.warning')
     def test_init_unknown_uri(self, mock_log_warn):
@@ -28,14 +30,12 @@ class TestRootImportBase:
         assert mock_log_warn.called
 
     @patch('os.path.exists')
-    @raises(KiwiRootImportError)
     def test_init_non_existing(self, mock_path):
         mock_path.return_value = False
         with patch.dict('os.environ', {'HOME': '../data'}):
-            RootImportBase('root_dir', Uri('file:///image.tar.xz'))
-        mock_path.assert_called_once_with('/image.tar.xz')
+            with raises(KiwiRootImportError):
+                RootImportBase('root_dir', Uri('file:///image.tar.xz'))
 
-    @raises(NotImplementedError)
     @patch('os.path.exists')
     def test_data_sync(self, mock_path):
         mock_path.return_value = True
@@ -43,4 +43,5 @@ class TestRootImportBase:
             root_import = RootImportBase(
                 'root_dir', Uri('file:///image.tar.xz')
             )
-        root_import.sync_data()
+        with raises(NotImplementedError):
+            root_import.sync_data()

--- a/test/unit/system_root_import_oci_test.py
+++ b/test/unit/system_root_import_oci_test.py
@@ -1,11 +1,11 @@
-import mock
-from mock import patch
-# from mock import call
-
-from .test_helper import raises
+from mock import (
+    patch, Mock
+)
+from pytest import raises
 
 from kiwi.system.uri import Uri
 from kiwi.system.root_import.oci import RootImportOCI
+
 from kiwi.exceptions import KiwiRootImportError
 
 
@@ -21,26 +21,26 @@ class TestRootImportOCI:
         assert self.oci_import.image_file == '/image.tar'
 
     @patch('os.path.exists')
-    @raises(KiwiRootImportError)
     def test_failed_init(self, mock_path):
         mock_path.return_value = False
-        RootImportOCI(
-            'root_dir', Uri('file:///image.tar.xz'),
-            {'archive_transport': 'oci-archive'}
-        )
+        with raises(KiwiRootImportError):
+            RootImportOCI(
+                'root_dir', Uri('file:///image.tar.xz'),
+                {'archive_transport': 'oci-archive'}
+            )
 
     @patch('kiwi.system.root_import.oci.Compress')
     @patch('kiwi.system.root_import.base.Checksum')
     @patch('kiwi.system.root_import.oci.Path.create')
     @patch('kiwi.system.root_import.oci.OCI')
     def test_sync_data(self, mock_OCI, mock_path, mock_md5, mock_compress):
-        oci = mock.Mock()
+        oci = Mock()
         mock_OCI.return_value = oci
-        md5 = mock.Mock()
-        mock_md5.return_value = mock.Mock()
+        md5 = Mock()
+        mock_md5.return_value = Mock()
 
-        uncompress = mock.Mock()
-        uncompress.get_format = mock.Mock(return_value=None)
+        uncompress = Mock()
+        uncompress.get_format = Mock(return_value=None)
         mock_compress.return_value = uncompress
 
         self.oci_import.sync_data()
@@ -62,13 +62,13 @@ class TestRootImportOCI:
     def test_sync_data_compressed_image(
         self, mock_OCI, mock_path, mock_md5, mock_compress
     ):
-        oci = mock.Mock()
+        oci = Mock()
         mock_OCI.return_value = oci
-        md5 = mock.Mock()
-        mock_md5.return_value = mock.Mock()
+        md5 = Mock()
+        mock_md5.return_value = Mock()
 
-        uncompress = mock.Mock()
-        uncompress.get_format = mock.Mock(return_value='xz')
+        uncompress = Mock()
+        uncompress.get_format = Mock(return_value='xz')
         mock_compress.return_value = uncompress
 
         self.oci_import.sync_data()
@@ -93,10 +93,10 @@ class TestRootImportOCI:
         self, mock_OCI, mock_path, mock_md5, mock_exists, mock_warn
     ):
         mock_exists.return_value = True
-        oci = mock.Mock()
+        oci = Mock()
         mock_OCI.return_value = oci
-        md5 = mock.Mock()
-        mock_md5.return_value = mock.Mock()
+        md5 = Mock()
+        mock_md5.return_value = Mock()
         with patch.dict('os.environ', {'HOME': '../data'}):
             oci_import = RootImportOCI(
                 'root_dir', Uri('docker:image:tag'),

--- a/test/unit/system_root_import_test.py
+++ b/test/unit/system_root_import_test.py
@@ -1,8 +1,8 @@
 from mock import patch
-
-from .test_helper import raises
+from pytest import raises
 
 from kiwi.system.root_import import RootImport
+
 from kiwi.exceptions import KiwiRootImportError
 
 
@@ -23,6 +23,6 @@ class TestRootImport:
             custom_args={'archive_transport': 'oci-archive'}
         )
 
-    @raises(KiwiRootImportError)
     def test_not_implemented_import(self):
-        RootImport('root_dir', 'file:///image.tar.xz', 'foo')
+        with raises(KiwiRootImportError):
+            RootImport('root_dir', 'file:///image.tar.xz', 'foo')

--- a/test/unit/system_root_init_test.py
+++ b/test/unit/system_root_init_test.py
@@ -1,25 +1,26 @@
-from mock import patch
-from mock import call
-import mock
+import sys
+from mock import (
+    patch, call, Mock
+)
+from pytest import raises
 
-from .test_helper import raises
+from .test_helper import argv_kiwi_tests
+
+from kiwi.system.root_init import RootInit
 
 from kiwi.exceptions import (
     KiwiRootDirExists,
     KiwiRootInitCreationError
 )
 
-from kiwi.system.root_init import RootInit
-
 
 class TestRootInit:
-    @raises(KiwiRootDirExists)
     @patch('os.path.exists')
     def test_init_raises_error(self, mock_path):
         mock_path.return_value = True
-        RootInit('root_dir')
+        with raises(KiwiRootDirExists):
+            RootInit('root_dir')
 
-    @raises(KiwiRootInitCreationError)
     @patch('os.path.exists')
     @patch('os.makedirs')
     @patch('os.chown')
@@ -36,7 +37,8 @@ class TestRootInit:
         mock_temp.return_value = 'tmpdir'
         mock_data_sync.side_effect = Exception
         root = RootInit('root_dir')
-        root.create()
+        with raises(KiwiRootInitCreationError):
+            root.create()
 
     @patch('os.path.exists')
     @patch('os.makedirs')
@@ -53,7 +55,7 @@ class TestRootInit:
         mock_makedev, mock_symlink, mock_chwon, mock_makedirs,
         mock_path
     ):
-        data_sync = mock.Mock()
+        data_sync = Mock()
         mock_data_sync.return_value = data_sync
         mock_makedev.return_value = 'makedev'
         mock_path_return = [
@@ -135,3 +137,6 @@ class TestRootInit:
         mock_command.assert_called_once_with(
             ['rm', '-r', '-f', 'root_dir']
         )
+
+    def teardown(self):
+        sys.argv = argv_kiwi_tests

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -1,44 +1,44 @@
-
-from mock import patch
-from mock import call
-
-import mock
-
-from .test_helper import raises, patch_open
+from mock import (
+    patch, call, Mock, MagicMock
+)
+from pytest import raises
 from collections import namedtuple
+
+from .test_helper import patch_open
 
 from kiwi.system.setup import SystemSetup
 from kiwi.xml_description import XMLDescription
 from kiwi.xml_state import XMLState
+from kiwi.defaults import Defaults
+
 from kiwi.exceptions import (
     KiwiScriptFailed,
     KiwiImportDescriptionError
 )
-from kiwi.defaults import Defaults
 
 
 class TestSystemSetup:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'
-        self.context_manager_mock = mock.Mock()
-        self.file_mock = mock.Mock()
-        self.enter_mock = mock.Mock()
-        self.exit_mock = mock.Mock()
+        self.context_manager_mock = Mock()
+        self.file_mock = Mock()
+        self.enter_mock = Mock()
+        self.exit_mock = Mock()
         self.enter_mock.return_value = self.file_mock
         setattr(self.context_manager_mock, '__enter__', self.enter_mock)
         setattr(self.context_manager_mock, '__exit__', self.exit_mock)
-        self.xml_state = mock.MagicMock()
-        self.xml_state.get_package_manager = mock.Mock(
+        self.xml_state = MagicMock()
+        self.xml_state.get_package_manager = Mock(
             return_value='zypper'
         )
-        self.xml_state.build_type.get_filesystem = mock.Mock(
+        self.xml_state.build_type.get_filesystem = Mock(
             return_value='ext3'
         )
-        self.xml_state.xml_data.get_name = mock.Mock(
+        self.xml_state.xml_data.get_name = Mock(
             return_value='some-image'
         )
-        self.xml_state.get_image_version = mock.Mock(
+        self.xml_state.get_image_version = Mock(
             return_value='1.2.3'
         )
         self.xml_state.xml_data.description_dir = 'description_dir'
@@ -65,7 +65,7 @@ class TestSystemSetup:
     def test_setup_ix86(self, mock_machine):
         mock_machine.return_value = 'i686'
         setup = SystemSetup(
-            mock.MagicMock(), 'root_dir'
+            MagicMock(), 'root_dir'
         )
         assert setup.arch == 'ix86'
 
@@ -145,7 +145,6 @@ class TestSystemSetup:
     @patch('kiwi.command.Command.run')
     @patch_open
     @patch('os.path.exists')
-    @raises(KiwiImportDescriptionError)
     def test_import_description_configured_editboot_scripts_not_found(
         self, mock_path, mock_open, mock_command
     ):
@@ -155,12 +154,12 @@ class TestSystemSetup:
             return path_return_values.pop()
 
         mock_path.side_effect = side_effect
-        self.setup_with_real_xml.import_description()
+        with raises(KiwiImportDescriptionError):
+            self.setup_with_real_xml.import_description()
 
     @patch('kiwi.command.Command.run')
     @patch_open
     @patch('os.path.exists')
-    @raises(KiwiImportDescriptionError)
     def test_import_description_configured_archives_not_found(
         self, mock_path, mock_open, mock_command
     ):
@@ -170,7 +169,8 @@ class TestSystemSetup:
             return path_return_values.pop()
 
         mock_path.side_effect = side_effect
-        self.setup_with_real_xml.import_description()
+        with raises(KiwiImportDescriptionError):
+            self.setup_with_real_xml.import_description()
 
     @patch('kiwi.command.Command.run')
     def test_cleanup(self, mock_command):
@@ -181,8 +181,8 @@ class TestSystemSetup:
 
     @patch_open
     def test_import_shell_environment(self, mock_open):
-        mock_profile = mock.MagicMock()
-        mock_profile.create = mock.Mock(
+        mock_profile = MagicMock()
+        mock_profile.create = Mock(
             return_value=['a']
         )
         mock_open.return_value = self.context_manager_mock
@@ -194,7 +194,7 @@ class TestSystemSetup:
     @patch('kiwi.system.setup.ArchiveTar')
     @patch('kiwi.system.setup.glob.iglob')
     def test_import_cdroot_files(self, mock_iglob, mock_ArchiveTar):
-        archive = mock.Mock()
+        archive = Mock()
         mock_ArchiveTar.return_value = archive
         mock_iglob.return_value = ['config-cdroot.tar.xz']
         self.setup.import_cdroot_files('target_dir')
@@ -208,7 +208,7 @@ class TestSystemSetup:
     def test_import_overlay_files_copy_links(
         self, mock_os_path, mock_DataSync, mock_command
     ):
-        data = mock.Mock()
+        data = Mock()
         mock_DataSync.return_value = data
         mock_os_path.return_value = True
         self.setup.import_overlay_files(
@@ -230,7 +230,7 @@ class TestSystemSetup:
     def test_import_overlay_files_links(
         self, mock_os_path, mock_DataSync, mock_command
     ):
-        data = mock.Mock()
+        data = Mock()
         mock_DataSync.return_value = data
         mock_os_path.return_value = True
         self.setup.import_overlay_files(
@@ -251,7 +251,7 @@ class TestSystemSetup:
     def test_import_overlay_files_from_archive(
         self, mock_os_path, mock_archive
     ):
-        archive = mock.Mock()
+        archive = Mock()
         mock_archive.return_value = archive
 
         exists_results = [True, False]
@@ -374,8 +374,8 @@ class TestSystemSetup:
 
     @patch('kiwi.system.setup.Users')
     def test_setup_groups(self, mock_users):
-        users = mock.Mock()
-        users.group_exists = mock.Mock(
+        users = Mock()
+        users.group_exists = Mock(
             return_value=False
         )
         mock_users.return_value = users
@@ -399,8 +399,8 @@ class TestSystemSetup:
     @patch('kiwi.system.setup.Users')
     @patch('kiwi.system.setup.Command.run')
     def test_setup_users_add(self, mock_command, mock_users):
-        users = mock.Mock()
-        users.user_exists = mock.Mock(
+        users = Mock()
+        users.user_exists = Mock(
             return_value=False
         )
         mock_users.return_value = users
@@ -448,8 +448,8 @@ class TestSystemSetup:
     @patch('kiwi.system.setup.Users')
     @patch('kiwi.system.setup.Command.run')
     def test_setup_users_modify(self, mock_command, mock_users):
-        users = mock.Mock()
-        users.user_exists = mock.Mock(
+        users = Mock()
+        users.user_exists = Mock(
             return_value=True
         )
         mock_users.return_value = users
@@ -489,11 +489,11 @@ class TestSystemSetup:
     @patch('kiwi.system.setup.Command.run')
     def test_setup_plymouth_splash(self, mock_command, mock_which):
         mock_which.return_value = 'plymouth-set-default-theme'
-        preferences = mock.Mock()
-        preferences.get_bootsplash_theme = mock.Mock(
+        preferences = Mock()
+        preferences.get_bootsplash_theme = Mock(
             return_value=['some-theme']
         )
-        self.xml_state.get_preferences_sections = mock.Mock(
+        self.xml_state.get_preferences_sections = Mock(
             return_value=[preferences]
         )
         self.setup.setup_plymouth_splash()
@@ -508,7 +508,7 @@ class TestSystemSetup:
     @patch_open
     @patch('os.path.exists')
     def test_import_image_identifier(self, mock_os_path, mock_open):
-        self.xml_state.xml_data.get_id = mock.Mock(
+        self.xml_state.xml_data.get_id = Mock(
             return_value='42'
         )
         mock_os_path.return_value = True
@@ -632,7 +632,6 @@ class TestSystemSetup:
             'my_image.raw /dev/mapper/loop0p1'
         ])
 
-    @raises(KiwiScriptFailed)
     @patch('kiwi.command.Command.call')
     @patch('kiwi.command_process.CommandProcess.poll_and_watch')
     @patch('os.path.exists')
@@ -648,10 +647,9 @@ class TestSystemSetup:
         mock_os_path.return_value = True
         mock_watch.return_value = mock_result
         mock_access.return_value = False
+        with raises(KiwiScriptFailed):
+            self.setup.call_image_script()
 
-        self.setup.call_image_script()
-
-    @raises(KiwiScriptFailed)
     @patch('kiwi.command.Command.call')
     @patch('kiwi.command_process.CommandProcess.poll_and_watch')
     @patch('os.path.exists')
@@ -664,9 +662,10 @@ class TestSystemSetup:
         mock_result = result_type(stderr='stderr', returncode=1)
         mock_os_path.return_value = True
         mock_watch.return_value = mock_result
-        self.setup.call_edit_boot_install_script(
-            'my_image.raw', '/dev/mapper/loop0p1'
-        )
+        with raises(KiwiScriptFailed):
+            self.setup.call_edit_boot_install_script(
+                'my_image.raw', '/dev/mapper/loop0p1'
+            )
 
     @patch('kiwi.command.Command.run')
     def test_create_init_link_from_linuxrc(self, mock_command):
@@ -726,11 +725,11 @@ class TestSystemSetup:
     ):
         mock_open.return_value = self.context_manager_mock
         mock_getsize.return_value = 42
-        compress = mock.Mock()
+        compress = Mock()
         mock_compress.return_value = compress
-        archive = mock.Mock()
+        archive = Mock()
         mock_archive.return_value = archive
-        tmpdir = mock.Mock()
+        tmpdir = Mock()
         tmpdir.name = 'tmpdir'
         mock_temp.return_value = tmpdir
         self.setup.oemconfig['recovery'] = True
@@ -796,7 +795,7 @@ class TestSystemSetup:
     def test_export_modprobe_setup(
         self, mock_exists, mock_DataSync, mock_path, mock_command
     ):
-        data = mock.Mock()
+        data = Mock()
         mock_DataSync.return_value = data
         mock_exists.return_value = True
         self.setup.export_modprobe_setup('target_root_dir')
@@ -815,12 +814,12 @@ class TestSystemSetup:
     def test_export_package_list_rpm(
         self, mock_open, mock_MountManager, mock_RpmDataBase, mock_command
     ):
-        rpmdb = mock.Mock()
+        rpmdb = Mock()
         rpmdb.rpmdb_image.expand_query.return_value = 'image_dbpath'
         rpmdb.rpmdb_host.expand_query.return_value = 'host_dbpath'
         rpmdb.has_rpm.return_value = True
         mock_RpmDataBase.return_value = rpmdb
-        command = mock.Mock()
+        command = Mock()
         command.output = 'packages_data'
         mock_command.return_value = command
         result = self.setup.export_package_list('target_dir')
@@ -880,10 +879,10 @@ class TestSystemSetup:
     def test_export_package_list_dpkg(
         self, mock_open, mock_command
     ):
-        command = mock.Mock()
+        command = Mock()
         command.output = 'packages_data'
         mock_command.return_value = command
-        self.xml_state.get_package_manager = mock.Mock(
+        self.xml_state.get_package_manager = Mock(
             return_value='apt-get'
         )
         result = self.setup.export_package_list('target_dir')
@@ -908,15 +907,15 @@ class TestSystemSetup:
         def is_mounted():
             return is_mounted_return.pop()
 
-        shared_mount = mock.Mock()
+        shared_mount = Mock()
         shared_mount.is_mounted.side_effect = is_mounted
         mock_MountManager.return_value = shared_mount
-        rpmdb = mock.Mock()
+        rpmdb = Mock()
         rpmdb.rpmdb_image.expand_query.return_value = 'image_dbpath'
         rpmdb.rpmdb_host.expand_query.return_value = 'host_dbpath'
         rpmdb.has_rpm.return_value = True
         mock_RpmDataBase.return_value = rpmdb
-        command = mock.Mock()
+        command = Mock()
         command.output = 'verification_data'
         mock_command.return_value = command
         result = self.setup.export_package_verification('target_dir')
@@ -955,10 +954,10 @@ class TestSystemSetup:
     def test_export_package_verification_dpkg(
         self, mock_open, mock_command
     ):
-        command = mock.Mock()
+        command = Mock()
         command.output = 'verification_data'
         mock_command.return_value = command
-        self.xml_state.get_package_manager = mock.Mock(
+        self.xml_state.get_package_manager = Mock(
             return_value='apt-get'
         )
         result = self.setup.export_package_verification('target_dir')
@@ -989,19 +988,19 @@ class TestSystemSetup:
     def test_import_repositories_marked_as_imageinclude(
         self, mock_uri, mock_repo
     ):
-        uri = mock.Mock()
+        uri = Mock()
         mock_uri.return_value = uri
-        uri.translate = mock.Mock(
+        uri.translate = Mock(
             return_value="uri"
         )
-        uri.alias = mock.Mock(
+        uri.alias = Mock(
             return_value="uri-alias"
         )
-        uri.credentials_file_name = mock.Mock(
+        uri.credentials_file_name = Mock(
             return_value='kiwiRepoCredentials'
         )
         mock_uri.return_value = uri
-        repo = mock.Mock()
+        repo = Mock()
         mock_repo.return_value = repo
         self.setup_with_real_xml.import_repositories_marked_as_imageinclude()
         assert repo.add_repo.call_args_list[0] == call(

--- a/test/unit/system_uri_test.py
+++ b/test/unit/system_uri_test.py
@@ -1,18 +1,15 @@
 from mock import patch
-
+from pytest import raises
+import hashlib
 import mock
 
-from .test_helper import raises
+from kiwi.system.uri import Uri
 
 from kiwi.exceptions import (
     KiwiUriStyleUnknown,
     KiwiUriTypeUnknown,
     KiwiUriOpenError
 )
-
-from kiwi.system.uri import Uri
-
-import hashlib
 
 
 class TestUri:
@@ -24,42 +21,42 @@ class TestUri:
             return_value='obs_server'
         )
 
-    @raises(KiwiUriStyleUnknown)
     def test_is_remote_raises_style_error(self):
         uri = Uri('xxx', 'rpm-md')
-        uri.is_remote()
+        with raises(KiwiUriStyleUnknown):
+            uri.is_remote()
 
-    @raises(KiwiUriTypeUnknown)
     def test_is_remote_raises_type_error(self):
         uri = Uri('xtp://download.example.com', 'rpm-md')
-        uri.is_remote()
+        with raises(KiwiUriTypeUnknown):
+            uri.is_remote()
 
-    @raises(KiwiUriStyleUnknown)
     def test_translate_unknown_style(self):
         uri = Uri('xxx', 'rpm-md')
-        uri.translate()
+        with raises(KiwiUriStyleUnknown):
+            uri.translate()
 
-    @raises(KiwiUriStyleUnknown)
     def test_translate_unsupported_style(self):
         uri = Uri('ms://foo', 'rpm-md')
-        uri.translate()
+        with raises(KiwiUriStyleUnknown):
+            uri.translate()
 
-    @raises(KiwiUriStyleUnknown)
     @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
     def test_translate_obsrepositories_outside_buildservice(
         self, mock_buildservice
     ):
         mock_buildservice.return_value = False
         uri = Uri('obsrepositories:/')
-        uri.translate()
+        with raises(KiwiUriStyleUnknown):
+            uri.translate()
 
-    @raises(KiwiUriOpenError)
     @patch('kiwi.system.uri.requests.get')
     def test_translate_obs_uri_not_found(mock_request_get, self):
         mock_request_get.side_effect = Exception
         uri = Uri('obs://openSUSE:Leap:42.2/standard', 'yast2')
         uri.runtime_config = self.runtime_config
-        assert uri.translate()
+        with raises(KiwiUriOpenError):
+            uri.translate()
 
     @patch('kiwi.logger.log.warning')
     @patch('kiwi.system.uri.Defaults.is_buildservice_worker')

--- a/test/unit/tasks_base_test.py
+++ b/test/unit/tasks_base_test.py
@@ -1,12 +1,14 @@
+import sys
 from mock import patch
-
+from pytest import raises
 import logging
-from .test_helper import raises
 
-from kiwi.tasks.base import CliTask
-from kiwi.exceptions import KiwiConfigFileNotFound
+from .test_helper import argv_kiwi_tests
 
 import kiwi.xml_parse
+from kiwi.tasks.base import CliTask
+
+from kiwi.exceptions import KiwiConfigFileNotFound
 
 
 class TestCliTask:
@@ -64,6 +66,9 @@ class TestCliTask:
         assert self.task.config_file == \
             '../data/description.buildservice/appliance.kiwi'
 
-    @raises(KiwiConfigFileNotFound)
     def test_load_xml_description_raises(self):
-        self.task.load_xml_description('foo')
+        with raises(KiwiConfigFileNotFound):
+            self.task.load_xml_description('foo')
+
+    def teardown(self):
+        sys.argv = argv_kiwi_tests

--- a/test/unit/tasks_result_bundle_test.py
+++ b/test/unit/tasks_result_bundle_test.py
@@ -1,15 +1,17 @@
-import sys
-import mock
 import os
+import sys
+from mock import (
+    patch, call, Mock
+)
+from pytest import raises
 
-from mock import patch, call
+from .test_helper import argv_kiwi_tests, patch_open
 
 import kiwi
-
-from .test_helper import raises, argv_kiwi_tests, patch_open
-from kiwi.exceptions import KiwiBundleError
 from kiwi.tasks.result_bundle import ResultBundleTask
 from kiwi.system.result import Result
+
+from kiwi.exceptions import KiwiBundleError
 
 
 class TestResultBundleTask:
@@ -20,21 +22,21 @@ class TestResultBundleTask:
         ]
         self.abs_target_dir = os.path.abspath('target_dir')
         self.abs_bundle_dir = os.path.abspath('bundle_dir')
-        self.context_manager_mock = mock.Mock()
-        self.file_mock = mock.Mock()
-        self.enter_mock = mock.Mock()
-        self.exit_mock = mock.Mock()
+        self.context_manager_mock = Mock()
+        self.file_mock = Mock()
+        self.enter_mock = Mock()
+        self.exit_mock = Mock()
         self.enter_mock.return_value = self.file_mock
         setattr(self.context_manager_mock, '__enter__', self.enter_mock)
         setattr(self.context_manager_mock, '__exit__', self.exit_mock)
 
         self.file_mock.read.return_value = b'data'
 
-        self.xml_state = mock.Mock()
-        self.xml_state.get_image_version = mock.Mock(
+        self.xml_state = Mock()
+        self.xml_state.get_image_version = Mock(
             return_value='1.2.3'
         )
-        self.xml_state.xml_data.get_name = mock.Mock(
+        self.xml_state.xml_data.get_name = Mock(
             return_value='test-image'
         )
 
@@ -44,13 +46,13 @@ class TestResultBundleTask:
             use_for_bundle=True, compress=True, shasum=True
         )
 
-        kiwi.tasks.result_bundle.Help = mock.Mock(
-            return_value=mock.Mock()
+        kiwi.tasks.result_bundle.Help = Mock(
+            return_value=Mock()
         )
         self.task = ResultBundleTask()
 
-        runtime_config = mock.Mock()
-        runtime_config.is_bundle_compression_requested = mock.Mock(
+        runtime_config = Mock()
+        runtime_config.is_bundle_compression_requested = Mock(
             return_value=True
         )
         self.task.runtime_config = runtime_config
@@ -67,13 +69,13 @@ class TestResultBundleTask:
         self.task.command_args['--id'] = 'Build_42'
         self.task.command_args['--zsync-source'] = None
 
-    @raises(KiwiBundleError)
     def test_process_invalid_bundle_directory(self):
         self._init_command_args()
         self.task.command_args['--bundle-dir'] = \
             self.task.command_args['--target-dir']
         self.task.command_args['bundle'] = True
-        self.task.process()
+        with raises(KiwiBundleError):
+            self.task.process()
 
     @patch('kiwi.tasks.result_bundle.Result.load')
     @patch('kiwi.tasks.result_bundle.Command.run')
@@ -93,8 +95,8 @@ class TestResultBundleTask:
             use_for_bundle=True, compress=False, shasum=False
         )
 
-        checksum = mock.Mock()
-        compress = mock.Mock()
+        checksum = Mock()
+        compress = Mock()
         mock_path_which.return_value = 'zsyncmake'
         compress.compressed_filename = 'compressed_filename'
         mock_compress.return_value = compress
@@ -154,7 +156,7 @@ class TestResultBundleTask:
             use_for_bundle=True, compress=False, shasum=False
         )
 
-        self.xml_state.xml_data.get_name = mock.Mock(
+        self.xml_state.xml_data.get_name = Mock(
             return_value='test-1.2.3-image'
         )
 
@@ -191,8 +193,8 @@ class TestResultBundleTask:
         self, mock_open, mock_exists, mock_checksum, mock_compress,
         mock_path_which, mock_path_create, mock_command, mock_load, mock_log
     ):
-        checksum = mock.Mock()
-        compress = mock.Mock()
+        checksum = Mock()
+        compress = Mock()
         mock_path_which.return_value = None
         compress.compressed_filename = 'compressed_filename'
         mock_compress.return_value = compress

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -1,5 +1,3 @@
-from functools import wraps
-
 import kiwi.logger
 import sys
 import logging
@@ -18,31 +16,6 @@ argv_kiwi_tests = sys.argv
 
 # mock open calls
 patch_open = patch('builtins.open')
-
-
-class raises:
-    """
-    exception decorator as used in nose, tools/nontrivial.py
-    """
-    def __init__(self, *exceptions):
-        self.exceptions = exceptions
-        self.valid = ' or '.join([e.__name__ for e in exceptions])
-
-    def __call__(self, func):
-        name = func.__name__
-
-        def newfunc(*args, **kw):
-            try:
-                func(*args, **kw)
-            except self.exceptions:
-                pass
-            except Exception:
-                raise
-            else:
-                message = "%s() did not raise %s" % (name, self.valid)
-                raise AssertionError(message)
-        newfunc = wraps(func)(newfunc)
-        return newfunc
 
 
 def mock_open(data=None):

--- a/test/unit/utils_checksum_test.py
+++ b/test/unit/utils_checksum_test.py
@@ -1,22 +1,23 @@
-from mock import call
-from mock import patch
-import mock
+from builtins import bytes
+from mock import (
+    patch, call, Mock
+)
+from pytest import raises
 
-from .test_helper import raises, patch_open
+from .test_helper import patch_open
 
-from kiwi.exceptions import KiwiFileNotFound
 from kiwi.utils.checksum import Checksum
 
-from builtins import bytes
+from kiwi.exceptions import KiwiFileNotFound
 
 
 class TestChecksum:
     @patch('os.path.exists')
     def setup(self, mock_exists):
-        self.context_manager_mock = mock.Mock()
-        self.file_mock = mock.Mock()
-        self.enter_mock = mock.Mock()
-        self.exit_mock = mock.Mock()
+        self.context_manager_mock = Mock()
+        self.file_mock = Mock()
+        self.enter_mock = Mock()
+        self.exit_mock = Mock()
         self.enter_mock.return_value = self.file_mock
         setattr(self.context_manager_mock, '__enter__', self.enter_mock)
         setattr(self.context_manager_mock, '__exit__', self.exit_mock)
@@ -31,9 +32,9 @@ class TestChecksum:
         mock_exists.return_value = True
         self.checksum = Checksum('some-file')
 
-    @raises(KiwiFileNotFound)
     def test_checksum_file_not_found(self):
-        Checksum('some-file')
+        with raises(KiwiFileNotFound):
+            Checksum('some-file')
 
     @patch('os.path.exists')
     def test_matches_checksum_file_does_not_exist(self, mock_exists):
@@ -59,19 +60,19 @@ class TestChecksum:
     def test_md5_xz(
         self, mock_open, mock_size, mock_md5, mock_compress, mock_which
     ):
-        checksum = mock.Mock
+        checksum = Mock
         checksum.uncompressed_filename = 'some-file-uncompressed'
         mock_which.return_value = 'factor'
-        compress = mock.Mock()
-        digest = mock.Mock()
+        compress = Mock()
+        digest = Mock()
         digest.block_size = 1024
-        digest._calculate_hash_hexdigest = mock.Mock(
+        digest._calculate_hash_hexdigest = Mock(
             return_value=checksum
         )
-        digest.hexdigest = mock.Mock(
+        digest.hexdigest = Mock(
             return_value='sum'
         )
-        compress.get_format = mock.Mock(
+        compress.get_format = Mock(
             return_value='xz'
         )
         mock_open.return_value = self.context_manager_mock
@@ -99,13 +100,13 @@ class TestChecksum:
         self, mock_open, mock_size, mock_md5, mock_compress, mock_which
     ):
         mock_which.return_value = 'factor'
-        compress = mock.Mock()
-        digest = mock.Mock()
+        compress = Mock()
+        digest = Mock()
         digest.block_size = 1024
-        digest.hexdigest = mock.Mock(
+        digest.hexdigest = Mock(
             return_value='sum'
         )
-        compress.get_format = mock.Mock(
+        compress.get_format = Mock(
             return_value=None
         )
         mock_open.return_value = self.context_manager_mock
@@ -132,13 +133,13 @@ class TestChecksum:
         self, mock_open, mock_size, mock_sha256, mock_compress, mock_which
     ):
         mock_which.return_value = 'factor'
-        compress = mock.Mock()
-        digest = mock.Mock()
+        compress = Mock()
+        digest = Mock()
         digest.block_size = 1024
-        digest.hexdigest = mock.Mock(
+        digest.hexdigest = Mock(
             return_value='sum'
         )
-        compress.get_format = mock.Mock(
+        compress.get_format = Mock(
             return_value=None
         )
         mock_open.return_value = self.context_manager_mock
@@ -159,9 +160,9 @@ class TestChecksum:
     @patch('hashlib.sha256')
     @patch_open
     def test_sha256_plain(self, mock_open, mock_sha256):
-        digest = mock.Mock()
+        digest = Mock()
         digest.block_size = 1024
-        digest.hexdigest = mock.Mock(
+        digest.hexdigest = Mock(
             return_value='sum'
         )
         mock_sha256.return_value = digest
@@ -171,9 +172,9 @@ class TestChecksum:
     @patch('hashlib.md5')
     @patch_open
     def test_md5_plain(self, mock_open, mock_md5):
-        digest = mock.Mock()
+        digest = Mock()
         digest.block_size = 1024
-        digest.hexdigest = mock.Mock(
+        digest.hexdigest = Mock(
             return_value='sum'
         )
         mock_md5.return_value = digest

--- a/test/unit/utils_codec_test.py
+++ b/test/unit/utils_codec_test.py
@@ -1,8 +1,8 @@
 from mock import patch
-
-from .test_helper import raises
+from pytest import raises
 
 from kiwi.utils.codec import Codec
+
 from kiwi.exceptions import KiwiDecodingError
 
 
@@ -35,11 +35,9 @@ class TestCodec:
         mock_decode.return_value = msg
         assert msg == Codec.decode(self.literal)
 
-    @raises(KiwiDecodingError)
     @patch('kiwi.utils.codec.Codec._wrapped_decode')
     @patch('kiwi.logger.log.warning')
     def test_decode_utf8_failure(self, mock_warn, mock_decode):
-
         def mocked_decode(literal, charset):
             if charset:
                 raise KiwiDecodingError('utf-8 decoding failure')
@@ -47,7 +45,8 @@ class TestCodec:
                 raise KiwiDecodingError('ascii decoding failure')
 
         mock_decode.side_effect = mocked_decode
-        Codec.decode(self.literal)
+        with raises(KiwiDecodingError):
+            Codec.decode(self.literal)
         assert mock_warn.called
 
     def test_wrapped_decode(self):

--- a/test/unit/utils_command_capabilities_test.py
+++ b/test/unit/utils_command_capabilities_test.py
@@ -1,10 +1,11 @@
-from mock import patch
-from mock import call
+from mock import (
+    patch, call
+)
+from pytest import raises
 from collections import namedtuple
 
-from .test_helper import raises
-
 from kiwi.utils.command_capabilities import CommandCapabilities
+
 from kiwi.exceptions import KiwiCommandCapabilitiesError
 
 
@@ -51,15 +52,15 @@ class TestCommandCapabilities:
         assert mock_warn.called
 
     @patch('kiwi.command.Command.run')
-    @raises(KiwiCommandCapabilitiesError)
     def test_has_option_in_help_command_failure_exception(self, mock_run):
         def side_effect():
             raise Exception("Something went wrong")
 
         mock_run.side_effect = side_effect
-        CommandCapabilities.has_option_in_help(
-            'command_that_fails', '--non-existing-flag'
-        )
+        with raises(KiwiCommandCapabilitiesError):
+            CommandCapabilities.has_option_in_help(
+                'command_that_fails', '--non-existing-flag'
+            )
 
     @patch('kiwi.command.Command.run')
     def test_check_version(self, mock_run):
@@ -85,13 +86,13 @@ class TestCommandCapabilities:
         ])
 
     @patch('kiwi.command.Command.run')
-    @raises(KiwiCommandCapabilitiesError)
     def test_check_version_no_match(self, mock_run):
         command_type = namedtuple('command', ['output'])
         mock_run.return_value = command_type(
             output="Dummy line\ncommand someother stuff\n"
         )
-        CommandCapabilities.check_version('command', (1, 2, 3))
+        with raises(KiwiCommandCapabilitiesError):
+            CommandCapabilities.check_version('command', (1, 2, 3))
 
     @patch('kiwi.command.Command.run')
     @patch('kiwi.logger.log.warning')
@@ -106,12 +107,12 @@ class TestCommandCapabilities:
         assert mock_warn.called
 
     @patch('kiwi.command.Command.run')
-    @raises(KiwiCommandCapabilitiesError)
     def test_check_version_failure_exception(self, mock_run):
         def side_effect():
             raise Exception("Something went wrong")
 
         mock_run.side_effect = side_effect
-        CommandCapabilities.check_version(
-            'command_that_fails', '--non-existing-flag'
-        )
+        with raises(KiwiCommandCapabilitiesError):
+            CommandCapabilities.check_version(
+                'command_that_fails', '--non-existing-flag'
+            )

--- a/test/unit/utils_compress_test.py
+++ b/test/unit/utils_compress_test.py
@@ -1,10 +1,10 @@
-from mock import patch
-
-import mock
-
-from .test_helper import raises
+from mock import (
+    patch, Mock
+)
+from pytest import raises
 
 from kiwi.utils.compress import Compress
+
 from kiwi.exceptions import (
     KiwiFileNotFound,
     KiwiCompressionFormatUnknown
@@ -17,9 +17,9 @@ class TestCompress:
         mock_exists.return_value = True
         self.compress = Compress('some-file', True)
 
-    @raises(KiwiFileNotFound)
     def test_source_file_not_found(self):
-        Compress('some-file')
+        with raises(KiwiFileNotFound):
+            Compress('some-file')
 
     @patch('kiwi.command.Command.run')
     def test_xz(self, mock_command):
@@ -66,7 +66,7 @@ class TestCompress:
     @patch('kiwi.utils.compress.NamedTemporaryFile')
     @patch('kiwi.utils.compress.Compress.get_format')
     def test_uncompress_temporary(self, mock_format, mock_temp, mock_command):
-        tempfile = mock.Mock()
+        tempfile = Mock()
         tempfile.name = 'tempfile'
         mock_temp.return_value = tempfile
         mock_format.return_value = 'xz'
@@ -76,11 +76,11 @@ class TestCompress:
         )
         assert self.compress.uncompressed_filename == 'tempfile'
 
-    @raises(KiwiCompressionFormatUnknown)
     @patch('kiwi.utils.compress.Compress.get_format')
     def test_uncompress_unknown_format(self, mock_format):
         mock_format.return_value = None
-        self.compress.uncompress()
+        with raises(KiwiCompressionFormatUnknown):
+            self.compress.uncompress()
 
     @patch('kiwi.path.Path.which')
     def test_get_format(self, mock_which):

--- a/test/unit/utils_size_test.py
+++ b/test/unit/utils_size_test.py
@@ -1,17 +1,17 @@
-from .test_helper import raises
+from pytest import raises
 
 from kiwi.utils.size import StringToSize
+
 from kiwi.exceptions import KiwiSizeError
 
 
 class TestStringToSize:
-
     def test_to_bytes(self):
         assert StringToSize.to_bytes('1m') == 1048576
         assert StringToSize.to_bytes('1M') == 1048576
         assert StringToSize.to_bytes('1g') == 1073741824
         assert StringToSize.to_bytes('1G') == 1073741824
 
-    @raises(KiwiSizeError)
     def test_to_bytes_wrong_format(self):
-        StringToSize.to_bytes('1mb')
+        with raises(KiwiSizeError):
+            StringToSize.to_bytes('1mb')

--- a/test/unit/volume_manager_base_test.py
+++ b/test/unit/volume_manager_base_test.py
@@ -1,12 +1,12 @@
-from mock import patch
-
-import mock
-
-from .test_helper import raises
-
 from collections import namedtuple
-from kiwi.exceptions import KiwiVolumeManagerSetupError
+from mock import (
+    patch, Mock
+)
+from pytest import raises
+
 from kiwi.volume_manager.base import VolumeManagerBase
+
+from kiwi.exceptions import KiwiVolumeManagerSetupError
 
 
 class TestVolumeManagerBase:
@@ -23,15 +23,15 @@ class TestVolumeManagerBase:
             ]
         )
         mock_path.return_value = True
-        self.device_provider = mock.Mock()
-        self.device_provider.is_loop = mock.Mock(
+        self.device_provider = Mock()
+        self.device_provider.is_loop = Mock(
             return_value=True
         )
-        self.device_provider.get_device = mock.Mock(
+        self.device_provider.get_device = Mock(
             return_value='/dev/storage'
         )
         self.volume_manager = VolumeManagerBase(
-            self.device_provider, 'root_dir', mock.Mock()
+            self.device_provider, 'root_dir', Mock()
         )
         self.volume_manager.volumes = [
             self.volume_type(
@@ -48,8 +48,7 @@ class TestVolumeManagerBase:
     def test_init_custom_args(self, mock_exists):
         mock_exists.return_value = True
         volume_manager = VolumeManagerBase(
-            mock.Mock(), 'root_dir', mock.Mock(),
-            {
+            Mock(), 'root_dir', Mock(), {
                 'fs_create_options': 'create-opts',
                 'fs_mount_options': 'mount-opts'
             }
@@ -60,10 +59,10 @@ class TestVolumeManagerBase:
             'create-opts'
 
     @patch('os.path.exists')
-    @raises(KiwiVolumeManagerSetupError)
     def test_root_dir_does_not_exist(self, mock_exists):
         mock_exists.return_value = False
-        VolumeManagerBase(mock.Mock(), 'root_dir', mock.Mock())
+        with raises(KiwiVolumeManagerSetupError):
+            VolumeManagerBase(Mock(), 'root_dir', Mock())
 
     def test_is_loop(self):
         assert self.volume_manager.is_loop() == \
@@ -75,17 +74,17 @@ class TestVolumeManagerBase:
         assert self.volume_manager.get_device()['root'].get_device() == \
             '/dev/storage'
 
-    @raises(NotImplementedError)
     def test_setup(self):
-        self.volume_manager.setup()
+        with raises(NotImplementedError):
+            self.volume_manager.setup()
 
-    @raises(NotImplementedError)
     def test_create_volumes(self):
-        self.volume_manager.create_volumes('ext3')
+        with raises(NotImplementedError):
+            self.volume_manager.create_volumes('ext3')
 
-    @raises(NotImplementedError)
     def test_get_fstab(self):
-        self.volume_manager.get_fstab('by-label', 'ext3')
+        with raises(NotImplementedError):
+            self.volume_manager.get_fstab('by-label', 'ext3')
 
     @patch('kiwi.volume_manager.base.Path.create')
     @patch('os.path.exists')
@@ -101,8 +100,8 @@ class TestVolumeManagerBase:
 
     @patch('kiwi.volume_manager.base.SystemSize')
     def test_get_volume_mbsize(self, mock_size):
-        size = mock.Mock()
-        size.customize = mock.Mock(
+        size = Mock()
+        size.customize = Mock(
             return_value=42
         )
         mock_size.return_value = size
@@ -113,8 +112,8 @@ class TestVolumeManagerBase:
 
     @patch('kiwi.volume_manager.base.SystemSize')
     def test_get_volume_mbsize_for_oem_type(self, mock_size):
-        size = mock.Mock()
-        size.customize = mock.Mock(
+        size = Mock()
+        size.customize = Mock(
             return_value=42
         )
         mock_size.return_value = size
@@ -125,8 +124,8 @@ class TestVolumeManagerBase:
 
     @patch('kiwi.volume_manager.base.SystemSize')
     def test_get_volume_mbsize_nested_volumes(self, mock_size):
-        size = mock.Mock()
-        size.customize = mock.Mock(
+        size = Mock()
+        size.customize = Mock(
             return_value=42
         )
         mock_size.return_value = size
@@ -150,8 +149,8 @@ class TestVolumeManagerBase:
 
     @patch('kiwi.volume_manager.base.SystemSize')
     def test_get_volume_mbsize_root_volume(self, mock_size):
-        size = mock.Mock()
-        size.customize = mock.Mock(
+        size = Mock()
+        size.customize = Mock(
             return_value=42
         )
         mock_size.return_value = size
@@ -177,17 +176,17 @@ class TestVolumeManagerBase:
             ['root_dir/usr', 'root_dir/usr/lib']
         )
 
-    @raises(NotImplementedError)
     def test_mount_volumes(self):
-        self.volume_manager.mount_volumes()
+        with raises(NotImplementedError):
+            self.volume_manager.mount_volumes()
 
-    @raises(NotImplementedError)
     def test_umount_volumes(self):
-        self.volume_manager.umount_volumes()
+        with raises(NotImplementedError):
+            self.volume_manager.umount_volumes()
 
-    @raises(NotImplementedError)
     def test_get_volumes(self):
-        self.volume_manager.get_volumes()
+        with raises(NotImplementedError):
+            self.volume_manager.get_volumes()
 
     @patch('kiwi.volume_manager.base.DataSync')
     @patch('kiwi.volume_manager.base.MountManager.is_mounted')
@@ -196,7 +195,7 @@ class TestVolumeManagerBase:
     def test_sync_data(
         self, mock_umount_volumes, mock_mount_volumes, mock_mounted, mock_sync
     ):
-        data_sync = mock.Mock()
+        data_sync = Mock()
         mock_sync.return_value = data_sync
         mock_mounted.return_value = False
         self.volume_manager.mountpoint = 'mountpoint'
@@ -217,9 +216,9 @@ class TestVolumeManagerBase:
         self.volume_manager.setup_mountpoint()
         assert self.volume_manager.mountpoint == 'tmpdir'
 
-    @raises(KiwiVolumeManagerSetupError)
     def test_set_property_readonly_root(self):
-        self.volume_manager.set_property_readonly_root()
+        with raises(KiwiVolumeManagerSetupError):
+            self.volume_manager.set_property_readonly_root()
 
     @patch('kiwi.volume_manager.base.Command.run')
     def test_apply_attributes_on_volume(self, mock_command):

--- a/test/unit/volume_manager_btrfs_test.py
+++ b/test/unit/volume_manager_btrfs_test.py
@@ -1,28 +1,29 @@
-from mock import patch
-from mock import call
-import mock
-
 import datetime
-
-from .test_helper import raises, patch_open
+from mock import (
+    patch, call, Mock
+)
+from pytest import raises
 from lxml import etree
 from xml.dom import minidom
 from collections import namedtuple
+
+from .test_helper import patch_open
+
+from kiwi.volume_manager.btrfs import VolumeManagerBtrfs
 
 from kiwi.exceptions import (
     KiwiVolumeRootIDError,
     KiwiVolumeManagerSetupError
 )
-from kiwi.volume_manager.btrfs import VolumeManagerBtrfs
 
 
 class TestVolumeManagerBtrfs:
     @patch('os.path.exists')
     def setup(self, mock_path):
-        self.context_manager_mock = mock.Mock()
-        self.file_mock = mock.Mock()
-        self.enter_mock = mock.Mock()
-        self.exit_mock = mock.Mock()
+        self.context_manager_mock = Mock()
+        self.file_mock = Mock()
+        self.enter_mock = Mock()
+        self.exit_mock = Mock()
         self.enter_mock.return_value = self.file_mock
         setattr(self.context_manager_mock, '__enter__', self.enter_mock)
         setattr(self.context_manager_mock, '__exit__', self.exit_mock)
@@ -59,11 +60,11 @@ class TestVolumeManagerBtrfs:
             )
         ]
         mock_path.return_value = True
-        self.device_provider = mock.Mock()
-        self.device_provider.is_loop = mock.Mock(
+        self.device_provider = Mock()
+        self.device_provider.is_loop = Mock(
             return_value=True
         )
-        self.device_provider.get_device = mock.Mock(
+        self.device_provider.get_device = Mock(
             return_value='/dev/storage'
         )
         self.volume_manager = VolumeManagerBtrfs(
@@ -85,9 +86,9 @@ class TestVolumeManagerBtrfs:
         mock_command, mock_os_exists
     ):
         mock_mkdtemp.return_value = 'tmpdir'
-        toplevel_mount = mock.Mock()
+        toplevel_mount = Mock()
         mock_mount.return_value = toplevel_mount
-        command_call = mock.Mock()
+        command_call = Mock()
         command_call.output = 'ID 256 gen 23 top level 5 path @'
         mock_mapped_device.return_value = 'mapped_device'
         mock_os_exists.return_value = False
@@ -116,9 +117,9 @@ class TestVolumeManagerBtrfs:
         mock_command, mock_os_exists
     ):
         mock_mkdtemp.return_value = 'tmpdir'
-        toplevel_mount = mock.Mock()
+        toplevel_mount = Mock()
         mock_mount.return_value = toplevel_mount
-        command_call = mock.Mock()
+        command_call = Mock()
         command_call.output = \
             'ID 258 gen 26 top level 257 path @/.snapshots/1/snapshot'
         mock_mapped_device.return_value = 'mapped_device'
@@ -146,7 +147,6 @@ class TestVolumeManagerBtrfs:
             call(['btrfs', 'subvolume', 'set-default', '258', 'tmpdir'])
         ]
 
-    @raises(KiwiVolumeRootIDError)
     @patch('os.path.exists')
     @patch('kiwi.volume_manager.btrfs.Command.run')
     @patch('kiwi.volume_manager.btrfs.FileSystem')
@@ -156,12 +156,13 @@ class TestVolumeManagerBtrfs:
         self, mock_mount, mock_mapped_device, mock_fs,
         mock_command, mock_os_exists
     ):
-        command_call = mock.Mock()
+        command_call = Mock()
         command_call.output = 'id-string-invalid'
         mock_mapped_device.return_value = 'mapped_device'
         mock_os_exists.return_value = False
         mock_command.return_value = command_call
-        self.volume_manager.setup()
+        with raises(KiwiVolumeRootIDError):
+            self.volume_manager.setup()
 
     @patch('os.path.exists')
     @patch('kiwi.volume_manager.btrfs.Command.run')
@@ -171,7 +172,7 @@ class TestVolumeManagerBtrfs:
     def test_create_volumes(
         self, mock_attrs, mock_path, mock_mount, mock_command, mock_os_exists
     ):
-        volume_mount = mock.Mock()
+        volume_mount = Mock()
         mock_mount.return_value = volume_mount
         self.volume_manager.mountpoint = 'tmpdir'
         self.volume_manager.custom_args['root_is_snapshot'] = True
@@ -223,7 +224,7 @@ class TestVolumeManagerBtrfs:
         ]
 
     def test_get_volumes(self):
-        volume_mount = mock.Mock()
+        volume_mount = Mock()
         volume_mount.mountpoint = \
             '/tmp/kiwi_volumes.xx/@/.snapshots/1/snapshot/boot/grub2'
         volume_mount.device = 'device'
@@ -239,10 +240,10 @@ class TestVolumeManagerBtrfs:
 
     @patch('kiwi.volume_manager.btrfs.Command.run')
     def test_get_fstab(self, mock_command):
-        blkid_result = mock.Mock()
+        blkid_result = Mock()
         blkid_result.output = 'id'
         mock_command.return_value = blkid_result
-        volume_mount = mock.Mock()
+        volume_mount = Mock()
         volume_mount.mountpoint = \
             '/tmp/kiwi_volumes.xx/@/.snapshots/1/snapshot/var/tmp'
         volume_mount.device = 'device'
@@ -257,12 +258,12 @@ class TestVolumeManagerBtrfs:
     @patch('os.path.exists')
     @patch('kiwi.volume_manager.btrfs.Path.create')
     def test_mount_volumes(self, mock_path, mock_os_exists):
-        self.volume_manager.toplevel_mount = mock.Mock()
-        self.volume_manager.toplevel_mount.is_mounted = mock.Mock(
+        self.volume_manager.toplevel_mount = Mock()
+        self.volume_manager.toplevel_mount.is_mounted = Mock(
             return_value=False
         )
         mock_os_exists.return_value = False
-        volume_mount = mock.Mock()
+        volume_mount = Mock()
         volume_mount.mountpoint = \
             '/tmp/kiwi_volumes.xx/@/.snapshots/1/snapshot/var/tmp'
         self.volume_manager.toplevel_volume = '@/.snapshots/1/snapshot'
@@ -288,12 +289,12 @@ class TestVolumeManagerBtrfs:
         mock_command, mock_os_exists
     ):
         mock_mkdtemp.return_value = '/tmp/kiwi_volumes.xx'
-        toplevel_mount = mock.Mock()
-        toplevel_mount.is_mounted = mock.Mock(
+        toplevel_mount = Mock()
+        toplevel_mount.is_mounted = Mock(
             return_value=False
         )
         mock_mount.return_value = toplevel_mount
-        command_call = mock.Mock()
+        command_call = Mock()
         command_call.output = \
             'ID 258 gen 26 top level 257 path @/.snapshots/1/snapshot'
         mock_mapped_device.return_value = 'mapped_device'
@@ -304,7 +305,7 @@ class TestVolumeManagerBtrfs:
         self.volume_manager.setup()
 
         mock_os_exists.return_value = True
-        volume_mount = mock.Mock()
+        volume_mount = Mock()
         volume_mount.mountpoint = \
             '/tmp/kiwi_volumes.xx/@/.snapshots/1/snapshot/var/tmp'
         self.volume_manager.subvol_mount_list = [volume_mount]
@@ -316,12 +317,12 @@ class TestVolumeManagerBtrfs:
         assert volume_mount.mountpoint == '/tmp/kiwi_volumes.xx/var/tmp'
 
     def test_umount_volumes(self):
-        self.volume_manager.toplevel_mount = mock.Mock()
-        volume_mount = mock.Mock()
-        volume_mount.is_mounted = mock.Mock(
+        self.volume_manager.toplevel_mount = Mock()
+        volume_mount = Mock()
+        volume_mount.is_mounted = Mock(
             return_value=True
         )
-        self.volume_manager.toplevel_mount.is_mounted = mock.Mock(
+        self.volume_manager.toplevel_mount.is_mounted = Mock(
             return_value=True
         )
         self.volume_manager.subvol_mount_list = [volume_mount]
@@ -332,27 +333,27 @@ class TestVolumeManagerBtrfs:
         self.volume_manager.toplevel_mount.umount.assert_called_once_with()
 
     def test_umount_sub_volumes_busy(self):
-        self.volume_manager.toplevel_mount = mock.Mock()
-        volume_mount = mock.Mock()
-        volume_mount.is_mounted = mock.Mock(
+        self.volume_manager.toplevel_mount = Mock()
+        volume_mount = Mock()
+        volume_mount.is_mounted = Mock(
             return_value=True
         )
-        volume_mount.umount = mock.Mock(
+        volume_mount.umount = Mock(
             return_value=False
         )
         self.volume_manager.subvol_mount_list = [volume_mount]
         assert self.volume_manager.umount_volumes() is False
 
     def test_umount_toplevel_busy(self):
-        self.volume_manager.toplevel_mount = mock.Mock()
-        volume_mount = mock.Mock()
-        volume_mount.is_mounted = mock.Mock(
+        self.volume_manager.toplevel_mount = Mock()
+        volume_mount = Mock()
+        volume_mount.is_mounted = Mock(
             return_value=True
         )
-        self.volume_manager.toplevel_mount.is_mounted = mock.Mock(
+        self.volume_manager.toplevel_mount.is_mounted = Mock(
             return_value=True
         )
-        self.volume_manager.toplevel_mount.umount = mock.Mock(
+        self.volume_manager.toplevel_mount.umount = Mock(
             return_value=False
         )
         assert self.volume_manager.umount_volumes() is False
@@ -363,7 +364,7 @@ class TestVolumeManagerBtrfs:
     @patch('kiwi.volume_manager.btrfs.Command.run')
     @patch('os.path.exists')
     @patch('shutil.copyfile')
-    @patch.object(datetime, 'datetime', mock.Mock(wraps=datetime.datetime))
+    @patch.object(datetime, 'datetime', Mock(wraps=datetime.datetime))
     def test_sync_data(
         self, mock_copy, mock_exists, mock_command,
         mock_sync, mock_sysconf, mock_open
@@ -387,10 +388,10 @@ class TestVolumeManagerBtrfs:
         self.volume_manager.custom_args['quota_groups'] = True
         mock_exists.side_effect = exists
 
-        sysconf = mock.Mock()
-        sysconf.__contains__ = mock.Mock(side_effect=contains)
-        sysconf.__getitem__ = mock.Mock(side_effect=getitem)
-        sysconf.__setitem__ = mock.Mock(side_effect=setitem)
+        sysconf = Mock()
+        sysconf.__contains__ = Mock(side_effect=contains)
+        sysconf.__getitem__ = Mock(side_effect=getitem)
+        sysconf.__setitem__ = Mock(side_effect=setitem)
         mock_sysconf.return_value = sysconf
 
         xml_info = etree.tostring(etree.parse(
@@ -398,10 +399,10 @@ class TestVolumeManagerBtrfs:
         ))
         datetime.datetime.now.return_value = datetime.datetime(2016, 1, 1)
         mock_open.return_value = self.context_manager_mock
-        self.volume_manager.toplevel_mount = mock.Mock()
+        self.volume_manager.toplevel_mount = Mock()
         self.volume_manager.mountpoint = 'tmpdir'
         self.volume_manager.custom_args['root_is_snapshot'] = True
-        sync = mock.Mock()
+        sync = Mock()
         mock_sync.return_value = sync
 
         self.volume_manager.sync_data(['exclude_me'])
@@ -430,13 +431,12 @@ class TestVolumeManagerBtrfs:
             ])
         ]
 
-    @raises(KiwiVolumeManagerSetupError)
     @patch_open
     @patch('kiwi.volume_manager.btrfs.SysConfig')
     @patch('kiwi.volume_manager.btrfs.DataSync')
     @patch('kiwi.volume_manager.btrfs.Command.run')
     @patch('os.path.exists')
-    @patch.object(datetime, 'datetime', mock.Mock(wraps=datetime.datetime))
+    @patch.object(datetime, 'datetime', Mock(wraps=datetime.datetime))
     def test_sync_data_existing_bad_snapper_config(
         self, mock_exists, mock_command, mock_sync, mock_sysconf, mock_open
     ):
@@ -448,9 +448,9 @@ class TestVolumeManagerBtrfs:
         def contains(key):
             return key in item
 
-        sysconf = mock.Mock()
-        sysconf.__contains__ = mock.Mock(side_effect=contains)
-        sysconf.__getitem__ = mock.Mock(side_effect=getitem)
+        sysconf = Mock()
+        sysconf.__contains__ = Mock(side_effect=contains)
+        sysconf.__getitem__ = Mock(side_effect=getitem)
         mock_sysconf.return_value = sysconf
 
         self.volume_manager.custom_args['quota_groups'] = True
@@ -460,13 +460,14 @@ class TestVolumeManagerBtrfs:
         ))
         datetime.datetime.now.return_value = datetime.datetime(2016, 1, 1)
         mock_open.return_value = self.context_manager_mock
-        self.volume_manager.toplevel_mount = mock.Mock()
+        self.volume_manager.toplevel_mount = Mock()
         self.volume_manager.mountpoint = 'tmpdir'
         self.volume_manager.custom_args['root_is_snapshot'] = True
-        sync = mock.Mock()
+        sync = Mock()
         mock_sync.return_value = sync
 
-        self.volume_manager.sync_data(['exclude_me'])
+        with raises(KiwiVolumeManagerSetupError):
+            self.volume_manager.sync_data(['exclude_me'])
 
         mock_sync.assert_called_once_with(
             'root_dir', 'tmpdir/@/.snapshots/1/snapshot'
@@ -485,20 +486,20 @@ class TestVolumeManagerBtrfs:
     @patch('kiwi.volume_manager.btrfs.DataSync')
     @patch('kiwi.volume_manager.btrfs.Command.run')
     @patch('os.path.exists')
-    @patch.object(datetime, 'datetime', mock.Mock(wraps=datetime.datetime))
+    @patch.object(datetime, 'datetime', Mock(wraps=datetime.datetime))
     def test_sync_data_no_root_snapshot(
         self, mock_exists, mock_command, mock_sync
     ):
         self.volume_manager.custom_args['quota_groups'] = True
         mock_exists.return_value = True
         datetime.datetime.now.return_value = datetime.datetime(2016, 1, 1)
-        self.file_mock.readlines = mock.Mock(
+        self.file_mock.readlines = Mock(
             return_value=[]
         )
-        self.volume_manager.toplevel_mount = mock.Mock()
+        self.volume_manager.toplevel_mount = Mock()
         self.volume_manager.mountpoint = 'tmpdir'
         self.volume_manager.custom_args['root_is_snapshot'] = False
-        sync = mock.Mock()
+        sync = Mock()
         mock_sync.return_value = sync
 
         self.volume_manager.sync_data(['exclude_me'])
@@ -527,7 +528,7 @@ class TestVolumeManagerBtrfs:
     @patch('kiwi.volume_manager.btrfs.Path.wipe')
     def test_destructor(self, mock_wipe, mock_umount_volumes):
         mock_umount_volumes.return_value = True
-        self.volume_manager.toplevel_mount = mock.Mock()
+        self.volume_manager.toplevel_mount = Mock()
         self.volume_manager.__del__()
         mock_umount_volumes.assert_called_once_with()
         mock_wipe.assert_called_once_with(self.volume_manager.mountpoint)

--- a/test/unit/volume_manager_lvm_test.py
+++ b/test/unit/volume_manager_lvm_test.py
@@ -1,15 +1,13 @@
-from mock import patch
-from mock import call
-import mock
-
-from .test_helper import raises
+from mock import (
+    patch, call, Mock
+)
+from pytest import raises
 from collections import namedtuple
 
-from kiwi.exceptions import KiwiVolumeGroupConflict
-
 from kiwi.volume_manager.lvm import VolumeManagerLVM
-
 from kiwi.defaults import Defaults
+
+from kiwi.exceptions import KiwiVolumeGroupConflict
 
 
 class TestVolumeManagerLVM:
@@ -45,11 +43,11 @@ class TestVolumeManagerLVM:
             ),
         ]
         mock_path.return_value = True
-        self.device_provider = mock.Mock()
-        self.device_provider.is_loop = mock.Mock(
+        self.device_provider = Mock()
+        self.device_provider.is_loop = Mock(
             return_value=True
         )
-        self.device_provider.get_device = mock.Mock(
+        self.device_provider.get_device = Mock(
             return_value='/dev/storage'
         )
         self.volume_manager = VolumeManagerLVM(
@@ -88,7 +86,7 @@ class TestVolumeManagerLVM:
     @patch('kiwi.volume_manager.base.mkdtemp')
     def test_setup(self, mock_mkdtemp, mock_command):
         mock_mkdtemp.return_value = 'tmpdir'
-        command = mock.Mock()
+        command = Mock()
         # no output for commands to mock empty information for
         # vgs command, indicating the volume group is not in use
         command.output = ''
@@ -117,13 +115,13 @@ class TestVolumeManagerLVM:
         assert self.volume_manager.volume_group == 'volume_group'
         self.volume_manager.volume_group = None
 
-    @raises(KiwiVolumeGroupConflict)
     @patch('kiwi.volume_manager.lvm.Command.run')
     def test_setup_volume_group_host_conflict(self, mock_command):
-        command = mock.Mock()
+        command = Mock()
         command.output = 'some_data_about_volume_group'
         mock_command.return_value = command
-        self.volume_manager.setup('volume_group')
+        with raises(KiwiVolumeGroupConflict):
+            self.volume_manager.setup('volume_group')
 
     @patch('os.path.exists')
     @patch('kiwi.volume_manager.base.SystemSize')
@@ -136,12 +134,12 @@ class TestVolumeManagerLVM:
         self, mock_attrs, mock_mount, mock_mapped_device, mock_fs,
         mock_command, mock_size, mock_os_exists
     ):
-        filesystem = mock.Mock()
+        filesystem = Mock()
         mock_fs.return_value = filesystem
         self.volume_manager.mountpoint = 'tmpdir'
         mock_mapped_device.return_value = 'mapped_device'
-        size = mock.Mock()
-        size.customize = mock.Mock(
+        size = Mock()
+        size.customize = Mock(
             return_value=42
         )
         mock_size.return_value = size
@@ -237,7 +235,7 @@ class TestVolumeManagerLVM:
 
     @patch('kiwi.volume_manager.lvm.Path')
     def test_mount_volumes(self, mock_path):
-        volume_mount = mock.Mock()
+        volume_mount = Mock()
         volume_mount.mountpoint = 'volume_mount_point'
         self.volume_manager.mount_list = [volume_mount]
         self.volume_manager.mount_volumes()
@@ -245,14 +243,14 @@ class TestVolumeManagerLVM:
         volume_mount.mount.assert_called_once_with(options=['a,b,c'])
 
     def test_umount_volumes(self):
-        volume_mount = mock.Mock()
+        volume_mount = Mock()
         volume_mount.mountpoint = 'volume_mount_point'
         self.volume_manager.mount_list = [volume_mount]
         assert self.volume_manager.umount_volumes() is True
         volume_mount.umount.assert_called_once_with()
 
     def test_get_volumes(self):
-        volume_mount = mock.Mock()
+        volume_mount = Mock()
         volume_mount.mountpoint = \
             '/tmp/kiwi_volumes.f2qx_d3y/boot/grub2/x86_64-efi'
         volume_mount.device = '/dev/mapper/vg1-LVRoot'
@@ -265,7 +263,7 @@ class TestVolumeManagerLVM:
         }
 
     def test_get_fstab(self):
-        volume_mount = mock.Mock()
+        volume_mount = Mock()
         volume_mount.mountpoint = '/tmp/kiwi_volumes.f2qx_d3y/var/tmp'
         volume_mount.device = 'device'
         self.volume_manager.mount_list = [volume_mount]
@@ -278,7 +276,7 @@ class TestVolumeManagerLVM:
     def test_destructor_busy_volumes(self, mock_command, mock_wipe):
         self.volume_manager.mountpoint = 'tmpdir'
         self.volume_manager.volume_group = 'volume_group'
-        volume_mount = mock.Mock()
+        volume_mount = Mock()
         volume_mount.is_mounted.return_value = True
         volume_mount.umount.return_value = False
         volume_mount.mountpoint = 'volume_mount_point'

--- a/test/unit/volume_manager_test.py
+++ b/test/unit/volume_manager_test.py
@@ -1,25 +1,24 @@
-from mock import patch
-
-import mock
-
-from .test_helper import raises
-
-from kiwi.exceptions import KiwiVolumeManagerSetupError
+from mock import (
+    patch, Mock
+)
+from pytest import raises
 
 from kiwi.volume_manager import VolumeManager
 
+from kiwi.exceptions import KiwiVolumeManagerSetupError
+
 
 class TestVolumeManager:
-    @raises(KiwiVolumeManagerSetupError)
     def test_volume_manager_not_implemented(self):
-        VolumeManager('foo', mock.Mock(), 'root_dir', mock.Mock())
+        with raises(KiwiVolumeManagerSetupError):
+            VolumeManager('foo', Mock(), 'root_dir', Mock())
 
     @patch('kiwi.volume_manager.VolumeManagerLVM')
     @patch('os.path.exists')
     def test_volume_manager_lvm(self, mock_path, mock_lvm):
         mock_path.return_value = True
-        provider = mock.Mock()
-        volumes = mock.Mock()
+        provider = Mock()
+        volumes = Mock()
         VolumeManager('lvm', provider, 'root_dir', volumes)
         mock_lvm.assert_called_once_with(
             provider, 'root_dir', volumes, None
@@ -29,8 +28,8 @@ class TestVolumeManager:
     @patch('os.path.exists')
     def test_volume_manager_btrfs(self, mock_path, mock_btrfs):
         mock_path.return_value = True
-        provider = mock.Mock()
-        volumes = mock.Mock()
+        provider = Mock()
+        volumes = Mock()
         VolumeManager('btrfs', provider, 'root_dir', volumes)
         mock_btrfs.assert_called_once_with(
             provider, 'root_dir', volumes, None

--- a/test/unit/xml_description_test.py
+++ b/test/unit/xml_description_test.py
@@ -2,9 +2,10 @@ from mock import patch
 import mock
 from builtins import bytes
 from lxml import etree
-
-from .test_helper import raises
+from pytest import raises
 from collections import namedtuple
+
+from kiwi.xml_description import XMLDescription
 
 from kiwi.exceptions import (
     KiwiSchemaImportError,
@@ -15,7 +16,6 @@ from kiwi.exceptions import (
     KiwiCommandNotFound,
     KiwiExtensionError
 )
-from kiwi.xml_description import XMLDescription
 
 
 class TestSchema:
@@ -126,9 +126,9 @@ class TestSchema:
             xml_content=test_xml_extension_invalid
         )
 
-    @raises(KiwiDescriptionConflict)
     def test_constructor_conflict(self):
-        XMLDescription(description='description', xml_content='content')
+        with raises(KiwiDescriptionConflict):
+            XMLDescription(description='description', xml_content='content')
 
     def test_load_schema_from_xml_content(self):
         schema = etree.parse('../../kiwi/schema/kiwi.rng')
@@ -141,16 +141,15 @@ class TestSchema:
         parsed = self.description_from_data.load()
         assert parsed.get_schemaversion() == schemaversion
 
-    @raises(KiwiSchemaImportError)
     @patch('lxml.etree.RelaxNG')
     @patch.object(XMLDescription, '_xsltproc')
     def test_load_schema_import_error(self, mock_xslt, mock_relax):
         mock_relax.side_effect = KiwiSchemaImportError(
             'ImportError'
         )
-        self.description_from_file.load()
+        with raises(KiwiSchemaImportError):
+            self.description_from_file.load()
 
-    @raises(KiwiValidationError)
     @patch('lxml.isoschematron.Schematron')
     @patch('lxml.etree.RelaxNG')
     @patch('lxml.etree.parse')
@@ -164,9 +163,9 @@ class TestSchema:
         )
         mock_relax.return_value = mock_validate
         mock_schematron.return_value = mock_validate
-        self.description_from_file.load()
+        with raises(KiwiValidationError):
+            self.description_from_file.load()
 
-    @raises(KiwiDescriptionInvalid)
     @patch('lxml.isoschematron.Schematron')
     @patch('lxml.etree.RelaxNG')
     @patch('lxml.etree.parse')
@@ -213,9 +212,9 @@ class TestSchema:
             error='',
             returncode=1
         )
-        self.description_from_file.load()
+        with raises(KiwiDescriptionInvalid):
+            self.description_from_file.load()
 
-    @raises(KiwiDescriptionInvalid)
     @patch('lxml.isoschematron.Schematron')
     @patch('lxml.etree.RelaxNG')
     @patch('lxml.etree.parse')
@@ -262,9 +261,9 @@ class TestSchema:
             error='',
             returncode=1
         )
-        self.description_from_data.load()
+        with raises(KiwiDescriptionInvalid):
+            self.description_from_data.load()
 
-    @raises(KiwiDescriptionInvalid)
     @patch('lxml.isoschematron.Schematron')
     @patch('lxml.etree.RelaxNG')
     @patch('lxml.etree.parse')
@@ -286,9 +285,9 @@ class TestSchema:
         mock_relax.return_value = mock_rng_validate
         mock_schematron.return_value = mock_sch_validate
         mock_command.side_effect = KiwiCommandNotFound('No jing command')
-        self.description_from_data.load()
+        with raises(KiwiDescriptionInvalid):
+            self.description_from_data.load()
 
-    @raises(KiwiDataStructureError)
     @patch('lxml.isoschematron.Schematron')
     @patch('lxml.etree.RelaxNG')
     @patch('lxml.etree.parse')
@@ -311,7 +310,8 @@ class TestSchema:
         mock_xml_parse.side_effect = KiwiDataStructureError(
             'DataStructureError'
         )
-        self.description_from_file.load()
+        with raises(KiwiDataStructureError):
+            self.description_from_file.load()
 
     @patch('kiwi.xml_description.Command.run')
     def test_load_extension(self, mock_command):
@@ -327,20 +327,20 @@ class TestSchema:
         )
         assert xml_data.getroot()[0].get('name') == 'cool stuff'
 
-    @raises(KiwiExtensionError)
     def test_load_extension_multiple_toplevel_error(self):
-        self.extension_multiple_toplevel_description_from_data.load()
+        with raises(KiwiExtensionError):
+            self.extension_multiple_toplevel_description_from_data.load()
 
-    @raises(KiwiExtensionError)
     @patch('kiwi.xml_description.Command.run')
     def test_load_extension_schema_error(self, mock_command):
         mock_command.side_effect = Exception
-        self.extension_description_from_data.load()
+        with raises(KiwiExtensionError):
+            self.extension_description_from_data.load()
 
     @patch('kiwi.xml_description.Command.run')
-    @raises(KiwiExtensionError)
     def test_load_extension_validation_error(self, mock_command):
         command_output = mock.Mock()
         command_output.output = 'file://../data/my_plugin.rng'
         mock_command.return_value = command_output
-        self.extension_invalid_description_from_data.load()
+        with raises(KiwiExtensionError):
+            self.extension_invalid_description_from_data.load()

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1,6 +1,5 @@
 from mock import patch
-
-from .test_helper import raises
+from pytest import raises
 
 from kiwi.xml_state import XMLState
 from kiwi.xml_description import XMLDescription
@@ -253,21 +252,21 @@ class TestXMLState:
         state = XMLState(xml_data, ['vmxFlavour'], 'vmx')
         assert state.get_build_type_name() == 'vmx'
 
-    @raises(KiwiTypeNotFound)
     def test_build_type_not_found(self):
         xml_data = self.description.load()
-        XMLState(xml_data, ['vmxFlavour'], 'foo')
+        with raises(KiwiTypeNotFound):
+            XMLState(xml_data, ['vmxFlavour'], 'foo')
 
-    @raises(KiwiTypeNotFound)
     def test_build_type_not_found_no_default_type(self):
         description = XMLDescription('../data/example_no_default_type.xml')
         xml_data = description.load()
-        XMLState(xml_data, ['minimal'])
+        with raises(KiwiTypeNotFound):
+            XMLState(xml_data, ['minimal'])
 
-    @raises(KiwiProfileNotFound)
     def test_profile_not_found(self):
         xml_data = self.description.load()
-        XMLState(xml_data, ['foo'])
+        with raises(KiwiProfileNotFound):
+            XMLState(xml_data, ['foo'])
 
     def test_profile_requires(self):
         xml_data = self.description.load()
@@ -565,19 +564,19 @@ class TestXMLState:
     def test_get_fs_create_option_list(self):
         assert self.state.get_fs_create_option_list() == ['-O', '^has_journal']
 
-    @raises(KiwiDistributionNameError)
     @patch('kiwi.xml_parse.type_.get_boot')
     def test_get_distribution_name_from_boot_attribute_no_boot(self, mock_boot):
         mock_boot.return_value = None
-        self.state.get_distribution_name_from_boot_attribute()
+        with raises(KiwiDistributionNameError):
+            self.state.get_distribution_name_from_boot_attribute()
 
-    @raises(KiwiDistributionNameError)
     @patch('kiwi.xml_parse.type_.get_boot')
     def test_get_distribution_name_from_boot_attribute_invalid_boot(
         self, mock_boot
     ):
         mock_boot.return_value = 'invalid'
-        self.state.get_distribution_name_from_boot_attribute()
+        with raises(KiwiDistributionNameError):
+            self.state.get_distribution_name_from_boot_attribute()
 
     def test_delete_repository_sections(self):
         self.state.delete_repository_sections()


### PR DESCRIPTION
Use raises as context manager instead of a method decorator.
This clearly identifies which code part is expected to raise
an exception. Related to Issue #1128


