### PR TITLE
Using the correct Tumbleweed base image

### DIFF
--- a/build-tests/x86/test-image-docker-derived/appliance.kiwi
+++ b/build-tests/x86/test-image-docker-derived/appliance.kiwi
@@ -7,7 +7,7 @@
         <specification>Builder image based on Tumbleweed</specification>
     </description>
     <preferences>
-        <type image="docker" derived_from="obs://openSUSE:Factory/images/opensuse/tumbleweed#latest">
+        <type image="docker" derived_from="obs://openSUSE:Containers:Tumbleweed/containers/opensuse/tumbleweed#latest"> 
             <containerconfig name="builder" tag="1.0" additionaltags="latest"/>
         </type>
         <version>1.0</version>


### PR DESCRIPTION
This PR fixes the derived docker image test.
