### PR TITLE
Added support for metalink repo defintions

### DIFF
--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -129,7 +129,8 @@ class RepositoryApt(RepositoryBase):
         self, name, uri, repo_type='deb',
         prio=None, dist=None, components=None,
         user=None, secret=None, credentials_file=None,
-        repo_gpgcheck=None, pkg_gpgcheck=None
+        repo_gpgcheck=None, pkg_gpgcheck=None,
+        sourcetype=None
     ):
         """
         Add apt_get repository
@@ -138,13 +139,14 @@ class RepositoryApt(RepositoryBase):
         :param str uri: repository URI
         :param repo_type: unused
         :param int prio: unused
-        :param dist: distribution name for non flat deb repos
-        :param components: distribution categories
-        :param user: unused
-        :param secret: unused
-        :param credentials_file: unused
+        :param str dist: distribution name for non flat deb repos
+        :param str components: distribution categories
+        :param str user: unused
+        :param str secret: unused
+        :param str credentials_file: unused
         :param bool repo_gpgcheck: enable repository signature validation
-        :param pkg_gpgcheck: unused
+        :param bool pkg_gpgcheck: unused
+        :param str sourcetype: unused
         """
         list_file = '/'.join(
             [self.shared_apt_get_dir['sources-dir'], name + '.list']
@@ -162,7 +164,9 @@ class RepositoryApt(RepositoryBase):
         self._add_components(components)
         with open(list_file, 'w') as repo:
             if repo_gpgcheck is False:
-                repo_line = 'deb [trusted=yes check-valid-until=no] {0}'.format(uri)
+                repo_line = 'deb [trusted=yes check-valid-until=no] {0}'.format(
+                    uri
+                )
             else:
                 repo_line = 'deb {0}'.format(uri)
             if not dist:

--- a/kiwi/repository/base.py
+++ b/kiwi/repository/base.py
@@ -63,7 +63,8 @@ class RepositoryBase:
 
     def add_repo(
         self, name, uri, repo_type, prio, dist, components,
-        user, secret, credentials_file, repo_gpgcheck, pkg_gpgcheck
+        user, secret, credentials_file, repo_gpgcheck, pkg_gpgcheck,
+        sourcetype
     ):
         """
         Add repository
@@ -74,13 +75,14 @@ class RepositoryBase:
         :param str uri: unused
         :param repo_type: unused
         :param int prio: unused
-        :param dist: unused
-        :param components: unused
-        :param user: unused
-        :param secret: unused
-        :param credentials_file: unused
-        :param repo_gpgcheck: unused
-        :param pkg_gpgcheck: unused
+        :param str dist: unused
+        :param str components: unused
+        :param str user: unused
+        :param str secret: unused
+        :param str credentials_file: unused
+        :param bool repo_gpgcheck: unused
+        :param bool pkg_gpgcheck: unused
+        :param str sourcetype: unused
         """
         raise NotImplementedError
 

--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -153,7 +153,8 @@ class RepositoryDnf(RepositoryBase):
         self, name, uri, repo_type='rpm-md',
         prio=None, dist=None, components=None,
         user=None, secret=None, credentials_file=None,
-        repo_gpgcheck=None, pkg_gpgcheck=None
+        repo_gpgcheck=None, pkg_gpgcheck=None,
+        sourcetype=None
     ):
         """
         Add dnf repository
@@ -162,13 +163,15 @@ class RepositoryDnf(RepositoryBase):
         :param str uri: repository URI
         :param repo_type: repostory type name
         :param int prio: dnf repostory priority
-        :param dist: unused
-        :param components: unused
-        :param user: unused
-        :param secret: unused
-        :param credentials_file: unused
+        :param str dist: unused
+        :param str components: unused
+        :param str user: unused
+        :param str secret: unused
+        :param str credentials_file: unused
         :param bool repo_gpgcheck: enable repository signature validation
         :param bool pkg_gpgcheck: enable package signature validation
+        :param str sourcetype:
+            source type, one of 'baseurl', 'metalink' or 'mirrorlist'
         """
         repo_file = self.shared_dnf_dir['reposd-dir'] + '/' + name + '.repo'
         self.repo_names.append(name + '.repo')
@@ -181,7 +184,7 @@ class RepositoryDnf(RepositoryBase):
             name, 'name', name
         )
         repo_config.set(
-            name, 'baseurl', uri
+            name, sourcetype if sourcetype else 'baseurl', uri
         )
         if prio:
             repo_config.set(

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -233,7 +233,8 @@ class RepositoryZypper(RepositoryBase):
         self, name, uri, repo_type='rpm-md',
         prio=None, dist=None, components=None,
         user=None, secret=None, credentials_file=None,
-        repo_gpgcheck=None, pkg_gpgcheck=None
+        repo_gpgcheck=None, pkg_gpgcheck=None,
+        sourcetype=None
     ):
         """
         Add zypper repository
@@ -242,13 +243,14 @@ class RepositoryZypper(RepositoryBase):
         :param str uri: repository URI
         :param repo_type: repostory type name
         :param int prio: zypper repostory priority
-        :param dist: unused
-        :param components: unused
-        :param user: credentials username
-        :param secret: credentials password
-        :param credentials_file: zypper credentials file
+        :param str dist: unused
+        :param str components: unused
+        :param str user: credentials username
+        :param str secret: credentials password
+        :param str credentials_file: zypper credentials file
         :param bool repo_gpgcheck: enable repository signature validation
         :param bool pkg_gpgcheck: enable package signature validation
+        :param str sourcetype: unused
         """
         if credentials_file:
             repo_secret = os.sep.join(

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -921,10 +921,21 @@ div {
         ## Channel username if required. It depends on the url type
         ## whether and how this information is passed
         k.username.attribute
+    k.repository.sourcetype.attribute =
+        ## Specify the source type of the repository path.
+        ## Depending on if the source path is a simple url or a
+        ## pointer to a metadata file or mirror list, the
+        ## configured package manager needs to be setup
+        ## appropriately. By default the source is expected to
+        ## be a simple repository url
+        attribute sourcetype {
+            "baseurl" | "metalink" | "mirrorlist"
+        }
     k.repository.attlist =
         k.repository.type.attribute? &
         k.repository.profiles.attribute? &
         k.repository.alias.attribute? &
+        k.repository.sourcetype.attribute? &
         k.repository.components.attribute? &
         k.repository.distribution.attribute? &
         (

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1429,6 +1429,21 @@ whether and how this information is passed</a:documentation>
 whether and how this information is passed</a:documentation>
       </ref>
     </define>
+    <define name="k.repository.sourcetype.attribute">
+      <attribute name="sourcetype">
+        <a:documentation>Specify the source type of the repository path.
+Depending on if the source path is a simple url or a
+pointer to a metadata file or mirror list, the
+configured package manager needs to be setup
+appropriately. By default the source is expected to
+be a simple repository url</a:documentation>
+        <choice>
+          <value>baseurl</value>
+          <value>metalink</value>
+          <value>mirrorlist</value>
+        </choice>
+      </attribute>
+    </define>
     <define name="k.repository.attlist">
       <interleave>
         <optional>
@@ -1439,6 +1454,9 @@ whether and how this information is passed</a:documentation>
         </optional>
         <optional>
           <ref name="k.repository.alias.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repository.sourcetype.attribute"/>
         </optional>
         <optional>
           <ref name="k.repository.components.attribute"/>

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -139,17 +139,19 @@ class SystemPrepare:
             repo_components = xml_repo.get_components()
             repo_repository_gpgcheck = xml_repo.get_repository_gpgcheck()
             repo_package_gpgcheck = xml_repo.get_package_gpgcheck()
+            repo_sourcetype = xml_repo.get_sourcetype()
             log.info('Setting up repository %s', repo_source)
-            log.info('--> Type: %s', repo_type)
+            log.info('--> Type: {0}'.format(repo_type))
+            log.info('--> Metalink: {0}'.format(repo_sourcetype))
             if repo_priority:
-                log.info('--> Priority: %s', repo_priority)
+                log.info('--> Priority: {0}'.format(repo_priority))
 
             uri = Uri(repo_source, repo_type)
             repo_source_translated = uri.translate()
-            log.info('--> Translated: %s', repo_source_translated)
+            log.info('--> Translated: {0}'.format(repo_source_translated))
             if not repo_alias:
                 repo_alias = uri.alias()
-            log.info('--> Alias: %s', repo_alias)
+            log.info('--> Alias: {0}'.format(repo_alias))
 
             if not uri.is_remote() and not os.path.exists(
                 repo_source_translated
@@ -167,7 +169,8 @@ class SystemPrepare:
                 repo_alias, repo_source_translated,
                 repo_type, repo_priority, repo_dist, repo_components,
                 repo_user, repo_secret, uri.credentials_file_name(),
-                repo_repository_gpgcheck, repo_package_gpgcheck
+                repo_repository_gpgcheck, repo_package_gpgcheck,
+                repo_sourcetype
             )
             if clear_cache:
                 repo.delete_repo_cache(repo_alias)

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -130,6 +130,7 @@ class SystemSetup:
             repo_components = xml_repo.get_components()
             repo_repository_gpgcheck = xml_repo.get_repository_gpgcheck()
             repo_package_gpgcheck = xml_repo.get_package_gpgcheck()
+            repo_sourcetype = xml_repo.get_sourcetype()
             uri = Uri(repo_source, repo_type)
             repo_source_translated = uri.translate(
                 check_build_environment=False
@@ -144,7 +145,8 @@ class SystemSetup:
                 repo_alias, repo_source_translated,
                 repo_type, repo_priority, repo_dist, repo_components,
                 repo_user, repo_secret, uri.credentials_file_name(),
-                repo_repository_gpgcheck, repo_package_gpgcheck
+                repo_repository_gpgcheck, repo_package_gpgcheck,
+                repo_sourcetype
             )
 
     def import_shell_environment(self, profile):

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -101,7 +101,7 @@ try:
     from generatedssuper import GeneratedsSuper
 except ImportError as exp:
     
-    class GeneratedsSuper:
+    class GeneratedsSuper(object):
         tzoff_pattern = re_.compile(r'(\+|-)((0\d|1[0-3]):[0-5]\d|14:00)$')
         class _FixedOffsetTZ(datetime_.tzinfo):
             def __init__(self, offset, name):
@@ -678,7 +678,7 @@ class MixedContainer:
             outfile.write(')\n')
 
 
-class MemberSpec_:
+class MemberSpec_(object):
     def __init__(self, name='', data_type='', container=0,
             optional=0, child_attrs=None, choice=None):
         self.name = name
@@ -2050,12 +2050,13 @@ class repository(k_source):
     """The Name of the Repository"""
     subclass = None
     superclass = k_source
-    def __init__(self, source=None, type_=None, profiles=None, alias=None, components=None, distribution=None, imageinclude=None, imageonly=None, repository_gpgcheck=None, package_gpgcheck=None, priority=None, password=None, username=None):
+    def __init__(self, source=None, type_=None, profiles=None, alias=None, sourcetype=None, components=None, distribution=None, imageinclude=None, imageonly=None, repository_gpgcheck=None, package_gpgcheck=None, priority=None, password=None, username=None):
         self.original_tagname_ = None
         super(repository, self).__init__(source, )
         self.type_ = _cast(None, type_)
         self.profiles = _cast(None, profiles)
         self.alias = _cast(None, alias)
+        self.sourcetype = _cast(None, sourcetype)
         self.components = _cast(None, components)
         self.distribution = _cast(None, distribution)
         self.imageinclude = _cast(bool, imageinclude)
@@ -2082,6 +2083,8 @@ class repository(k_source):
     def set_profiles(self, profiles): self.profiles = profiles
     def get_alias(self): return self.alias
     def set_alias(self, alias): self.alias = alias
+    def get_sourcetype(self): return self.sourcetype
+    def set_sourcetype(self, sourcetype): self.sourcetype = sourcetype
     def get_components(self): return self.components
     def set_components(self, components): self.components = components
     def get_distribution(self): return self.distribution
@@ -2139,6 +2142,9 @@ class repository(k_source):
         if self.alias is not None and 'alias' not in already_processed:
             already_processed.add('alias')
             outfile.write(' alias=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.alias), input_name='alias')), ))
+        if self.sourcetype is not None and 'sourcetype' not in already_processed:
+            already_processed.add('sourcetype')
+            outfile.write(' sourcetype=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.sourcetype), input_name='sourcetype')), ))
         if self.components is not None and 'components' not in already_processed:
             already_processed.add('components')
             outfile.write(' components=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.components), input_name='components')), ))
@@ -2189,6 +2195,11 @@ class repository(k_source):
         if value is not None and 'alias' not in already_processed:
             already_processed.add('alias')
             self.alias = value
+        value = find_attr_value_('sourcetype', node)
+        if value is not None and 'sourcetype' not in already_processed:
+            already_processed.add('sourcetype')
+            self.sourcetype = value
+            self.sourcetype = ' '.join(self.sourcetype.split())
         value = find_attr_value_('components', node)
         if value is not None and 'components' not in already_processed:
             already_processed.add('components')

--- a/test/unit/repository_base_test.py
+++ b/test/unit/repository_base_test.py
@@ -23,7 +23,7 @@ class TestRepositoryBase:
         with raises(NotImplementedError):
             self.repo.add_repo(
                 'name', 'uri', 'type', 'prio', 'dist', ['components'],
-                'user', 'secret', 'credentials-file', False, False
+                'user', 'secret', 'credentials-file', False, False, False
             )
 
     def test_setup_package_database_configuration(self):

--- a/test/unit/repository_dnf_test.py
+++ b/test/unit/repository_dnf_test.py
@@ -106,6 +106,23 @@ class TestRepositoryDnf:
                 '/shared-dir/dnf/repos/foo.repo', 'w'
             )
 
+        repo_config.add_section.reset_mock()
+        repo_config.set.reset_mock()
+        mock_exists.return_value = False
+        with patch('builtins.open', create=True) as mock_open:
+            self.repo.add_repo(
+                'bar', 'https://metalink', 'rpm-md', sourcetype='metalink'
+            )
+
+            repo_config.add_section.assert_called_once_with('bar')
+            assert repo_config.set.call_args_list == [
+                call('bar', 'name', 'bar'),
+                call('bar', 'metalink', 'https://metalink')
+            ]
+            mock_open.assert_called_once_with(
+                '/shared-dir/dnf/repos/bar.repo', 'w'
+            )
+
     @patch('kiwi.repository.dnf.RpmDataBase')
     def test_setup_package_database_configuration(self, mock_RpmDataBase):
         rpmdb = mock.Mock()

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -209,11 +209,11 @@ class TestSystemPrepare:
         assert repo.add_repo.call_args_list == [
             call(
                 'uri-alias', 'uri', None, 42,
-                None, None, None, None, 'credentials-file', None, None
+                None, None, None, None, 'credentials-file', None, None, None
             ),
             call(
                 'uri-alias', 'uri', 'rpm-md', None,
-                None, None, None, None, 'credentials-file', None, None
+                None, None, None, None, 'credentials-file', None, None, None
             )
         ]
         assert repo.delete_repo_cache.call_args_list == [

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -1005,5 +1005,5 @@ class TestSystemSetup:
         self.setup_with_real_xml.import_repositories_marked_as_imageinclude()
         assert repo.add_repo.call_args_list[0] == call(
             'uri-alias', 'uri', 'rpm-md', None, None, None, None, None,
-            'kiwiRepoCredentials', None, None
+            'kiwiRepoCredentials', None, None, None
         )


### PR DESCRIPTION
Repository source paths that points to a metalink file which
needs to be downloaded and handled by the configured package
manager requires a different repository configuration. Thus
we now support a new attribute metalink which allows to flag
the repository definition as a metalink source. Currently
the dnf repository class is the only one that makes use of
the information. This change is required to support
Fedora >= 30 images. I also expect this concept to be used
by other distributions in the future


