### PR TITLE
Delete use of linuxefi/initrdefi grub commands

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -485,8 +485,6 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         * SUSE_BTRFS_SNAPSHOT_BOOTING
         * GRUB_BACKGROUND
         * GRUB_THEME
-        * GRUB_USE_LINUXEFI
-        * GRUB_USE_INITRDEFI
         * GRUB_SERIAL_COMMAND
         * GRUB_CMDLINE_LINUX_DEFAULT
         """
@@ -518,11 +516,6 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
             if os.path.exists(os.sep.join([self.root_dir, theme_background])):
                 grub_default_entries['GRUB_BACKGROUND'] = theme_background
-        if self.firmware.efi_mode():
-            # linuxefi/initrdefi only exist on x86, others always use efi
-            if self.arch == 'ix86' or self.arch == 'x86_64':
-                grub_default_entries['GRUB_USE_LINUXEFI'] = 'true'
-                grub_default_entries['GRUB_USE_INITRDEFI'] = 'true'
         if self.xml_state.build_type.get_btrfs_root_is_snapshot():
             grub_default_entries['SUSE_BTRFS_SNAPSHOT_BOOTING'] = 'true'
         if self.custom_args.get('boot_is_crypto'):

--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -45,12 +45,6 @@ class BootLoaderTemplateGrub2:
         self.header_hybrid = dedent('''
             set linux=linux
             set initrd=initrd
-            if [ "$${grub_cpu}" = "x86_64" -o "$${grub_cpu}" = "i386" ];then
-                if [ "$${grub_platform}" = "efi" ]; then
-                    set linux=linuxefi
-                    set initrd=initrdefi
-                fi
-            fi
         ''').strip() + os.linesep
 
         self.header_gfxterm = dedent('''

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -415,8 +415,7 @@ class Defaults:
         ]
         if host_architecture == 'x86_64':
             modules += [
-                'efi_uga',
-                'linuxefi'
+                'efi_uga'
             ]
         return modules
 

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -311,8 +311,6 @@ class TestBootLoaderConfigGrub2:
             ),
             call('GRUB_THEME', '/boot/grub2/themes/openSUSE/theme.txt'),
             call('GRUB_TIMEOUT', 10),
-            call('GRUB_USE_INITRDEFI', 'true'),
-            call('GRUB_USE_LINUXEFI', 'true'),
             call('SUSE_BTRFS_SNAPSHOT_BOOTING', 'true')
         ]
 
@@ -557,7 +555,7 @@ class TestBootLoaderConfigGrub2:
                 'btrfs', 'lvm', 'luks', 'gcry_rijndael', 'gcry_sha256',
                 'gcry_sha512', 'crypto', 'cryptodisk', 'test', 'true',
                 'multiboot', 'part_gpt', 'part_msdos', 'efi_gop',
-                'efi_uga', 'linuxefi'
+                'efi_uga'
             ])
         ]
 
@@ -626,7 +624,7 @@ class TestBootLoaderConfigGrub2:
                 'minicmd', 'gfxterm', 'gfxmenu', 'all_video', 'xfs',
                 'btrfs', 'lvm', 'luks', 'gcry_rijndael', 'gcry_sha256',
                 'gcry_sha512', 'crypto', 'cryptodisk', 'test', 'true',
-                'part_gpt', 'part_msdos', 'efi_gop', 'efi_uga', 'linuxefi'
+                'part_gpt', 'part_msdos', 'efi_gop', 'efi_uga'
             ])
         ]
         assert mock_sync.call_args_list == [
@@ -990,7 +988,7 @@ class TestBootLoaderConfigGrub2:
                     'all_video', 'xfs', 'btrfs', 'lvm', 'luks',
                     'gcry_rijndael', 'gcry_sha256', 'gcry_sha512',
                     'crypto', 'cryptodisk', 'test', 'true', 'part_gpt',
-                    'part_msdos', 'efi_gop', 'efi_uga', 'linuxefi'
+                    'part_msdos', 'efi_gop', 'efi_uga'
                 ]
             )
         ]


### PR DESCRIPTION
The above commands were used by kiwi on x86 in EFI mode but
seems to be deleted from upstream grub and therefore tend
to be no longer present on the distributions. In addition
my tests with older distributions and simple use of the
linux/initrd standard commands in EFI mode were successful
which lead to this patch.

