### PR TITLE
Complete dracut setup for luks boot

### DIFF
--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -110,6 +110,12 @@ class BootImageDracut(BootImageBase):
                     ' '.join(config['omit_modules'])
                 )
             )
+        if config.get('install_items'):
+            dracut_config.append(
+                'install_items+=" {0} "\n'.format(
+                    ' '.join(config['install_items'])
+                )
+            )
         if dracut_config:
             with open(config_file, 'w') as config:
                 config.writelines(dracut_config)

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -272,8 +272,9 @@ class DiskBuilder:
         # create luks on current root device if requested
         if self.luks:
             self.luks_root = LuksDevice(device_map['root'])
+            self.luks_boot_keyname = '/.root.keyfile'
             self.luks_boot_keyfile = ''.join(
-                [self.root_dir, '/.root.keyfile']
+                [self.root_dir, self.luks_boot_keyname]
             )
             self.luks_root.create_crypto_luks(
                 passphrase=self.luks,
@@ -281,6 +282,13 @@ class DiskBuilder:
                 keyfile=self.luks_boot_keyfile if self.boot_is_crypto else None
             )
             if self.boot_is_crypto:
+                self.luks_boot_keyfile_setup = ''.join(
+                    [self.root_dir, '/etc/dracut.conf.d/99-luks-boot.conf']
+                )
+                self.boot_image.write_system_config_file(
+                    config={'install_items': [self.luks_boot_keyname]},
+                    config_file=self.luks_boot_keyfile_setup
+                )
                 self.boot_image.include_file(
                     os.sep + os.path.basename(self.luks_boot_keyfile)
                 )

--- a/test/unit/boot_image_dracut_test.py
+++ b/test/unit/boot_image_dracut_test.py
@@ -81,13 +81,18 @@ class TestBootImageKiwi:
     def test_write_system_config_file(self):
         with patch('builtins.open', create=True) as mock_write:
             self.boot_image.write_system_config_file(
-                config={'modules': ['module'], 'omit_modules': ['foobar']},
+                config={
+                    'modules': ['module'],
+                    'omit_modules': ['foobar'],
+                    'install_items': ['foo', 'bar']
+                },
                 config_file='/root/dir/my_dracut_conf.conf'
             )
             assert call().__enter__().writelines(
                 [
                     'add_dracutmodules+=" module "\n',
-                    'omit_dracutmodules+=" foobar "\n'
+                    'omit_dracutmodules+=" foobar "\n',
+                    'install_items+=" foo bar "\n',
                 ]
             ) in mock_write.mock_calls
             assert call(

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -689,6 +689,10 @@ class TestDiskBuilder:
             call('/config.partids'),
             call('/etc/crypttab')
         ]
+        self.boot_image_task.write_system_config_file.assert_called_once_with(
+            config={'install_items': ['/.root.keyfile']},
+            config_file='root_dir/etc/dracut.conf.d/99-luks-boot.conf'
+        )
 
     @patch('kiwi.builder.disk.FileSystem')
     @patch('kiwi.builder.disk.VolumeManager')


### PR DESCRIPTION
An image that is configured with an encrypted root including /boot
includes a /.root.keyfile in initrd to let dracut/systemd decrypt
the root and mount it without asking the password. On rebuild of
the initrd, dracut has no configuration that tells it to include
the /.root.keyfile again. This patch adds that configuration and
Fixes #1192

