### PR TITLE
Fixed rpmdb compat link setup

### DIFF
--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -193,18 +193,18 @@ class RepositoryZypper(RepositoryBase):
         # For further details on the motivation in zypper please
         # refer to bsc#1112357
         rpmdb.init_database()
-        Path.create(
-            os.sep.join([self.root_dir, 'var', 'lib'])
-        )
-        Command.run(
-            [
-                'ln', '-s', ''.join(
-                    ['../..', rpmdb.rpmdb_host.expand_query('%_dbpath')]
-                ), os.sep.join(
-                    [self.root_dir, 'var', 'lib', 'rpm']
-                )
-            ], raise_on_error=False
-        )
+        image_rpm_compat_link = '/var/lib/rpm'
+        host_rpm_dbpath = rpmdb.rpmdb_host.expand_query('%_dbpath')
+        if host_rpm_dbpath != image_rpm_compat_link:
+            Path.create(
+                self.root_dir + os.path.dirname(image_rpm_compat_link)
+            )
+            Command.run(
+                [
+                    'ln', '-s', ''.join(['../..', host_rpm_dbpath]),
+                    self.root_dir + image_rpm_compat_link
+                ], raise_on_error=False
+            )
 
     def use_default_location(self):
         """

--- a/test/unit/repository_zypper_test.py
+++ b/test/unit/repository_zypper_test.py
@@ -250,6 +250,10 @@ class TestRepositoryZypper:
                 'ln', '-s', '../../usr/lib/sysimage/rpm', '../data/var/lib/rpm'
             ], raise_on_error=False
         )
+        mock_Command_run.reset_mock()
+        rpmdb.rpmdb_host.expand_query.return_value = '/var/lib/rpm'
+        self.repo.setup_package_database_configuration()
+        assert not mock_Command_run.called
 
     @patch('kiwi.repository.zypper.RpmDataBase')
     @patch('kiwi.command.Command.run')


### PR DESCRIPTION
On older versions of zypper the path /var/lib/rpm was hardcoded
and not used from the rpm macro definition. For such systems and
to support them properly on hosts that have the rpm database
already moved a compat link was created. However if the host has
the rpm database at /var/lib/rpm the link doesn't make sense.
This patch fixes this and therefore bsc#1150190

