### PR TITLE
Fix the sha256 generated file content

### DIFF
--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -163,7 +163,8 @@ class ResultBundleTask(CliTask):
                     with open(bundle_file + '.sha256', 'w') as shasum:
                         shasum.write(
                             '{0}  {1}'.format(
-                                checksum.sha256(), bundle_file_basename
+                                checksum.sha256(),
+                                os.path.basename(bundle_file)
                             )
                         )
 

--- a/test/unit/tasks_result_bundle_test.py
+++ b/test/unit/tasks_result_bundle_test.py
@@ -138,7 +138,7 @@ class TestResultBundleTask:
         )
         checksum.sha256.assert_called_once_with()
         self.file_mock.write.assert_called_once_with(
-            '{0}  test-image-1.2.3-Build_42'.format(
+            '{0}  compressed_filename'.format(
                 checksum.sha256.return_value
             )
         )


### PR DESCRIPTION
This commit makes sure the generated sha256 file in a 'kiwi result
bundle' call includes the filename with the correct extension. For
compressed files it was omiting the suffix that included during the
compression.

Fixes #1223 and related to bsc#1139915