### PR TITLE
Flexible use of linuxefi module

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -349,6 +349,20 @@ class Defaults:
             return 'grub'
 
     @staticmethod
+    def get_grub_config_tool():
+        """
+        Provides full qualified path name to grub mkconfig utility
+
+        :return: file path name
+
+        :rtype: str
+        """
+        for grub_mkconfig_tool in ['grub2-mkconfig', 'grub-mkconfig']:
+            grub_mkconfig_tool_file_path = Path.which(grub_mkconfig_tool)
+            if grub_mkconfig_tool_file_path:
+                return grub_mkconfig_tool_file_path
+
+    @staticmethod
     def get_grub_basic_modules(multiboot):
         """
         Provides list of basic grub modules
@@ -415,8 +429,7 @@ class Defaults:
         ]
         if host_architecture == 'x86_64':
             modules += [
-                'efi_uga',
-                'linuxefi'
+                'efi_uga'
             ]
         return modules
 
@@ -560,7 +573,8 @@ class Defaults:
         """
         unsigned_grub_file_patterns = [
             '/usr/share/grub*/*-efi/grub.efi',
-            '/usr/lib/grub*/*-efi/grub.efi'
+            '/usr/lib/grub*/*-efi/grub.efi',
+            '/boot/efi/EFI/*/grubx64.efi'
         ]
         for unsigned_grub_file_pattern in unsigned_grub_file_patterns:
             for unsigned_grub_file in glob.iglob(

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -110,6 +110,9 @@ Requires:       squashfs
 Requires:       gptfdisk
 %endif
 %if 0%{?fedora} || 0%{?rhel}
+%ifarch x86_64
+Requires:       grub2-efi-x64
+%endif
 Requires:         chkconfig
 Requires(post):   chkconfig
 Requires(postun): chkconfig

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -281,7 +281,13 @@ class TestBootLoaderConfigGrub2:
 
     @patch('os.path.exists')
     @patch('kiwi.bootloader.config.grub2.SysConfig')
-    def test__setup_default_grub(self, mock_sysconfig, mock_exists):
+    @patch('kiwi.bootloader.config.grub2.Command.run')
+    def test_setup_default_grub(
+        self, mock_Command_run, mock_sysconfig, mock_exists
+    ):
+        use_linuxefi_implemented = mock.Mock()
+        use_linuxefi_implemented.returncode = 0
+        mock_Command_run.return_value = use_linuxefi_implemented
         grub_default = mock.MagicMock()
         mock_sysconfig.return_value = grub_default
         mock_exists.return_value = True
@@ -525,6 +531,7 @@ class TestBootLoaderConfigGrub2:
         self.os_exists['root_dir/usr/share/grub2/unicode.pf2'] = True
         self.os_exists['root_dir/usr/share/grub2/x86_64-efi'] = True
         self.os_exists['root_dir/usr/share/grub2/x86_64-xen'] = True
+        self.os_exists['root_dir/usr/share/grub2/x86_64-efi/linuxefi.mod'] = True
 
         def side_effect(arg):
             return self.os_exists[arg]
@@ -576,6 +583,7 @@ class TestBootLoaderConfigGrub2:
         self.os_exists['root_dir/usr/share/grub2/unicode.pf2'] = True
         self.os_exists['root_dir/usr/share/grub2/i386-pc'] = True
         self.os_exists['root_dir/usr/share/grub2/x86_64-efi'] = True
+        self.os_exists['root_dir/usr/share/grub2/x86_64-efi/linuxefi.mod'] = True
 
         def side_effect(arg):
             return self.os_exists[arg]
@@ -905,6 +913,7 @@ class TestBootLoaderConfigGrub2:
         self.os_exists['root_dir/usr/share/grub2/unicode.pf2'] = True
         self.os_exists['root_dir/usr/share/grub2/i386-pc'] = True
         self.os_exists['root_dir/usr/share/grub2/x86_64-efi'] = True
+        self.os_exists['root_dir/usr/share/grub2/x86_64-efi/linuxefi.mod'] = True
         self.os_exists['root_dir/boot/efi/'] = False
 
         def side_effect(arg):


### PR DESCRIPTION
Not all distributions provides the grub linuxefi module anymore.
This means a static list for building an efi grub image if needed
is no longer appropriate. This patch changes the module handling
at the following places

1. Use linuxefi for building custom efi modules only if present
   on the host system

2. Use linuxefi related grub2-mkconfig variables only if the
   host grub2-mkconfig implementation supports it

3. Prevent building custom efi image on Fedora by extending
   the search path for the distro provided efi image and also
   adapt the spec file accordingly

