### PR TITLE
Refactor patch_open use in builder's tests

### DIFF
--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -258,9 +258,9 @@ class BootImageDracut(BootImageBase):
         if dracut_tool:
             outfile_expression = r'outfile="/boot/(init.*\$kernel.*)"'
             with open(dracut_tool) as dracut:
-                outfile = re.findall(outfile_expression, dracut.read())[0]
-                if outfile:
-                    return outfile.replace('$kernel', '{kernel_version}')
+                matches = re.findall(outfile_expression, dracut.read())
+                if matches:
+                    return matches[0].replace('$kernel', '{kernel_version}')
 
         log.warning('Could not detect dracut output file format')
         log.warning('Using default initrd file name format {0}'.format(

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -3,9 +3,10 @@ from mock import (
 )
 from pytest import raises
 import mock
+import sys
 import kiwi
 
-from .test_helper import patch_open
+from .test_helper import argv_kiwi_tests
 
 from kiwi.builder.live import LiveImageBuilder
 from kiwi.exceptions import KiwiLiveBootImageError
@@ -109,16 +110,11 @@ class TestLiveImageBuilder:
             custom_args={'signing_keys': ['key_file_a', 'key_file_b']}
         )
 
-        self.context_manager_mock = mock.Mock()
-        self.file_mock = mock.Mock()
-        self.enter_mock = mock.Mock()
-        self.exit_mock = mock.Mock()
-        self.enter_mock.return_value = self.file_mock
-        setattr(self.context_manager_mock, '__enter__', self.enter_mock)
-        setattr(self.context_manager_mock, '__exit__', self.exit_mock)
-
         self.result = mock.Mock()
         self.live_image.result = self.result
+
+    def teardown(self):
+        sys.argv = argv_kiwi_tests
 
     @patch('platform.machine')
     def test_init_for_ix86_platform(self, mock_machine):
@@ -144,9 +140,8 @@ class TestLiveImageBuilder:
     @patch('kiwi.builder.live.SystemSize')
     @patch('kiwi.builder.live.Defaults.get_grub_boot_directory_name')
     @patch('os.path.exists')
-    @patch_open
     def test_create_overlay_structure(
-        self, mock_open, mock_exists, mock_grub_dir, mock_size,
+        self, mock_exists, mock_grub_dir, mock_size,
         mock_isofs, mock_tag, mock_shutil, mock_tmpfile, mock_dtemp,
         mock_setup_media_loader_directory
     ):
@@ -161,8 +156,6 @@ class TestLiveImageBuilder:
             return tmpdir_name.pop()
 
         mock_dtemp.side_effect = side_effect
-
-        mock_open.return_value = self.context_manager_mock
 
         self.live_image.live_type = 'overlay'
 
@@ -318,9 +311,8 @@ class TestLiveImageBuilder:
     @patch('kiwi.builder.live.IsoToolsBase.setup_media_loader_directory')
     @patch('kiwi.builder.live.mkdtemp')
     @patch('kiwi.builder.live.shutil')
-    @patch_open
     def test_create_no_kernel_found(
-        self, mock_open, mock_shutil, mock_dtemp,
+        self, mock_shutil, mock_dtemp,
         mock_setup_media_loader_directory
     ):
         mock_dtemp.return_value = 'tmpdir'
@@ -331,9 +323,8 @@ class TestLiveImageBuilder:
     @patch('kiwi.builder.live.IsoToolsBase.setup_media_loader_directory')
     @patch('kiwi.builder.live.mkdtemp')
     @patch('kiwi.builder.live.shutil')
-    @patch_open
     def test_create_no_hypervisor_found(
-        self, mock_open, mock_shutil, mock_dtemp,
+        self, mock_shutil, mock_dtemp,
         mock_setup_media_loader_directory
     ):
         mock_dtemp.return_value = 'tmpdir'
@@ -345,9 +336,8 @@ class TestLiveImageBuilder:
     @patch('kiwi.builder.live.mkdtemp')
     @patch('kiwi.builder.live.shutil')
     @patch('os.path.exists')
-    @patch_open
     def test_create_no_initrd_found(
-        self, mock_open, mock_exists, mock_shutil, mock_dtemp,
+        self, mock_exists, mock_shutil, mock_dtemp,
         mock_setup_media_loader_directory
     ):
         mock_dtemp.return_value = 'tmpdir'

--- a/test/unit/container_setup_docker_test.py
+++ b/test/unit/container_setup_docker_test.py
@@ -1,49 +1,13 @@
 from mock import patch
-from mock import call
-import mock
-
-from .test_helper import patch_open
 
 from kiwi.container.setup.docker import ContainerSetupDocker
 
 
 class TestContainerSetupDocker:
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def test_init(self, mock_exists):
         mock_exists.return_value = True
-        self.context_manager_mock = mock.MagicMock()
-        self.file_mock = mock.MagicMock()
-        self.enter_mock = mock.MagicMock()
-        self.exit_mock = mock.MagicMock()
-        self.enter_mock.return_value = self.file_mock
-        setattr(self.context_manager_mock, '__enter__', self.enter_mock)
-        setattr(self.context_manager_mock, '__exit__', self.exit_mock)
-
-        self.container = ContainerSetupDocker(
+        container = ContainerSetupDocker(
             'root_dir', {'container_name': 'system'}
         )
-
-        self.container.create_fstab = mock.Mock()
-        self.container.deactivate_bootloader_setup = mock.Mock()
-        self.container.deactivate_root_filesystem_check = mock.Mock()
-        self.container.setup_static_device_nodes = mock.Mock()
-        self.container.setup_root_console = mock.Mock()
-        self.container.deactivate_systemd_service = mock.Mock()
-
-    @patch_open
-    def test_setup(self, mock_open):
-        self.container.setup()
-        self.container.create_fstab.assert_called_once_with()
-        self.container.deactivate_bootloader_setup.assert_called_once_with()
-        self.container.deactivate_root_filesystem_check.assert_called_once_with()
-        self.container.setup_static_device_nodes.assert_called_once_with()
-        assert self.container.deactivate_systemd_service.call_args_list == [
-            call('device-mapper.service'),
-            call('kbd.service'),
-            call('swap.service'),
-            call('udev.service'),
-            call('proc-sys-fs-binfmt_misc.automount')
-        ]
-
-    def test_post_init(self):
-        self.container.custom_args['container_name'] == 'system'
+        assert container.custom_args['container_name'] == 'system'

--- a/test/unit/container_setup_oci_test.py
+++ b/test/unit/container_setup_oci_test.py
@@ -2,8 +2,6 @@ from mock import patch
 from mock import call
 import mock
 
-from .test_helper import patch_open
-
 from kiwi.container.setup.oci import ContainerSetupOCI
 
 
@@ -11,13 +9,6 @@ class TestContainerSetupOCI:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         mock_exists.return_value = True
-        self.context_manager_mock = mock.MagicMock()
-        self.file_mock = mock.MagicMock()
-        self.enter_mock = mock.MagicMock()
-        self.exit_mock = mock.MagicMock()
-        self.enter_mock.return_value = self.file_mock
-        setattr(self.context_manager_mock, '__enter__', self.enter_mock)
-        setattr(self.context_manager_mock, '__exit__', self.exit_mock)
 
         self.container = ContainerSetupOCI(
             'root_dir', {'container_name': 'system'}
@@ -30,8 +21,7 @@ class TestContainerSetupOCI:
         self.container.setup_root_console = mock.Mock()
         self.container.deactivate_systemd_service = mock.Mock()
 
-    @patch_open
-    def test_setup(self, mock_open):
+    def test_setup(self):
         self.container.setup()
         self.container.create_fstab.assert_called_once_with()
         self.container.deactivate_bootloader_setup.assert_called_once_with()

--- a/test/unit/partitioner_dasd_test.py
+++ b/test/unit/partitioner_dasd_test.py
@@ -1,8 +1,8 @@
-from mock import patch
+from mock import (
+    patch, mock_open
+)
 
 import mock
-
-from .test_helper import patch_open
 
 from kiwi.partitioner.dasd import PartitionerDasd
 
@@ -10,20 +10,11 @@ from kiwi.partitioner.dasd import PartitionerDasd
 class TestPartitionerDasd:
     @patch('kiwi.partitioner.dasd.Command.run')
     @patch('kiwi.partitioner.dasd.NamedTemporaryFile')
-    @patch_open
-    def setup(self, mock_open, mock_temp, mock_command):
+    def setup(self, mock_temp, mock_command):
         self.tempfile = mock.Mock()
         self.tempfile.name = 'tempfile'
-        self.context_manager_mock = mock.Mock()
-        self.file_mock = mock.Mock()
-        self.enter_mock = mock.Mock()
-        self.exit_mock = mock.Mock()
-        self.enter_mock.return_value = self.file_mock
-        setattr(self.context_manager_mock, '__enter__', self.enter_mock)
-        setattr(self.context_manager_mock, '__exit__', self.exit_mock)
 
         mock_temp.return_value = self.tempfile
-        mock_open.return_value = self.context_manager_mock
 
         disk_provider = mock.Mock()
         disk_provider.get_device = mock.Mock(
@@ -34,16 +25,16 @@ class TestPartitionerDasd:
 
     @patch('kiwi.partitioner.dasd.Command.run')
     @patch('kiwi.partitioner.dasd.NamedTemporaryFile')
-    @patch_open
     @patch('kiwi.logger.log.debug')
-    def test_create(self, mock_debug, mock_open, mock_temp, mock_command):
+    def test_create(self, mock_debug, mock_temp, mock_command):
         mock_command.side_effect = Exception
         mock_temp.return_value = self.tempfile
-        mock_open.return_value = self.context_manager_mock
 
-        self.partitioner.create('name', 100, 't.linux', ['f.active'])
+        m_open = mock_open()
+        with patch('builtins.open', m_open, create=True):
+            self.partitioner.create('name', 100, 't.linux', ['f.active'])
 
-        self.file_mock.write.assert_called_once_with(
+        m_open.return_value.write.assert_called_once_with(
             'n\np\n\n+100M\nw\nq\n'
         )
         mock_command.assert_called_once_with(
@@ -53,16 +44,14 @@ class TestPartitionerDasd:
 
     @patch('kiwi.partitioner.dasd.Command.run')
     @patch('kiwi.partitioner.dasd.NamedTemporaryFile')
-    @patch_open
-    def test_create_all_free(
-        self, mock_open, mock_temp, mock_command
-    ):
+    def test_create_all_free(self, mock_temp, mock_command):
         mock_temp.return_value = self.tempfile
-        mock_open.return_value = self.context_manager_mock
 
-        self.partitioner.create('name', 'all_free', 't.linux')
+        m_open = mock_open()
+        with patch('builtins.open', m_open, create=True):
+            self.partitioner.create('name', 'all_free', 't.linux')
 
-        self.file_mock.write.assert_called_once_with(
+        m_open.return_value.write.assert_called_once_with(
             'n\np\n\n\nw\nq\n'
         )
 

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -1,8 +1,6 @@
 from mock import patch
 from pytest import raises
 
-from .test_helper import patch_open
-
 from kiwi.runtime_config import RuntimeConfig
 from kiwi.defaults import Defaults
 
@@ -29,9 +27,9 @@ class TestRuntimeConfig:
             return exists_call_results.pop()
 
         mock_exists.side_effect = os_path_exists
-        with patch_open as mock_open:
+        with patch('builtins.open') as m_open:
             self.runtime_config = RuntimeConfig()
-            mock_open.assert_called_once_with('/etc/kiwi.yml', 'r')
+            m_open.assert_called_once_with('/etc/kiwi.yml', 'r')
 
     def test_invalid_yaml_format(self):
         self.runtime_config.config_data = {'xz': None}

--- a/test/unit/solver_repository_base_test.py
+++ b/test/unit/solver_repository_base_test.py
@@ -1,11 +1,11 @@
-from mock import patch, call
+from mock import (
+    patch, call, mock_open
+)
 from pytest import raises
 import os
 import mock
 
 from lxml import etree
-
-from .test_helper import patch_open
 
 from kiwi.solver.repository.base import SolverRepositoryBase
 
@@ -14,14 +14,6 @@ from kiwi.exceptions import KiwiUriOpenError
 
 class TestSolverRepositoryBase:
     def setup(self):
-        self.context_manager_mock = mock.Mock()
-        self.file_mock = mock.Mock()
-        self.enter_mock = mock.Mock()
-        self.exit_mock = mock.Mock()
-        self.enter_mock.return_value = self.file_mock
-        setattr(self.context_manager_mock, '__enter__', self.enter_mock)
-        setattr(self.context_manager_mock, '__exit__', self.exit_mock)
-
         self.uri = mock.Mock()
 
         self.solver = SolverRepositoryBase(self.uri)
@@ -58,31 +50,31 @@ class TestSolverRepositoryBase:
         assert self.solver.repository_metadata_dirs == ['tmpdir']
         mock_mkdtemp.assert_called_once_with(prefix='metadata_dir.')
 
-    @patch_open
     @patch('os.path.exists')
-    def test_is_uptodate_static_time(self, mock_exists, mock_open):
+    def test_is_uptodate_static_time(self, mock_exists):
         mock_exists.return_value = True
-        mock_open.return_value = self.context_manager_mock
-        self.file_mock.read.return_value = 'static'
         self.uri.alias.return_value = 'repo-alias'
-        assert self.solver.is_uptodate() is False
-        mock_open.assert_called_once_with(
+
+        m_open = mock_open(read_data='static')
+        with patch('builtins.open', m_open, create=True):
+            assert self.solver.is_uptodate() is False
+
+        m_open.assert_called_once_with(
             '/var/tmp/kiwi/satsolver/repo-alias.timestamp'
         )
 
-    @patch_open
     @patch('os.path.exists')
     @patch('kiwi.solver.repository.base.SolverRepositoryBase.timestamp')
-    def test_is_uptodate_some_time(
-        self, mock_timestamp, mock_exists, mock_open
-    ):
+    def test_is_uptodate_some_time(self, mock_timestamp, mock_exists):
         mock_exists.return_value = True
-        mock_open.return_value = self.context_manager_mock
-        self.file_mock.read.return_value = 'some-time'
         mock_timestamp.return_value = 'some-time'
         self.uri.alias.return_value = 'repo-alias'
-        assert self.solver.is_uptodate() is True
-        mock_open.assert_called_once_with(
+
+        m_open = mock_open(read_data='some-time')
+        with patch('builtins.open', m_open, create=True):
+            assert self.solver.is_uptodate() is True
+
+        m_open.assert_called_once_with(
             '/var/tmp/kiwi/satsolver/repo-alias.timestamp'
         )
 
@@ -91,23 +83,25 @@ class TestSolverRepositoryBase:
 
     @patch('kiwi.solver.repository.base.urlopen')
     @patch('kiwi.solver.repository.base.Request')
-    @patch_open
     def test_download_from_repository_with_credentials(
-        self, mock_open, mock_request, mock_urlopen
+        self, mock_request, mock_urlopen
     ):
         request = mock.Mock()
         mock_request.return_value = request
         location = mock.Mock()
         location.read.return_value = 'data-from-network'
         mock_urlopen.return_value = location
-        mock_open.return_value = self.context_manager_mock
         self.uri.is_remote.return_value = True
         self.uri.translate.return_value = 'http://myrepo/file'
         self.solver.user = 'user'
         self.solver.secret = 'secret'
-        self.solver.download_from_repository(
-            'repodata/file', 'target-file'
-        )
+
+        m_open = mock_open()
+        with patch('builtins.open', m_open, create=True):
+            self.solver.download_from_repository(
+                'repodata/file', 'target-file'
+            )
+
         mock_urlopen.assert_called_once_with(request)
         mock_request.assert_called_once_with(
             'http://myrepo/file/repodata/file'
@@ -115,62 +109,66 @@ class TestSolverRepositoryBase:
         request.add_header.assert_called_once_with(
             'Authorization', b'Basic dXNlcjpzZWNyZXQ='
         )
-        mock_open.assert_called_once_with(
+        m_open.assert_called_once_with(
             'target-file', 'wb'
         )
-        self.file_mock.write.assert_called_once_with(
+        m_open.return_value.write.assert_called_once_with(
             'data-from-network'
         )
 
     @patch('kiwi.solver.repository.base.urlopen')
     @patch('kiwi.solver.repository.base.Request')
-    @patch_open
     def test_download_from_repository_remote(
-        self, mock_open, mock_request, mock_urlopen
+        self, mock_request, mock_urlopen
     ):
         request = mock.Mock()
         mock_request.return_value = request
         location = mock.Mock()
         location.read.return_value = 'data-from-network'
         mock_urlopen.return_value = location
-        mock_open.return_value = self.context_manager_mock
         self.uri.is_remote.return_value = True
         self.uri.translate.return_value = 'http://myrepo/file'
-        self.solver.download_from_repository('repodata/file', 'target-file')
+
+        m_open = mock_open()
+        with patch('builtins.open', m_open, create=True):
+            self.solver.download_from_repository('repodata/file', 'target-file')
+
         mock_urlopen.assert_called_once_with(request)
         mock_request.assert_called_once_with(
             'http://myrepo/file/repodata/file'
         )
-        mock_open.assert_called_once_with(
+        m_open.assert_called_once_with(
             'target-file', 'wb'
         )
-        self.file_mock.write.assert_called_once_with(
+        m_open.return_value.write.assert_called_once_with(
             'data-from-network'
         )
 
     @patch('kiwi.solver.repository.base.urlopen')
     @patch('kiwi.solver.repository.base.Request')
-    @patch_open
     def test_download_from_repository_local(
-        self, mock_open, mock_request, mock_urlopen
+        self, mock_request, mock_urlopen
     ):
         request = mock.Mock()
         mock_request.return_value = request
         location = mock.Mock()
         location.read.return_value = 'data'
         mock_urlopen.return_value = location
-        mock_open.return_value = self.context_manager_mock
         self.uri.is_remote.return_value = False
         self.uri.translate.return_value = '/my_local_repo/file'
-        self.solver.download_from_repository('repodata/file', 'target-file')
+
+        m_open = mock_open()
+        with patch('builtins.open', m_open, create=True):
+            self.solver.download_from_repository('repodata/file', 'target-file')
+
         mock_urlopen.assert_called_once_with(request)
         mock_request.assert_called_once_with(
             'file:///my_local_repo/file/repodata/file'
         )
-        mock_open.assert_called_once_with(
+        m_open.assert_called_once_with(
             'target-file', 'wb'
         )
-        self.file_mock.write.assert_called_once_with(
+        m_open.return_value.write.assert_called_once_with(
             'data'
         )
 
@@ -228,18 +226,20 @@ class TestSolverRepositoryBase:
     @patch('kiwi.solver.repository.base.Path.create')
     @patch('kiwi.solver.repository.base.SolverRepositoryBase.is_uptodate')
     @patch.object(SolverRepositoryBase, '_setup_repository_metadata')
-    @patch_open
     def test_create_repository_solvable(
-        self, mock_open, mock_setup_repository_metadata, mock_is_uptodate,
+        self, mock_setup_repository_metadata, mock_is_uptodate,
         mock_path_create, mock_path_wipe, mock_command
     ):
         mock_is_uptodate.return_value = False
-        mock_open.return_value = self.context_manager_mock
         self.solver.repository_solvable_dir = 'solvable_dir.XX'
         self.uri.alias.return_value = 'repo-alias'
         self.uri.uri = 'repo-uri'
-        assert self.solver.create_repository_solvable('target_dir') == \
-            'target_dir/repo-alias'
+
+        m_open = mock_open()
+        with patch('builtins.open', m_open, create=True):
+            assert self.solver.create_repository_solvable('target_dir') == \
+                'target_dir/repo-alias'
+
         mock_is_uptodate.assert_called_once_with('target_dir')
         mock_setup_repository_metadata.assert_called_once_with()
         mock_command.assert_called_once_with(
@@ -248,11 +248,11 @@ class TestSolverRepositoryBase:
                 'mergesolv solvable_dir.XX/* > target_dir/repo-alias'
             ]
         )
-        assert mock_open.call_args_list == [
+        assert m_open.call_args_list == [
             call('target_dir/repo-alias.info', 'w'),
             call('target_dir/repo-alias.timestamp', 'w')
         ]
-        assert self.file_mock.write.call_args_list == [
+        assert m_open.return_value.write.call_args_list == [
             call(''.join(['repo-uri', os.linesep])),
             call('static')
         ]

--- a/test/unit/storage_subformat_vagrant_virtualbox_test.py
+++ b/test/unit/storage_subformat_vagrant_virtualbox_test.py
@@ -1,12 +1,9 @@
-import io
 from mock import (
-    call, patch, Mock, MagicMock
+    call, patch, Mock, MagicMock, mock_open
 )
 
 from textwrap import dedent
 from collections import namedtuple
-
-from .test_helper import patch_open
 
 from kiwi.storage.subformat.vagrant_virtualbox import (
     DiskFormatVagrantVirtualBox
@@ -42,12 +39,7 @@ class TestDiskFormatVagrantVirtualBox:
 
     @patch('kiwi.storage.subformat.vagrant_virtualbox.Command.run')
     @patch('kiwi.storage.subformat.vagrant_virtualbox.DiskFormatVmdk')
-    @patch_open
-    def test_create_box_img(
-        self, mock_open, mock_vmdk, mock_command
-    ):
-        mock_open.return_value = MagicMock(spec=io.IOBase)
-        file_handle = mock_open.return_value.__enter__.return_value
+    def test_create_box_img(self, mock_vmdk, mock_command):
         vmdk = Mock()
         vmdk.image_format = 'vmdk'
         mock_vmdk.return_value = vmdk
@@ -64,9 +56,11 @@ class TestDiskFormatVagrantVirtualBox:
                 specification="OpenSUSE Leap 15.0"
             )
 
-        assert self.disk_format.create_box_img('tmpdir') == [
-            'tmpdir/box.vmdk', 'tmpdir/box.ovf'
-        ]
+        m_open = mock_open()
+        with patch('builtins.open', m_open, create=True):
+            assert self.disk_format.create_box_img('tmpdir') == [
+                'tmpdir/box.vmdk', 'tmpdir/box.ovf'
+            ]
         vmdk.create_image_format.assert_called_once_with()
         mock_command.assert_called_once_with(
             [
@@ -74,9 +68,9 @@ class TestDiskFormatVagrantVirtualBox:
                 'tmpdir/box.vmdk'
             ]
         )
-        mock_open.assert_called_once_with('tmpdir/box.ovf', 'w')
+        m_open.assert_called_once_with('tmpdir/box.ovf', 'w')
 
-        assert file_handle.write.call_args_list[0] == call(self.Leap_15_ovf)
+        assert m_open.return_value.write.call_args_list[0] == call(self.Leap_15_ovf)
 
     @patch('kiwi.storage.subformat.vagrant_virtualbox.random.randrange')
     def test_get_additional_vagrant_config_settings(self, mock_rand):
@@ -94,29 +88,29 @@ class TestDiskFormatVagrantVirtualBox:
     @patch('kiwi.storage.subformat.vagrant_base.mkdtemp')
     @patch('kiwi.storage.subformat.vagrant_virtualbox.random.randrange')
     @patch.object(DiskFormatVagrantVirtualBox, 'create_box_img')
-    @patch_open
     def test_create_image_format_with_and_without_guest_additions(
-        self, mock_open, mock_create_box_img, mock_rand,
+        self, mock_create_box_img, mock_rand,
         mock_mkdtemp, mock_command
     ):
         mock_mkdtemp.return_value = 'tmpdir'
         mock_create_box_img.return_value = ['arbitrary']
-        mock_open.return_value = MagicMock(spec=io.IOBase)
-        file_handle = mock_open.return_value.__enter__.return_value
 
         # without guest additions
         self.xml_state.get_vagrant_config_virtualbox_guest_additions \
             .return_value = \
             Defaults.get_vagrant_config_virtualbox_guest_additions()
-        self.disk_format.create_image_format()
+
+        m_open = mock_open()
+        with patch('builtins.open', m_open, create=True):
+            self.disk_format.create_image_format()
+
         vagrantfile = dedent('''
             Vagrant.configure("2") do |config|
               config.vm.base_mac = "00163E010101"
               config.vm.synced_folder ".", "/vagrant", type: "rsync"
             end
         ''').strip()
-        assert file_handle.write.call_args_list[1] == call(vagrantfile)
-        file_handle.write.reset_mock()
+        assert m_open.return_value.write.call_args_list[1] == call(vagrantfile)
 
         # without guest additions
         self.xml_state.get_vagrant_config_virtualbox_guest_additions \
@@ -126,5 +120,9 @@ class TestDiskFormatVagrantVirtualBox:
               config.vm.base_mac = "00163E010101"
             end
         ''').strip()
-        self.disk_format.create_image_format()
-        assert file_handle.write.call_args_list[1] == call(vagrantfile)
+
+        m_open.reset_mock()
+        with patch('builtins.open', m_open, create=True):
+            self.disk_format.create_image_format()
+
+        assert m_open.return_value.write.call_args_list[1] == call(vagrantfile)

--- a/test/unit/system_identifier_test.py
+++ b/test/unit/system_identifier_test.py
@@ -1,8 +1,6 @@
-from mock import patch
-
-import mock
-
-from .test_helper import patch_open
+from mock import (
+    patch, mock_open
+)
 
 from kiwi.system.identifier import SystemIdentifier
 
@@ -20,17 +18,12 @@ class TestSystemIdentifier:
         self.identifier.calculate_id()
         assert self.identifier.get_id() == '0x0f0f0f0f'
 
-    @patch_open
-    def test_write(self, mock_open):
+    def test_write(self):
         self.identifier.image_id = 'some-id'
-        context_manager_mock = mock.Mock()
-        mock_open.return_value = context_manager_mock
-        file_mock = mock.Mock()
-        enter_mock = mock.Mock()
-        exit_mock = mock.Mock()
-        enter_mock.return_value = file_mock
-        setattr(context_manager_mock, '__enter__', enter_mock)
-        setattr(context_manager_mock, '__exit__', exit_mock)
-        self.identifier.write('mbrid-file')
-        mock_open.assert_called_once_with('mbrid-file', 'w')
-        file_mock.write.assert_called_once_with('some-id\n')
+
+        m_open = mock_open()
+        with patch('builtins.open', m_open, create=True):
+            self.identifier.write('mbrid-file')
+
+        m_open.assert_called_once_with('mbrid-file', 'w')
+        m_open.return_value.write.assert_called_once_with('some-id\n')

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -1,8 +1,6 @@
 import kiwi.logger
 import sys
 import logging
-from io import BytesIO
-from mock import MagicMock, patch
 
 # default log level, overwrite when needed
 kiwi.logger.log.setLevel(logging.WARN)
@@ -13,23 +11,3 @@ sys.argv = [
     '--description', 'description', '--root', 'directory'
 ]
 argv_kiwi_tests = sys.argv
-
-# mock open calls
-patch_open = patch('builtins.open')
-
-
-def mock_open(data=None):
-    '''
-    Mock "open" function.
-
-    :param data:
-    :return:
-    '''
-    data = BytesIO(data)
-    mock = MagicMock()
-    handle = MagicMock()
-    handle.write.return_value = None
-    handle.__enter__.return_value = data or handle
-    mock.return_value = handle
-
-    return mock

--- a/test/unit/utils_sysconfig_test.py
+++ b/test/unit/utils_sysconfig_test.py
@@ -1,22 +1,12 @@
-from mock import call
-
-import mock
-
-from .test_helper import patch_open
+from mock import (
+    call, mock_open, patch
+)
 
 from kiwi.utils.sysconfig import SysConfig
 
 
 class TestSysConfig:
     def setup(self):
-        self.context_manager_mock = mock.Mock()
-        self.file_mock = mock.Mock()
-        self.enter_mock = mock.Mock()
-        self.exit_mock = mock.Mock()
-        self.enter_mock.return_value = self.file_mock
-        setattr(self.context_manager_mock, '__enter__', self.enter_mock)
-        setattr(self.context_manager_mock, '__exit__', self.exit_mock)
-
         self.sysconfig = SysConfig('../data/sysconfig_example.txt')
 
     def test_get_item(self):
@@ -36,11 +26,12 @@ class TestSysConfig:
         assert 'non_existing_key' not in self.sysconfig
         assert 'name' in self.sysconfig
 
-    @patch_open
-    def test_write(self, mock_open):
-        mock_open.return_value = self.context_manager_mock
-        self.sysconfig.write()
-        assert self.file_mock.write.call_args_list == [
+    def test_write(self):
+        m_open = mock_open()
+        with patch('builtins.open', m_open, create=True):
+            self.sysconfig.write()
+
+        assert m_open.return_value.write.call_args_list == [
             call('# some name'),
             call('\n'),
             call('name= "Marcus"'),


### PR DESCRIPTION
This commit removes the use of `@patch_open` decorator
in favor of directly patching `builtins.open` and use
mock.mock_open utility to mock the context manager.

Related to #1128
