### PR TITLE
Remove universal flag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,3 @@
-[bdist_wheel]
-# This flag says that the code is written to work on both Python 2 and Python
-# 3. If at all possible, it is good practice to do this. If you cannot, you
-# will need to generate wheels for each Python version that you support.
-universal = 1
-
 [sdist]
 # Used by setup.py sdist
 formats=gztar


### PR DESCRIPTION
kiwi is no longer an universal python module, since it does not support
python 2 anymore. This will prevent to install future versions on
python2 environments using pip.

Related with #1226
