### PR TITLE
Install all kiwi executables at setuptools level

### DIFF
--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -93,12 +93,12 @@ environment for Python 3:
    $ source .tox/3/bin/activate
 
 The commands above automatically creates the application script
-called :command:`kiwi-ng-3`, which allows you to run KIWI from the
+called :command:`kiwi-ng`, which allows you to run KIWI from the
 Python sources inside the virtual environment:
 
 .. code:: shell-session
 
-    $ kiwi-ng-3 --help
+    $ kiwi-ng --help
 
 .. warning::
 
@@ -108,7 +108,7 @@ Python sources inside the virtual environment:
 
    .. code:: shell-session
 
-      $ sudo $PWD/.tox/3/bin/kiwi-ng-3 system build ...
+      $ sudo $PWD/.tox/3/bin/kiwi-ng system build ...
 
 To leave the development mode, run:
 

--- a/doc/source/working_with_kiwi.rst
+++ b/doc/source/working_with_kiwi.rst
@@ -199,9 +199,9 @@ The prepare step consists of the following substeps:
 
    .. code:: shell-session
 
-      $ kiwi system prepare $ARGS
+      $ kiwi-ng system prepare $ARGS
       $ # make your changes
-      $ kiwi system create $ARGS
+      $ kiwi-ng system create $ARGS
 
    .. warning:: Modifications of the unpacked root tree
 

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -373,8 +373,8 @@ make buildroot=%{buildroot}/ docdir=%{_defaultdocdir}/ install_package_docs
 
 # Create symlinks for correct binaries
 ln -sr %{buildroot}%{_bindir}/kiwi-ng %{buildroot}%{_bindir}/kiwi
-ln -sr %{buildroot}%{_bindir}/kiwi-ng-3 %{buildroot}%{_bindir}/kiwi-ng
-ln -sr %{buildroot}%{_bindir}/kiwicompat-3 %{buildroot}%{_bindir}/kiwicompat
+ln -sr %{buildroot}%{_bindir}/kiwi-ng %{buildroot}%{_bindir}/kiwi-ng-3
+ln -sr %{buildroot}%{_bindir}/kiwicompat %{buildroot}%{_bindir}/kiwicompat-3
 
 %if %{_vendor} != "debbuild"
 # kiwi pxeboot directory structure to be packed in kiwi-pxeboot

--- a/setup.py
+++ b/setup.py
@@ -200,8 +200,8 @@ config = {
     },
     'entry_points': {
         'console_scripts': [
-            'kiwi-ng-{0}=kiwi.kiwi:main'.format(python_version),
-            'kiwicompat-{0}=kiwi.kiwi_compat:main'.format(python_version)
+            'kiwi-ng=kiwi.kiwi:main',
+            'kiwicompat=kiwi.kiwi_compat:main'
         ]
     },
     'include_package_data': True,


### PR DESCRIPTION
This PR changes the console script installed by pip to be `kiwi-ng` and `kiwicompat` instead of `kiwi-ng-3` or `kiwicompat-3`. The former ones are still accessible by symlinks provided by the `python3-kiwi` RPM.

Fixes #1226