### PR TITLE
Fixed fallback copy of grub config file

### DIFF
--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -48,6 +48,7 @@ class BootLoaderConfigBase:
         self.volumes_mount = []
         self.root_mount = None
         self.boot_mount = None
+        self.efi_mount = None
         self.device_mount = None
         self.proc_mount = None
 
@@ -470,7 +471,9 @@ class BootLoaderConfigBase:
         else:
             return gfxmode
 
-    def _mount_system(self, root_device, boot_device, volumes=None):
+    def _mount_system(
+        self, root_device, boot_device, efi_device=None, volumes=None
+    ):
         self.root_mount = MountManager(
             device=root_device
         )
@@ -478,11 +481,19 @@ class BootLoaderConfigBase:
             device=boot_device,
             mountpoint=self.root_mount.mountpoint + '/boot'
         )
+        if efi_device:
+            self.efi_mount = MountManager(
+                device=efi_device,
+                mountpoint=self.root_mount.mountpoint + '/boot/efi'
+            )
 
         self.root_mount.mount()
 
         if not self.root_mount.device == self.boot_mount.device:
             self.boot_mount.mount()
+
+        if efi_device:
+            self.efi_mount.mount()
 
         if volumes:
             for volume_path in Path.sort_by_hierarchy(
@@ -549,6 +560,8 @@ class BootLoaderConfigBase:
             self.device_mount.umount()
         if self.proc_mount:
             self.proc_mount.umount()
+        if self.efi_mount:
+            self.efi_mount.umount()
         if self.boot_mount:
             self.boot_mount.umount()
         if self.root_mount:

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -990,7 +990,6 @@ class DiskBuilder:
         self.bootloader_config.setup_disk_image_config(
             boot_options=custom_install_arguments
         )
-        self.bootloader_config.write()
 
         # cleanup bootloader config resources taken prior to next steps
         del self.bootloader_config

--- a/test/unit/bootloader_config_base_test.py
+++ b/test/unit/bootloader_config_base_test.py
@@ -283,10 +283,13 @@ class TestBootLoaderConfigBase:
         root_mount.device = 'rootdev'
         boot_mount = MagicMock()
         boot_mount.device = 'bootdev'
+        efi_mount = MagicMock()
+        efi_mount.device = 'efidev'
         volume_mount = MagicMock()
 
         mount_managers = [
-            proc_mount, dev_mount, volume_mount, boot_mount, root_mount
+            proc_mount, dev_mount, volume_mount,
+            efi_mount, boot_mount, root_mount
         ]
 
         def mount_managers_effect(**args):
@@ -294,7 +297,7 @@ class TestBootLoaderConfigBase:
 
         mock_MountManager.side_effect = mount_managers_effect
         self.bootloader._mount_system(
-            'rootdev', 'bootdev', {
+            'rootdev', 'bootdev', 'efidev', {
                 'boot/grub2': {
                     'volume_options': 'subvol=@/boot/grub2',
                     'volume_device': 'device'
@@ -304,12 +307,14 @@ class TestBootLoaderConfigBase:
         assert mock_MountManager.call_args_list == [
             call(device='rootdev'),
             call(device='bootdev', mountpoint='root_mount_point/boot'),
+            call(device='efidev', mountpoint='root_mount_point/boot/efi'),
             call(device='device', mountpoint='root_mount_point/boot/grub2'),
             call(device='/dev', mountpoint='root_mount_point/dev'),
             call(device='/proc', mountpoint='root_mount_point/proc')
         ]
         root_mount.mount.assert_called_once_with()
         boot_mount.mount.assert_called_once_with()
+        efi_mount.mount.assert_called_once_with()
         volume_mount.mount.assert_called_once_with(
             options=['subvol=@/boot/grub2']
         )
@@ -321,6 +326,7 @@ class TestBootLoaderConfigBase:
         volume_mount.umount.assert_called_once_with()
         dev_mount.umount.assert_called_once_with()
         proc_mount.umount.assert_called_once_with()
+        efi_mount.umount.assert_called_once_with()
         boot_mount.umount.assert_called_once_with()
         root_mount.umount.assert_called_once_with()
 

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -309,6 +309,9 @@ class TestDiskBuilder:
         self.bootloader_config.setup_disk_boot_images.assert_called_once_with(
             '0815'
         )
+        self.bootloader_config.write_meta_data.assert_called_once_with(
+            boot_options='', root_uuid='0815'
+        )
         self.bootloader_config.setup_disk_image_config.assert_called_once_with(
             boot_options={
                 'boot_device': '/dev/boot-device',
@@ -424,6 +427,9 @@ class TestDiskBuilder:
         self.disk.map_partitions.assert_called_once_with()
         self.bootloader_config.setup_disk_boot_images.assert_called_once_with(
             '0815'
+        )
+        self.bootloader_config.write_meta_data.assert_called_once_with(
+            boot_options='', root_uuid='0815'
         )
         self.bootloader_config.setup_disk_image_config.assert_called_once_with(
             boot_options={


### PR DESCRIPTION
For ISO images that are EFI bootable as well as for EFI
secure boot configurations that are not based on shim-install
kiwi provides a fallback code that copies the grub config file
to the efi/efi-vendor boot path. This fallback code was broken
because of the recent change to let grub2 mkconfig create the
config file. The call of grub2 mkconfig happens at a later
stage which required an adaption of the fallback mechanism.
This is related to Issue #1194

