### PR TITLE
Lookup grub mkconfig tool

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -224,7 +224,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         )
         Command.run(
             [
-                'chroot', self.root_mount.mountpoint, 'grub2-mkconfig', '-o',
+                'chroot', self.root_mount.mountpoint,
+                self._get_grub2_mkconfig_tool(), '-o',
                 config_file.replace(self.root_mount.mountpoint, '')
             ]
         )
@@ -794,6 +795,11 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         for grub_mkimage_tool in ['grub2-mkimage', 'grub-mkimage']:
             if Path.which(grub_mkimage_tool):
                 return grub_mkimage_tool
+
+    def _get_grub2_mkconfig_tool(self):
+        for grub_mkconfig_tool in ['grub2-mkconfig', 'grub-mkconfig']:
+            if Path.which(grub_mkconfig_tool):
+                return grub_mkconfig_tool
 
     def _get_grub2_boot_path(self):
         return self.boot_dir + '/boot/' + self.boot_directory_name


### PR DESCRIPTION
In the same way as we need to lookup the name for the mkimage
tool we also have to lookup the name of the config tool.
That's because distributions do not handle that consistently


