### PR TITLE
Fixed oem resize message and invokation

### DIFF
--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -233,7 +233,7 @@ function check_repart_possible {
     if [ -n "${kiwi_oemrootMB}" ];then
         if [ "${kiwi_oemrootMB}" -lt "${disk_root_mbytes}" ];then
             # specified oem-systemsize is smaller than root partition
-            warn "Requested OEM systemsize is smaller than root partition"
+            warn "Requested OEM systemsize is smaller than root partition:"
             warn "Disk won't be re-partitioned !"
             echo
             warn "Current Root partition: ${disk_root_mbytes} MB"
@@ -243,18 +243,20 @@ function check_repart_possible {
     fi
     if [ "${min_additional_mbytes}" -gt "${disk_free_mbytes}" ];then
         # Requested sizes for root and swap exceeds free space on disk
-        warn "Requested sizes exceeds free space on the disk:"
-        warn "Disk won't be re-partitioned !"
-        echo
-        warn "Minimum required additional size: ${min_additional_mbytes} MB:"
+        local requested_size
         if [ -n "${kiwi_oemrootMB}" ];then
-            local share=$((kiwi_oemrootMB - disk_root_mbytes))
-            warn "==> Root's share is: ${share} MB"
+            requested_size="root:($((kiwi_oemrootMB - disk_root_mbytes)) MB)"
+        else
+            requested_size="root:(keep)"
         fi
         if [ ${swapsize} -gt 0 ];then
-            warn "==> Swap's share is: ${swapsize} MB"
+            requested_size="${requested_size}, swap:(${swapsize} MB)"
         fi
-        warn "Free Space on disk: ${disk_free_mbytes} MB"
+        warn "Requested OEM systemsize exceeds free space on the disk:"
+        warn "Disk won't be re-partitioned !"
+        echo
+        warn "Requested size(s): ${requested_size}"
+        warn "==> Free Space on disk: ${disk_free_mbytes} MB"
         return 1
     fi
     return 0
@@ -277,6 +279,14 @@ PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
 setup_debug
 
+# initialize for disk repartition
+initialize
+
+if ! disk_has_unallocated_space "${disk}";then
+    # already resized or disk has not received any geometry change
+    return
+fi
+
 # when repartitioning disks, parted and friends might trigger re-reads of
 # the partition table, in turn triggering systemd-fsck-root.service
 # repeatedly via udev events, which finally can cause booting to fail with
@@ -292,9 +302,6 @@ setup_debug
 trap unmask_fsck_root_service EXIT
 
 mask_fsck_root_service
-
-# initialize for disk repartition
-initialize
 
 # prepare disk for repartition
 if [ "$(get_partition_table_type "${disk}")" = 'gpt' ];then

--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -307,11 +307,24 @@ function relocate_gpt_at_end_of_disk {
     fi
 }
 
+function disk_has_unallocated_space {
+    local disk_device=$1
+    local pt_table_type
+    pt_table_type=$(get_partition_table_type "${disk_device}")
+    if [ "${pt_table_type}" = "dos" ];then
+        sfdisk --verify "${disk_device}" 2>&1 | grep -q "unallocated"
+    else
+        sgdisk --verify "${disk_device}" 2>&1 | grep -q "end of the disk"
+    fi
+}
+
 function activate_boot_partition {
     local disk_device=$1
     local boot_partition_id=$2
+    local pt_table_type
+    pt_table_type=$(get_partition_table_type "${disk_device}")
     if [[ "$(uname -m)" =~ i.86|x86_64 ]];then
-        if [ "$(get_partition_table_type)" = "msdos" ];then
+        if [ "${pt_table_type}" = "dos" ];then
             parted "${disk_device}" set "${boot_partition_id}" boot on
         fi
     fi

--- a/dracut/modules.d/99kiwi-lib/module-setup.sh
+++ b/dracut/modules.d/99kiwi-lib/module-setup.sh
@@ -17,7 +17,7 @@ install() {
     inst_multiple \
         blkid blockdev parted dd mkdir rmdir \
         grep cut tail head tr bc \
-        basename partprobe sgdisk mkswap readlink lsblk \
+        basename partprobe sfdisk sgdisk mkswap readlink lsblk \
         btrfs xfs_growfs resize2fs \
         e2fsck btrfsck xfs_repair \
         vgs vgchange lvextend lvcreate lvresize pvresize \


### PR DESCRIPTION
The oem resize should only start if there is unallocated
space on the disk available. If it starts the message in
case of a not applicable resize should be more meaningful
This commit addresses both issues and Fixes #1102


