### PR TITLE
Skip isolinux ui setup on serial terminal config

### DIFF
--- a/kiwi/bootloader/template/isolinux.py
+++ b/kiwi/bootloader/template/isolinux.py
@@ -178,10 +178,11 @@ class BootLoaderTemplateIsoLinux:
         if terminal and 'serial' in terminal:
             template_data += self.serial
             with_theme = False
-        if with_theme:
-            template_data += self.ui_theme
-        else:
-            template_data += self.ui_plain
+        if terminal != 'serial':
+            if with_theme:
+                template_data += self.ui_theme
+            else:
+                template_data += self.ui_plain
         template_data += self.menu_entry
         if failsafe:
             template_data += self.menu_entry_failsafe
@@ -209,10 +210,11 @@ class BootLoaderTemplateIsoLinux:
         if terminal and 'serial' in terminal:
             template_data += self.serial
             with_theme = False
-        if with_theme:
-            template_data += self.ui_theme
-        else:
-            template_data += self.ui_plain
+        if terminal != 'serial':
+            if with_theme:
+                template_data += self.ui_theme
+            else:
+                template_data += self.ui_plain
         template_data += self.menu_entry_multiboot
         if failsafe:
             template_data += self.menu_entry_failsafe_multiboot
@@ -240,10 +242,11 @@ class BootLoaderTemplateIsoLinux:
         if terminal and 'serial' in terminal:
             template_data += self.serial
             with_theme = False
-        if with_theme:
-            template_data += self.ui_theme
-        else:
-            template_data += self.ui_plain
+        if terminal != 'serial':
+            if with_theme:
+                template_data += self.ui_theme
+            else:
+                template_data += self.ui_plain
         template_data += self.menu_harddisk_entry
         template_data += self.menu_install_entry
         if failsafe:
@@ -270,10 +273,11 @@ class BootLoaderTemplateIsoLinux:
         if terminal and 'serial' in terminal:
             template_data += self.serial
             with_theme = False
-        if with_theme:
-            template_data += self.ui_theme
-        else:
-            template_data += self.ui_plain
+        if terminal != 'serial':
+            if with_theme:
+                template_data += self.ui_theme
+            else:
+                template_data += self.ui_plain
         template_data += self.menu_harddisk_entry
         template_data += self.menu_install_entry_multiboot
         if failsafe:


### PR DESCRIPTION
If the attribute

```xml
bootloader_console="serial"
```

is set, the expectation that there is no graphics hardware available is valid. Thus the isolinux setup should not contain any ui configuration instructions because that leads to run the graphics initialization which blocks the system if not present. Please note the bootloader_console allows for
multiple console configuration. In mixed setup the ui configuration still applies.

This Fixes #1153

