### PR TITLE
Fix btrfs_root_is_snapshot

### DIFF
--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -118,6 +118,11 @@ class VolumeManagerBtrfs(VolumeManagerBase):
             Command.run(
                 ['btrfs', 'subvolume', 'create', snapshot_volume]
             )
+            volume_mount = MountManager(
+                device=self.device,
+                mountpoint=self.mountpoint + '/.snapshots'
+            )
+            self.subvol_mount_list.append(volume_mount)
             Path.create(snapshot_volume + '/1')
             snapshot = self.mountpoint + '/@/.snapshots/1/snapshot'
             Command.run(
@@ -200,15 +205,6 @@ class VolumeManagerBtrfs(VolumeManagerBase):
         block_operation = BlockID(self.device)
         blkid_type = 'LABEL' if persistency_type == 'by-label' else 'UUID'
         device_id = block_operation.get_blkid(blkid_type)
-        if self.custom_args['root_is_snapshot']:
-            mount_entry_options = mount_options + ['subvol=@/.snapshots']
-            fstab_entry = ' '.join(
-                [
-                    blkid_type + '=' + device_id, '/.snapshots',
-                    'btrfs', ','.join(mount_entry_options), '0 0'
-                ]
-            )
-            fstab_entries.append(fstab_entry)
         for volume_mount in self.subvol_mount_list:
             subvol_name = self._get_subvol_name_from_mountpoint(volume_mount)
             mount_entry_options = mount_options + ['subvol=' + subvol_name]

--- a/test/unit/volume_manager/btrfs_test.py
+++ b/test/unit/volume_manager/btrfs_test.py
@@ -121,9 +121,10 @@ class TestVolumeManagerBtrfs:
 
         self.volume_manager.setup()
 
-        mock_mount.assert_called_once_with(
-            device='/dev/storage', mountpoint='tmpdir'
-        )
+        assert mock_mount.call_args_list == [
+            call(device='/dev/storage', mountpoint='tmpdir'),
+            call(device='/dev/storage', mountpoint='tmpdir/.snapshots')
+        ]
         toplevel_mount.mount.assert_called_once_with([])
         assert mock_command.call_args_list == [
             call(['btrfs', 'quota', 'enable', 'tmpdir']),
@@ -240,9 +241,7 @@ class TestVolumeManagerBtrfs:
         volume_mount.device = 'device'
         self.volume_manager.toplevel_volume = '@/.snapshots/1/snapshot'
         self.volume_manager.subvol_mount_list = [volume_mount]
-        self.volume_manager.custom_args['root_is_snapshot'] = True
         assert self.volume_manager.get_fstab() == [
-            'LABEL=id /.snapshots btrfs defaults,subvol=@/.snapshots 0 0',
             'LABEL=id /var/tmp btrfs defaults,subvol=@/var/tmp 0 0'
         ]
 


### PR DESCRIPTION
This commit makes sure the chrooted operations of over a loop device
including btrfs subvolumes and root as an snapshot include the
`/.snapshots` subvolume mount. This is necessary for certain operations
that depend on the layout, e.g. grub configuration using `grub2-mkconfig`.