### PR TITLE
Enable BLS configuration if is supported

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -560,6 +560,15 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         if self.custom_args.get('boot_is_crypto'):
             grub_default_entries['GRUB_ENABLE_CRYPTODISK'] = 'y'
 
+        enable_blscfg_implemented = Command.run(
+            [
+                'grep', '-q', 'GRUB_ENABLE_BLSCFG',
+                Defaults.get_grub_config_tool()
+            ], raise_on_error=False
+        )
+        if enable_blscfg_implemented.returncode == 0:
+            grub_default_entries['GRUB_ENABLE_BLSCFG'] = 'true'
+
         if grub_default_entries:
             log.info('Writing grub2 defaults file')
             grub_default_location = ''.join([self.root_dir, '/etc/default/'])

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -308,9 +308,9 @@ class TestBootLoaderConfigGrub2:
     def test_setup_default_grub(
         self, mock_Command_run, mock_sysconfig, mock_exists
     ):
-        use_linuxefi_implemented = Mock()
-        use_linuxefi_implemented.returncode = 0
-        mock_Command_run.return_value = use_linuxefi_implemented
+        grep_grub_option = Mock()
+        grep_grub_option.returncode = 0
+        mock_Command_run.return_value = grep_grub_option
         grub_default = MagicMock()
         mock_sysconfig.return_value = grub_default
         mock_exists.return_value = True
@@ -329,6 +329,7 @@ class TestBootLoaderConfigGrub2:
             ),
             call('GRUB_CMDLINE_LINUX_DEFAULT', '"some-cmdline"'),
             call('GRUB_DISTRIBUTOR', '"Bob"'),
+            call('GRUB_ENABLE_BLSCFG', 'true'),
             call('GRUB_ENABLE_CRYPTODISK', 'y'),
             call('GRUB_GFXMODE', '800x600'),
             call(


### PR DESCRIPTION
Fedora now uses a BLS configuration by default, but this is not supported
by all distributions. So check if is supported by the grub2-mkconfig tool
and only enable the option if that's the case.

Fixes: #1248