### PR TITLE
Ensure grub.cfg is copied in EFI/BOOT folder

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,7 +64,7 @@ build_doc:
       texlive-tabulary texlive-framed texlive-wrapfig texlive-parskip
       texlive-upquote texlive-capt-of texlive-needspace texlive-makeindex
       texlive-times texlive-helvetic texlive-courier texlive-gsftopk
-      texlive-updmap-map texlive-dvips
+      texlive-updmap-map texlive-dvips make
     - tox -e packagedoc
   artifacts:
     paths:

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -157,7 +157,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
 
             if self.firmware.efi_mode():
                 self._copy_grub_config_to_efi_path(
-                    self.root_dir, config_file
+                    self.boot_dir, config_file
                 )
 
     def write_meta_data(self, root_uuid=None, boot_options='', iso_boot=False):
@@ -431,7 +431,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
             if not efi_boot_path:
                 efi_boot_path = os.path.normpath(
-                    os.sep.join([root_path, 'boot/efi/EFI/BOOT'])
+                    os.sep.join([root_path, 'EFI/BOOT'])
                 )
             Path.create(efi_boot_path)
             grub_config_file_for_efi_boot = os.sep.join(

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -274,7 +274,6 @@ class TestBootLoaderConfigGrub2:
         self, mock_Path_create, mock_shutil_copy, mock_glob
     ):
         self.bootloader.shim_fallback_setup = True
-        self.bootloader.efi_boot_path = 'root_dir/boot/efi/EFI/BOOT/'
         mock_glob.return_value = []
 
         self.bootloader._copy_grub_config_to_efi_path(
@@ -282,24 +281,24 @@ class TestBootLoaderConfigGrub2:
         )
 
         mock_Path_create.assert_called_once_with(
-            'root_dir/boot/efi/EFI/BOOT'
+            'root_dir/EFI/BOOT'
         )
         mock_shutil_copy.assert_called_once_with(
-            'config_file', 'root_dir/boot/efi/EFI/BOOT/grub.cfg'
+            'config_file', 'root_dir/EFI/BOOT/grub.cfg'
         )
         mock_shutil_copy.reset_mock()
         mock_Path_create.reset_mock()
-        mock_glob.return_value = ['root_dir/boot/efi/EFI/fedora/shim.efi']
+        mock_glob.return_value = ['root_dir/EFI/fedora/shim.efi']
 
         self.bootloader._copy_grub_config_to_efi_path(
             'root_dir', 'config_file'
         )
 
         mock_Path_create.assert_called_once_with(
-            'root_dir/boot/efi/EFI/fedora'
+            'root_dir/EFI/fedora'
         )
         mock_shutil_copy.assert_called_once_with(
-            'config_file', 'root_dir/boot/efi/EFI/fedora/grub.cfg'
+            'config_file', 'root_dir/EFI/fedora/grub.cfg'
         )
 
     @patch('os.path.exists')


### PR DESCRIPTION
This commit fixes the live images in efi mode. Grub configuration file
is copied to the correct location in <boot_dir>/EFI/BOOT.

Fixes bsc#1155815
