### PR TITLE
Allow use of relative paths for `dir:<path>` URIs

### DIFF
--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -246,7 +246,7 @@ class Uri:
         return iso_mount.mountpoint
 
     def _local_path(self, path):
-        return os.path.normpath(path)
+        return os.path.abspath(os.path.normpath(path))
 
     def _obs_project_download_link(self, name):
         name_parts = name.split(os.sep)

--- a/test/unit/system/uri_test.py
+++ b/test/unit/system/uri_test.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from mock import patch
 from pytest import (
     raises, fixture
@@ -157,6 +158,14 @@ class TestUri:
     def test_translate_dir_path(self):
         uri = Uri('dir:///some/path', 'rpm-md')
         assert uri.translate() == '/some/path'
+
+    @patch('os.path.abspath')
+    def test_translate_dir_relative_path(self, mock_abspath):
+        mock_abspath.side_effect = lambda path: os.sep.join(
+            ['/current/dir', path]
+        )
+        uri = Uri('dir:some/path', 'rpm-md')
+        assert uri.translate() == '/current/dir/some/path'
 
     def test_translate_http_path(self):
         uri = Uri('http://example.com/foo', 'rpm-md')


### PR DESCRIPTION
This commit allows the use of relative paths for local URIs using the
the following format:

`dir:<path>`

This is helpful to set in config.xml local URIs for repositories.

Fixes #1261