### PR TITLE
Adapt s390 oem test

### DIFF
--- a/build-tests/s390/suse/test-image-oem/appliance.kiwi
+++ b/build-tests/s390/suse/test-image-oem/appliance.kiwi
@@ -4,7 +4,7 @@
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>
-        <specification>oem disk s390 to run on DASD</specification>
+        <specification>oem disk s390 to run on emulated DASD(FBA mode)</specification>
     </description>
     <preferences>
         <version>1.1.0</version>
@@ -14,14 +14,13 @@
         <locale>en_US</locale>
         <keytable>us</keytable>
         <timezone>Europe/Berlin</timezone>
-        <type image="oem" filesystem="xfs" initrd_system="dracut" bootloader="grub2_s390x_emu" target_blocksize="4096" zipl_targettype="CDL" kernelcmdline="cio_ignore=all,!ipldev,!condev" bootloader_console="serial">
-            <size unit="G">20</size>
+        <type image="oem" filesystem="xfs" initrd_system="dracut" bootloader="grub2_s390x_emu" zipl_targettype="FBA" kernelcmdline="cio_ignore=all,!ipldev,!condev" bootloader_console="serial">
             <systemdisk>
                 <volume name="home"/>
             </systemdisk>
             <oemconfig>
                 <oem-swap>true</oem-swap>
-                <oem-swapsize>512</oem-swapsize>
+                <oem-swapsize>4096</oem-swapsize>
             </oemconfig>
         </type>
     </preferences>
@@ -32,7 +31,7 @@
         <source path='obsrepositories:/'/>
     </repository>
     <packages type="image">
-        <package name="patterns-openSUSE-base"/>
+        <package name="patterns-base-minimal_base"/>
         <package name="cmsfs"/>
         <package name="kernel-default"/>
         <package name="iputils"/>

--- a/kiwi/bootloader/template/zipl.py
+++ b/kiwi/bootloader/template/zipl.py
@@ -77,7 +77,8 @@ class BootLoaderTemplateZipl:
         :rtype: Template
         """
         template_data = self.header
-        if targettype and targettype != 'SCSI':
+        unsupported_for_target_geometry = ['FBA', 'SCSI']
+        if targettype and targettype not in unsupported_for_target_geometry:
             template_data += self.add_targetgeometry
         template_data += self.activate_menu_entry
         if failsafe:


### PR DESCRIPTION
This patch is two fold

**Fixed zipl bootloader config template**
    
    The targetgeometry value is not allowed for SCSI and FBA
    mode. So far we handled only SCSI and failed on FBA mode.
    This commit fixes it

**Adapt test-image-oem integration test for s390**
    
    The test was originally designed to test for DASD 4k block
    storage. However the kpartx utility in the Leap15, TW code
    stream has issues mapping partitions if the loop device
    was setup using 4k sector size. So far we can't create
    images with 4k blocksize due to that issue. Thus the
    integration test is now adapted for an emulated DASD device
    in FBA mode which is not using 4k blocksize. Once the
    problem with kpartx is solved on s390 we will create another
    integration test to test 4k image builds
