### PR TITLE
Improve alias documentation in XML schema

### DIFF
--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -876,10 +876,10 @@ div {
     k.repository.alias.attribute =
         ## Alias name to be used for this repository. This is an
         ## optional free form text. If not set the source attribute
-        ## value is used and builds the alias name by replacing
-        ## each '/' with a '_'. An alias name should be set if the
-        ## source argument doesn't really explain what this repository
-        ## contains
+        ## value is used and builds the alias name by running a md5 digest
+        ## of the defined URI of the repository. An alias name should be
+        ## set if the source argument doesn't really explain what this
+        ## repository contains.
         attribute alias { text }
     k.repository.components.attribute =
         ## Distribution components, used for deb repositories. If

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1360,10 +1360,10 @@ definition can be composed by other existing profiles.</a:documentation>
       <attribute name="alias">
         <a:documentation>Alias name to be used for this repository. This is an
 optional free form text. If not set the source attribute
-value is used and builds the alias name by replacing
-each '/' with a '_'. An alias name should be set if the
-source argument doesn't really explain what this repository
-contains</a:documentation>
+value is used and builds the alias name by running a md5 digest
+of the defined URI of the repository. An alias name should be
+set if the source argument doesn't really explain what this
+repository contains.</a:documentation>
       </attribute>
     </define>
     <define name="k.repository.components.attribute">


### PR DESCRIPTION
This commit aligns the documentation of the default repository alias
with the current implementation.

Fixes #1247