### PR TITLE
Fixed subsequent reboot of oem disk

### DIFF
--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -279,14 +279,6 @@ PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
 setup_debug
 
-# initialize for disk repartition
-initialize
-
-if ! disk_has_unallocated_space "${disk}";then
-    # already resized or disk has not received any geometry change
-    return
-fi
-
 # when repartitioning disks, parted and friends might trigger re-reads of
 # the partition table, in turn triggering systemd-fsck-root.service
 # repeatedly via udev events, which finally can cause booting to fail with
@@ -302,6 +294,14 @@ fi
 trap unmask_fsck_root_service EXIT
 
 mask_fsck_root_service
+
+# initialize for disk repartition
+initialize
+
+if ! disk_has_unallocated_space "${disk}";then
+    # already resized or disk has not received any geometry change
+    return
+fi
 
 # prepare disk for repartition
 if [ "$(get_partition_table_type "${disk}")" = 'gpt' ];then


### PR DESCRIPTION
On a second reboot of an oem disk we check with gdisk's
verification command if the disk needs to be resized.
That command however mounts the disk in the background
and therefore it's urgently required to mask the systemd
rootfs service before. Otherwise systemd thinks this is
evil and drops into a rescue shell


