### PR TITLE
Include grub.cfg inside the efi partition

### DIFF
--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -76,13 +76,12 @@ class BootLoaderConfigBase:
         """
         raise NotImplementedError
 
-    def write_meta_data(self, root_uuid=None, boot_options='', iso_boot=False):
+    def write_meta_data(self, root_uuid=None, boot_options=''):
         """
         Write bootloader setup meta data files
 
         :param string root_uuid: root device UUID
         :param string boot_options: kernel options as string
-        :param bool iso_boot: indicate target is an ISO
 
         Implementation in specialized bootloader class optional
         """

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -143,9 +143,10 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         """
         Write bootloader configuration
 
-        Writes grub.cfg template by KIWI if template system is used
-        Also copies grub config file to alternative boot path for
-        EFI systems in fallback mode
+        * writes grub.cfg template by KIWI if template system is used
+        * copies grub config file to alternative boot path for EFI systems
+          in fallback mode
+        * creates an embedded fat efi image for EFI ISO boot
         """
         if self.config:
             log.info('Writing KIWI template grub.cfg file')
@@ -159,13 +160,14 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 self._copy_grub_config_to_efi_path(
                     self.boot_dir, config_file
                 )
+                if self.iso_boot:
+                    self._create_embedded_fat_efi_image()
 
-    def write_meta_data(self, root_uuid=None, boot_options='', iso_boot=False):
+    def write_meta_data(self, root_uuid=None, boot_options=''):
         """
         Write bootloader setup meta data files
 
         * cmdline arguments initialization
-        * creation of embedded fat efi image for EFI ISO boot
         * etc/default/grub setup file
         * etc/sysconfig/bootloader
 
@@ -179,10 +181,6 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         self.cmdline_failsafe = ' '.join(
             [self.cmdline, Defaults.get_failsafe_kernel_options(), boot_options]
         )
-        self.iso_boot = iso_boot
-
-        if self.iso_boot:
-            self._create_embedded_fat_efi_image()
 
         self._setup_default_grub()
         self._setup_sysconfig_bootloader()
@@ -249,6 +247,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         :param string initrd: initrd name
         """
         log.info('Creating grub2 install config file from template')
+        self.iso_boot = True
         parameters = {
             'search_params': '--file --set=root /boot/' + mbrid.get_id(),
             'default_boot': self.get_install_image_boot_default(),
@@ -302,6 +301,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         :param string initrd: initrd name
         """
         log.info('Creating grub2 live ISO config file from template')
+        self.iso_boot = True
         parameters = {
             'search_params': '--file --set=root /boot/' + mbrid.get_id(),
             'default_boot': '0',

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -219,7 +219,7 @@ class InstallImageBuilder:
             self.boot_image_task.boot_root_directory, self.media_dir,
             bootloader_config.get_boot_theme()
         )
-        bootloader_config.write_meta_data(iso_boot=True)
+        bootloader_config.write_meta_data()
         bootloader_config.setup_install_image_config(
             mbrid=self.mbrid
         )

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -168,7 +168,7 @@ class LiveImageBuilder:
             self.boot_image.boot_root_directory, self.media_dir,
             bootloader_config.get_boot_theme()
         )
-        bootloader_config.write_meta_data(iso_boot=True)
+        bootloader_config.write_meta_data()
         bootloader_config.setup_live_image_config(
             mbrid=self.mbrid
         )

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -166,7 +166,7 @@ class TestInstallImageBuilder:
             'initrd_dir', 'temp_media_dir',
             bootloader_config.get_boot_theme.return_value
         )
-        bootloader_config.write_meta_data.assert_called_once_with(iso_boot=True)
+        bootloader_config.write_meta_data.assert_called_once_with()
         bootloader_config.setup_install_image_config.assert_called_once_with(
             mbrid=self.mbrid
         )

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -232,7 +232,7 @@ class TestLiveImageBuilder:
             'initrd_dir', 'temp_media_dir',
             self.bootloader.get_boot_theme.return_value
         )
-        self.bootloader.write_meta_data.assert_called_once_with(iso_boot=True)
+        self.bootloader.write_meta_data.assert_called_once_with()
         self.bootloader.setup_live_image_config.assert_called_once_with(
             mbrid=self.mbrid
         )


### PR DESCRIPTION
This commit ensures the grub.cfg file is included within the vfat efi
partition.

This fixes #1271 and bsc#1157354
