### PR TITLE
Fixed VolumeManager device map handling

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -323,7 +323,7 @@ class DiskBuilder:
                     self.xml_state.get_build_type_name()
             }
             volume_manager = VolumeManager(
-                self.volume_manager_name, device_map['root'],
+                self.volume_manager_name, device_map,
                 self.root_dir + '/',
                 self.volumes,
                 volume_manager_custom_parameters

--- a/kiwi/volume_manager/__init__.py
+++ b/kiwi/volume_manager/__init__.py
@@ -29,21 +29,22 @@ class VolumeManager:
     **VolumeManager factory**
 
     :param str name: volume management name
-    :param object device_provider: instance of a class based on DeviceProvider
+    :param dict device_map:
+        dictionary of low level DeviceProvider intances
     :param str root_dir: root directory path name
     :param list volumes: list of volumes from :class:`XMLState::get_volumes()`
     :param dict custom_args: dictionary of custom volume manager arguments
     """
     def __new__(
-        self, name, device_provider, root_dir, volumes, custom_args=None
+        self, name, device_map, root_dir, volumes, custom_args=None
     ):
         if name == 'lvm':
             return VolumeManagerLVM(
-                device_provider, root_dir, volumes, custom_args
+                device_map, root_dir, volumes, custom_args
             )
         elif name == 'btrfs':
             return VolumeManagerBtrfs(
-                device_provider, root_dir, volumes, custom_args
+                device_map, root_dir, volumes, custom_args
             )
         else:
             raise KiwiVolumeManagerSetupError(

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -23,15 +23,17 @@ class TestVolumeManagerBase:
             ]
         )
         mock_path.return_value = True
-        self.device_provider = Mock()
-        self.device_provider.is_loop = Mock(
+        self.device_map = {
+            'root': Mock()
+        }
+        self.device_map['root'].is_loop = Mock(
             return_value=True
         )
-        self.device_provider.get_device = Mock(
+        self.device_map['root'].get_device = Mock(
             return_value='/dev/storage'
         )
         self.volume_manager = VolumeManagerBase(
-            self.device_provider, 'root_dir', Mock()
+            self.device_map, 'root_dir', Mock()
         )
         self.volume_manager.volumes = [
             self.volume_type(
@@ -48,7 +50,7 @@ class TestVolumeManagerBase:
     def test_init_custom_args(self, mock_exists):
         mock_exists.return_value = True
         volume_manager = VolumeManagerBase(
-            Mock(), 'root_dir', Mock(), {
+            self.device_map, 'root_dir', Mock(), {
                 'fs_create_options': 'create-opts',
                 'fs_mount_options': 'mount-opts'
             }
@@ -62,11 +64,11 @@ class TestVolumeManagerBase:
     def test_root_dir_does_not_exist(self, mock_exists):
         mock_exists.return_value = False
         with raises(KiwiVolumeManagerSetupError):
-            VolumeManagerBase(Mock(), 'root_dir', Mock())
+            VolumeManagerBase(self.device_map, 'root_dir', Mock())
 
     def test_is_loop(self):
         assert self.volume_manager.is_loop() == \
-            self.device_provider.is_loop()
+            self.device_map['root'].is_loop()
 
     @patch('os.path.exists')
     def test_get_device(self, mock_exists):

--- a/test/unit/volume_manager/init_test.py
+++ b/test/unit/volume_manager/init_test.py
@@ -17,20 +17,20 @@ class TestVolumeManager:
     @patch('os.path.exists')
     def test_volume_manager_lvm(self, mock_path, mock_lvm):
         mock_path.return_value = True
-        provider = Mock()
+        device_map = Mock()
         volumes = Mock()
-        VolumeManager('lvm', provider, 'root_dir', volumes)
+        VolumeManager('lvm', device_map, 'root_dir', volumes)
         mock_lvm.assert_called_once_with(
-            provider, 'root_dir', volumes, None
+            device_map, 'root_dir', volumes, None
         )
 
     @patch('kiwi.volume_manager.VolumeManagerBtrfs')
     @patch('os.path.exists')
     def test_volume_manager_btrfs(self, mock_path, mock_btrfs):
         mock_path.return_value = True
-        provider = Mock()
+        device_map = Mock()
         volumes = Mock()
-        VolumeManager('btrfs', provider, 'root_dir', volumes)
+        VolumeManager('btrfs', device_map, 'root_dir', volumes)
         mock_btrfs.assert_called_once_with(
-            provider, 'root_dir', volumes, None
+            device_map, 'root_dir', volumes, None
         )

--- a/test/unit/volume_manager/lvm_test.py
+++ b/test/unit/volume_manager/lvm_test.py
@@ -54,15 +54,17 @@ class TestVolumeManagerLVM:
             ),
         ]
         mock_path.return_value = True
-        self.device_provider = Mock()
-        self.device_provider.is_loop = Mock(
+        self.device_map = {
+            'root': Mock()
+        }
+        self.device_map['root'].is_loop = Mock(
             return_value=True
         )
-        self.device_provider.get_device = Mock(
+        self.device_map['root'].get_device = Mock(
             return_value='/dev/storage'
         )
         self.volume_manager = VolumeManagerLVM(
-            self.device_provider, 'root_dir', self.volumes,
+            self.device_map, 'root_dir', self.volumes,
             {'some-arg': 'some-val', 'fs_mount_options': ['a,b,c']}
         )
         assert self.volume_manager.mount_options == 'a,b,c'


### PR DESCRIPTION
The former implementation builds a new device map which is
a subset of the low level device map. However due to the
additional swap partition the maps provided by the VolumeManager
classes are now incomplete. Instead this commit changes the
VolumeManager interface to receive the current low level
device_map and merged device changes on top of it when
needed.

