### PR TITLE
Do not rsync kernel filesystems on debootstrap

### DIFF
--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -163,7 +163,8 @@ class PackageManagerApt(PackageManagerBase):
                 bootstrap_dir + '/', self.root_dir
             )
             data.sync_data(
-                options=['-a', '-H', '-X', '-A']
+                options=['-a', '-H', '-X', '-A'],
+                exclude=['proc', 'sys']
             )
             for key in self.repository.signing_keys:
                 Command.run([

--- a/test/unit/package_manager/apt_test.py
+++ b/test/unit/package_manager/apt_test.py
@@ -105,7 +105,7 @@ class TestPackageManagerApt:
         )
         with self._caplog.at_level(logging.WARNING):
             data.sync_data.assert_called_once_with(
-                options=['-a', '-H', '-X', '-A']
+                exclude=['proc', 'sys'], options=['-a', '-H', '-X', '-A']
             )
             assert mock_run.call_args_list == [
                 call(


### PR DESCRIPTION
This commit ensures that /proc and /sys are not rsynched when
debootstrapping an apt based image.

Fixes #1270
