### PR TITLE
Do not rsync /dev on debootstrap

### DIFF
--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -21,7 +21,6 @@ import logging
 
 # project
 from kiwi.command import Command
-from kiwi.mount_manager import MountManager
 from kiwi.utils.sync import DataSync
 from kiwi.path import Path
 from kiwi.package_manager.base import PackageManagerBase
@@ -135,10 +134,6 @@ class PackageManagerApt(PackageManagerBase):
             # debootstrap takes care to install apt-get
             self.package_requests.remove('apt-get')
         try:
-            dev_mount = MountManager(
-                device='/dev', mountpoint=self.root_dir + '/dev'
-            )
-            dev_mount.umount()
             if self.repository.unauthenticated == 'false':
                 log.warning(
                     'KIWI does not support signature checks for apt-get '
@@ -164,7 +159,7 @@ class PackageManagerApt(PackageManagerBase):
             )
             data.sync_data(
                 options=['-a', '-H', '-X', '-A'],
-                exclude=['proc', 'sys']
+                exclude=['proc', 'sys', 'dev']
             )
             for key in self.repository.signing_keys:
                 Command.run([

--- a/test/unit/package_manager/apt_test.py
+++ b/test/unit/package_manager/apt_test.py
@@ -105,13 +105,10 @@ class TestPackageManagerApt:
         )
         with self._caplog.at_level(logging.WARNING):
             data.sync_data.assert_called_once_with(
-                exclude=['proc', 'sys'], options=['-a', '-H', '-X', '-A']
+                exclude=['proc', 'sys', 'dev'],
+                options=['-a', '-H', '-X', '-A']
             )
             assert mock_run.call_args_list == [
-                call(
-                    command=['mountpoint', '-q', 'root-dir/dev'],
-                    raise_on_error=False
-                ),
                 call(
                     [
                         'debootstrap', '--no-check-gpg', '--variant=minbase',


### PR DESCRIPTION
This commit does not rsync /dev on debootstrap and instead it uses
the bind mount for /dev the same way it is done for other non apt
based bootstrap processes.
