### PR TITLE
Lookup distribution specific grub font dir

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -865,6 +865,10 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
     def _copy_theme_data_to_boot_directory(self, lookup_path, target):
         if not lookup_path:
             lookup_path = self.boot_dir
+        font_name = 'unicode.pf2'
+        efi_font_dir = Defaults.get_grub_efi_font_directory(
+            lookup_path
+        )
         boot_fonts_dir = os.path.normpath(
             os.sep.join(
                 [
@@ -875,20 +879,23 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 ]
             )
         )
-        Path.create(boot_fonts_dir)
-        boot_unicode_font = boot_fonts_dir + '/unicode.pf2'
-        if not os.path.exists(boot_unicode_font):
-            try:
-                unicode_font = Defaults.get_grub_path(
-                    lookup_path, 'unicode.pf2'
-                )
+        try:
+            unicode_font = Defaults.get_grub_path(
+                lookup_path, font_name
+            )
+            if not os.path.exists(os.sep.join([boot_fonts_dir, font_name])):
+                Path.create(boot_fonts_dir)
                 Command.run(
-                    ['cp', unicode_font, boot_unicode_font]
+                    ['cp', unicode_font, boot_fonts_dir]
                 )
-            except Exception as issue:
-                raise KiwiBootLoaderGrubFontError(
-                    'Setting up unicode font failed with {0}'.format(issue)
+            if efi_font_dir:
+                Command.run(
+                    ['cp', unicode_font, efi_font_dir]
                 )
+        except Exception as issue:
+            raise KiwiBootLoaderGrubFontError(
+                'Setting up unicode font failed with {0}'.format(issue)
+            )
 
         boot_theme_dir = os.sep.join(
             [self.boot_dir, 'boot', self.boot_directory_name, 'themes']

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -565,6 +565,24 @@ class Defaults:
                 return shim_file
 
     @staticmethod
+    def get_grub_efi_font_directory(root_path):
+        """
+        Provides distribution specific EFI font directory used with grub.
+
+        :param string root_path: image root path
+
+        :return: file path or None
+
+        :rtype: str
+        """
+        font_dir_patterns = [
+            '/boot/efi/EFI/*/fonts'
+        ]
+        for font_dir_pattern in font_dir_patterns:
+            for font_dir in glob.iglob(root_path + font_dir_pattern):
+                return font_dir
+
+    @staticmethod
     def get_unsigned_grub_loader(root_path):
         """
         Provides unsigned grub efi loader file path

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -56,7 +56,8 @@ class TestBootLoaderConfigGrub2:
         }
         self.glob_iglob = [
             ['root_dir/usr/lib64/efi/shim.efi'],
-            ['root_dir/usr/lib64/efi/grub.efi']
+            ['root_dir/usr/lib64/efi/grub.efi'],
+            ['root_dir/boot/efi/EFI/DIST/fonts']
         ]
         mock_machine.return_value = 'x86_64'
         mock_theme.return_value = None
@@ -141,6 +142,7 @@ class TestBootLoaderConfigGrub2:
         self.os_exists['root_dir/boot/grub2/themes/some-theme'] = False
         self.os_exists['root_dir/usr/share/grub2/i386-pc'] = True
         self.os_exists['root_dir/usr/share/grub2/x86_64-efi'] = True
+        self.os_exists['root_dir/usr/share/grub2/unicode.pf2'] = True
 
         def side_effect(arg):
             return self.os_exists[arg]
@@ -464,6 +466,7 @@ class TestBootLoaderConfigGrub2:
         self.os_exists['root_dir/usr/lib/grub2/i386-pc'] = False
         self.os_exists['root_dir/usr/share/grub/i386-pc'] = False
         self.os_exists['root_dir/usr/lib/grub/i386-pc'] = False
+        self.os_exists['root_dir/usr/share/grub2/unicode.pf2'] = True
 
         def side_effect(arg):
             return self.os_exists[arg]
@@ -546,7 +549,7 @@ class TestBootLoaderConfigGrub2:
             call(
                 [
                     'cp', 'root_dir/usr/share/grub2/unicode.pf2',
-                    'root_dir/boot/grub2/fonts/unicode.pf2'
+                    'root_dir/boot/grub2/fonts'
                 ]
             ),
             call(
@@ -617,7 +620,7 @@ class TestBootLoaderConfigGrub2:
             call(
                 [
                     'cp', 'root_dir/usr/share/grub2/unicode.pf2',
-                    'root_dir/grub2/fonts/unicode.pf2'
+                    'root_dir/grub2/fonts'
                 ]
             ),
             call(
@@ -680,7 +683,7 @@ class TestBootLoaderConfigGrub2:
             call(
                 [
                     'cp', 'root_dir/usr/share/grub2/unicode.pf2',
-                    'root_dir/grub2/fonts/unicode.pf2'
+                    'root_dir/grub2/fonts'
                 ]
             ),
             call(
@@ -720,7 +723,7 @@ class TestBootLoaderConfigGrub2:
         mock_command.assert_called_once_with(
             [
                 'cp', 'root_dir/usr/share/grub2/unicode.pf2',
-                'root_dir/boot/grub2/fonts/unicode.pf2'
+                'root_dir/boot/grub2/fonts'
             ]
         )
         mock_sync.assert_called_once_with(
@@ -757,7 +760,7 @@ class TestBootLoaderConfigGrub2:
         mock_command.assert_called_once_with(
             [
                 'cp', 'root_dir/usr/share/grub2/unicode.pf2',
-                'root_dir/boot/grub2/fonts/unicode.pf2'
+                'root_dir/boot/grub2/fonts'
             ]
         )
 
@@ -778,6 +781,7 @@ class TestBootLoaderConfigGrub2:
         )
         self.os_exists['root_dir/usr/share/grub2/i386-pc'] = True
         self.os_exists['root_dir/usr/share/grub2/x86_64-efi'] = True
+        self.os_exists['root_dir/usr/share/grub2/unicode.pf2'] = True
 
         def side_effect(arg):
             return self.os_exists[arg]
@@ -824,6 +828,7 @@ class TestBootLoaderConfigGrub2:
         )
         self.os_exists['root_dir/usr/share/grub2/i386-pc'] = True
         self.os_exists['root_dir/usr/share/grub2/x86_64-efi'] = True
+        self.os_exists['root_dir/usr/share/grub2/unicode.pf2'] = True
 
         def side_effect(arg):
             return self.os_exists[arg]
@@ -836,6 +841,12 @@ class TestBootLoaderConfigGrub2:
         with self._caplog.at_level(logging.WARNING):
             self.bootloader.setup_disk_boot_images('uuid')
             assert mock_command.call_args_list == [
+                call(
+                    [
+                        'cp', 'root_dir/usr/share/grub2/unicode.pf2',
+                        'root_dir/boot/efi/EFI/DIST/fonts'
+                    ]
+                ),
                 call(
                     [
                         'rsync', '-a', '--exclude', '/*.module',
@@ -888,6 +899,7 @@ class TestBootLoaderConfigGrub2:
         )
         self.os_exists['root_dir/usr/share/grub2/i386-pc'] = True
         self.os_exists['root_dir/usr/share/grub2/x86_64-efi'] = True
+        self.os_exists['root_dir/usr/share/grub2/unicode.pf2'] = True
 
         def side_effect(arg):
             return self.os_exists[arg]
@@ -900,6 +912,12 @@ class TestBootLoaderConfigGrub2:
         with self._caplog.at_level(logging.WARNING):
             self.bootloader.setup_disk_boot_images('uuid')
             assert mock_command.call_args_list == [
+                call(
+                    [
+                        'cp', 'root_dir/usr/share/grub2/unicode.pf2',
+                        'root_dir/boot/efi/EFI/DIST/fonts'
+                    ]
+                ),
                 call(
                     [
                         'rsync', '-a', '--exclude', '/*.module',
@@ -978,7 +996,7 @@ class TestBootLoaderConfigGrub2:
             call(
                 [
                     'cp', 'root_dir/usr/share/grub2/unicode.pf2',
-                    'root_dir/boot/grub2/fonts/unicode.pf2'
+                    'root_dir/boot/grub2/fonts'
                 ]
             ),
             call(
@@ -1063,7 +1081,7 @@ class TestBootLoaderConfigGrub2:
             call(
                 [
                     'cp', 'root_dir/usr/share/grub2/unicode.pf2',
-                    'root_dir/boot/grub2/fonts/unicode.pf2'
+                    'root_dir/boot/grub2/fonts'
                 ]
             ),
             call(
@@ -1099,6 +1117,7 @@ class TestBootLoaderConfigGrub2:
         )
         self.os_exists['root_dir/usr/share/grub2/i386-pc'] = True
         self.os_exists['root_dir/usr/share/grub2/x86_64-efi'] = True
+        self.os_exists['root_dir/usr/share/grub2/unicode.pf2'] = True
 
         def side_effect_exists(arg):
             return self.os_exists[arg]
@@ -1111,6 +1130,12 @@ class TestBootLoaderConfigGrub2:
         with self._caplog.at_level(logging.INFO):
             self.bootloader.setup_install_boot_images(self.mbrid, 'root_dir')
             assert mock_command.call_args_list == [
+                call(
+                    [
+                        'cp', 'root_dir/usr/share/grub2/unicode.pf2',
+                        'root_dir/boot/efi/EFI/DIST/fonts'
+                    ]
+                ),
                 call(
                     [
                         'rsync', '-a', 'root_dir/boot/efi/', 'root_dir'
@@ -1137,6 +1162,7 @@ class TestBootLoaderConfigGrub2:
                 )
             ]
 
+    @patch('kiwi.defaults.Defaults.get_grub_efi_font_directory')
     @patch.object(BootLoaderConfigGrub2, '_supports_bios_modules')
     @patch('kiwi.bootloader.config.grub2.Command.run')
     @patch('kiwi.bootloader.config.grub2.DataSync')
@@ -1145,8 +1171,10 @@ class TestBootLoaderConfigGrub2:
     @patch('glob.iglob')
     def test_setup_install_boot_images_with_theme_from_usr_share(
         self, mock_glob, mock_machine, mock_exists,
-        mock_sync, mock_command, mock_supports_bios_modules
+        mock_sync, mock_command, mock_supports_bios_modules,
+        mock_get_grub_efi_font_directory
     ):
+        mock_get_grub_efi_font_directory.return_value = None
         mock_supports_bios_modules.return_value = False
         mock_glob.return_value = [
             'root_dir/boot/grub2/themes/some-theme/background.png'
@@ -1161,6 +1189,7 @@ class TestBootLoaderConfigGrub2:
         self.os_exists['lookup_path/usr/share/grub2/themes/some-theme'] = True
         self.os_exists['lookup_path/boot/grub2/themes/some-theme'] = True
         self.os_exists['root_dir/boot/grub2/themes/some-theme'] = True
+        self.os_exists['lookup_path/usr/share/grub2/unicode.pf2'] = True
 
         def side_effect(arg):
             return self.os_exists[arg]
@@ -1195,6 +1224,7 @@ class TestBootLoaderConfigGrub2:
             options=['-a']
         )
 
+    @patch('kiwi.defaults.Defaults.get_grub_efi_font_directory')
     @patch('kiwi.bootloader.config.grub2.Command.run')
     @patch('kiwi.bootloader.config.grub2.DataSync')
     @patch('os.path.exists')
@@ -1203,8 +1233,10 @@ class TestBootLoaderConfigGrub2:
     @patch('kiwi.defaults.Defaults.get_grub_path')
     def test_setup_install_boot_images_with_theme_from_boot(
         self, mock_get_grub_path, mock_glob, mock_machine,
-        mock_exists, mock_sync, mock_command
+        mock_exists, mock_sync, mock_command,
+        mock_get_grub_efi_font_directory
     ):
+        mock_get_grub_efi_font_directory.return_value = None
         mock_glob.return_value = [
             'lookup_path/boot/grub2/themes/some-theme/background.png'
         ]
@@ -1218,6 +1250,7 @@ class TestBootLoaderConfigGrub2:
 
         self.find_grub['themes/some-theme'] = 'some-theme'
         self.find_grub['i386-pc'] = 'i386-pc'
+        self.find_grub['unicode.pf2'] = True
 
         def find_grub_data_side_effect(
             root_path, filename, raise_on_error=True


### PR DESCRIPTION
In addition to the generic grub font directory also lookup
distribution specific font paths in the system and copy the
grub unicode font into it. This Fixes #1253

