### PR TITLE
Fixed setup of default grub config

### DIFF
--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -96,8 +96,10 @@ class TestBootLoaderConfigGrub2:
                 'grub_directory_name': 'grub2', 'boot_is_crypto': True
             }
         )
-        self.bootloader.cmdline = 'some-cmdline'
-        self.bootloader.cmdline_failsafe = 'some-failsafe-cmdline'
+        self.bootloader.cmdline = 'some-cmdline root=UUID=foo'
+        self.bootloader.cmdline_failsafe = ' '.join(
+            [self.bootloader.cmdline, 'failsafe-options']
+        )
 
     @patch('platform.machine')
     @patch('kiwi.bootloader.config.grub2.Path.which')
@@ -358,8 +360,11 @@ class TestBootLoaderConfigGrub2:
         )
         sysconfig_bootloader.write.assert_called_once_with()
         assert sysconfig_bootloader.__setitem__.call_args_list == [
-            call('DEFAULT_APPEND', '"some-cmdline"'),
-            call('FAILSAFE_APPEND', '"some-failsafe-cmdline"'),
+            call('DEFAULT_APPEND', '"some-cmdline root=UUID=foo"'),
+            call(
+                'FAILSAFE_APPEND',
+                '"some-cmdline root=UUID=foo failsafe-options"'
+            ),
             call('LOADER_LOCATION', 'mbr'),
             call('LOADER_TYPE', 'grub2')
         ]
@@ -369,8 +374,11 @@ class TestBootLoaderConfigGrub2:
         sysconfig_bootloader.__setitem__.reset_mock()
         self.bootloader._setup_sysconfig_bootloader()
         assert sysconfig_bootloader.__setitem__.call_args_list == [
-            call('DEFAULT_APPEND', '"some-cmdline"'),
-            call('FAILSAFE_APPEND', '"some-failsafe-cmdline"'),
+            call('DEFAULT_APPEND', '"some-cmdline root=UUID=foo"'),
+            call(
+                'FAILSAFE_APPEND',
+                '"some-cmdline root=UUID=foo failsafe-options"'
+            ),
             call('LOADER_LOCATION', 'none'),
             call('LOADER_TYPE', 'grub2-efi')
         ]
@@ -406,23 +414,34 @@ class TestBootLoaderConfigGrub2:
         self.firmware.efi_mode = Mock(
             return_value='uefi'
         )
+        self.bootloader.root_filesystem_is_overlay = True
+        self.bootloader.root_reference = 'root=overlay:UUID=ID'
         self.bootloader.root_mount = Mock()
         self.bootloader.root_mount.mountpoint = 'root_mount_point'
-        self.bootloader.setup_disk_image_config(
-            boot_options={'root_device': 'rootdev', 'boot_device': 'bootdev'}
-        )
-        mock_mount_system.assert_called_once_with(
-            'rootdev', 'bootdev', None, None
-        )
-        mock_Command_run.assert_called_once_with(
-            [
-                'chroot', self.bootloader.root_mount.mountpoint,
-                'grub2-mkconfig', '-o', '/boot/grub2/grub.cfg'
-            ]
-        )
-        mock_copy_grub_config_to_efi_path.assert_called_once_with(
-            'root_mount_point', 'root_mount_point/boot/grub2/grub.cfg'
-        )
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            file_handle.read.return_value = 'root=rootdev'
+            self.bootloader.setup_disk_image_config(
+                boot_options={
+                    'root_device': 'rootdev', 'boot_device': 'bootdev'
+                }
+            )
+            mock_mount_system.assert_called_once_with(
+                'rootdev', 'bootdev', None, None
+            )
+            mock_Command_run.assert_called_once_with(
+                [
+                    'chroot', self.bootloader.root_mount.mountpoint,
+                    'grub2-mkconfig', '-o', '/boot/grub2/grub.cfg'
+                ]
+            )
+            mock_copy_grub_config_to_efi_path.assert_called_once_with(
+                'root_mount_point', 'root_mount_point/boot/grub2/grub.cfg'
+            )
+            file_handle.write.assert_called_once_with(
+                'root=overlay:UUID=ID'
+            )
 
     def test_setup_install_image_config_standard(self):
         self.bootloader.multiboot = False


### PR DESCRIPTION
In /etc/default/grub GRUB_CMDLINE_LINUX_DEFAULT also contained
the root= information. If grub2-mkconfig runs with that information
it places the root device information twice because grub2-mkconfig
resolves this information itself. This commit prevents the root=
information to be placed in the default grub config and
Fixes bsc#1156908

