### PR TITLE
Open image files in UTF-8

### DIFF
--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -91,7 +91,7 @@ class SystemSetup:
         description = self.root_dir + '/image/config.xml'
         log.info('--> Importing state XML description as image/config.xml')
         Path.create(self.root_dir + '/image')
-        with open(description, 'w') as config:
+        with open(description, 'w', encoding='utf-8') as config:
             config.write('<?xml version="1.0" encoding="utf-8"?>')
             self.xml_state.xml_data.export(outfile=config, level=0)
 
@@ -1004,7 +1004,7 @@ class SystemSetup:
                 ) + '\\n'
             ] + dbpath_option
         )
-        with open(filename, 'w') as packages:
+        with open(filename, 'w', encoding='utf-8') as packages:
             packages.write(
                 os.linesep.join(sorted(query_call.output.splitlines()))
             )
@@ -1024,7 +1024,7 @@ class SystemSetup:
                 ) + '\\n'
             ]
         )
-        with open(filename, 'w') as packages:
+        with open(filename, 'w', encoding='utf-8') as packages:
             packages.write(
                 os.linesep.join(sorted(query_call.output.splitlines()))
             )
@@ -1039,7 +1039,7 @@ class SystemSetup:
             command=['rpm', '--root', self.root_dir, '-Va'] + dbpath_option,
             raise_on_error=False
         )
-        with open(filename, 'w') as verified:
+        with open(filename, 'w', encoding='utf-8') as verified:
             verified.write(query_call.output)
 
     def _export_deb_package_verification(self, filename):
@@ -1051,7 +1051,7 @@ class SystemSetup:
             ],
             raise_on_error=False
         )
-        with open(filename, 'w') as verified:
+        with open(filename, 'w', encoding='utf-8') as verified:
             verified.write(query_call.output)
 
     def _get_rpm_database_location(self):

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -831,7 +831,8 @@ class TestSystemSetup:
         with patch('builtins.open') as m_open:
             result = self.setup.export_package_list('target_dir')
             m_open.assert_called_once_with(
-                'target_dir/some-image.x86_64-1.2.3.packages', 'w'
+                'target_dir/some-image.x86_64-1.2.3.packages', 'w',
+                encoding='utf-8'
             )
 
         assert result == 'target_dir/some-image.x86_64-1.2.3.packages'
@@ -899,7 +900,8 @@ class TestSystemSetup:
         with patch('builtins.open') as m_open:
             result = self.setup.export_package_list('target_dir')
             m_open.assert_called_once_with(
-                'target_dir/some-image.x86_64-1.2.3.packages', 'w'
+                'target_dir/some-image.x86_64-1.2.3.packages', 'w',
+                encoding='utf-8'
             )
 
         assert result == 'target_dir/some-image.x86_64-1.2.3.packages'
@@ -934,7 +936,8 @@ class TestSystemSetup:
         with patch('builtins.open') as m_open:
             result = self.setup.export_package_verification('target_dir')
             m_open.assert_called_once_with(
-                'target_dir/some-image.x86_64-1.2.3.verified', 'w'
+                'target_dir/some-image.x86_64-1.2.3.verified', 'w',
+                encoding='utf-8'
             )
 
         assert result == 'target_dir/some-image.x86_64-1.2.3.verified'
@@ -980,7 +983,8 @@ class TestSystemSetup:
         with patch('builtins.open') as m_open:
             result = self.setup.export_package_verification('target_dir')
             m_open.assert_called_once_with(
-                'target_dir/some-image.x86_64-1.2.3.verified', 'w'
+                'target_dir/some-image.x86_64-1.2.3.verified', 'w',
+                encoding='utf-8'
             )
 
         assert result == 'target_dir/some-image.x86_64-1.2.3.verified'


### PR DESCRIPTION
Post image build metadata like the packages file which are
created from data produced by the package manager can contain
multibyte characters and should be written into files opened
with the UTF-8 encoding. The same applies to the image imported
XML description. This Fixes #1290

