### PR TITLE
Fixed result map for OEM pxe install

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -583,7 +583,7 @@ class DiskBuilder:
                 install_image.create_install_pxe_archive()
                 result_instance.add(
                     key='installation_pxe_archive',
-                    filename=install_image.pxename,
+                    filename=install_image.pxetarball,
                     use_for_bundle=True,
                     compress=False,
                     shasum=True


### PR DESCRIPTION
The result map for OEM images with installpxe enabled
contained a wrong file name. Thus the result bundler
was not able to fetch the tarball


