### PR TITLE
Fixed scope of kiwi-man-pages sub package

### DIFF
--- a/kiwi.yml
+++ b/kiwi.yml
@@ -30,8 +30,7 @@
 # Setup behaviour of XZ compressor
 #xz:
 #  # Specify options used in any xz compression call
-#  - options:
-#      - '--threads=0'
+#  - options: '--threads=0'
 
 
 # Setup process parameters for container image creation

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -141,7 +141,6 @@ Requires:       dosfstools
 Requires:       e2fsprogs
 Requires:       xorriso
 Requires:       grub2
-Requires:       kiwi-man-pages
 Requires:       kiwi-tools
 Requires:       lvm2
 Requires:       mtools
@@ -160,6 +159,7 @@ Requires:       u-boot-tools
 %ifarch s390 s390x
 Requires:       s390-tools
 %endif
+Recommends:     kiwi-man-pages
 
 %description -n python%{python3_pkgversion}-kiwi
 Python 3 library of the KIWI Image System. Provides an operating system
@@ -405,19 +405,19 @@ fi
 %endif
 
 %files -n python%{python3_pkgversion}-kiwi
+%dir %{_defaultdocdir}/python-kiwi
 %{_bindir}/kiwi
 %{_bindir}/kiwi-ng
 %{_bindir}/kiwicompat
 %{_bindir}/kiwi-ng-3*
 %{_bindir}/kiwicompat-3*
 %{python3_sitelib}/kiwi*
-
-%files -n kiwi-man-pages
-%dir %{_defaultdocdir}/python-kiwi
-%{_defaultdocdir}/python-kiwi/kiwi.pdf
+%config %_sysconfdir/bash_completion.d/kiwi-ng.sh
 %{_defaultdocdir}/python-kiwi/LICENSE
 %{_defaultdocdir}/python-kiwi/README
-%config %_sysconfdir/bash_completion.d/kiwi-ng.sh
+
+%files -n kiwi-man-pages
+%{_defaultdocdir}/python-kiwi/kiwi.pdf
 %config %_sysconfdir/kiwi.yml
 %doc %{_mandir}/man8/*
 


### PR DESCRIPTION
The kiwi-man-pages package provided data that belongs to
the main package, e.g the completion as well as the
license information. In addition kiwi-man-pages should
not be a requirement.


