### PR TITLE
Fixed swap setup if btrfs is used

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -870,7 +870,7 @@ class DiskBuilder:
                 device_map['spare'].get_device(), self.spare_part_mountpoint
             )
         if device_map.get('swap'):
-            if self.volume_manager_name:
+            if self.volume_manager_name and self.volume_manager_name == 'lvm':
                 self._add_simple_fstab_entry(
                     device_map['swap'].get_device(), 'swap', 'swap'
                 )


### PR DESCRIPTION
In case of a volume manager the simplified variant of the
device name is used in the fstab file to reference the
swap device. However this is only correct for the lvm
volume management but not for btrfs. In case of btrfs
the swap space is not a subvolume but a real partition
and thus the simplified device spec in fstab puts in the
loop mapped device which is wrong. This patch fixes it


