### PR TITLE
Ensure no swap volume is added on btrfs

### DIFF
--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1207,7 +1207,7 @@ class XMLState:
                 )
             )
 
-        if swap_mbytes:
+        if swap_mbytes and self.get_volume_management() == 'lvm':
             volume_type_list.append(
                 volume_type(
                     name='LVSwap',


### PR DESCRIPTION
When the selected filesystem is btrfs the volume manager is not LVM.
In that case the swap partition is not volume, it is a completely
independent partition. So that we cannot add and additional volume
for swap when swap is specified in the description file.

This patch fixes #1301 and fulfills #1297
