### PR TITLE
Update libyui-ncurses-pkg10 to libyui-ncurses-pkg11

### DIFF
--- a/build-tests/x86/suse/test-image-qcow-openstack/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-qcow-openstack/appliance.kiwi
@@ -111,7 +111,7 @@
         <package name="sg3_utils"/>
         <package name="elfutils"/>
         <package name="iputils"/>
-        <package name="libyui-ncurses-pkg10"/>
+        <package name="libyui-ncurses-pkg11"/>
         <package name="timezone"/>
         <package name="yast2"/>
         <package name="yast2-add-on"/>


### PR DESCRIPTION
In Tumbleweed there is no longer the libyui-ncurses-pkg10 its been
superseded by libyui-ncurses-pkg11.

This fixes the test-image-qcow-openstack integration test
