### PR TITLE
fix grub config for Fedora > 29

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -590,6 +590,10 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         )
         if enable_blscfg_implemented.returncode == 0:
             grub_default_entries['GRUB_ENABLE_BLSCFG'] = 'true'
+            if self.cmdline:
+                grub_default_entries['GRUB_CMDLINE_LINUX'] = '"{0}"'.format(
+                    re.sub(r'root=.* |root=.*$', '', self.cmdline).strip()
+                )
 
         if grub_default_entries:
             log.info('Writing grub2 defaults file')


### PR DESCRIPTION
As documented here:

https://fedoraproject.org/wiki/Changes/BootLoaderSpecByDefault

Fedora >= 30 uses BootLoaderSpec (BLS). This means that
GRUB_CMDLINE_LINUX is used in favour of GRUB_CMDLINE_LINUX_DEFAULT.
(SEE https://fedoraproject.org/wiki/Changes/BootLoaderSpecByDefault#Config_files_provided_by_kernel.2C_grub2-switch-to-blscfg.2C_and_zipl-switch-to-blscfg)

This patch ensures that GRUB_CMDLINE_LINUX is also set to the same values
of GRUB_CMDLINE_LINUX_DEFAULT in case that BLS was detected.

