### PR TITLE
Start using tftp system user package

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -189,6 +189,9 @@ Requires(pre):  shadow-utils
 %else
 Requires(pre):  shadow
 %endif
+%if 0%{?suse_version} >= 1550
+Requires(pre):  user(tftp)
+%endif
 License:        GPL-3.0-or-later
 Group:          %{sysgroup}
 
@@ -391,7 +394,7 @@ done
 %fdupes %{buildroot}/srv/tftpboot
 %endif
 
-%if %{_vendor} != "debbuild"
+%if %{_vendor} != "debbuild" && 0%{?suse_version} < 1550
 %ifarch %{ix86} x86_64
 %pre -n kiwi-pxeboot
 #============================================================
@@ -447,7 +450,9 @@ fi
 %if %{_vendor} != "debbuild"
 %ifarch %{ix86} x86_64
 %files -n kiwi-pxeboot
+%if 0%{?suse_version} < 1550
 %dir %attr(0755,tftp,tftp) /srv/tftpboot
+%endif
 %dir /srv/tftpboot/KIWI
 %dir /srv/tftpboot/pxelinux.cfg
 %dir /srv/tftpboot/image


### PR DESCRIPTION
With this commit we start requiring tftp system user package. This
user was created and managed by multiple packages before, with the
risk of having inconsistent criteria on its defaults. Now there there
a system user package so whatever package that requries this user should
just require this package and do not create or modify the tftp user.

Related with bsc#1143454