### PR TITLE
Added support for spare partition fs attributes

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -645,12 +645,19 @@ class DiskBuilder:
     def _build_spare_filesystem(self, device_map):
         if 'spare' in device_map and self.spare_part_fs:
             spare_part_data_path = None
+            spare_part_custom_parameters = {
+                'fs_attributes':
+                    self.xml_state.get_build_type_spare_part_fs_attributes()
+            }
             if self.spare_part_mountpoint:
                 spare_part_data_path = self.root_dir + '{0}/'.format(
                     self.spare_part_mountpoint
                 )
             filesystem = FileSystem(
-                self.spare_part_fs, device_map['spare'], spare_part_data_path
+                self.spare_part_fs,
+                device_map['spare'],
+                spare_part_data_path,
+                spare_part_custom_parameters
             )
             filesystem.create_on_device(
                 label='SPARE'

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -36,6 +36,7 @@ groups-list = xsd:token {pattern = "[a-zA-Z0-9_\-\.]+(,[a-zA-Z0-9_\-\.]+)*"}
 arch-name = xsd:token {pattern = "(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x))*"}
 portnum-type = xsd:token {pattern = "(\d+|\d+/(udp|tcp))"}
 grub_console = xsd:token {pattern = "(console|gfxterm|serial)( (console|gfxterm|serial))*"}
+fs_attributes = xsd:token {pattern = "(no-copy-on-write|synchronous-updates)(,(no-copy-on-write|synchronous-updates))*"}
 
 #==========================================
 # start with image description
@@ -1264,6 +1265,15 @@ div {
             sch:param [ name = "attr" value = "spare_part_fs" ]
             sch:param [ name = "types" value = "oem vmx" ]
         ]
+    k.type.spare_part_fs_attributes.attribute =
+        ## Specify filesystem attributes for the spare partition.
+        ## Attributes can be specified as comma separated list.
+        ## Can only be configured for the disk image types oem and vmx
+        attribute spare_part_fs_attributes { fs_attributes }
+        >> sch:pattern [ id = "spare_part_fs_attributes" is-a = "image_type"
+            sch:param [ name = "attr" value = "spare_part_fs_attributes" ]
+            sch:param [ name = "types" value = "oem vmx" ]
+        ]
     k.type.spare_part_is_last.attribute =
         ## Specify if the spare partition should be the last one in
         ## the partition table. Can only be configured for the vmx
@@ -1762,6 +1772,7 @@ div {
         k.type.spare_part.attribute? &
         k.type.spare_part_mountpoint.attribute? &
         k.type.spare_part_fs.attribute? &
+        k.type.spare_part_fs_attributes.attribute? &
         k.type.spare_part_is_last.attribute? &
         k.type.target_blocksize.attribute? &
         k.type.target_removable.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -81,6 +81,11 @@
       <param name="pattern">(console|gfxterm|serial)( (console|gfxterm|serial))*</param>
     </data>
   </define>
+  <define name="fs_attributes">
+    <data type="token">
+      <param name="pattern">(no-copy-on-write|synchronous-updates)(,(no-copy-on-write|synchronous-updates))*</param>
+    </data>
+  </define>
   <!--
     ==========================================
     start with image description
@@ -1900,6 +1905,18 @@ Can only be configured for the disk image types oem and vmx</a:documentation>
         <sch:param name="types" value="oem vmx"/>
       </sch:pattern>
     </define>
+    <define name="k.type.spare_part_fs_attributes.attribute">
+      <attribute name="spare_part_fs_attributes">
+        <a:documentation>Specify filesystem attributes for the spare partition.
+Attributes can be specified as comma separated list.
+Can only be configured for the disk image types oem and vmx</a:documentation>
+        <ref name="fs_attributes"/>
+      </attribute>
+      <sch:pattern id="spare_part_fs_attributes" is-a="image_type">
+        <sch:param name="attr" value="spare_part_fs_attributes"/>
+        <sch:param name="types" value="oem vmx"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.spare_part_is_last.attribute">
       <attribute name="spare_part_is_last">
         <a:documentation>Specify if the spare partition should be the last one in
@@ -2681,6 +2698,9 @@ default.</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.spare_part_fs.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.spare_part_fs_attributes.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.spare_part_is_last.attribute"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.29.24.
-# Python 3.6.5 (default, Mar 31 2018, 19:45:04) [GCC]
+# Python 3.6.9 (default, Oct 29 2019, 10:39:36) [GCC]
 #
 # Command line options:
 #   ('-f', '')
@@ -2566,7 +2566,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, boottimeout=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, boottimeout=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2619,6 +2619,7 @@ class type_(GeneratedsSuper):
         self.spare_part = _cast(None, spare_part)
         self.spare_part_mountpoint = _cast(None, spare_part_mountpoint)
         self.spare_part_fs = _cast(None, spare_part_fs)
+        self.spare_part_fs_attributes = _cast(None, spare_part_fs_attributes)
         self.spare_part_is_last = _cast(bool, spare_part_is_last)
         self.target_blocksize = _cast(int, target_blocksize)
         self.target_removable = _cast(bool, target_removable)
@@ -2797,6 +2798,8 @@ class type_(GeneratedsSuper):
     def set_spare_part_mountpoint(self, spare_part_mountpoint): self.spare_part_mountpoint = spare_part_mountpoint
     def get_spare_part_fs(self): return self.spare_part_fs
     def set_spare_part_fs(self, spare_part_fs): self.spare_part_fs = spare_part_fs
+    def get_spare_part_fs_attributes(self): return self.spare_part_fs_attributes
+    def set_spare_part_fs_attributes(self, spare_part_fs_attributes): self.spare_part_fs_attributes = spare_part_fs_attributes
     def get_spare_part_is_last(self): return self.spare_part_is_last
     def set_spare_part_is_last(self, spare_part_is_last): self.spare_part_is_last = spare_part_is_last
     def get_target_blocksize(self): return self.target_blocksize
@@ -2833,6 +2836,13 @@ class type_(GeneratedsSuper):
                     self.validate_partition_size_type_patterns_, value):
                 warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_partition_size_type_patterns_, ))
     validate_partition_size_type_patterns_ = [['^\\d+|\\d+M|\\d+G$']]
+    def validate_fs_attributes(self, value):
+        # Validate type fs_attributes, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_fs_attributes_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_fs_attributes_patterns_, ))
+    validate_fs_attributes_patterns_ = [['^(no-copy-on-write|synchronous-updates)(,(no-copy-on-write|synchronous-updates))*$']]
     def validate_vhd_tag_type(self, value):
         # Validate type vhd-tag-type, a restriction on xs:token.
         if value is not None and Validate_simpletypes_:
@@ -3034,6 +3044,9 @@ class type_(GeneratedsSuper):
         if self.spare_part_fs is not None and 'spare_part_fs' not in already_processed:
             already_processed.add('spare_part_fs')
             outfile.write(' spare_part_fs=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.spare_part_fs), input_name='spare_part_fs')), ))
+        if self.spare_part_fs_attributes is not None and 'spare_part_fs_attributes' not in already_processed:
+            already_processed.add('spare_part_fs_attributes')
+            outfile.write(' spare_part_fs_attributes=%s' % (quote_attrib(self.spare_part_fs_attributes), ))
         if self.spare_part_is_last is not None and 'spare_part_is_last' not in already_processed:
             already_processed.add('spare_part_is_last')
             outfile.write(' spare_part_is_last="%s"' % self.gds_format_boolean(self.spare_part_is_last, input_name='spare_part_is_last'))
@@ -3416,6 +3429,12 @@ class type_(GeneratedsSuper):
             already_processed.add('spare_part_fs')
             self.spare_part_fs = value
             self.spare_part_fs = ' '.join(self.spare_part_fs.split())
+        value = find_attr_value_('spare_part_fs_attributes', node)
+        if value is not None and 'spare_part_fs_attributes' not in already_processed:
+            already_processed.add('spare_part_fs_attributes')
+            self.spare_part_fs_attributes = value
+            self.spare_part_fs_attributes = ' '.join(self.spare_part_fs_attributes.split())
+            self.validate_fs_attributes(self.spare_part_fs_attributes)    # validate type fs_attributes
         value = find_attr_value_('spare_part_is_last', node)
         if value is not None and 'spare_part_is_last' not in already_processed:
             already_processed.add('spare_part_is_last')

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -885,6 +885,19 @@ class XMLState:
         if spare_part_size:
             return self._to_mega_byte(spare_part_size)
 
+    def get_build_type_spare_part_fs_attributes(self):
+        """
+        Build type specific list of filesystem attributes applied to
+        the spare partition.
+
+        :return: list of strings or empty list
+
+        :rtype: list
+        """
+        spare_part_attributes = self.build_type.get_spare_part_fs_attributes()
+        if spare_part_attributes:
+            return spare_part_attributes.strip().split(',')
+
     def get_build_type_format_options(self):
         """
         Disk format options returned as a dictionary

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -40,7 +40,7 @@
         <rpm-locale-filtering>true</rpm-locale-filtering>
     </preferences>
     <preferences>
-        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" fscreateoptions="-O ^has_journal" btrfs_root_is_snapshot="true" spare_part="200M" xen_server="true" formatoptions="force_size,super=man" filesystem="ext4">
+        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" fscreateoptions="-O ^has_journal" btrfs_root_is_snapshot="true" spare_part="200M" spare_part_fs_attributes="no-copy-on-write" xen_server="true" formatoptions="force_size,super=man" filesystem="ext4">
             <size unit="G" additive="true">1</size>
             <systemdisk name="mydisk"/>
             <machine memory="512" xen_loader="hvmloader">

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -837,7 +837,8 @@ class TestDiskBuilder:
         assert mock_fs.call_args_list[0] == call(
             self.disk_builder.spare_part_fs,
             self.device_map['spare'],
-            'root_dir/var/'
+            'root_dir/var/',
+            {'fs_attributes': None}
         )
         assert filesystem.sync_data.call_args_list.pop() == call(
             [

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -743,6 +743,9 @@ class TestXMLState:
 
     def test_get_spare_part(self):
         assert self.state.get_build_type_spare_part_size() == 200
+        assert self.state.get_build_type_spare_part_fs_attributes() == [
+            'no-copy-on-write'
+        ]
 
     def test_get_build_type_format_options(self):
         assert self.state.get_build_type_format_options() == {


### PR DESCRIPTION
Added new type attribute:

```xml
<type ... spare_part_fs_attributes="..."/>
```

which can be a comma separated list of the following currently
supported filesystem attributes:

* no-copy-on-write
* synchronous-updates

See chattr and filesystem manual pages for details on those
attributes. More attributes for the spare part context can be
added on request. This Fixes #1233


