### PR TITLE
Fixed order of fstab entries

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -335,9 +335,6 @@ class DiskBuilder:
                 self.requested_filesystem
             )
             volume_manager.mount_volumes()
-            self.generic_fstab_entries += volume_manager.get_fstab(
-                self.persistency_type, self.requested_filesystem
-            )
             self.system = volume_manager
             device_map['root'] = volume_manager.get_device().get('root')
             device_map['swap'] = volume_manager.get_device().get('swap')
@@ -871,6 +868,13 @@ class DiskBuilder:
             device_map['root'].get_device(), '/',
             custom_root_mount_args, fs_check_interval
         )
+        if self.volume_manager_name:
+            volume_fstab_entries = self.system.get_fstab(
+                self.persistency_type, self.requested_filesystem
+            )
+            for volume_fstab_entry in volume_fstab_entries:
+                if volume_fstab_entry not in self.generic_fstab_entries:
+                    self.generic_fstab_entries.append(volume_fstab_entry)
         if device_map.get('spare') and \
            self.spare_part_fs and self.spare_part_mountpoint:
             self._add_generic_fstab_entry(

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -736,7 +736,10 @@ class TestDiskBuilder:
         volume_manager.setup.assert_called_once_with('systemVG')
         volume_manager.create_volumes.assert_called_once_with('btrfs')
         volume_manager.mount_volumes.call_args_list[0].assert_called_once_with()
-        volume_manager.get_fstab.assert_called_once_with(None, 'btrfs')
+        assert volume_manager.get_fstab.call_args_list == [
+            call(None, 'btrfs'),
+            call(None, 'btrfs')
+        ]
         volume_manager.sync_data.assert_called_once_with(
             [
                 'image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi',
@@ -747,8 +750,8 @@ class TestDiskBuilder:
         )
         self.setup.create_fstab.assert_called_once_with(
             [
-                'fstab_volume_entries',
                 'UUID=blkid_result / blkid_result_fs ro 0 0',
+                'fstab_volume_entries',
                 '/dev/systemVG/LVSwap swap swap defaults 0 0',
                 'UUID=blkid_result /boot blkid_result_fs defaults 0 0',
                 'UUID=blkid_result /boot/efi blkid_result_fs defaults 0 0'
@@ -756,8 +759,8 @@ class TestDiskBuilder:
         )
         self.boot_image_task.setup.create_fstab.assert_called_once_with(
             [
-                'fstab_volume_entries',
                 'UUID=blkid_result / blkid_result_fs ro 0 0',
+                'fstab_volume_entries',
                 '/dev/systemVG/LVSwap swap swap defaults 0 0',
                 'UUID=blkid_result /boot blkid_result_fs defaults 0 0',
                 'UUID=blkid_result /boot/efi blkid_result_fs defaults 0 0'


### PR DESCRIPTION
If a volume manager is used the volumes are added before the
root filesystem(/) entry in fstab. This does not hurt because
at boot time systemd manages the mounting of the rootfs prior
to any other information in the fstab file but it's conceptually
broken. Users justifiably can expect the fstab entries in the
correct order such that mounting from top to bottom leads
to a consistent root filesystem state.

