### PR TITLE
Remove RootBind.move_to_root method

### DIFF
--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -183,13 +183,17 @@ class PackageManagerApt(PackageManagerBase):
         :rtype: namedtuple
         """
         update_command = ['chroot', self.root_dir, 'apt-get']
-        update_command.extend(self.root_bind.move_to_root(self.apt_get_args))
+        update_command.extend(
+            Path.move_to_root(self.root_dir, self.apt_get_args)
+        )
         update_command.extend(self.custom_args)
         update_command.append('update')
         Command.run(update_command, self.command_env)
 
         apt_get_command = ['chroot', self.root_dir, 'apt-get']
-        apt_get_command.extend(self.root_bind.move_to_root(self.apt_get_args))
+        apt_get_command.extend(
+            Path.move_to_root(self.root_dir, self.apt_get_args)
+        )
         apt_get_command.extend(self.custom_args)
         apt_get_command.append('install')
         apt_get_command.extend(self._package_requests())
@@ -232,7 +236,7 @@ class PackageManagerApt(PackageManagerBase):
         else:
             apt_get_command = ['chroot', self.root_dir, 'apt-get']
             apt_get_command.extend(
-                self.root_bind.move_to_root(self.apt_get_args)
+                Path.move_to_root(self.root_dir, self.apt_get_args)
             )
             apt_get_command.extend(self.custom_args)
             apt_get_command.extend(['--auto-remove', 'remove'])
@@ -251,7 +255,9 @@ class PackageManagerApt(PackageManagerBase):
         :rtype: namedtuple
         """
         apt_get_command = ['chroot', self.root_dir, 'apt-get']
-        apt_get_command.extend(self.root_bind.move_to_root(self.apt_get_args))
+        apt_get_command.extend(
+            Path.move_to_root(self.root_dir, self.apt_get_args)
+        )
         apt_get_command.extend(self.custom_args)
         apt_get_command.append('upgrade')
 

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -24,7 +24,6 @@ class PackageManagerBase:
 
     :param object repository: instance of :class:`Repository`
     :param str root_dir: root directory path name
-    :param object root_bind: instance of :class:`RootBind`
     :param list package_requests: list of packages to install or delete
     :param list collection_requests: list of collections to install
     :param list product_requests: list of products to install
@@ -32,7 +31,6 @@ class PackageManagerBase:
     def __init__(self, repository, custom_args=None):
         self.repository = repository
         self.root_dir = repository.root_dir
-        self.root_bind = repository.root_bind
         self.package_requests = []
         self.collection_requests = []
         self.product_requests = []

--- a/kiwi/package_manager/dnf.py
+++ b/kiwi/package_manager/dnf.py
@@ -21,6 +21,7 @@ import re
 from kiwi.command import Command
 from kiwi.utils.rpm_database import RpmDataBase
 from kiwi.package_manager.base import PackageManagerBase
+from kiwi.path import Path
 from kiwi.exceptions import KiwiRequestError
 
 
@@ -125,8 +126,8 @@ class PackageManagerDnf(PackageManagerBase):
             # hard required by another package, it will break the transaction.
             for package in self.exclude_requests:
                 self.custom_args.append('--exclude=' + package)
-        chroot_dnf_args = self.root_bind.move_to_root(
-            self.dnf_args
+        chroot_dnf_args = Path.move_to_root(
+            self.root_dir, self.dnf_args
         )
         bash_command = [
             'chroot', self.root_dir, 'dnf'
@@ -178,7 +179,7 @@ class PackageManagerDnf(PackageManagerBase):
                 self.command_env
             )
         else:
-            chroot_dnf_args = self.root_bind.move_to_root(self.dnf_args)
+            chroot_dnf_args = Path.move_to_root(self.root_dir, self.dnf_args)
             return Command.call(
                 [
                     'chroot', self.root_dir, 'dnf'
@@ -196,9 +197,7 @@ class PackageManagerDnf(PackageManagerBase):
 
         :rtype: namedtuple
         """
-        chroot_dnf_args = self.root_bind.move_to_root(
-            self.dnf_args
-        )
+        chroot_dnf_args = Path.move_to_root(self.root_dir, self.dnf_args)
         return Command.call(
             [
                 'chroot', self.root_dir, 'dnf'

--- a/kiwi/package_manager/zypper.py
+++ b/kiwi/package_manager/zypper.py
@@ -51,15 +51,15 @@ class PackageManagerZypper(PackageManagerBase):
         runtime_config = self.repository.runtime_config()
 
         self.zypper_args = runtime_config['zypper_args']
-        self.chroot_zypper_args = self.root_bind.move_to_root(
-            self.zypper_args
+        self.chroot_zypper_args = Path.move_to_root(
+            self.root_dir, self.zypper_args
         )
 
         self.command_env = runtime_config['command_env']
         self.chroot_command_env = dict(self.command_env)
         if 'ZYPP_CONF' in self.command_env:
-            self.chroot_command_env['ZYPP_CONF'] = self.root_bind.move_to_root(
-                [self.command_env['ZYPP_CONF']]
+            self.chroot_command_env['ZYPP_CONF'] = Path.move_to_root(
+                self.root_dir, [self.command_env['ZYPP_CONF']]
             )[0]
 
     def request_package(self, name):

--- a/kiwi/system/root_bind.py
+++ b/kiwi/system/root_bind.py
@@ -163,26 +163,6 @@ class RootBind:
                 '%s: %s' % (type(e).__name__, format(e))
             )
 
-    def move_to_root(self, elements):
-        """
-        Change the given path elements to a new root directory
-
-        :param list elements: list of path names
-
-        :return: changed elements
-
-        :rtype: list
-        """
-        result = []
-        for element in elements:
-            normalized_element = os.path.normpath(element)
-            result.append(
-                normalized_element.replace(
-                    os.path.normpath(self.root_dir), os.sep
-                ).replace('{0}{0}'.format(os.sep), os.sep)
-            )
-        return result
-
     def cleanup(self):
         """
         Cleanup mounted locations, directories and intermediate config files

--- a/test/unit/package_manager/apt_test.py
+++ b/test/unit/package_manager/apt_test.py
@@ -27,12 +27,6 @@ class TestPackageManagerApt:
         repository.unauthenticated = 'false'
         repository.components = ['main', 'restricted']
 
-        root_bind = mock.Mock()
-        root_bind.move_to_root = mock.Mock(
-            return_value=['root-moved-arguments']
-        )
-        repository.root_bind = root_bind
-
         repository.runtime_config = mock.Mock(
             return_value={
                 'apt_get_args': ['-c', 'apt.conf', '-y'],
@@ -127,13 +121,13 @@ class TestPackageManagerApt:
                 call(
                     [
                         'chroot', 'root-dir', 'apt-get',
-                        'root-moved-arguments', 'update'
+                        '-c', 'apt.conf', '-y', 'update'
                     ], ['env']
                 )
             ]
             mock_call.assert_called_once_with([
                 'chroot', 'root-dir', 'apt-get',
-                'root-moved-arguments', 'install', 'vim'],
+                '-c', 'apt.conf', '-y', 'install', 'vim'],
                 ['env']
             )
 
@@ -142,12 +136,9 @@ class TestPackageManagerApt:
     def test_process_install_requests(self, mock_run, mock_call):
         self.manager.request_package('vim')
         self.manager.process_install_requests()
-        self.manager.root_bind.move_to_root(
-            self.manager.apt_get_args
-        )
         mock_call.assert_called_once_with([
             'chroot', 'root-dir', 'apt-get',
-            'root-moved-arguments', 'install', 'vim'],
+            '-c', 'apt.conf', '-y', 'install', 'vim'],
             ['env']
         )
 
@@ -158,7 +149,7 @@ class TestPackageManagerApt:
         self.manager.process_delete_requests()
         mock_call.assert_called_once_with(
             [
-                'chroot', 'root-dir', 'apt-get', 'root-moved-arguments',
+                'chroot', 'root-dir', 'apt-get', '-c', 'apt.conf', '-y',
                 '--auto-remove', 'remove', 'vim'
             ], ['env']
         )
@@ -183,12 +174,9 @@ class TestPackageManagerApt:
     @patch('kiwi.command.Command.call')
     def test_update(self, mock_call):
         self.manager.update()
-        self.manager.root_bind.move_to_root(
-            self.manager.apt_get_args
-        )
         mock_call.assert_called_once_with([
             'chroot', 'root-dir', 'apt-get',
-            'root-moved-arguments', 'upgrade'],
+            '-c', 'apt.conf', '-y', 'upgrade'],
             ['env']
         )
 

--- a/test/unit/package_manager/zypper_test.py
+++ b/test/unit/package_manager/zypper_test.py
@@ -2,6 +2,7 @@ from mock import patch
 from pytest import raises
 import mock
 
+from kiwi.path import Path
 from kiwi.package_manager.zypper import PackageManagerZypper
 
 from kiwi.exceptions import KiwiRequestError
@@ -11,12 +12,6 @@ class TestPackageManagerZypper:
     def setup(self):
         repository = mock.Mock()
         repository.root_dir = 'root-dir'
-
-        root_bind = mock.Mock()
-        root_bind.move_to_root = mock.Mock(
-            return_value=['root-moved-arguments']
-        )
-        repository.root_bind = root_bind
 
         self.command_env = {
             'HOME': '/home/ms', 'ZYPP_CONF': 'root-dir/my/zypp.conf'
@@ -29,13 +24,13 @@ class TestPackageManagerZypper:
         )
         self.manager = PackageManagerZypper(repository)
 
-        self.chroot_zypper_args = self.manager.root_bind.move_to_root(
-            self.manager.zypper_args
+        self.chroot_zypper_args = Path.move_to_root(
+            'root-dir', self.manager.zypper_args
         )
         self.chroot_command_env = self.manager.command_env
         zypp_conf = self.manager.command_env['ZYPP_CONF']
         self.chroot_command_env['ZYPP_CONF'] = \
-            self.manager.root_bind.move_to_root(zypp_conf)[0]
+            Path.move_to_root('root-dir', [zypp_conf])[0]
 
     def test_request_package(self):
         self.manager.request_package('name')

--- a/test/unit/repository/apt_test.py
+++ b/test/unit/repository/apt_test.py
@@ -22,9 +22,6 @@ class TestRepositoryApt:
         tmpfile.name = 'tmpfile'
         mock_temp.return_value = tmpfile
         root_bind = mock.Mock()
-        root_bind.move_to_root = mock.Mock(
-            return_value=['root-moved-arguments']
-        )
         root_bind.root_dir = '../data'
         root_bind.shared_location = '/shared-dir'
 

--- a/test/unit/repository/dnf_test.py
+++ b/test/unit/repository/dnf_test.py
@@ -22,9 +22,6 @@ class TestRepositoryDnf:
         tmpfile.name = 'tmpfile'
         mock_temp.return_value = tmpfile
         root_bind = mock.Mock()
-        root_bind.move_to_root = mock.Mock(
-            return_value=['root-moved-arguments']
-        )
         root_bind.root_dir = '../data'
         root_bind.shared_location = '/shared-dir'
 

--- a/test/unit/repository/zypper_test.py
+++ b/test/unit/repository/zypper_test.py
@@ -27,9 +27,6 @@ class TestRepositoryZypper:
         tmpfile.name = 'tmpfile'
         mock_temp.return_value = tmpfile
         self.root_bind = mock.Mock()
-        self.root_bind.move_to_root = mock.Mock(
-            return_value=['root-moved-arguments']
-        )
         self.root_bind.root_dir = '../data'
         self.root_bind.shared_location = '/shared-dir'
         with patch('builtins.open', create=True):

--- a/test/unit/system/root_bind_test.py
+++ b/test/unit/system/root_bind_test.py
@@ -204,8 +204,3 @@ class TestRootBind:
         with self._caplog.at_level(logging.WARNING):
             self.bind_root.cleanup()
             assert 'Path /mountpoint not a mountpoint' in self._caplog.text
-
-    def test_move_to_root(self):
-        assert self.bind_root.move_to_root(
-            [self.bind_root.root_dir + '/argument']
-        ) == ['/argument']


### PR DESCRIPTION
This commit removes the RootBind.move_to_root method as this can all be
done by using the Path.move_to_root utility method. This allows
to drop the RootBind attribute in PackageManager classes and focus
path manipulation methods into a common utility.

Related to #1281
