### PR TITLE
Make PXE oem deployment genericly useable

### DIFF
--- a/doc/source/building/build_oem_disk.rst
+++ b/doc/source/building/build_oem_disk.rst
@@ -180,7 +180,7 @@ target system:
           scp pxeboot.{exc_image_base_name}.x86_64-{exc_image_version}.initrd.xz PXE_SERVER_IP:/srv/tftpboot/boot/initrd
           scp pxeboot.{exc_image_base_name}.x86_64-{exc_image_version}.kernel PXE_SERVER_IP:/srv/tftpboot/boot/linux
 
-3. Copy the OEM disk image, MD5 file, system kernel and initrd to
+3. Copy the OEM disk image, MD5 file, system kernel, initrd and bootoptions to
    the PXE boot server:
 
    Activation of the deployed system is done via `kexec` of the kernel
@@ -193,12 +193,23 @@ target system:
           scp {exc_image_base_name}.x86_64-{exc_image_version}.xz PXE_SERVER_IP:/srv/tftpboot/image/
           scp {exc_image_base_name}.x86_64-{exc_image_version}.md5 PXE_SERVER_IP:/srv/tftpboot/image/
 
-   b) Copy kernel and initrd used for booting the system via kexec
+   b) Copy kernel, initrd and bootoptions used for booting the system via kexec
 
       .. code:: bash
 
           scp {exc_image_base_name}.x86_64-{exc_image_version}.initrd PXE_SERVER_IP:/srv/tftpboot/image/
           scp {exc_image_base_name}.x86_64-{exc_image_version}.kernel PXE_SERVER_IP:/srv/tftpboot/image/
+          scp {exc_image_base_name}.x86_64-{exc_image_version}.config.bootoptions PXE_SERVER_IP:/srv/tftpboot/image/
+
+      .. note::
+
+         The config.bootoptions file is used together with kexec to boot the
+         previously dumped image. The information in that file references the
+         root of the dumped image and can also include any other type of
+         boot options. The file provided with the KIWI built image is
+         by default connected to the image present in the PXE TAR archive.
+         If other images got deployed the contents of this file must be
+         adapted to match the correct root reference.
 
 4. Add/Update the kernel command line parameters
 

--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -361,6 +361,10 @@ function get_remote_image_source_files {
     image_kernel_uri=$(
         echo "${image_uri}" | awk '{ gsub("\\.xz",".kernel", $1); print $1 }'
     )
+    image_config_uri=$(
+        echo "${image_uri}" | \
+        awk '{ gsub("\\.xz",".config.bootoptions", $1); print $1 }'
+    )
 
     # if we can not access image_md5_uri, maybe network setup
     # by dracut did fail, so collect some additional info
@@ -382,6 +386,12 @@ function get_remote_image_source_files {
     then
         report_and_quit \
             "Failed to fetch ${image_initrd_uri}, see /tmp/fetch.info"
+    fi
+
+    if ! fetch_file "${image_config_uri}" > "/config.bootoptions"
+    then
+        report_and_quit \
+            "Failed to fetch ${image_config_uri}, see /tmp/fetch.info"
     fi
 
     echo "${image_uri}|${image_md5}"

--- a/dracut/modules.d/90kiwi-dump/kiwi-ramdisk-deployment-generator.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-ramdisk-deployment-generator.sh
@@ -6,6 +6,8 @@ GENERATOR_DIR="$1"
 [ -z "${GENERATOR_DIR}" ] && exit 1
 [ -d "${GENERATOR_DIR}" ] || mkdir -p "${GENERATOR_DIR}"
 
+[ -e /config.bootoptions ] || exit 1
+
 root_uuid=$(
     while read -r -d ' ' opt; do echo "${opt}";done < /config.bootoptions |\
     grep root= | cut -f2- -d=

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -332,6 +332,15 @@ class InstallImageBuilder:
         log.info('Creating pxe install boot image')
         self._create_pxe_install_kernel_and_initrd()
 
+        # create pxe image bound boot config file, contents can be
+        # changed but presence is required.
+        log.info('Creating pxe install boot options file')
+        configname = 'pxeboot.{0}.config.bootoptions'.format(self.pxename)
+        shutil.copy(
+            os.sep.join([self.root_dir, 'config.bootoptions']),
+            os.sep.join([self.pxe_dir, configname])
+        )
+
         # create pxe install tarball
         log.info('Creating pxe install archive')
         archive = ArchiveTar(self.pxetarball)
@@ -375,7 +384,6 @@ class InstallImageBuilder:
                 self.boot_image_task.omit_module(
                     'multipath', install_media=True
                 )
-            self._add_system_image_boot_options_to_boot_image()
         self.boot_image_task.create_initrd(
             self.mbrid, 'initrd_kiwi_install',
             install_initrd=True

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -362,18 +362,22 @@ class TestInstallImageBuilder:
         archive.create.assert_called_once_with('tmpdir')
 
         mock_chmod.reset_mock()
+        mock_copy.reset_mock()
         self.install_image.initrd_system = 'dracut'
         m_open.reset_mock()
         with patch('builtins.open', m_open, create=True):
             self.install_image.create_install_pxe_archive()
 
-        self.boot_image_task.include_file.assert_called_once_with(
-            '/config.bootoptions', install_media=True
-        )
-        mock_copy.assert_called_once_with(
-            'root_dir/boot/initrd-kernel_version',
-            'tmpdir/result-image.x86_64-1.2.3.initrd'
-        )
+        assert mock_copy.call_args_list == [
+            call(
+                'root_dir/boot/initrd-kernel_version',
+                'tmpdir/result-image.x86_64-1.2.3.initrd'
+            ),
+            call(
+                'root_dir/config.bootoptions',
+                'tmpdir/pxeboot.result-image.x86_64-1.2.3.config.bootoptions'
+            )
+        ]
         assert mock_chmod.call_args_list == [
             call('tmpdir/result-image.x86_64-1.2.3.initrd', 420),
             call('tmpdir/pxeboot.result-image.x86_64-1.2.3.initrd.xz', 420)


### PR DESCRIPTION
When deploying a disk image via PXE the initrd contained a config
file which connects it to a certain image. This has the disadvantage
that no other image could be deployed with it. This commit changes the
deployment code in a way that the config file is read from the
network if the disk is deployed via PXE. The tarball created by
kiwi provides the image connected config file but users now have
the opportunity to create their own boot configurations which allows
deployment of different images with the same kiwi built deployment
initrd. This Fixes #1298 and is one first step into a more generic
PXE support offered by kiwi.

