### PR TITLE
Make use of Path.which including root_dir parameter

### DIFF
--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -401,11 +401,8 @@ class BootImageBase:
             default_outfile_format = 'initrd-{kernel_version}'
         else:
             default_outfile_format = 'initramfs-{kernel_version}.img'
-        dracut_search_env = {
-            'PATH': os.sep.join([self.boot_root_directory, 'usr', 'bin'])
-        }
         dracut_tool = Path.which(
-            'dracut', custom_env=dracut_search_env, access_mode=os.X_OK
+            'dracut', root_dir=self.boot_root_directory, access_mode=os.X_OK
         )
         if dracut_tool:
             outfile_expression = r'outfile="/boot/(init.*\$kernel.*)"'

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -1028,9 +1028,6 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
 
     def _get_shim_install(self):
-        chroot_env = {
-            'PATH': os.sep.join([self.boot_dir, 'usr', 'sbin'])
-        }
         return Path.which(
-            filename='shim-install', custom_env=chroot_env
+            filename='shim-install', root_dir=self.boot_dir
         )

--- a/kiwi/bootloader/install/grub2.py
+++ b/kiwi/bootloader/install/grub2.py
@@ -312,9 +312,8 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
     def _get_tool_name(
         self, root_path, lookup_list, fallback_on_not_found=True
     ):
-        chroot_env = {'PATH': os.sep.join([root_path, 'usr', 'sbin'])}
         for tool in lookup_list:
-            if Path.which(filename=tool, custom_env=chroot_env):
+            if Path.which(filename=tool, root_dir=root_path):
                 return tool
 
         if fallback_on_not_found:

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -343,10 +343,7 @@ class Defaults:
 
         :rtype: str
         """
-        chroot_env = {
-            'PATH': os.sep.join([lookup_path, 'usr', 'sbin'])
-        }
-        if Path.which(filename='grub2-install', custom_env=chroot_env):
+        if Path.which(filename='grub2-install', root_dir=lookup_path):
             # the presence of grub2-install is an indicator to put all
             # grub2 data below boot/grub2
             return 'grub2'

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -263,11 +263,8 @@ class SystemSetup:
         If not present KIWI skips this step and continuous with a
         warning.
         """
-        chkstat_search_env = {
-            'PATH': os.sep.join([self.root_dir, 'usr', 'bin'])
-        }
         chkstat = Path.which(
-            'chkstat', custom_env=chkstat_search_env, access_mode=os.X_OK
+            'chkstat', root_dir=self.root_dir, access_mode=os.X_OK
         )
         if chkstat:
             log.info('Check/Fix File Permissions')
@@ -432,11 +429,8 @@ class SystemSetup:
         be found in the image root, it is assumed plymouth splash is in
         use and the tool is called in a chroot operation
         """
-        chroot_env = {
-            'PATH': os.sep.join([self.root_dir, 'usr', 'sbin'])
-        }
         theme_setup = 'plymouth-set-default-theme'
-        if Path.which(filename=theme_setup, custom_env=chroot_env):
+        if Path.which(filename=theme_setup, root_dir=self.root_dir):
             for preferences in self.xml_state.get_preferences_sections():
                 splash_section_content = preferences.get_bootsplash_theme()
                 if splash_section_content:

--- a/kiwi/utils/rpm_database.py
+++ b/kiwi/utils/rpm_database.py
@@ -38,11 +38,8 @@ class RpmDataBase:
         Check if rpmdb binary was found in root_dir to indicate
         that the rpm system is present.
         """
-        rpm_search_env = {
-            'PATH': os.sep.join([self.root_dir, 'usr', 'bin'])
-        }
         rpm_bin = Path.which(
-            'rpmdb', custom_env=rpm_search_env, access_mode=os.X_OK
+            'rpmdb', root_dir=self.root_dir, access_mode=os.X_OK
         )
         if not rpm_bin:
             return False

--- a/test/unit/bootloader/install/grub2_test.py
+++ b/test/unit/bootloader/install/grub2_test.py
@@ -167,7 +167,7 @@ class TestBootLoaderInstallGrub2:
             'tmp_root/boot/grub2/grubenv'
         )
         mock_which.assert_called_once_with(
-            custom_env={'PATH': 'tmp_root/usr/sbin'}, filename='grub2-install'
+            root_dir='tmp_root', filename='grub2-install'
         )
         mock_command.assert_called_once_with(
             [

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -504,7 +504,7 @@ class TestSystemSetup:
         )
         self.setup.setup_plymouth_splash()
         mock_which.assert_called_once_with(
-            custom_env={'PATH': 'root_dir/usr/sbin'},
+            root_dir='root_dir',
             filename='plymouth-set-default-theme'
         )
         mock_command.assert_called_once_with(

--- a/test/unit/utils/rpm_database_test.py
+++ b/test/unit/utils/rpm_database_test.py
@@ -16,7 +16,7 @@ class TestRpmDataBase:
         mock_Path_which.return_value = None
         assert self.rpmdb.has_rpm() is False
         mock_Path_which.assert_called_once_with(
-            'rpmdb', access_mode=1, custom_env={'PATH': 'root_dir/usr/bin'}
+            'rpmdb', access_mode=1, root_dir='root_dir'
         )
         mock_Path_which.return_value = 'rpm'
         assert self.rpmdb.has_rpm() is True


### PR DESCRIPTION
This commit refactors the use of Path.which in several parts of the
code. Since dd4d2ed78 the Path utility is capable to run Path.which
on certain chroot env, thus no need to adapt the PATH environment
variable.

Fixes #1281
