### PR TITLE
Fixed sat solver flags validation

### DIFF
--- a/kiwi/solver/sat.py
+++ b/kiwi/solver/sat.py
@@ -204,7 +204,7 @@ class Sat:
             selection = self.pool.select(
                 job_name, selection_name | selection_provides
             )
-            if selection.flags() & self.solv.Selection.SELECTION_PROVIDES:
+            if selection.flags & self.solv.Selection.SELECTION_PROVIDES:
                 log.info('--> Using capability match for {0}'.format(job_name))
             if selection.isempty():
                 if skip_missing:

--- a/test/unit/solver/sat_test.py
+++ b/test/unit/solver/sat_test.py
@@ -99,9 +99,7 @@ class TestSat:
             return_value=None
         )
         self.sat.solv.Selection.SELECTION_PROVIDES = 0
-        self.selection.flags = Mock(
-            return_value=0
-        )
+        self.selection.flags = 0
         self.selection.isempty = Mock(
             return_value=True
         )
@@ -141,9 +139,7 @@ class TestSat:
             return_value=None
         )
         self.sat.solv.Selection.SELECTION_PROVIDES = 1
-        self.selection.flags = Mock(
-            return_value=1
-        )
+        self.selection.flags = 1
         self.selection.isempty = Mock(
             return_value=False
         )


### PR DESCRIPTION
The sat library from the python3-solv plugin does not expose
the flags information as method. Instead the flags value is
a variable pointing to an integer that has a name mapping
in self.solv.Selection from the library.

