### PR TITLE
Fixed ppc kernel lookup

### DIFF
--- a/kiwi/system/kernel.py
+++ b/kiwi/system/kernel.py
@@ -154,7 +154,7 @@ class Kernel:
             # depending on the arch and os they are different
             # in their prefix
             kernel_prefixes = [
-                'uImage', 'Image', 'zImage', 'vmlinuz', 'image'
+                'uImage', 'Image', 'zImage', 'vmlinuz', 'image', 'vmlinux'
             ]
             kernel_name_pattern = '{prefix}-{name}'
             for kernel_prefix in kernel_prefixes:

--- a/test/unit/system/kernel_test.py
+++ b/test/unit/system/kernel_test.py
@@ -18,7 +18,8 @@ class TestKernel:
             'Image-1.2.3-default',
             'zImage-1.2.3-default',
             'vmlinuz-1.2.3-default',
-            'image-1.2.3-default'
+            'image-1.2.3-default',
+            'vmlinux-1.2.3-default'
         ]
 
     def test_get_kernel_raises_if_no_kernel_found(self):


### PR DESCRIPTION
On power the kernel is named e.g vmlinux-4.12.14-197.29-default
kiwi was missing that name match. This commit fixes it

