### PR TITLE
Disable RPM module content validation and filtering when building in OBS

### DIFF
--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -198,6 +198,13 @@ class RepositoryDnf(RepositoryBase):
             repo_config.set(
                 name, 'gpgcheck', '1' if pkg_gpgcheck else '0'
             )
+        if Defaults.is_buildservice_worker():
+            # when building in the build service, modular metadata is inaccessible...
+            # in order to use modular content in the build service, we need to disable
+            # modular filtering, which is done with module_hotfixes option
+            repo_config.set(
+                name, 'module_hotfixes', '1'
+            )
         with open(repo_file, 'w') as repo:
             repo_config.write(repo)
 


### PR DESCRIPTION
The Open Build Service builds images by identifying the requested dependencies,
downloading them into an isolated environment, regenerating the repository
metadata from scratch with *only* that content, and then passing those
new repositories to be used for building images. This enforces the
reproducibility of the image build process.

However, when building images for Linux distributions that have
AppStreams/modules (such as Red Hat Enterprise Linux/CentOS 8)
in an Open Build Service system, the repository metadata associated
with modules is not present as OBS does not generate it.

This causes the image build to fail because the normal module
content filtering rules make it so that modular RPMs are disabled
unless there is module metadata in the repository that identifies
them and that the module has been configured to be enabled.

As it is not possible for us to satisfy those conditions, instead
we disable modular filtering entirely when we detect that the image
build is occurring inside the build service, as we are reasonably
certain that OBS will not give us bad or broken package sets.
