### PR TITLE
Allow custom modules to be run after image dump

### DIFF
--- a/doc/source/working_with_kiwi/customize_the_boot_process.rst
+++ b/doc/source/working_with_kiwi/customize_the_boot_process.rst
@@ -21,6 +21,10 @@ of KIWI the following dracut modules are used:
   This module is required if one of the attributes `installiso`, `installstick`
   or `installpxe` is set to `true` in the image type definition
 
+``kiwi-dump-reboot``
+  Serves to boot the system into the installed image after installation is
+  completed.
+
 ``kiwi-live``
   Boots up a KIWI live image. This module is required
   if the `iso` image type is selected

--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -397,33 +397,6 @@ function get_remote_image_source_files {
     echo "${image_uri}|${image_md5}"
 }
 
-function boot_installed_system {
-    local boot_options
-    # if rd.kiwi.install.pass.bootparam is given, pass on most
-    # boot options to the kexec kernel
-    if getargbool 0 rd.kiwi.install.pass.bootparam; then
-        local cmdline
-        local option
-        read -r cmdline < /proc/cmdline
-        for option in ${cmdline}; do
-            case ${option} in
-                rd.kiwi.*) ;; # skip all rd.kiwi options, they might do harm
-                *)  boot_options="${boot_options}${option} ";;
-            esac
-        done
-    fi
-    boot_options="${boot_options}$(cat /config.bootoptions)"
-    if getargbool 0 rd.kiwi.debug; then
-        boot_options="${boot_options} rd.kiwi.debug"
-    fi
-    kexec -l /run/install/boot/*/loader/linux \
-        --initrd /run/install/initrd.system_image \
-        --command-line "${boot_options}"
-    if ! kexec -e; then
-        report_and_quit "Failed to kexec boot system"
-    fi
-}
-
 #======================================
 # Perform image dump/install operations
 #--------------------------------------
@@ -450,15 +423,3 @@ else
 fi
 
 check_image_integrity "${image_target}"
-
-if getargbool 0 rd.kiwi.ramdisk; then
-    # For ramdisk deployment a kexec boot is not possible as it
-    # will wipe the contents of the ramdisk. Therefore we prepare
-    # the switch_root from this deployment initrd. Also see the
-    # unit generator: dracut-kiwi-ramdisk-generator
-    kpartx -s -a "${image_target}"
-else
-    # Standard deployment will use kexec to activate and boot the
-    # deployed system
-    boot_installed_system
-fi

--- a/dracut/modules.d/99kiwi-dump-reboot/kiwi-dump-reboot-system.sh
+++ b/dracut/modules.d/99kiwi-dump-reboot/kiwi-dump-reboot-system.sh
@@ -1,0 +1,50 @@
+type report_and_quit >/dev/null 2>&1 || . /lib/kiwi-dump-image.sh
+type get_selected_disk >/dev/null 2>&1 || . /lib/kiwi-dump-image.sh
+type run_dialog >/dev/null 2>&1 || . /lib/kiwi-dialog-lib.sh
+
+#======================================
+# Functions
+#--------------------------------------
+function boot_installed_system {
+    local boot_options
+    # if rd.kiwi.install.pass.bootparam is given, pass on most
+    # boot options to the kexec kernel
+    if getargbool 0 rd.kiwi.install.pass.bootparam; then
+        local cmdline
+        local option
+        read -r cmdline < /proc/cmdline
+        for option in ${cmdline}; do
+            case ${option} in
+                rd.kiwi.*) ;; # skip all rd.kiwi options, they might do harm
+                *)  boot_options="${boot_options}${option} ";;
+            esac
+        done
+    fi
+    boot_options="${boot_options}$(cat /config.bootoptions)"
+    if getargbool 0 rd.kiwi.debug; then
+        boot_options="${boot_options} rd.kiwi.debug"
+    fi
+    kexec -l /run/install/boot/*/loader/linux \
+        --initrd /run/install/initrd.system_image \
+        --command-line "${boot_options}"
+    if ! kexec -e; then
+        report_and_quit "Failed to kexec boot system"
+    fi
+}
+
+#======================================
+# Reboot into system
+#--------------------------------------
+
+if getargbool 0 rd.kiwi.ramdisk; then
+    # For ramdisk deployment a kexec boot is not possible as it
+    # will wipe the contents of the ramdisk. Therefore we prepare
+    # the switch_root from this deployment initrd. Also see the
+    # unit generator: dracut-kiwi-ramdisk-generator
+    image_target=$(get_selected_disk)
+    kpartx -s -a "${image_target}"
+else
+    # Standard deployment will use kexec to activate and boot the
+    # deployed system
+    boot_installed_system
+fi

--- a/dracut/modules.d/99kiwi-dump-reboot/module-setup.sh
+++ b/dracut/modules.d/99kiwi-dump-reboot/module-setup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+    return 255
+}
+
+# called by dracut
+depends() {
+    echo network rootfs-block dm kiwi-lib kiwi-dump
+    return 0
+}
+
+# called by dracut
+installkernel() {
+    return 0
+}
+
+# called by dracut
+install() {
+    declare moddir=${moddir}
+
+    inst_hook pre-mount 40 "${moddir}/kiwi-dump-reboot-system.sh"
+}

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -380,6 +380,9 @@ class InstallImageBuilder:
             self.boot_image_task.include_module(
                 'kiwi-dump', install_media=True
             )
+            self.boot_image_task.include_module(
+                'kiwi-dump-reboot', install_media=True
+            )
             if self.root_filesystem_is_multipath is False:
                 self.boot_image_task.omit_module(
                     'multipath', install_media=True
@@ -418,6 +421,9 @@ class InstallImageBuilder:
         if self.initrd_system == 'dracut':
             self.boot_image_task.include_module(
                 'kiwi-dump', install_media=True
+            )
+            self.boot_image_task.include_module(
+                'kiwi-dump-reboot', install_media=True
             )
             if self.root_filesystem_is_multipath is False:
                 self.boot_image_task.omit_module(

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -284,12 +284,12 @@ License:        GPL-3.0-or-later
 Group:          %{sysgroup}
 
 %description -n dracut-kiwi-oem-dump
-This package contains the kiwi-dump dracut module which is
-used to install an oem image onto a target disk. It implements
-a simple installer which allows for user selected target disk
-or unattended installation to target. The source of the image
-to install could be either from media(CD/DVD/USB) or from
-remote
+This package contains the kiwi-dump and kiwi-dump-reboot dracut
+modules which is used to install an oem image onto a target disk.
+It implements a simple installer which allows for user selected
+target disk or unattended installation to target. The source of
+the image to install could be either from media(CD/DVD/USB) or
+from remote
 
 %package -n dracut-kiwi-live
 Summary:        KIWI - Dracut module for iso(live) image type
@@ -439,6 +439,7 @@ fi
 
 %files -n dracut-kiwi-oem-dump
 %{_usr}/lib/dracut/modules.d/90kiwi-dump
+%{_usr}/lib/dracut/modules.d/99kiwi-dump-reboot
 
 %files -n dracut-kiwi-live
 %{_usr}/lib/dracut/modules.d/90kiwi-live

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -204,8 +204,11 @@ class TestInstallImageBuilder:
         with patch('builtins.open', m_open, create=True):
             self.install_image.create_install_iso()
 
-        self.boot_image_task.include_module.assert_called_once_with(
+        self.boot_image_task.include_module.assert_any_call(
             'kiwi-dump', install_media=True
+        )
+        self.boot_image_task.include_module.assert_any_call(
+            'kiwi-dump-reboot', install_media=True
         )
         self.boot_image_task.omit_module.assert_called_once_with(
             'multipath', install_media=True
@@ -395,8 +398,11 @@ class TestInstallImageBuilder:
             )
         ]
 
-        self.boot_image_task.include_module.assert_called_once_with(
+        self.boot_image_task.include_module.assert_any_call(
             'kiwi-dump', install_media=True
+        )
+        self.boot_image_task.include_module.assert_any_call(
+            'kiwi-dump-reboot', install_media=True
         )
         self.boot_image_task.omit_module.assert_called_once_with(
             'multipath', install_media=True


### PR DESCRIPTION
Currently the kiwi-dump module boots the installed system right after the image dump and verification.
This means that modules cannot be added after the image dump.

The kiwi-dump module has been split into kiwi-dump and kiwi-dump-reboot. This allows custom modules to be run after the image dump has been completed and before booting into the installed system, which effectively ends the install process.