### PR TITLE
PPC oem integration test

### DIFF
--- a/build-tests/ppc/suse/test-image-oem/appliance.kiwi
+++ b/build-tests/ppc/suse/test-image-oem/appliance.kiwi
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="7.1" name="OEM-openSUSE-Tumbleweed">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>ms@suse.com</contact>
+        <specification>oem disk test build</specification>
+    </description>
+    <preferences>
+        <version>1.15.1</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>false</rpm-check-signatures>
+        <bootsplash-theme>bgrt</bootsplash-theme>
+        <bootloader-theme>openSUSE</bootloader-theme>
+        <type image="oem" filesystem="ext4" initrd_system="dracut" bootloader="grub2" bootloader_console="serial" kernelcmdline="console=ttyS0 splash" firmware="ofw" installiso="true" installboot="install"/>
+    </preferences>
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
+    </users>
+    <repository type="rpm-md" >
+        <source path='obsrepositories:/'/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-base-minimal_base"/>
+        <package name="bind-utils"/>
+        <package name="systemd"/>
+        <package name="plymouth-theme-bgrt"/>
+        <package name="iputils"/>
+        <package name="vim"/>
+        <package name="grub2"/>
+        <package name="grub2-powerpc-ieee1275"/>
+        <package name="lvm2"/>
+        <package name="plymouth"/>
+        <package name="fontconfig"/>
+        <package name="fonts-config"/>
+        <package name="tar"/>
+        <package name="parted"/>
+        <package name="openssh"/>
+        <package name="iproute2"/>
+        <package name="less"/>
+        <package name="bash-completion"/>
+        <package name="dhcp-client"/>
+        <package name="which"/>
+        <package name="kernel-default"/>
+        <package name="timezone"/>
+        <package name="dracut-kiwi-oem-repart"/>
+        <package name="dracut-kiwi-oem-dump"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+        <package name="cracklib-dict-full"/>
+        <package name="ca-certificates"/>
+        <package name="openSUSE-release"/>
+    </packages>
+</image>

--- a/build-tests/ppc/suse/test-image-oem/config.sh
+++ b/build-tests/ppc/suse/test-image-oem/config.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#================
+# FILE          : config.sh
+#----------------
+# PROJECT       : OpenSuSE KIWI Image System
+# COPYRIGHT     : (c) 2006 SUSE LINUX Products GmbH. All rights reserved
+#               :
+# AUTHOR        : Marcus Schaefer <ms@suse.de>
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : configuration script for SUSE based
+#               : operating systems
+#               :
+#               :
+# STATUS        : BETA
+#----------------
+#======================================
+# Functions...
+#--------------------------------------
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+#======================================
+# Greeting...
+#--------------------------------------
+echo "Configure image: [$kiwi_iname]..."
+
+#======================================
+# Setup baseproduct link
+#--------------------------------------
+suseSetupProduct
+
+#======================================
+# Activate services
+#--------------------------------------
+suseInsertService sshd
+
+#======================================
+# Setup default target, multi-user
+#--------------------------------------
+baseSetRunlevel 3

--- a/build-tests/ppc/suse/test-image-oem/root/etc/sysconfig/network/ifcfg-lan0
+++ b/build-tests/ppc/suse/test-image-oem/root/etc/sysconfig/network/ifcfg-lan0
@@ -1,0 +1,4 @@
+BOOTPROTO='dhcp'
+MTU=''
+REMOTE_IPADDR=''
+STARTMODE='onboot'

--- a/build-tests/ppc/suse/test-image-oem/root/etc/udev/rules.d/70-persistent-net.rules
+++ b/build-tests/ppc/suse/test-image-oem/root/etc/udev/rules.d/70-persistent-net.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="?*", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="?*", NAME="lan0"

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -146,7 +146,8 @@ class InstallImageBuilder:
             'meta_data': {
                 'volume_id': self.iso_volume_id,
                 'mbr_id': self.mbrid.get_id(),
-                'efi_mode': self.firmware.efi_mode()
+                'efi_mode': self.firmware.efi_mode(),
+                'ofw_mode': self.firmware.ofw_mode()
             }
         }
 

--- a/kiwi/filesystem/isofs.py
+++ b/kiwi/filesystem/isofs.py
@@ -44,10 +44,11 @@ class FileSystemIsoFs(FileSystemBase):
         """
         meta_data = self.custom_args['meta_data']
         efi_mode = meta_data.get('efi_mode')
+        ofw_mode = meta_data.get('ofw_mode')
         iso_tool = IsoTools(self.root_dir)
 
         iso = Iso(self.root_dir)
-        if not efi_mode:
+        if not efi_mode and not ofw_mode:
             iso.setup_isolinux_boot_path()
 
         if not iso_tool.has_iso_hybrid_capability():
@@ -60,7 +61,7 @@ class FileSystemIsoFs(FileSystemBase):
         iso_tool.create_iso(filename)
 
         if not iso_tool.has_iso_hybrid_capability():
-            if not efi_mode:
+            if not efi_mode and not ofw_mode:
                 hybrid_offset = iso.create_header_end_block(filename)
                 iso_tool.create_iso(
                     filename, hidden_files=[iso.header_end_name]


### PR DESCRIPTION
 Added suse OEM ppc integration test
    
Added obs integration test for building a simple disk image
to be started in a VM on power. Related to Issue #1325

Along with this change a change in kiwi was needed to support iso creation on ppc.
I can't tell if that makes sense for bare metal but it at least enables the builder to
produce iso/install iso files
