### PR TITLE
Move gitlab stages to use gitlab registry

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,21 +6,11 @@ variables:
   LANG: en_US.UTF-8
   BUILD_IMAGES_PROJECT: kiwi3/kiwi-ci-containers
   TUMBLEWEED_BUILD: buildenv-tumbleweed
-
-.install_deps: &install_system_deps
-  before_script:
-    - >
-      dnf install -y --refresh
-      python3 python3-devel 'python3dist(pip)' 'python3dist(tox)'
-      gcc xz libxml2-devel libxslt-devel enchant
+  FEDORA_BUILD: buildenv-fedora
 
 .install_and_build_src_package: &install_and_build_system_src_package
   before_script:
     - groupadd -f -g 135 -r mock # workaround RHBZ#1740545
-    - >
-      dnf install -y --refresh
-      mock gzip tar git python3 python3-dateutil python3-docopt
-      make which
     - 'sed -i "s|build: clean tox|build:|" Makefile'
     - make build
     - mv dist/python-kiwi.spec .
@@ -33,19 +23,9 @@ variables:
     - "export SRC_RPM=$(ls $(grep 'INFO: Results ' srpm_build_out | awk -F ':' '{print $3}')/*.src.rpm)"
     - mv $SRC_RPM .
 
-.add_cache: &set_cache_dir
-  cache:
-    key: "$CI_JOB_NAME"
-    paths:
-      - .tox
-
 code_style_plus_unit_test:
-  image: fedora:latest
-  <<: *install_system_deps
+  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
   script:
-    - >
-      dnf install -y
-      python36 xorriso genisoimage ShellCheck
     # Flake
     - tox -e check
     # Python 3.6
@@ -54,7 +34,10 @@ code_style_plus_unit_test:
     # Python 3.7
     - export PYTHON=python3.7
     - tox -e unit_py3_7 "-n $(nproc)"
-  <<: *set_cache_dir
+  cache:
+    key: "$CI_JOB_NAME"
+    paths:
+      - .tox
 
 build_doc:
   image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$TUMBLEWEED_BUILD
@@ -66,11 +49,10 @@ build_doc:
   cache:
     key: "$CI_JOB_NAME"
     paths:
-      - .tox/
-      - doc/build/
+      - doc/build
 
 rpm_fedora_30:
-  image: fedora:latest
+  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
   stage: package
   <<: *install_and_build_system_src_package
   script:
@@ -82,7 +64,7 @@ rpm_fedora_30:
     - build_doc
 
 rpm_suse_TW:
-  image: fedora:latest
+  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
   stage: package
   <<: *install_and_build_system_src_package
   script:
@@ -90,6 +72,5 @@ rpm_suse_TW:
       mock
       --old-chroot
       -r /etc/mock/opensuse-tumbleweed-x86_64.cfg $(basename $SRC_RPM)
-  allow_failure: true
   dependencies:
     - build_doc


### PR DESCRIPTION
The kiwi-ci-containers project on gitlab now builds all
containers that are needed to run all type of tests we
have in the gitlab pipeline for kiwi. This commit moves
the tests to fetch the containers from the gitlab
registry and avoids any requirement to install packages
prior to running the tests. This will speedup the
overall test time and makes the system also more robust
in case the repo servers hosting the packages can't
be accessed for some reason


