### PR TITLE
Turn btrfs requirement into a recommend

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -212,12 +212,16 @@ BuildRequires:  dracut
 Requires:       bc
 Requires:       cryptsetup
 %if 0%{?fedora} || 0%{?rhel} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
+%if 0%{?rhel} && 0%{?rhel} < 8
 Requires:       btrfs-progs
+%else
+Recommends:     btrfs-progs
+%endif
 Requires:       gdisk
 Requires:       dracut-network
 %else
 %if 0%{?debian} || 0%{?ubuntu}
-Requires:       btrfs-tools
+Recommends:     btrfs-tools
 Requires:       gdisk
 %else
 Requires:       btrfsprogs


### PR DESCRIPTION
Only on suse systems btrfs is eligable to be a required package
because it's the default filesystem of that distribution. In any
other case it should be a recommended package. As a side effect
of this change we will be able to activate the CentOS-8 build
target

