### PR TITLE
Do not create empty macros file

### DIFF
--- a/kiwi/path.py
+++ b/kiwi/path.py
@@ -104,9 +104,10 @@ class Path:
 
         :param string path: path name
         """
-        Command.run(
-            ['mkdir', '-p', path]
-        )
+        if not os.path.exists(path):
+            Command.run(
+                ['mkdir', '-p', path]
+            )
 
     @staticmethod
     def wipe(path):
@@ -115,9 +116,10 @@ class Path:
 
         :param string path: path name
         """
-        Command.run(
-            ['rm', '-r', '-f', path]
-        )
+        if os.path.exists(path):
+            Command.run(
+                ['rm', '-r', '-f', path]
+            )
 
     @staticmethod
     def remove(path):

--- a/kiwi/utils/rpm.py
+++ b/kiwi/utils/rpm.py
@@ -98,10 +98,11 @@ class Rpm:
 
         Write bootstrap macro file to the custom rpm macros path
         """
-        Path.create(self.macro_path)
-        with open(self.macro_file, 'w') as macro:
-            for entry in self.custom_config:
-                macro.write('{0}{1}'.format(entry, os.linesep))
+        if self.custom_config:
+            Path.create(self.macro_path)
+            with open(self.macro_file, 'w') as macro:
+                for entry in self.custom_config:
+                    macro.write('{0}{1}'.format(entry, os.linesep))
 
     def wipe_config(self):
         """

--- a/test/unit/path_test.py
+++ b/test/unit/path_test.py
@@ -21,19 +21,31 @@ class TestPath:
         )
         assert ordered == ['usr', 'etc', 'usr/bin', 'usr/lib']
 
+    @patch('kiwi.command.os.path.exists')
     @patch('kiwi.command.Command.run')
-    def test_create(self, mock_command):
+    def test_create(self, mock_command, mock_exists):
+        mock_exists.return_value = False
         Path.create('foo')
         mock_command.assert_called_once_with(
             ['mkdir', '-p', 'foo']
         )
+        mock_exists.return_value = True
+        mock_command.reset_mock()
+        Path.create('foo')
+        assert not mock_command.called
 
+    @patch('kiwi.command.os.path.exists')
     @patch('kiwi.command.Command.run')
-    def test_wipe(self, mock_command):
+    def test_wipe(self, mock_command, mock_exists):
+        mock_exists.return_value = True
         Path.wipe('foo')
         mock_command.assert_called_once_with(
             ['rm', '-r', '-f', 'foo']
         )
+        mock_exists.return_value = False
+        mock_command.reset_mock()
+        Path.wipe('foo')
+        assert not mock_command.called
 
     @patch('kiwi.command.Command.run')
     def test_remove(self, mock_command):

--- a/test/unit/repository/zypper_test.py
+++ b/test/unit/repository/zypper_test.py
@@ -355,19 +355,12 @@ class TestRepositoryZypper:
             call('../data/shared-dir/zypper/repos/spam')
         ]
 
-    @patch('kiwi.command.Command.run')
-    def test_delete_all_repos(self, mock_command):
+    @patch('kiwi.path.Path.wipe')
+    @patch('kiwi.path.Path.create')
+    def test_delete_all_repos(self, mock_create, mock_wipe):
         self.repo.delete_all_repos()
-        call = mock_command.call_args_list[0]
-        assert mock_command.call_args_list[0] == \
-            call([
-                'rm', '-r', '-f', '../data/shared-dir/zypper/repos'
-            ])
-        call = mock_command.call_args_list[1]
-        assert mock_command.call_args_list[1] == \
-            call([
-                'mkdir', '-p', '../data/shared-dir/zypper/repos'
-            ])
+        mock_wipe.assert_called_once_with('../data/shared-dir/zypper/repos')
+        mock_create.assert_called_once_with('../data/shared-dir/zypper/repos')
 
     @patch('kiwi.path.Path.wipe')
     def test_delete_repo_cache(self, mock_wipe):

--- a/test/unit/system/root_init_test.py
+++ b/test/unit/system/root_init_test.py
@@ -45,6 +45,7 @@ class TestRootInit:
     @patch('os.chown')
     @patch('os.symlink')
     @patch('os.makedev')
+    @patch('kiwi.path.Path.create')
     @patch('kiwi.system.root_init.copy')
     @patch('kiwi.system.root_init.rmtree')
     @patch('kiwi.system.root_init.DataSync')
@@ -52,7 +53,7 @@ class TestRootInit:
     @patch('kiwi.system.root_init.Command.run')
     def test_create(
         self, mock_command, mock_temp, mock_data_sync, mock_rmtree, mock_copy,
-        mock_makedev, mock_symlink, mock_chwon, mock_makedirs,
+        mock_create, mock_makedev, mock_symlink, mock_chwon, mock_makedirs,
         mock_path
     ):
         data_sync = Mock()
@@ -97,7 +98,6 @@ class TestRootInit:
             call('/run', 'tmpdir/var/run')
         ]
         assert mock_command.call_args_list == [
-            call(['mkdir', '-p', 'root_dir']),
             call([
                 'cp',
                 '/var/adm/fillup-templates/group.aaa_base',
@@ -127,16 +127,15 @@ class TestRootInit:
         mock_copy.assert_called_once_with(
             '/.buildenv', 'root_dir'
         )
+        mock_create.assert_called_once_with('root_dir')
 
-    @patch('kiwi.command.Command.run')
+    @patch('kiwi.path.Path.wipe')
     @patch('os.path.exists')
-    def test_delete(self, mock_path, mock_command):
+    def test_delete(self, mock_path, mock_wipe):
         mock_path.return_value = False
         root = RootInit('root_dir')
         root.delete()
-        mock_command.assert_called_once_with(
-            ['rm', '-r', '-f', 'root_dir']
-        )
+        mock_wipe.assert_called_once_with('root_dir')
 
     def teardown(self):
         sys.argv = argv_kiwi_tests

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -89,7 +89,6 @@ class TestSystemSetup:
             '../data/config-cdroot.tar*'
         )
         assert mock_command.call_args_list == [
-            call(['mkdir', '-p', 'root_dir/image']),
             call(['cp', '../data/config.sh', 'root_dir/image/config.sh']),
             call([
                 'cp', '../data/my_edit_boot_script',
@@ -109,10 +108,11 @@ class TestSystemSetup:
             call(['cp', 'config-cdroot.tar.xz', 'root_dir/image/'])
         ]
 
+    @patch('kiwi.path.Path.create')
     @patch('kiwi.command.Command.run')
     @patch('os.path.exists')
     def test_import_description_archive_from_derived(
-        self, mock_path, mock_command
+        self, mock_path, mock_command, mock_create
     ):
         path_return_values = [
             True, False, True, True, True, True, True
@@ -127,7 +127,6 @@ class TestSystemSetup:
             self.setup_with_real_xml.import_description()
 
         assert mock_command.call_args_list == [
-            call(['mkdir', '-p', 'root_dir/image']),
             call(['cp', '../data/config.sh', 'root_dir/image/config.sh']),
             call([
                 'cp', '../data/my_edit_boot_script',
@@ -147,6 +146,7 @@ class TestSystemSetup:
                 'cp', 'derived/description/bootstrap.tgz', 'root_dir/image/'
             ])
         ]
+        mock_create.assert_called_once_with('root_dir/image')
 
     @patch('kiwi.command.Command.run')
     @patch('os.path.exists')
@@ -372,7 +372,6 @@ class TestSystemSetup:
         self.setup.preferences['timezone'] = 'timezone'
         self.setup.setup_timezone()
         mock_command.assert_has_calls([
-            call(['rm', '-r', '-f', 'root_dir/etc/localtime']),
             call([
                 'chroot', 'root_dir', 'systemd-firstboot',
                 '--timezone=timezone'

--- a/test/unit/volume_manager/lvm_test.py
+++ b/test/unit/volume_manager/lvm_test.py
@@ -140,6 +140,7 @@ class TestVolumeManagerLVM:
             self.volume_manager.setup('volume_group')
 
     @patch('os.path.exists')
+    @patch('kiwi.path.Path.create')
     @patch('kiwi.volume_manager.base.SystemSize')
     @patch('kiwi.volume_manager.lvm.Command.run')
     @patch('kiwi.volume_manager.lvm.FileSystem')
@@ -148,7 +149,7 @@ class TestVolumeManagerLVM:
     @patch('kiwi.volume_manager.base.VolumeManagerBase.apply_attributes_on_volume')
     def test_create_volumes(
         self, mock_attrs, mock_mount, mock_mapped_device, mock_fs,
-        mock_command, mock_size, mock_os_exists
+        mock_command, mock_size, mock_create, mock_os_exists
     ):
         mock_os_exists_return_list = [True, True, False, False, False]
 
@@ -208,15 +209,6 @@ class TestVolumeManagerLVM:
             call(device='/dev/volume_group/LVhome', mountpoint='tmpdir//home')
         ]
         assert mock_command.call_args_list == [
-            call(
-                ['mkdir', '-p', 'root_dir/etc']
-            ),
-            call(
-                ['mkdir', '-p', 'root_dir/data']
-            ),
-            call(
-                ['mkdir', '-p', 'root_dir/home']
-            ),
             call(
                 [
                     'lvcreate', '-Zn', '-L', '100', '-n', 'LVSwap',
@@ -290,6 +282,10 @@ class TestVolumeManagerLVM:
             call(label=None),
             call(label='etc'),
             call(label=None)
+        ]
+
+        assert mock_create.call_args_list == [
+            call('root_dir/etc'), call('root_dir/data'), call('root_dir/home')
         ]
         self.volume_manager.volume_group = None
 


### PR DESCRIPTION
This commit makes shure to empty RPM macros files are created during
the build.

Fixes #1316