### PR TITLE
Fixup documentation for consistency

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1,11 +1,16 @@
 .. _api:
   
-KIWI API
-========
+Python API
+==========
+
+.. note::
+
+   This API documentation covers {kiwi} |version|
 
 .. toctree::
    :maxdepth: 1
 
+   api/kiwi
    api/kiwi.archive
    api/kiwi.boot.image
    api/kiwi.bootloader.config
@@ -22,7 +27,6 @@ KIWI API
    api/kiwi.partitioner
    api/kiwi.repository
    api/kiwi.repository.template
-   api/kiwi
    api/kiwi.solver.repository
    api/kiwi.solver
    api/kiwi.storage

--- a/doc/source/api/kiwi.rst
+++ b/doc/source/api/kiwi.rst
@@ -1,5 +1,5 @@
-API Documentation |version|
-===========================
+kiwi Package
+============
 
 .. default-domain:: py
 
@@ -84,6 +84,22 @@ Submodules
 --------------------
 
 .. automodule:: kiwi.logger
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+`kiwi.logger_color_formatter` Module
+------------------------------------
+
+.. automodule:: kiwi.logger_color_formatter
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+`kiwi.logger_filter` Module
+---------------------------
+
+.. automodule:: kiwi.logger_filter
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/source/building.rst
+++ b/doc/source/building.rst
@@ -5,8 +5,8 @@ Building Images
 
 .. note::
 
-   This document provides an overview about the supported KIWI image
-   types. Before building an image with KIWI it's important to understand
+   This document provides an overview about the supported {kiwi} image
+   types. Before building an image with {kiwi} it's important to understand
    the different image types and their meaning.
 
 .. toctree::
@@ -42,7 +42,7 @@ OEM Expandable Disk Image
   can be created in addition.
 
 PXE root File System Image
-  A root filesystem image which can be deployed via KIWI's PXE netboot
+  A root filesystem image which can be deployed via {kiwi}'s PXE netboot
   infrastructure. A client configuration file on the pxe server controls
   how the root filesystem image should be deployed. Many different
   deployment strategies are possible, e.g root over NBD, AoE or NFS for
@@ -58,9 +58,9 @@ Docker Container Image
 Supported Distributions
 -----------------------
 
-KIWI can build images for the distributions which are **equal** or **newer**
+{kiwi} can build images for the distributions which are **equal** or **newer**
 compared to the table below. For anything older use the
-legacy KIWI version *v7.x* For more details on the legacy KIWI,
+legacy {kiwi} version *v7.x* For more details on the legacy {kiwi},
 see: :ref:`legacy_kiwi`
 
 The most compatible environment is provided if the build host is of the same
@@ -95,11 +95,11 @@ is known to be supported.
 .. admonition:: dnf
 
    dnf is the package manager used on Fedora and RHEL and is
-   the successor of yum. When KIWI builds images for this distributions
+   the successor of yum. When {kiwi} builds images for this distributions
    the latest version of dnf is required to be installed on the host to
    build the image.
 
-In general, our goal is to support any major distribution with KIWI. However
+In general, our goal is to support any major distribution with {kiwi}. However
 for building images we rely on core tools which are not under our control.
 Also several design aspects of distributions like **secure boot** and working
 with **upstream projects** are different and not influenced by us. There
@@ -109,10 +109,10 @@ is not of the same distribution vendor than the image target.
 Supported Platforms and Architectures
 -------------------------------------
 
-Images built with KIWI are designed for a specific use case. The author of
-the image description sets this with the contents in the KIWI XML document
+Images built with {kiwi} are designed for a specific use case. The author of
+the image description sets this with the contents in the {kiwi} XML document
 as well as custom scripts and services. The following list provides an
-abstract of the platforms where KIWI built images are productively used:
+abstract of the platforms where {kiwi} built images are productively used:
 
 * Amazon EC2
 * Microsoft Azure
@@ -121,7 +121,7 @@ abstract of the platforms where KIWI built images are productively used:
 * Bare metal deployments e.g Microsoft Azure Large Instance
 * SAP workloads
 
-The majority of the workloads is based on the x86 architecture. KIWI
+The majority of the workloads is based on the x86 architecture. {kiwi}
 also supports other architectures, shown in the table below:
 
 .. table::
@@ -145,4 +145,4 @@ also supports other architectures, shown in the table below:
 
    The support status for an architecture depends on the distribution.
    If the distribution does not build its packages for the desired
-   architecture, KIWI will not be able to build an image for it
+   architecture, {kiwi} will not be able to build an image for it

--- a/doc/source/building/build_containerized.rst
+++ b/doc/source/building/build_containerized.rst
@@ -5,13 +5,13 @@ Building in a Self-Contained Environment
 
 .. note:: **Abstract**
 
-   Users building images with KIWI face problems if they want
+   Users building images with {kiwi} face problems if they want
    to build an image matching one of the following criteria:
 
    * build should happen as non root user.
 
    * build should happen on a host system distribution for which
-     no KIWI packages exists.
+     no {kiwi} packages exists.
 
    * build happens on an incompatible host system distribution
      compared to the target image distribution. For example
@@ -22,7 +22,7 @@ Building in a Self-Contained Environment
 
    This document describes how to perform the build process in
    a Docker container using the Dice containment build system
-   written for KIWI in order to address the issues listed above.
+   written for {kiwi} in order to address the issues listed above.
 
    The changes on the machine to become a build host will
    be reduced to the requirements of Dice and Docker.
@@ -32,12 +32,12 @@ Requirements
 
 The following components needs to be installed on the build system:
 
-* Dice - a containment build system for KIWI.
+* Dice - a containment build system for {kiwi}.
 
 * Docker - a container framework based on the Linux
   container support in the kernel.
 
-* Docker Image - a docker build container for KIWI.
+* Docker Image - a docker build container for {kiwi}.
 
 * optionally Vagrant - a framework to run, provision and control
   virtual machines and container instances. Vagrant has a very nice
@@ -50,9 +50,9 @@ The following components needs to be installed on the build system:
   capabilities of Linux. In combination with vagrant, libvirt can
   be used as provider for provision and control full virtual
   instances running via qemu. As docker shares the host system
-  kernel and thus any device, because KIWI needs to use privileged
+  kernel and thus any device, because {kiwi} needs to use privileged
   docker containers for building images, the more secure but less
-  performant solution is to use virtual machines to run the KIWI
+  performant solution is to use virtual machines to run the {kiwi}
   build.
 
 Installing and Setting up Dice
@@ -120,12 +120,12 @@ Finally start the docker service:
     $ sudo systemctl restart docker
 
 Installing and Setting up the Build Container
-----------------------------------------------
+---------------------------------------------
 
 In order to build in a contained environment Docker has to start a
 privileged system container. Such a container must be imported before
 Docker can use it. The build container is provided to you as a
-service and build with KIWI in the project
+service and build with {kiwi} in the project
 at http://download.opensuse.org/repositories/Virtualization:/Appliances:/Images.
 The result image is pushed to https://hub.docker.com/r/opensuse/dice.
 
@@ -167,7 +167,7 @@ Installing and Setting up Vagrant
 
 .. note:: Optional step
 
-    By default Dice shares the KIWI image description directory with
+    By default Dice shares the {kiwi} image description directory with
     the Docker instance. If more data from the host should be shared
     with the Docker instance we recommend to use Vagrant for this
     provision tasks.
@@ -177,7 +177,7 @@ https://www.vagrantup.com/docs/installation/index.html
 
 Access to a machine started by Vagrant is done through SSH exclusively.
 Because of that an initial key setup is required in the Docker image vagrant
-should start. The KIWI Docker image includes the public key of the Vagrant
+should start. The {kiwi} Docker image includes the public key of the Vagrant
 key pair and thus allows access. It is important to understand that the
 private Vagrant key is not a secure key because the private key is not
 protected.
@@ -197,15 +197,15 @@ executed as root, but as the intended user to build images.
 Configuring Dice
 ----------------
 
-If you build in a contained environment, there is no need to have KIWI
-installed on the host system. KIWI is part of the container and is only
-called there. However, a KIWI image description and some metadata
+If you build in a contained environment, there is no need to have {kiwi}
+installed on the host system. {kiwi} is part of the container and is only
+called there. However, a {kiwi} image description and some metadata
 defining how to run the container are required as input data.
 
-Selecting a KIWI Template
--------------------------
+Selecting a Template
+--------------------
 
-If you don't have a KIWI description select one from the templates
+If you don't have a {kiwi} description select one from the templates
 provided at the GitHub project hosting example appliance descriptions.
 
 .. code:: bash
@@ -251,7 +251,7 @@ Buildsystem Backends
 Dice currently supports three build system backends:
 
 1. Host buildsystem - Dice builds on the host like if you would call
-   KIWI on the host directly.
+   {kiwi} on the host directly.
 
 2. Vagrant Buildsystem - Dice uses Vagrant to run a virtual system which
    could also be a container and build the image on this machine.
@@ -267,10 +267,10 @@ Building with the Host Buildsystem
 ----------------------------------
 
 Using the Host Buildsystem basically tells Dice to ssh into the
-specified machine with the specified user and run KIWI. This is
+specified machine with the specified user and run {kiwi}. This is
 also the information which needs to be provided in a Dicefile.
 Using the Host Buildsystem is recommended if there are dedicated
-build machines available to take over KIWI build jobs.
+build machines available to take over {kiwi} build jobs.
 
 The Dicefile
 ------------
@@ -283,7 +283,7 @@ The Dicefile
     end
 
 After these changes a :command:`dice build` command will make use
-of the Host Buildsystem and starts the KIWI build process there.
+of the Host Buildsystem and starts the {kiwi} build process there.
 
 .. note:: Provisioning of the Host Buildsystem
 
@@ -358,7 +358,7 @@ the Vagrantfile with the following content:
 
 After these changes a :command:`dice build` command will make use
 of the Vagrant build system and offers a nice way to provision
-the Docker container instances prior to the actual KIWI build process.
+the Docker container instances prior to the actual {kiwi} build process.
 Vagrant will take over the task to run and manage the docker container
 via the `docker` tool chain.
 
@@ -374,7 +374,7 @@ The Vagrant Build Box
 
 Apart from the Docker build container the Dice infrastructure also
 provides a virtual machine image also known as vagrant box which
-contains a system ready to build images with KIWI.
+contains a system ready to build images with {kiwi}.
 
 Download the Vagrant build box which starts with
 :file:`Vagrant-Libvirt-Tumbleweed` from the Open BuildService and add
@@ -408,6 +408,6 @@ The Vagrantfile
 
 After these changes a :command:`dice build` command will make use
 of the Vagrant build system and offers a nice way to provision
-fully isolated qemu instances via libvirt prior to the actual KIWI
+fully isolated qemu instances via libvirt prior to the actual {kiwi}
 build process. Vagrant will take over the task to run and manage the
 virtual machines via the `libvirt` tool chain.

--- a/doc/source/building/build_docker_container.rst
+++ b/doc/source/building/build_docker_container.rst
@@ -11,12 +11,12 @@ Build a Docker Container Image
    * how to build a Docker image
    * how to run it with the Docker daemon
 
-KIWI is capable of building native Docker images, from scratch and derived
-ones. KIWI Docker images are considered to be native since the KIWI
+{kiwi} is capable of building native Docker images, from scratch and derived
+ones. {kiwi} Docker images are considered to be native since the {kiwi}
 tarball image is ready to be loaded to a Docker daemon, including common
 container configurations.
 
-The Docker configuration metadata is provided to KIWI as part of the
+The Docker configuration metadata is provided to {kiwi} as part of the
 :ref:`XML description file <description_components>` using the
 ``<containerconfig>`` tag. The following configuration metadata can be
 specified:
@@ -52,7 +52,7 @@ specified:
   one or more `VOLUME` directives of a Docker file.
 
 Other Docker file directives such as ``RUN``, ``COPY`` or ``ADD``, can be
-mapped to KIWI by using the :ref:`config.sh <description_components>`
+mapped to {kiwi} by using the :ref:`config.sh <description_components>`
 script file to run bash commands or the
 :ref:`overlay tree <description_components>` to include extra files.
 
@@ -76,7 +76,7 @@ openSUSE Leap:
 
       $ zypper in umoci skopeo
 
-#. Build the image with KIWI:
+#. Build the image with {kiwi}:
 
    .. code:: bash
 

--- a/doc/source/building/build_in_buildservice.rst
+++ b/doc/source/building/build_in_buildservice.rst
@@ -4,12 +4,12 @@ Building in the Open Build Service
 .. note:: **Abstract**
 
    This document gives a brief overview how to build images with
-   KIWI in version |version| inside of the Open Build Service.
+   {kiwi} in version |version| inside of the Open Build Service.
    A tutorial on the Open Buildservice itself can be found here:
    https://en.opensuse.org/openSUSE:Build_Service_Tutorial
 
 
-The next generation KIWI is fully integrated with the Open Build Service.
+The next generation {kiwi} is fully integrated with the Open Build Service.
 In order to start it's best to checkout one of the integration test
 image build projects from the base Testing project
 `Virtualization:Appliances:Images:Testing_$ARCH:$DISTRO` at:
@@ -23,14 +23,14 @@ For example the test images for SUSE on x86 can be found `here
 Advantages of using the Open Build Service (OBS)
 ------------------------------------------------
 
-The Open Build Service offers multiple advantages over running KIWI
+The Open Build Service offers multiple advantages over running {kiwi}
 locally:
 
 * OBS will host the latest successful build for you without having to setup
   a server yourself.
 
-* As KIWI is fully integrated into OBS, OBS will automatically rebuild your
-  images if one of the included packages or one of its dependencies or KIWI
+* As {kiwi} is fully integrated into OBS, OBS will automatically rebuild your
+  images if one of the included packages or one of its dependencies or {kiwi}
   itself get updated.
 
 * The builds will no longer have to be executed on your own machine, but
@@ -42,13 +42,13 @@ locally:
 Differences Between Building Locally and on OBS
 -----------------------------------------------
 
-Note, there is a number of differences when building images with KIWI using
+Note, there is a number of differences when building images with {kiwi} using
 the Open Build Service. Your image that build locally just fine, might not
 build without modifications.
 
-The notable differences to running KIWI locally include:
+The notable differences to running {kiwi} locally include:
 
-* OBS will pick the KIWI package from the repositories configured in your
+* OBS will pick the {kiwi} package from the repositories configured in your
   project, which will most likely not be the same version that you are
   running locally.
   This is especially relevant when building images for older versions like
@@ -56,7 +56,7 @@ The notable differences to running KIWI locally include:
   repository as described in the following section:
   :ref:`obs-recommended-settings`.
 
-* When KIWI runs on OBS, OBS will extract the list of packages from
+* When {kiwi} runs on OBS, OBS will extract the list of packages from
   :file:`config.xml` and use it to create a build root. In contrast to a
   local build (where your distributions package manager will resolve the
   dependencies and install the packages), OBS will **not** build your image
@@ -201,7 +201,7 @@ your dependent packages. These repositories can be provided in two ways:
 
    Don't forget to add the repository from the
    `Virtualization:Appliances:Builder` project, providing the latest stable
-   version of KIWI (which you are very likely using for your local builds).
+   version of {kiwi} (which you are very likely using for your local builds).
 
    The following example repository configuration [#f3]_ adds the
    repositories from the `Virtualization:Appliances:Builder` project and
@@ -239,10 +239,10 @@ your dependent packages. These repositories can be provided in two ways:
    repository list.
 
 #. Keep the repositories in your :file:`config.xml` configuration file. If
-   you have installed the latest stable KIWI as described in
+   you have installed the latest stable {kiwi} as described in
    :ref:`kiwi-installation` then you should add the following repository to
    your projects configuration (accessible via :command:`osc meta -e
-   prjconf`), so that OBS will pick the latest stable KIWI version too:
+   prjconf`), so that OBS will pick the latest stable {kiwi} version too:
 
    .. code:: xml
 
@@ -278,7 +278,7 @@ OBS though. If building locally is required, use the second method.
 Project Configuration
 ^^^^^^^^^^^^^^^^^^^^^
 
-The Open Build Service will by default create the same output file as KIWI
+The Open Build Service will by default create the same output file as {kiwi}
 when run locally, but with a custom filename ending (that is unfortunately
 unpredictable). This has the consequence that the download URL of your
 image will change with every rebuild (and thus break automated

--- a/doc/source/building/build_live_iso.rst
+++ b/doc/source/building/build_live_iso.rst
@@ -51,7 +51,7 @@ live ISO images:
   file. Possible values are `ext4` or `xfs`, with `ext4` being the default.
 
 
-With the appropriate settings present in :file:`config.xml` KIWI can now
+With the appropriate settings present in :file:`config.xml` {kiwi} can now
 build the image:
 
 .. code:: bash
@@ -93,9 +93,9 @@ ISO scan
 
 ISO in RAM completely
   Usable with the `dmsquash` module through `rd.live.ram`. The `overlay`
-  module does not support this mode but KIWI supports RAM only systems
+  module does not support this mode but {kiwi} supports RAM only systems
   as OEM deployment into RAM from an install ISO media. For details how
-  to setup RAM only deployments in KIWI see: :ref:`ramdisk_deployment`
+  to setup RAM only deployments in {kiwi} see: :ref:`ramdisk_deployment`
 
 Overlay based on overlayfs
   Usable with the `overlay` module. A squashfs compressed readonly root

--- a/doc/source/building/build_oem_disk.rst
+++ b/doc/source/building/build_oem_disk.rst
@@ -23,7 +23,7 @@ system:
 1. Make sure you have checked out the example image descriptions,
    see :ref:`example-descriptions`.
 
-2. Build the image with KIWI:
+2. Build the image with {kiwi}:
 
    .. code:: bash
 
@@ -57,12 +57,12 @@ There are the following basic deployment strategies:
 
 2. :ref:`deploy_from_iso`
 
-   Boot the OEM installation image and let KIWI's OEM installer
+   Boot the OEM installation image and let {kiwi}'s OEM installer
    deploy the OEM disk image from CD/DVD or USB stick onto the target disk
 
 3. :ref:`deploy_from_network`
 
-   PXE boot the target system and let KIWI's OEM installer
+   PXE boot the target system and let {kiwi}'s OEM installer
    deploy the OEM disk image from the network onto the target disk
 
 .. _deploy_manually:
@@ -126,7 +126,7 @@ The following steps shows how to do it:
 
    .. note:: USB Stick Deployment
 
-       Like any other iso image built with KIWI, also the OEM installation
+       Like any other iso image built with {kiwi}, also the OEM installation
        image is a hybrid image. Thus it can also be used on USB stick and
        serve as installation stick image like it is explained in
        :ref:`hybrid_iso`
@@ -206,7 +206,7 @@ target system:
          The config.bootoptions file is used together with kexec to boot the
          previously dumped image. The information in that file references the
          root of the dumped image and can also include any other type of
-         boot options. The file provided with the KIWI built image is
+         boot options. The file provided with the {kiwi} built image is
          by default connected to the image present in the PXE TAR archive.
          If other images got deployed the contents of this file must be
          adapted to match the correct root reference.
@@ -222,12 +222,12 @@ target system:
        append initrd=boot/initrd rd.kiwi.install.pxe rd.kiwi.install.image=tftp://192.168.100.16/image/{exc_image_base_name}.x86_64-{exc_image_version}.xz
 
    The location of the image is specified as a source URI which can point
-   to any location supported by the `curl` command. KIWI calls `curl` to fetch
+   to any location supported by the `curl` command. {kiwi} calls `curl` to fetch
    the data from this URI. This also means your image, MD5 file, system kernel
    and initrd could be fetched from any server and doesn't have to be stored
    on the `PXE_SERVER`.
 
-   By default KIWI does not use specific `curl` options or flags. However it
+   By default {kiwi} does not use specific `curl` options or flags. However it
    is possible to add custom ones by adding the 
    `rd.kiwi.install.pxe.curl_options` flag into the kernel command line.
    `curl` options are passed as comma separated values. Consider the following
@@ -237,7 +237,7 @@ target system:
 
        rd.kiwi.install.pxe.curl_options=--retry,3,--retry-delay,3,--speed-limit,2048
 
-   The above tells KIWI to call `curl` with:
+   The above tells {kiwi} to call `curl` with:
 
    .. code:: bash
 
@@ -249,7 +249,7 @@ target system:
 
    .. note::
 
-      KIWI just replaces commas with spaces and appends it to the
+      {kiwi} just replaces commas with spaces and appends it to the
       `curl` call. This is relevant since command line options including
       commas will always fail.
 

--- a/doc/source/building/build_pxe_root_filesystem.rst
+++ b/doc/source/building/build_pxe_root_filesystem.rst
@@ -12,7 +12,7 @@ Build a PXE Root File System Image
 .. sidebar:: Abstract
 
    This page explains how to build a file system image for use with
-   KIWI's PXE boot infrastructure. It contains:
+   {kiwi}'s PXE boot infrastructure. It contains:
 
    * how to build a PXE file system image
    * how to setup the PXE file system image on the PXE server
@@ -22,11 +22,11 @@ Build a PXE Root File System Image
 implementations. The protocol sends a DHCP request to get an IP
 address. When an IP address is assigned, it uses the `TFTP`_ protocol
 to download a Kernel and boot instructions. Contrary to other images
-built with KIWI, a PXE image consists of separate boot, kernel and root
+built with {kiwi}, a PXE image consists of separate boot, kernel and root
 filesystem images, since those images need to be made available in
 different locations on the PXE boot server.
 
-A root filesystem image which can be deployed via KIWI’s PXE
+A root filesystem image which can be deployed via {kiwi}'s PXE
 netboot infrastructure represents the system rootfs in a linux
 filesystem. A user could loop mount the image and access the
 contents of the root filesystem. The image does not contain
@@ -61,14 +61,14 @@ system. As diskless client, a QEMU virtual machine is used.
 
    * The PXE root filesystem image approach is considered to be a
      legacy setup. The required netboot initrd code will be maintained
-     outside of the KIWI appliance builder code base. If possible,
+     outside of the {kiwi} appliance builder code base. If possible,
      we recommend to switch to the OEM disk image deployment via
      PXE.
 
 1. Make sure you have checked out the example image descriptions,
    see :ref:`example-descriptions`.
 
-2. Build the image with KIWI:
+2. Build the image with {kiwi}:
 
    .. code:: bash
 
@@ -128,7 +128,7 @@ system. As diskless client, a QEMU virtual machine is used.
    to find the image and how to activate it. In this case the image
    will be deployed into a ramdisk (ram1) and overlay mounted such
    that all write operations will land in another ramdisk (ram2).
-   KIWI supports a variety of different deployment strategies based
+   {kiwi} supports a variety of different deployment strategies based
    on the rootfs image created beforehand. For details, refer
    to :ref:`pxe_client_config`
 

--- a/doc/source/building/build_vmx_disk.rst
+++ b/doc/source/building/build_vmx_disk.rst
@@ -15,7 +15,7 @@ A Virtual Disk Image is a compressed system disk with additional metadata
 useful for cloud frameworks like Amazon EC2, Google Compute Engine, or
 Microsoft Azure.
 
-To instruct KIWI to build a VMX image add a `type` element with
+To instruct {kiwi} to build a VMX image add a `type` element with
 `image="vmx"` in :file:`config.xml`. An example configuration for a 42 GB
 large VMDK image with 512 MB RAM, an IDE controller and a bridged network
 interface is shown below:
@@ -49,7 +49,7 @@ when building VMX images:
 - `formatoptions`: Specifies additional format options passed to
   :command:`qemu-img`. `formatoptions` is a comma separated list of format
   specific options in a ``name=value`` format like :command:`qemu-img`
-  expects it. KIWI will forward the settings from this attribute as a
+  expects it. {kiwi} will forward the settings from this attribute as a
   parameter to the `-o` option in the :command:`qemu-img` call.
 
 The `size` and `machine` child-elements of `type` can be used to customize
@@ -59,7 +59,7 @@ sections (see :ref:`vmx-the-size-element` and
 
 Once your image description is finished (or you are content with a image
 from the :ref:`example descriptions <example-descriptions>` and use one of
-them) build the image with KIWI:
+them) build the image with {kiwi}:
 
 .. code:: bash
 
@@ -187,7 +187,7 @@ the `vmdk` format where the provided strings are directly pasted into the
 
 The `vmconfig-entry` element has no attributes and can appear multiple
 times, the entries are added to the configuration file in the provided
-order. Note, that KIWI does not check the entries for correctness. KIWI only
+order. Note, that {kiwi} does not check the entries for correctness. {kiwi} only
 forwards them.
 
 The following example adds the two entries `numvcpus = "4"` and
@@ -244,7 +244,7 @@ The `vmnic` element supports the following attributes:
 
 - `mode`: this interfaces' mode.
 
-Note that KIWI will **not** verify the values that are passed to these
+Note that {kiwi} will **not** verify the values that are passed to these
 attributes, it will only paste them into the appropriate configuration
 files.
 
@@ -296,7 +296,7 @@ attributes:
 Adding CD/DVD Drives
 ^^^^^^^^^^^^^^^^^^^^
 
-KIWI supports the addition of IDE and SCSCI CD/DVD drives to the virtual
+{kiwi} supports the addition of IDE and SCSCI CD/DVD drives to the virtual
 machine using the `vmdvd` element for the `vmdk` image format. In the
 following example we add two drives: one with a SCSCI and another with a
 IDE controller:

--- a/doc/source/building/build_with_profiles.rst
+++ b/doc/source/building/build_with_profiles.rst
@@ -3,7 +3,7 @@
 Building Images with Profiles
 =============================
 
-KIWI supports so-called *profiles* inside the XML image description. Profiles
+{kiwi} supports so-called *profiles* inside the XML image description. Profiles
 act as namespaces for additional settings to be applied on top of the
 defaults. For further details, see :ref:`image-profiles`.
 
@@ -11,7 +11,7 @@ defaults. For further details, see :ref:`image-profiles`.
 Local Builds
 ------------
 
-To execute local KIWI builds with a specific, selected profile, add the
+To execute local {kiwi} builds with a specific, selected profile, add the
 command line flag `--profile=$PROFILE_NAME`:
 
 .. code:: shell-session

--- a/doc/source/commands.rst
+++ b/doc/source/commands.rst
@@ -1,9 +1,9 @@
-KIWI Commands
-=============
+Command Line
+============
 
 .. note::
 
-   This document provides a list of the existing KIWI commands
+   This document provides a list of the existing {kiwi-product} commands
    for version |version|.
 
 .. toctree::

--- a/doc/source/commands/kiwi.rst
+++ b/doc/source/commands/kiwi.rst
@@ -18,14 +18,14 @@ SYNOPSIS
         [--color-output]
        image <command> [<args>...]
    kiwi [--debug]
-        [--color-output]
+           [--color-output]
        result <command> [<args>...]
    kiwi [--profile=<name>...]
-        [--shared-cache-dir=<directory>]
-        [--type=<build_type>]
-        [--logfile=<filename>]
-        [--debug]
-        [--color-output]
+           [--shared-cache-dir=<directory>]
+           [--type=<build_type>]
+           [--logfile=<filename>]
+           [--debug]
+           [--color-output]
        system <command> [<args>...]
    kiwi compat <legacy_args>...
    kiwi -v | --version
@@ -36,7 +36,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-KIWI is an imaging solution that is based on an image XML description.
+{kiwi} is an imaging solution that is based on an image XML description.
 Such a description is represented by a directory which includes at least
 one :file:`config.xml` or :file:`.kiwi` file and may as well include other files like
 scripts or configuration data.
@@ -48,8 +48,8 @@ Operating System. A JeOS is a small, text only based image including a
 predefined remote source setup to allow installation of missing
 software components at a later point in time.
 
-KIWI operates in two steps. The system build command combines
-both steps into one to make it easier to start with KIWI. The first
+{kiwi} operates in two steps. The system build command combines
+both steps into one to make it easier to start with {kiwi}. The first
 step is the preparation step and if that step was successful, a
 creation step follows which is able to create different image output
 types.
@@ -60,7 +60,7 @@ The creation step is based on the result of the preparation step and
 uses the contents of the new image root tree to create the output
 image.
 
-KIWI supports the creation of the following image types:
+{kiwi} supports the creation of the following image types:
 
 - ISO Live Systems
 - Virtual Disk for e.g cloud frameworks
@@ -134,9 +134,9 @@ EXAMPLE
 COMPATIBILITY
 -------------
 
-This version of KIWI uses a different caller syntax compared to
+This version of {kiwi} uses a different caller syntax compared to
 former versions. However there is a compatibility mode which allows
-to use a legacy KIWI commandline as follows:
+to use a legacy {kiwi} commandline as follows:
 
 .. code:: bash
 

--- a/doc/source/commands/result_bundle.rst
+++ b/doc/source/commands/result_bundle.rst
@@ -51,7 +51,7 @@ OPTIONS
   used to sync the bundle.
 
   * The zsync control file is only created for those bundle files
-    which are marked for compression because in a KIWI build only those
+    which are marked for compression because in a {kiwi} build only those
     are meaningful for a partial binary file download.
 
   * It is expected that all files from a bundle are placed to the same

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# kiwi documentation build configuration file, created by
-# sphinx-quickstart on Fri Feb  5 11:03:18 2016.
+# KIWI NG documentation build configuration file
 #
 import sys
 from os.path import abspath, dirname, join, normpath
@@ -74,11 +73,14 @@ prolog_replacements = {
     '{exc_repo}': 'obs://openSUSE:Leap:15.1/standard',
     '{exc_kiwi_repo}':
         'obs://Virtualization:Appliances:Builder/openSUSE_Leap_15.1',
-    '{schema_version}': '7.1'
+    '{schema_version}': '7.1',
+    '{kiwi}': 'KIWI NG',
+    '{kiwi-product}': 'KIWI Next Generation (KIWI NG)',
+    '{kiwi-legacy}': 'KIWI Legacy'
 }
 
 latex_documents = [
-    ('index', 'kiwi.tex', 'KIWI Documentation', 'Marcus Schäfer', 'manual')
+    ('index', 'kiwi.tex', 'KIWI NG Documentation', 'Marcus Schäfer', 'manual')
 ]
 latex_elements = {
     'papersize': 'a4paper',
@@ -117,8 +119,8 @@ master_doc = 'index'
 default_role="py:obj"
 
 # General information about the project.
-project = 'kiwi'
-copyright = '2019, Marcus Schäfer'
+project = 'KIWI NG'
+copyright = '2020, Marcus Schäfer'
 author = 'Marcus Schäfer'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -1,9 +1,9 @@
-Development and Contributing
-============================
+Contributing
+============
 
 .. note:: **Abstract**
 
-   This document describes the development process of KIWI
+   This document describes the development process of {kiwi}
    and how you can be part of it. This description applies
    to version |version|.
 
@@ -23,15 +23,15 @@ If you want to implement a bigger feature, consider opening an issue on
 GitHub first to discuss the changes. Or join the discussion in the
 ``#kiwi`` channel on `Riot.im <https://about.riot.im>`_.
 
-Fork the upstream KIWI repository
----------------------------------
+Fork the upstream repository
+----------------------------
 
 1. On GitHub, navigate to: https://github.com/OSInside/kiwi
 
 2. In the top-right corner of the page, click :command:`Fork`.
 
-Create a local clone of the forked KIWI repository
---------------------------------------------------
+Create a local clone of the forked repository
+---------------------------------------------
 
 .. code:: shell-session
 
@@ -42,7 +42,7 @@ Create a local clone of the forked KIWI repository
 Install Required Operating System Packages
 ------------------------------------------
 
-KIWI requires the following additional packages which are not provided by
+{kiwi} requires the following additional packages which are not provided by
 :command:`pip`:
 
 XML processing libraries
@@ -94,7 +94,7 @@ environment for Python 3:
    $ source .tox/3/bin/activate
 
 The commands above automatically creates the application script
-called :command:`kiwi-ng`, which allows you to run KIWI from the
+called :command:`kiwi-ng`, which allows you to run {kiwi} from the
 Python sources inside the virtual environment:
 
 .. code:: shell-session
@@ -104,7 +104,7 @@ Python sources inside the virtual environment:
 .. warning::
 
    The virtualenv's `$PATH` will not be taken into account when calling
-   KIWI via :command:`sudo`! Use the absolute path to the KIWI executable
+   {kiwi} via :command:`sudo`! Use the absolute path to the {kiwi} executable
    to run an actual build using your local changes:
 
    .. code:: shell-session
@@ -214,14 +214,14 @@ create a pull request into the upstream repository.
 
     $ git push origin my-topic-branch
 
-Thank you much for contributing to KIWI. Your time and work effort is very
+Thank you much for contributing to {kiwi}. Your time and work effort is very
 much appreciated!
 
 
 Coding Style
 ------------
 
-KIWI follows the general PEP8 guidelines with the following exceptions:
+{kiwi} follows the general PEP8 guidelines with the following exceptions:
 
 - We do not use free functions at all. Even utility functions must be part
   of a class, but should be either prefixed with the `@classmethod` or
@@ -236,7 +236,7 @@ KIWI follows the general PEP8 guidelines with the following exceptions:
 Documentation
 ~~~~~~~~~~~~~
 
-KIWI uses `Sphinx <https://www.sphinx-doc.org/en/master/>`_ for the API and
+{kiwi} uses `Sphinx <https://www.sphinx-doc.org/en/master/>`_ for the API and
 user documentation.
 
 In order to build the HTML documentation call:
@@ -363,11 +363,11 @@ To prepare Git to sign commits, follow these instructions:
 Bumping the Version
 ~~~~~~~~~~~~~~~~~~~
 
-The KIWI project follows the `Semantic Versioning <https://semver.org>`_
+The {kiwi} project follows the `Semantic Versioning <https://semver.org>`_
 scheme. We use the :command:`bumpversion` tool for consistent versioning.
 
 Follow these instructions to bump the major, minor, or patch part of the
-KIWI version. Ensure that your repository is clean (i.e. no modified and
+{kiwi} version. Ensure that your repository is clean (i.e. no modified and
 unknown files exist) beforehand running :command:`bumpversion`.
 
 *  For backwards-compatible bug fixes:

--- a/doc/source/development/kiwi_from_python.rst
+++ b/doc/source/development/kiwi_from_python.rst
@@ -1,13 +1,13 @@
-Using KIWI NG in a Python Project
+Using {kiwi} in a Python Project
 =================================
 
 .. note:: **Abstract**
 
-   KIWI is provided as python module under the **kiwi** namespace.
-   It is available for the python 2 and 3 versions. The following
-   description applies for KIWI version |version|.
+   {kiwi} is provided as python module under the **kiwi** namespace.
+   It is available for the python 3 version. The following
+   description applies for {kiwi} version |version|.
 
-KIWI NG can also function as a module for other Python projects.
+{kiwi} can also function as a module for other Python projects.
 The following example demonstrates how to read an existing image
 description, add a new repository definition and export the
 modified description on stdout.
@@ -41,5 +41,5 @@ modified description on stdout.
 
 All classes are written in a way to care for a single responsibility
 in order to allow for re-use on other use cases. Therefore it is possible
-to use KIWI NG outside of the main image building scope to manage e.g
+to use {kiwi} outside of the main image building scope to manage e.g
 the setup of loop devices, filesystems, partitions, etc...

--- a/doc/source/development/schema_extensions.rst
+++ b/doc/source/development/schema_extensions.rst
@@ -1,25 +1,25 @@
-Extending KIWI with Custom Operations
-=====================================
+Extending {kiwi} with Custom Operations
+========================================
 
 .. note:: **Abstract**
 
-   Users building images with KIWI need to implement their
+   Users building images with {kiwi} need to implement their
    own infrastructure if the image description does not
    provide a way to embed custom information which is
    outside of the scope of the general schema as it is
-   provided by KIWI today.
+   provided by {kiwi} today.
 
    This document describes how to create an extension plugin
-   for the KIWI schema to add and validate additional information
-   in the KIWI image description.
+   for the {kiwi} schema to add and validate additional information
+   in the {kiwi} image description.
 
-   Such a schema extension can be used in an additional KIWI
-   task plugin to provide a new subcommand for KIWI.
+   Such a schema extension can be used in an additional {kiwi}
+   task plugin to provide a new subcommand for {kiwi}.
    As of today there is no other plugin interface except for
-   providing additional KIWI commands implemented.
+   providing additional {kiwi} commands implemented.
 
    Depending on the demand for custom plugins, the interface
-   to hook in code into other parts of the KIWI processing
+   to hook in code into other parts of the {kiwi} processing
    needs to be extended.
 
    This description applies for version |version|.
@@ -27,7 +27,7 @@ Extending KIWI with Custom Operations
 The <extension> Section
 -----------------------
 
-The main KIWI schema supports an extension section which allows
+The main {kiwi} schema supports an extension section which allows
 to specify any XML structure and attributes as long as they are
 connected to a namespace. According to this any custom XML
 structure can be implemented like the following example shows:
@@ -50,7 +50,7 @@ structure can be implemented like the following example shows:
 RELAX NG Schema for the Extension
 ---------------------------------
 
-If an extension section is found, KIWI looks up its namespace and asks
+If an extension section is found, {kiwi} looks up its namespace and asks
 the main XML catalog for the schema file to validate the extension data.
 The schema file must be a RELAX NG schema in the .rng format. We recommend
 to place the schema as :file:`/usr/share/xml/kiwi/my_plugin.rng`
@@ -107,13 +107,13 @@ XML catalog for the example use here looks like this:
             uri="file:////usr/share/xml/kiwi/my_plugin.rng"/>
     </catalog>
 
-For resolving the catalog KIWI uses the :command:`xmlcatalog` command
+For resolving the catalog {kiwi} uses the :command:`xmlcatalog` command
 and the main XML catalog from the system which is :file:`/etc/xml/catalog`.
 
 .. note::
 
     It depends on the distribution and its version how the main catalog
-    gets informed about the existence of the KIWI extension catalog file.
+    gets informed about the existence of the {kiwi} extension catalog file.
     Please consult the distribution manual about adding XML catalogs.
 
 If the following command provides the information to the correct

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,23 +1,26 @@
 .. kiwi documentation master file
 
-KIWI Documentation
-==================
+{kiwi} Documentation
+=====================
 
-.. note::
+.. note:: {kiwi} vs. {kiwi-legacy}
 
-   This documentation covers KIWI |version|- the command line utility to
-   build Linux system appliances. For versions of KIWI older or equal to
-   v7.x.x please refer to `Legacy KIWI <https://doc.opensuse.org/projects/kiwi/doc>`__
-
+   This documentation covers {kiwi-product} |version|- the command line
+   utility to build Linux system appliances. {kiwi} is stable and all
+   new features, bugfixes, and improvements will be developed here.
+   Versions older or equal to v7.x.x are out of maintenance and do
+   not get any updates or bugfixes. If you still need this version,
+   refer to the documentation for
+   `{kiwi-legacy} <https://doc.opensuse.org/projects/kiwi/doc>`__
 
 .. toctree::
    :maxdepth: 1
 
    quickstart
    installation
+   overview
    working_with_kiwi
    working_with_images
-   overview
    building
    commands
    development
@@ -50,11 +53,11 @@ a pre-configured application for a specific use case. The appliance is
 provided as an image file and needs to be deployed to, or activated in
 the target system or service.
 
-KIWI can create appliances in various forms: beside classical installation
+{kiwi} can create appliances in various forms: beside classical installation
 ISOs and images for virtual machines it can also build images that boot via
 PXE or Vagrant boxes.
 
-In KIWI, the appliance is specified via a collection of human readable files
+In {kiwi}, the appliance is specified via a collection of human readable files
 in a directory, also called the `image description`. At least one XML file
 :file:`config.xml` or :file:`.kiwi` is required. In addition there may as
 well be other files like scripts or configuration data.
@@ -67,21 +70,21 @@ below:
 
 * You are a system administrator and wish to create a customized installer
   for your network that includes additional software and your organizations
-  certificates? KIWI allows you to select which packages will be included
+  certificates? {kiwi} allows you to select which packages will be included
   in the final image. On top of that you can add files to arbitrary
   locations in the filesystem, for example to include SSL or SSH keys. You
-  can also tell KIWI to create an image that can be booted via PXE, so that
+  can also tell {kiwi} to create an image that can be booted via PXE, so that
   you don't even have to leave your desk to reinstall a system.
 
 * You want to create a custom spin of your favorite Linux distribution with
   additional repositories and packages that are not present by default?
-  With KIWI you can configure the repositories of your final image via the
+  With {kiwi} you can configure the repositories of your final image via the
   image description and tweak the list of packages that are going to be
   installed to match your target audience.
 
 * The Raspberry Pi that is coordinating your home's Internet of Thing (IoT)
   devices got very popular among your friends and every single one of them
-  wants a copy of that? KIWI will build you ready to deploy images for your
+  wants a copy of that? {kiwi} will build you ready to deploy images for your
   Raspberry Pi, tweaked to your needs.
 
 Contact

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -5,8 +5,8 @@ Installation
 
 .. note::
 
-   This document describes how to install KIWI. Apart from the preferred
-   method to install KIWI via rpm, it is also available on `pypi
+   This document describes how to install {kiwi}. Apart from the preferred
+   method to install {kiwi} via rpm, it is also available on `pypi
    <https://pypi.org/project/kiwi/>`__ and can be installed via pip.
 
 .. _installation-from-obs:
@@ -14,12 +14,12 @@ Installation
 Installation from OBS
 ---------------------
 
-The most up to date packages of KIWI can be found on the Open Build Service
+The most up to date packages of {kiwi} can be found on the Open Build Service
 in the `Virtualization:Appliances:Builder
 <https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder>`__
 project.
 
-To install KIWI, follow these steps:
+To install {kiwi}, follow these steps:
 
 1. Open the URL https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder
    in your browser.
@@ -60,7 +60,7 @@ To install KIWI, follow these steps:
             F7E82012C74FD0B85F5334DC994B195474CBE823
       uid           Virtualization:Appliances OBS Project <Virtualization:Appliances@build.opensuse.org>
 
-5. Install KIWI:
+5. Install {kiwi}:
 
    .. code:: shell-session
 
@@ -72,18 +72,18 @@ Installation from your distribution's repositories
 
 .. note::
 
-   There are many packages that contain the name KIWI in their name, some
+   There are many packages that contain the name {kiwi} in their name, some
    of these are even python packages. Please double check the packages'
-   description whether it is actually the KIWI Appliance builder before
+   description whether it is actually the {kiwi} Appliance builder before
    installing it.
 
 
-Some Linux distributions ship KIWI in their official repositories. These
+Some Linux distributions ship {kiwi} in their official repositories. These
 include openSUSE Tumbleweed, openSUSE Leap, and Fedora since
 version 28. Note, these packages tend to not be as up to date as the
 packages from OBS, so some features described here might not exist yet.
 
-To install KIWI on openSUSE, run the following command:
+To install {kiwi} on openSUSE, run the following command:
 
 .. code:: shell-session
 
@@ -99,7 +99,7 @@ On Fedora, use the following command instead:
 Installation from PyPI
 ----------------------
 
-KIWI can be obtained from the Python Package Index (PyPi) via Python's
+{kiwi} can be obtained from the Python Package Index (PyPi) via Python's
 package manager pip:
 
 .. code:: shell-session
@@ -113,7 +113,7 @@ Example Appliance Descriptions
 ------------------------------
 
 There is a GitHub project hosting example appliance descriptions to be used
-with the next generation KIWI. Users who need an example to start with
+with the next generation {kiwi}. Users who need an example to start with
 should clone the project as follows:
 
 .. code:: shell-session

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -6,9 +6,9 @@ Overview
 .. note:: **Abstract**
 
    This document provides a conceptual overview about the steps
-   of creating an image with KIWI. It also explains the terminology
+   of creating an image with {kiwi}. It also explains the terminology
    regarding the concept and process when building system images
-   with KIWI |version|.
+   with {kiwi} |version|.
 
 .. toctree::
    :maxdepth: 1
@@ -22,7 +22,7 @@ A system image (usually called "image"), is a *complete installation* of a Linux
 system within a file. The image represents an operation system and,
 optionally, contains the "final" configuration.
 
-KIWI creates images in a two step process:
+{kiwi} creates images in a two step process:
 
 1. The first step, the *prepare operation*, generates a so-called
    *unpacked image tree* (directory) using the information provided in
@@ -32,7 +32,7 @@ KIWI creates images in a two step process:
    *image* in the specified format based on the unpacked image and the
    information provided in the configuration file.
 
-The image creation process with KIWI is automated and does not require any
+The image creation process with {kiwi} is automated and does not require any
 user interaction. The information required for the image creation process is
 provided by the image description.
 
@@ -47,14 +47,14 @@ Appliance
    deployed to, or activated in the target system or service.
 
 Image
-   The result of a KIWI build process.
+   The result of a {kiwi} build process.
 
 Image Description
    Specification to define an appliance. The image description is a
    collection of human readable files in a directory. At least one XML
    file :file:`config.xml` or :file:`.kiwi` is required. In addition
    there may be as well other files like scripts or configuration data.
-   These can be used to customize certain parts either of the KIWI
+   These can be used to customize certain parts either of the {kiwi}
    build process or of the initial start-up behavior of the image.
 
 Overlay Files
@@ -65,7 +65,7 @@ Overlay Files
    the the existing file system (overlayed) of the appliance root.
    This also includes permissions and attributes as a supplement.
 
-KIWI
+{kiwi}
    An OS appliance builder.
 
 Virtualization Technology
@@ -77,11 +77,11 @@ Virtualization Technology
 System Requirements
 -------------------
 
-To use and run KIWI, you need:
+To use and run {kiwi}, you need:
 
 * A recent Linux distribution, see :ref:`supported-distributions` for
   details. Alternatively a Linux distribution which supports the docker
-  container system, where KIWI can be run inside a container, see:
+  container system, where {kiwi} can be run inside a container, see:
   :ref:`container-building`
 
 * Enough free disk space to build and store the image. We recommend a

--- a/doc/source/overview/workflow.rst
+++ b/doc/source/overview/workflow.rst
@@ -23,7 +23,7 @@ system within a file. The image represents an operational system and,
 optionally, contains the "final" configuration.
 
 The behavior of the image upon deployment varies depending on the image type
-and the image configuration since KIWI allows you to completely customize
+and the image configuration since {kiwi} allows you to completely customize
 the initial start-up behavior of the image. Among others, this includes
 images that:
 
@@ -32,7 +32,7 @@ images that:
 * automatically configure themselves in a known target environment.
 * prompt the user for an interactive system configuration.
 
-The image creation process with KIWI is automated and does not require any
+The image creation process with {kiwi} is automated and does not require any
 user interaction. The information required for the image creation process is
 provided by the primary configuration file named :file:`config.xml`.
 This file is validated against the schema documented in
@@ -53,8 +53,8 @@ See :ref:`description_components` section for further details.
 Components of an Image Description
 ----------------------------------
 
-A KIWI image description can composed by several parts. The main part is
-the KIWI description file itself (named :file:`config.xml` or an arbitrary
+A {kiwi} image description can composed by several parts. The main part is
+the {kiwi} description file itself (named :file:`config.xml` or an arbitrary
 name plus the :file:`*.kiwi` extension). The configuration XML is the
 only required component, others are optional.
 

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -5,14 +5,14 @@ Quick Start
 
 .. note:: **Abstract**
 
-   This document describes how to start working with KIWI, an OS appliance
+   This document describes how to start working with {kiwi}, an OS appliance
    builder.
    This description applies for version |version|.
 
 Before you start
 ----------------
 
-1. Install KIWI first, either via your distributions' package manager (see
+1. Install {kiwi} first, either via your distributions' package manager (see
    :ref:`kiwi-installation`) or via:
 
    .. code:: bash
@@ -39,7 +39,7 @@ Build your First Image
 ----------------------
 
 Your first image will be a simple system disk image which can run
-in any full virtualization system like QEMU. Invoke the following KIWI
+in any full virtualization system like QEMU. Invoke the following {kiwi}
 command in order to build it:
 
 .. code:: bash

--- a/doc/source/schema.rst
+++ b/doc/source/schema.rst
@@ -1,7 +1,7 @@
 .. _schema-docs:
 
-Schema Documentation 7.1
-========================
+Image Description XML Schema
+============================
 
 .. raw:: html
     :file: schema/schema.html

--- a/doc/source/working_with_images/custom_fstab_extension.rst
+++ b/doc/source/working_with_images/custom_fstab_extension.rst
@@ -9,10 +9,10 @@ Add or Update the Fstab File
    the `/etc/fstab` file which controls the mounting of
    filesystems at boot time.
 
-In KIWI, all major filesystems that were created at image
-build time are handled by KIWI itself and setup in `/etc/fstab`.
+In {kiwi}, all major filesystems that were created at image
+build time are handled by {kiwi} itself and setup in `/etc/fstab`.
 Thus there is usually no need to add entries or change the
-ones added by KIWI. However depending on where the image is
+ones added by {kiwi}. However depending on where the image is
 deployed later it might be required to pre-populate fstab
 entries that are unknown at the time the image is build.
 
@@ -42,11 +42,11 @@ The optimal way to provide custom fstab information is through a
 package. If this can't be done the files can also be provided via
 the overlay file tree of the image description.
 
-KIWI supports three ways to modify the contents of the `/etc/fstab`
+{kiwi} supports three ways to modify the contents of the `/etc/fstab`
 file:
 
 Providing an `/etc/fstab.append` file
-  If that file exists in the image root tree, KIWI will take its
+  If that file exists in the image root tree, {kiwi} will take its
   contents and append it to the existing `/etc/fstab` file. The
   provided `/etc/fstab.append` file will be deleted after successful
   modification.

--- a/doc/source/working_with_images/custom_partitions.rst
+++ b/doc/source/working_with_images/custom_partitions.rst
@@ -5,17 +5,17 @@ Custom Disk Partitions
 
 .. sidebar:: Abstract
 
-   This page provides some details about what KIWI supports and does
+   This page provides some details about what {kiwi} supports and does
    not support regarding customization over the partition scheme. It also
    provides some guidance in case the user requires some custom layout
-   beyond KIWI supported features.
+   beyond {kiwi} supported features.
 
-By design, KIWI does not support a customized partition table. Alternatively,
-KIWI supports the definition of user-defined volumes which covers most of
+By design, {kiwi} does not support a customized partition table. Alternatively,
+{kiwi} supports the definition of user-defined volumes which covers most of
 common use cases. See :ref:`Custom Disk Volumes <custom_volumes>` for
 further details about that.
 
-KIWI has its own partitioning schema which is defined according to several
+{kiwi} has its own partitioning schema which is defined according to several
 different user configurations: boot firmware, boot partition,
 expandable layouts, etc. Those supported features have an impact on the
 partitioning schema. MBR or GUID partition tables are not flexible,
@@ -23,12 +23,12 @@ carry limitations and are tied to some specific disk geometry. Because
 of that the preferred alternative to disk layouts based on traditional
 partition tables is using flexible approaches like logic volumes.
 
-As an example, expandable OEM images is a relevant KIWI feature that
+As an example, expandable OEM images is a relevant {kiwi} feature that
 is incompatible with the idea of adding user defined partitions on the
 system area.
 
 Despite no full customization is supported, some aspects of the partition
-schema can be customized. KIWI supports:
+schema can be customized. {kiwi} supports:
 
 1. Adding a spare partition *before* the root (`/`) partition.
 
@@ -44,13 +44,13 @@ schema can be customized. KIWI supports:
    the *end* of the disk.
 
      A built image can be resized by using the `kiwi-ng image resize` command
-     and set a new extended size for the disk. See KIWI commands docs
+     and set a new extended size for the disk. See {kiwi} commands docs
      :ref:`here <db_kiwi_image_resize>`.
 
 Custom Partitioning at Boot Time
 ++++++++++++++++++++++++++++++++
 
-Adding additional partitions at boot time of KIWI images is also possible,
+Adding additional partitions at boot time of {kiwi} images is also possible,
 however, setting the tools and scripts for doing so needs to be handled by
 the user. A possible strategy to add partitions on system area are described
 below.

--- a/doc/source/working_with_images/custom_volumes.rst
+++ b/doc/source/working_with_images/custom_volumes.rst
@@ -6,13 +6,13 @@ Custom Disk Volumes
 .. sidebar:: Abstract
 
    This chapter provides high level explanations on how to handle volumes
-   or subvolumes definitions for disk images using KIWI.
+   or subvolumes definitions for disk images using {kiwi}.
 
-KIWI supports defining custom volumes by using the logical volume manager
+{kiwi} supports defining custom volumes by using the logical volume manager
 (LVM) for the Linux kernel or by setting volumes at filesystem level when
 filesystem supports it (e.g. btrfs).
 
-Volumes are defined in the KIWI description file :file:`config.xml`,
+Volumes are defined in the {kiwi} description file :file:`config.xml`,
 using `systemdisk`. This element is a child of the `type`.
 Volumes themselves are added via (multiple) `volume` child
 elements of the `systemdisk` element:
@@ -75,5 +75,5 @@ attributes:
 - `name`: The volume group name, by default `kiwiVG` is used. This setting
   is only relevant for LVM volumes.
 
-- `preferlvm`: Boolean value instructing KIWI to prefer LVM even if the
+- `preferlvm`: Boolean value instructing {kiwi} to prefer LVM even if the
   used filesystem has its own volume management system.

--- a/doc/source/working_with_images/iso_to_usb_stick_deployment.rst
+++ b/doc/source/working_with_images/iso_to_usb_stick_deployment.rst
@@ -6,12 +6,12 @@ Deploy ISO Image on an USB Stick
 .. sidebar:: Abstract
 
    This page provides further information for handling
-   ISO images built with KIWI and references the following
+   ISO images built with {kiwi} and references the following
    articles:
 
    * :ref:`hybrid_iso`
 
-In KIWI all generated ISO images are created to be hybrid. This means,
+In {kiwi} all generated ISO images are created to be hybrid. This means,
 the image can be used as a CD/DVD or as a disk. This works because
 the ISO image also has a partition table embedded. With more and more
 computers delivered without a CD/DVD drive this becomes important.

--- a/doc/source/working_with_images/iso_to_usb_stick_file_based_deployment.rst
+++ b/doc/source/working_with_images/iso_to_usb_stick_file_based_deployment.rst
@@ -6,12 +6,12 @@ Deploy ISO Image as File on a FAT32 Formated USB Stick
 .. sidebar:: Abstract
 
    This page provides further information for handling
-   ISO images built with KIWI and references the following
+   ISO images built with {kiwi} and references the following
    articles:
 
    * :ref:`hybrid_iso`
 
-In KIWI, all generated ISO images are created to be hybrid. This means,
+In {kiwi}, all generated ISO images are created to be hybrid. This means,
 the image can be used as a CD/DVD or as a disk. The deployment of such
 an image onto a disk like an USB stick normally destroys all existing
 data on this device. Most USB sticks are pre-formatted with a FAT32
@@ -26,8 +26,8 @@ kernel and initrd directly from the ISO file.
 
 The initrd loaded in this process must also be able to loopback
 mount the ISO file to access the root filesystem and boot the
-live system. The dracut initrd system used by KIWI provides this
-feature upstream called as "iso-scan". Therefore all KIWI generated
+live system. The dracut initrd system used by {kiwi} provides this
+feature upstream called as "iso-scan". Therefore all {kiwi} generated
 live ISO images supports this deployment mode.
 
 For copying the ISO file on the USB stick and the setup of the

--- a/doc/source/working_with_images/oem_ramdisk_deployment.rst
+++ b/doc/source/working_with_images/oem_ramdisk_deployment.rst
@@ -6,14 +6,14 @@ Deploy and Run System in a RamDisk
 .. sidebar:: Abstract
 
    This page provides further information for handling
-   oem images built with KIWI and references the following
+   oem images built with {kiwi} and references the following
    articles:
 
    * :ref:`oem`
 
 If a machine should run the OS completely in memory without
 the need for any persistent storage, the approach to deploy
-the image into a ramdisk serves this purpose. KIWI allows
+the image into a ramdisk serves this purpose. {kiwi} allows
 to create a bootable ISO image which deploys the image
 into a ramdisk and activates that image with the following
 oem type definition:
@@ -57,7 +57,7 @@ follows:
     The machine, no matter if it's a virtual machine like QEMU
     or a real machine, must provide enough RAM to hold the image
     in the ramdisk as well as have enough RAM available to operate
-    the OS and its applications. The KIWI build image with the
+    the OS and its applications. The {kiwi} build image with the
     extension .raw provides the System Image which gets deployed
     into the RAM space. Substract the size of the System Image
     from the RAM space the machine offers and make sure the result
@@ -66,7 +66,7 @@ follows:
     this calculation. In case of QEMU this can be done with
     the `-m` option
 
-Like all other oem KIWI images, also the ramdisk setup supports
+Like all other oem {kiwi} images, also the ramdisk setup supports
 all the deployments methods as explained in :ref:`deployment_methods`
 This means it's also possible to dump the ISO image on a USB
 stick let the system boot from it and unplug the stick from
@@ -75,7 +75,7 @@ the machine because the system was deployed into RAM
 .. note:: Limitations Of RamDisk Deployments
 
     Only standard images which can be booted by a simple root mount
-    and root switch can be used. Usually KIWI calls kexec after deployment
+    and root switch can be used. Usually {kiwi} calls kexec after deployment
     such that the correct, for the image created dracut initrd, will boot
     the image. In case of a RAM only system kexec does not work because
     it would loose the ramdisk contents. Thus the dracut initrd driving

--- a/doc/source/working_with_images/pxe_client_configuration.rst
+++ b/doc/source/working_with_images/pxe_client_configuration.rst
@@ -6,7 +6,7 @@ PXE Client Setup Configuration
 .. sidebar:: Abstract
 
    This page provides further information for handling
-   PXE images built with KIWI and references the following
+   PXE images built with {kiwi} and references the following
    articles:
 
    * :ref:`build_pxe`
@@ -83,7 +83,7 @@ write operations on a tmpfs, the following setup is required:
    UNIONFS_CONFIG=tmpfs,nbd,overlay
 
 The above setup shows the most common use case where the image built
-with KIWI is populated over the network using either AoE, NBD or NFS
+with {kiwi} is populated over the network using either AoE, NBD or NFS
 in combination with overlayfs which redirects all write operations
 to be local to the client. In any case a setup of either AoE, NBD or
 NFS on the image server is required beforehand.
@@ -156,7 +156,7 @@ the following setup is required:
 
    CONF="hosts;/etc/hosts;192.168.1.2;4096;ffffffff"
 
-On boot of the client KIWI's boot code will fetch the :file:`hosts` file
+On boot of the client {kiwi}'s boot code will fetch the :file:`hosts` file
 from the root of the server (192.168.1.2) with 4k blocksize and deploy
 it as :file:`/etc/hosts` on the client. The protocol is by default tftp
 but can be changed via the ``kiwiservertype`` kernel commandline option.
@@ -235,11 +235,11 @@ the following setup is required.
 Setup a Different Download Protocol and Server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default all downloads controlled by the KIWI linuxrc code are
+By default all downloads controlled by the {kiwi} linuxrc code are
 performed by an atftp call using the TFTP protocol. With PXE the download
 protocol is fixed and thus you cannot change the way how the kernel and
 the boot image (:file:`initrd`) is downloaded. As soon as Linux takes over, the
-download protocols http, https and ftp are supported too. KIWI uses
+download protocols http, https and ftp are supported too. {kiwi} uses
 the curl program to support the additional protocols.
 
 To select one of the additional download protocols the following

--- a/doc/source/working_with_images/pxe_live_iso_boot.rst
+++ b/doc/source/working_with_images/pxe_live_iso_boot.rst
@@ -6,12 +6,12 @@ Booting a Live ISO Image from Network
 .. sidebar:: Abstract
 
    This page provides further information for handling
-   ISO images built with KIWI and references the following
+   ISO images built with {kiwi} and references the following
    articles:
 
    * :ref:`hybrid_iso`
 
-In KIWI, live ISO images can be configured to boot via PXE.
+In {kiwi}, live ISO images can be configured to boot via PXE.
 This functionality requires a network boot server setup on the
 system. Details how to setup such a server can be found in
 :ref:`pxe-boot-server`.
@@ -40,7 +40,7 @@ the network:
 2. Export Live ISO To The Network
 
    Access to the live ISO file is implemented using the AoE protocol
-   in KIWI. This requires the export of the live ISO file as remote
+   in {kiwi}. This requires the export of the live ISO file as remote
    block device which is typically done with the :command:`vblade`
    toolkit. Install the following package on the system which is
    expected to export the live ISO image:
@@ -80,7 +80,7 @@ the network:
        be connected through a bridge. In this case INTERFACE
        is the bridge device. The availability scope of the live
        ISO image on the network is in general not influenced
-       by KIWI and is a task for the network administrators.
+       by {kiwi} and is a task for the network administrators.
 
 3. Setup live ISO boot entry in PXE configuration
 
@@ -93,7 +93,7 @@ the network:
           kernel boot/linux
           append initrd=boot/initrd rd.kiwi.live.pxe root=live:AOEINTERFACE=e0.1
 
-   * The boot parameter `rd.kiwi.live.pxe` tells the KIWI boot process to
+   * The boot parameter `rd.kiwi.live.pxe` tells the {kiwi} boot process to
      setup the network and to load the required :mod:`aoe` kernel module.
 
    * The boot parameter `root=live:AOEINTERFACE=e0.1` specifies the

--- a/doc/source/working_with_images/setup_pxe_bootserver.rst
+++ b/doc/source/working_with_images/setup_pxe_bootserver.rst
@@ -6,12 +6,12 @@ Setting Up a Network Boot Server
 .. sidebar:: Abstract
 
    This page provides further information for handling
-   PXE images built with KIWI and references the following
+   PXE images built with {kiwi} and references the following
    articles:
 
    * :ref:`build_pxe`
 
-To be able to deploy PXE bot images created with KIWI, you need to
+To be able to deploy PXE bot images created with {kiwi}, you need to
 set up a network boot server providing the services DHCP and atftp.
 
 Installing and Configuring atftp

--- a/doc/source/working_with_images/setup_yast_on_first_boot.rst
+++ b/doc/source/working_with_images/setup_yast_on_first_boot.rst
@@ -5,7 +5,7 @@ Setting Up YaST at First Boot
 
 .. sidebar:: Abstract
 
-    This page provides information how to setup the KIWI
+    This page provides information how to setup the {kiwi}
     XML description to start the SUSE YaST system setup
     utility at first boot of the image
 
@@ -17,17 +17,17 @@ To create the profile, run:
 
     yast autoyast
 
-Once the YaST profile exists, update the KIWI XML description
+Once the YaST profile exists, update the {kiwi} XML description
 as follows:
 
-1. Edit the KIWI XML file and add the following package to
+1. Edit the {kiwi} XML file and add the following package to
    the `<packages type="image">` section:
 
    .. code:: xml
 
        <package name="yast2-firstboot"/>
 
-2. Copy the YaST profile file as overlay file to your KIWI image
+2. Copy the YaST profile file as overlay file to your {kiwi} image
    description overlay directory:
 
    .. code:: bash
@@ -38,7 +38,7 @@ as follows:
 
 3. Copy and activate the YaST firstboot template.
    This is done by the following instructions which needs to be written
-   into the KIWI :file:`config.sh` which is stored in the image
+   into the {kiwi} :file:`config.sh` which is stored in the image
    description directory:
 
    .. code:: bash

--- a/doc/source/working_with_images/vmx_setup_for_azure.rst
+++ b/doc/source/working_with_images/vmx_setup_for_azure.rst
@@ -1,12 +1,12 @@
 .. _setup_for_azure:
 
-KIWI Image Description for Microsoft Azure
-==========================================
+Image Description for Microsoft Azure
+=====================================
 
 .. sidebar:: Abstract
 
    This page provides further information for handling
-   vmx images built with KIWI and references the following
+   vmx images built with {kiwi} and references the following
    articles:
 
    * :ref:`vmx`
@@ -19,7 +19,7 @@ cloud framework has to comply the following constraints:
 * Disk size must be set to 30G
 * Kernel parameters must allow for serial console
 
-To meet this requirements update the KIWI image
+To meet this requirements update the {kiwi} image
 description as follows:
 
 1. Software packages

--- a/doc/source/working_with_images/vmx_setup_for_ec2.rst
+++ b/doc/source/working_with_images/vmx_setup_for_ec2.rst
@@ -1,12 +1,12 @@
 .. _setup_for_ec2:
 
-KIWI Image Description for Amazon EC2
-=====================================
+Image Description for Amazon EC2
+================================
 
 .. sidebar:: Abstract
 
    This page provides further information for handling
-   vmx images built with KIWI and references the following
+   vmx images built with {kiwi} and references the following
    articles:
 
    * :ref:`vmx`
@@ -22,7 +22,7 @@ cloud framework has to comply the following constraints:
 * Disk size must be set to 10G
 * Kernel parameters must allow for xen console
 
-To meet this requirements add or update the KIWI image
+To meet this requirements add or update the {kiwi} image
 description as follows:
 
 1. Software packages
@@ -66,7 +66,7 @@ description as follows:
    to customize the system by activating one ore more cloud init
    modules. For Amazon EC2 the following configuration file
    :file:`/etc/cloud/cloud.cfg` needs to be provided as part of the
-   overlay files in your KIWI image description
+   overlay files in your {kiwi} image description
 
    .. code:: yaml
 

--- a/doc/source/working_with_images/vmx_setup_for_google.rst
+++ b/doc/source/working_with_images/vmx_setup_for_google.rst
@@ -1,12 +1,12 @@
 .. _setup_for_gce:
 
-KIWI Image Description for Google Compute Engine
-================================================
+Image Description for Google Compute Engine
+===========================================
 
 .. sidebar:: Abstract
 
    This page provides further information for handling
-   vmx images built with KIWI and references the following
+   vmx images built with {kiwi} and references the following
    articles:
 
    * :ref:`vmx`
@@ -14,12 +14,12 @@ KIWI Image Description for Google Compute Engine
 A virtual disk image which is able to boot in the Google Compute Engine
 cloud framework has to comply the following constraints:
 
-* KIWI type must be an expandable disk
+* {kiwi} type must be an expandable disk
 * Google Compute Engine init must be installed
 * Disk size must be set to 10G
 * Kernel parameters must allow for serial console
 
-To meet this requirements update the KIWI image
+To meet this requirements update the {kiwi} image
 description as follows:
 
 1. Software packages
@@ -40,10 +40,10 @@ description as follows:
 
    To allow the image to be expanded to the configured disk
    geometry of the instance started by Google Compute Engine it is
-   suggested to let KIWI's OEM boot code take over that task. It would
+   suggested to let {kiwi}'s OEM boot code take over that task. It would
    also be possible to try cloud-init's resize module but we found
    conflicts when two cloud init systems, `google-compute-engine-init` and
-   `cloud-init` were used together. Thus for now we stick with KIWI's
+   `cloud-init` were used together. Thus for now we stick with {kiwi}'s
    boot code which can resize the disk from within the initrd before
    the system gets activated through systemd.
 

--- a/doc/source/working_with_images/vmx_setup_for_luks.rst
+++ b/doc/source/working_with_images/vmx_setup_for_luks.rst
@@ -1,7 +1,7 @@
 .. _setup_for_luks:
 
-KIWI Image Description Encrypted Disk
-=====================================
+Image Description Encrypted Disk
+================================
 
 .. sidebar:: Abstract
 
@@ -13,7 +13,7 @@ KIWI Image Description Encrypted Disk
    * :ref:`vmx`
 
 A virtual disk image can be partially or fully encrypted
-using the LUKS extension supported by KIWI. A fully encrypted
+using the LUKS extension supported by {kiwi}. A fully encrypted
 image also includes the data in :file:`/boot` to be encrypted.
 Such an image requests the passphrase for the master key
 to be entered at the bootloader stage. A partialy encrypted
@@ -23,7 +23,7 @@ in the boot process when the root partition gets accessed by
 the systemd mount service. In any case the master passphrase
 is requested only once.
 
-Update the KIWI image description as follows:
+Update the {kiwi} image description as follows:
 
 1. Software packages
 

--- a/doc/source/working_with_images/vmx_vagrant_setup.rst
+++ b/doc/source/working_with_images/vmx_vagrant_setup.rst
@@ -1,12 +1,12 @@
 .. _setup_vagrant:
 
-KIWI Image Description for Vagrant
-==================================
+Image Description for Vagrant
+=============================
 
 .. sidebar:: Abstract
 
    This page provides further information for handling
-   VMX images built with KIWI and references the following
+   VMX images built with {kiwi} and references the following
    article:
 
    * :ref:`vmx`
@@ -21,21 +21,21 @@ To build Vagrant boxes, you can use `Packer <https://www.packer.io>`_ which
 is provided by Hashicorp itself. Packer is based on the official
 installation media (DVDs) as shipped by the distribution vendor.
 
-The KIWI way of building images might be helpful, if such a media does not
+The {kiwi} way of building images might be helpful, if such a media does not
 exist or does not suit your needs. For example, if the distribution is
 still under development or you want to use a collection of your own
-repositories. Note, that in contrast to Packer KIWI only supports the
+repositories. Note, that in contrast to Packer {kiwi} only supports the
 libvirt and VirtualBox providers. Other providers require a different box
-layout that is currently not supported by KIWI.
+layout that is currently not supported by {kiwi}.
 
-In addition, you can use the KIWI image description as source for the
+In addition, you can use the {kiwi} image description as source for the
 `Open Build Service <https://openbuildservice.org>`_ which allows
 building and maintaining boxes.
 
 Vagrant expects boxes to be setup in a specific way (for details refer to
 the `Vagrant box documentation
 <https://www.vagrantup.com/docs/boxes/base.html>`_.), applied to the
-referenced KIWI image description from :ref:`vmx`, the following steps are
+referenced {kiwi} image description from :ref:`vmx`, the following steps are
 required:
 
 1. Update the image type setup
@@ -53,7 +53,7 @@ required:
 
    For the VirtualBox provider, the additional attribute
    ``virtualbox_guest_additions_present`` can be set to ``true`` when the
-   VirtualBox guest additions are installed in the KIWI image:
+   VirtualBox guest additions are installed in the {kiwi} image:
 
    .. code:: xml
 
@@ -94,7 +94,7 @@ required:
 
       <package name="rsync"/>
 
-   Note that KIWI cannot verify whether these packages are installed. If
+   Note that {kiwi} cannot verify whether these packages are installed. If
    they are missing, the resulting Vagrant box will be broken.
 
 4. Add Vagrant user
@@ -136,7 +136,7 @@ required:
    files and ensure that the user ``vagrant`` has write permissions to
    it.
 
-   Note, that the boxes that KIWI produces **require** this folder to
+   Note, that the boxes that {kiwi} produces **require** this folder to
    exist, otherwise Vagrant will not be able to start them properly.
 
 7. Setup and start SSH daemon
@@ -210,11 +210,11 @@ Customizing the embedded Vagrantfile
 
 Vagrant ship with an embedded :file:`Vagrantfile` that carries settings
 specific to this box, for instance the synchronization mechanism for the
-shared folder. KIWI generates such a file automatically for you and it
+shared folder. {kiwi} generates such a file automatically for you and it
 should be sufficient for most use cases.
 
 If a box requires different settings in the embedded :file:`Vagrantfile`,
-then the user can provide KIWI with a path to an alternative via the
+then the user can provide {kiwi} with a path to an alternative via the
 attribute `embebbed_vagrantfile` of the `vagrantconfig` element: it
 specifies a relative path to the :file:`Vagrantfile` that will be included
 in the finished box.

--- a/doc/source/working_with_kiwi.rst
+++ b/doc/source/working_with_kiwi.rst
@@ -1,10 +1,10 @@
-Working with KIWI
-=================
+Concept and Workflow
+====================
 
 .. note:: **Abstract**
 
-   The following sections describe the general workflow of building
-   appliances with KIWI |version|.
+   The following sections describe the concept and general workflow
+   of building appliances with {kiwi} |version|.
 
 .. toctree::
    :maxdepth: 1
@@ -19,7 +19,7 @@ Working with KIWI
 Overview
 --------
 
-KIWI builds so-called *system images* (a fully installed and optionally
+{kiwi} builds so-called *system images* (a fully installed and optionally
 configured system in a single file) of a Linux distribution in two steps (for
 further details, see :ref:`working-with-kiwi-image-building-process`):
 
@@ -31,7 +31,7 @@ further details, see :ref:`working-with-kiwi-image-building-process`):
    into the format required for the final usage (e.g. a ``qcow2`` disk
    image to launch the image with QEMU).
 
-KIWI executes these steps using the following components, which it expects
+{kiwi} executes these steps using the following components, which it expects
 to find in the *description directory*:
 
 #. :file:`config.xml`: :ref:`xml-description`
@@ -42,7 +42,7 @@ to find in the *description directory*:
 
    The filename :file:`config.xml` is not mandatory, the image description
    file can also have an arbitrary name plus the :file:`*.kiwi` extension.
-   KIWI first looks for a :file:`config.xml` file. If it cannot be found,
+   {kiwi} first looks for a :file:`config.xml` file. If it cannot be found,
    it picks the first :file:`*.kiwi` file.
 
 #. :file:`config.sh` and :file:`images.sh`:
@@ -92,7 +92,7 @@ to find in the *description directory*:
 Image Building Process
 ----------------------
 
-KIWI creates images in a two step process: The first step, the *prepare*
+{kiwi} creates images in a two step process: The first step, the *prepare*
 operation, generates a so-called *unpacked image tree* (directory) using
 the information provided in the :file:`config.xml` configuration file
 (see :ref:`xml-description`)
@@ -113,24 +113,24 @@ information provided in the :file:`config.xml` configuration file.
 The Prepare Step
 ^^^^^^^^^^^^^^^^
 
-As the first step, KIWI creates an *unpackaged image tree*, also called "root tree". This
+As the first step, {kiwi} creates an *unpackaged image tree*, also called "root tree". This
 directory will be the installation target for software packages to be
 installed during the image creation process.
 
-For the package installation, KIWI relies on the package manager specified
-in the ``packagemanager`` element in :file:`config.xml`. KIWI supports the
+For the package installation, {kiwi} relies on the package manager specified
+in the ``packagemanager`` element in :file:`config.xml`. {kiwi} supports the
 following package managers: ``dnf``, ``zypper`` (default) and ``apt-get``.
 
 The prepare step consists of the following substeps:
 
 #. **Create Target Root Directory**
 
-   KIWI aborts with an error if the target root tree already exists to
+   {kiwi} aborts with an error if the target root tree already exists to
    avoid accidental deletion of an existing unpacked image.
 
 #. **Install Packages**
 
-   First, KIWI configures the package manager to use the repositories
+   First, {kiwi} configures the package manager to use the repositories
    specified in the configuration file, via the command line, or
    both. After the repository setup, the packages specified in the
    ``bootstrap`` section of the image description are installed in a
@@ -153,7 +153,7 @@ The prepare step consists of the following substeps:
 
 #. **Apply the Overlay Tree**
 
-   Next, KIWI applies all files and directories present in the overlay
+   Next, {kiwi} applies all files and directories present in the overlay
    directory named :file:`root` or in the compressed overlay
    :file:`root.tar.gz` to the target root tree. Files already present in
    the target root directory are overwritten. This allows you to
@@ -189,10 +189,10 @@ The prepare step consists of the following substeps:
    root (:command:`chroot`)" into it, for instance to invoke the package
    manager. Beside the standard file system layout, the unpacked image tree
    contains an additional directory named :file:`/image` that is not
-   present in a regular system. It contains information KIWI requires
+   present in a regular system. It contains information {kiwi} requires
    during the create step, including a copy of the :file:`config.xml` file.
 
-   By default, KIWI will not stop after the *prepare step* and will
+   By default, {kiwi} will not stop after the *prepare step* and will
    directly proceed with the *create step*. Therfore to perform manual
    modifications, proceed as follows:
 
@@ -217,7 +217,7 @@ The prepare step consists of the following substeps:
 The Create Step
 ^^^^^^^^^^^^^^^
 
-KIWI creates the final image during the *create step*: it converts the
+{kiwi} creates the final image during the *create step*: it converts the
 unpacked root tree into one or multiple output files appropriate for the
 respective build type.
 
@@ -226,7 +226,7 @@ root tree, for example, a self installing OEM
 image and a virtual machine image from the same image description. The only
 prerequisite is that both image types are specified in :file:`config.xml`.
 
-During the *create step* the following operations are performed by KIWI:
+During the *create step* the following operations are performed by {kiwi}:
 
 #. **Execute the User-defined Script** :file:`images.sh`
 
@@ -241,5 +241,5 @@ During the *create step* the following operations are performed by KIWI:
 
 #. **Create the Requested Image Type**
 
-   KIWI converts the unpacked root into an output format appropriate for
+   {kiwi} converts the unpacked root into an output format appropriate for
    the requested build type.

--- a/doc/source/working_with_kiwi/customize_the_boot_process.rst
+++ b/doc/source/working_with_kiwi/customize_the_boot_process.rst
@@ -9,15 +9,15 @@ operating system. This boot image is called the :file:`initrd`. The Linux kernel
 loads the :file:`initrd`, a compressed cpio initial RAM disk, into the RAM and
 executes :command:`init` or, if present, :command:`linuxrc`.
 
-Depending on the image type, KIWI creates the boot image automatically during
+Depending on the image type, {kiwi} creates the boot image automatically during
 the ``create`` step. It uses a tool called `dracut` to create this initrd.
 Dracut generated initrd archives can be extended by custom modules to add
 functionality which is not natively provided by dracut itself. In the scope
-of KIWI the following dracut modules are used:
+of {kiwi} the following dracut modules are used:
 
 ``kiwi-dump``
   Serves as an image installer. It provides the
-  required implementation to install a KIWI image on a selectable target.
+  required implementation to install a {kiwi} image on a selectable target.
   This module is required if one of the attributes `installiso`, `installstick`
   or `installpxe` is set to `true` in the image type definition
 
@@ -26,7 +26,7 @@ of KIWI the following dracut modules are used:
   completed.
 
 ``kiwi-live``
-  Boots up a KIWI live image. This module is required
+  Boots up a {kiwi} live image. This module is required
   if the `iso` image type is selected
 
 ``kiwi-overlay``
@@ -50,7 +50,7 @@ of KIWI the following dracut modules are used:
 
 .. note:: Using Custom Boot Image Support
 
-   Apart from the standard dracut based creation of the boot image, KIWI
+   Apart from the standard dracut based creation of the boot image, {kiwi}
    supports the use of custom boot images for the image types ``oem``
    and ``pxe``. The use of a custom boot image is activated by setting the
    following attribute in the image description:
@@ -68,7 +68,7 @@ of KIWI the following dracut modules are used:
       <type ... boot="{exc_netboot}"/>
 
    Such boot descriptions for the OEM and PXE types are currently still
-   provided by the KIWI packages but will be moved into its own repository
+   provided by the {kiwi} packages but will be moved into its own repository
    and package soon.
 
    The custom boot image descriptions allows a user to completely customize
@@ -86,7 +86,7 @@ of services which are documented in the bootup man page at:
 http://man7.org/linux/man-pages/man7/dracut.bootup.7.html
 
 To hook in a custom boot script into this workflow it's required to provide
-a dracut module which is picked up by dracut at the time KIWI calls it.
+a dracut module which is picked up by dracut at the time {kiwi} calls it.
 The module files can be either provided as a package or as part of the
 overlay directory in your image description
 
@@ -144,7 +144,7 @@ right before the system rootfs gets mounted.
            inst_hook pre-mount 30 "${moddir}/my-script.sh"
        }
 
-That's it! At the time KIWI calls dracut the :file:`90my-module` will be taken
+That's it! At the time {kiwi} calls dracut the :file:`90my-module` will be taken
 into account and is installed into the generated initrd. At boot time
 systemd calls the scripts as part of the :file:`dracut-pre-mount.service`.
 
@@ -156,12 +156,12 @@ the `dracut project page <http://people.redhat.com/harald/dracut.html>`_.
 Boot Image Parameters
 .....................
 
-A dracut generated initrd in a KIWI image build process includes one or
-more of the KIWI provided dracut modules. The following list documents
+A dracut generated initrd in a {kiwi} image build process includes one or
+more of the {kiwi} provided dracut modules. The following list documents
 the available kernel boot parameters for this modules:
 
 ``rd.kiwi.debug``
-  Activates the debug log file for the KIWI part of
+  Activates the debug log file for the {kiwi} part of
   the boot process at :file:`/run/initramfs/log/boot.kiwi`.
 
 ``rd.kiwi.install.pxe``

--- a/doc/source/working_with_kiwi/legacy_kiwi.rst
+++ b/doc/source/working_with_kiwi/legacy_kiwi.rst
@@ -1,7 +1,7 @@
 .. _legacy_kiwi:
 
-Legacy KIWI vs. Next Generation
-===============================
+Legacy KIWI vs. {kiwi-product}
+==============================================
 
 .. note:: **Abstract**
 
@@ -10,7 +10,8 @@ Legacy KIWI vs. Next Generation
    maintenance state of the legacy kiwi version and under which
    circumstances the use of the legacy kiwi version is required.
 
-There is still the former `KIWI <https://github.com/OSInside/kiwi-legacy>`__
+There is still the former
+`{kiwi-legacy} <https://github.com/OSInside/kiwi-legacy>`__
 version and we decided to rewrite it.
 
 The reasons to rewrite software from scratch could be very different
@@ -20,7 +21,7 @@ variety of groups with different use cases and requirements. It
 became more and more difficult to handle those requests in good
 quality and without regressions. At some point we asked ourselves:
 
-  `Is KIWI really well prepared for future challenges?`
+  `Is {kiwi-legacy} really well prepared for future challenges?`
 
 The conclusion was that the former version has some major weaknesses
 which has to be addressed prior to continue with future development.
@@ -39,28 +40,28 @@ In order to address all of these the questions came up:
   `How to change/drop features without making anybody unhappy?`
 
 As there is no good way to achieve this in the former code base the
-decision was made to start a rewrite of KIWI with a maintained and
+decision was made to start a rewrite of {kiwi-legacy} with a maintained and
 stable version in the background.
 
-Users will be able to use both versions in parallel. In addition, the
-next generation KIWI will be fully compatible with the current format of
+Users will be able to use both versions in parallel. In addition,
+{kiwi} will be fully compatible with the current format of
 the appliance description. This means, users can build an appliance from
-the same appliance description with the legacy and the next generation
-KIWI, if the distribution and all configured features are supported by
-the used KIWI version.
+the same appliance description with {kiwi-legacy} and
+{kiwi}, if the distribution and all configured features are
+supported by the used version.
 
-This provides an opportunity for users to test the next generation KIWI
+This provides an opportunity for users to test {kiwi}
 with their appliance descriptions without risk. If it builds and works
-as expected, I recommend to switch to the next generation KIWI. If not,
+as expected, I recommend to switch to the {kiwi}. If not,
 please open an issue on https://github.com/OSInside/kiwi.
 
-The legacy KIWI version will be further developed in maintenance mode.
+The {kiwi-legacy} version will be further developed in maintenance mode.
 There won't be any new features added in that code base though.
 Packages will be available at the known place:
-`Legacy KIWI packages <http://download.opensuse.org/repositories/Virtualization:/Appliances>`__
+`{kiwi-legacy} packages <http://download.opensuse.org/repositories/Virtualization:/Appliances>`__
 
-When Do I need to use the legacy kiwi
--------------------------------------
+When Do I need to use {kiwi-legacy}
+-----------------------------------
 
 * If you are building images using one of the features of the dropped
   features list below.
@@ -72,10 +73,10 @@ Dropped Features
 ----------------
 
 The following features have been dropped. If you make use of them
-consider to use the legacy KIWI version.
+consider to use the {kiwi-legacy} version.
 
 Split systems
-  The legacy KIWI version supports building of split systems
+  The {kiwi-legacy} version supports building of split systems
   which uses a static definition of files and directories marked
   as read-only or read-write. Evolving technologies like overlayfs
   makes this feature obsolete.
@@ -112,12 +113,12 @@ OEM Recovery/Restore
   and snapshots for consumer machines are provided as features of the
   distribution. SUSE as an example provides this via Rear
   (Relax-and-Recover) and snapshot based filesystems (btrfs+snapper).
-  Therefore the recovery feature offered in the legacy KIWI version
+  Therefore the recovery feature offered in the {kiwi-legacy} version
   will not be continued.
 
 Partition based install method in OEM install image
   The section :ref:`deployment_methods` describes the supported OEM
-  installation procedures. The legacy KIWI version also provided a method
+  installation procedures. The {kiwi-legacy} version also provided a method
   to install an image based on the partitions of the OEM disk image.
   Instead of selecting one target disk to dump the entire image file to,
   the user selects target partitions. Target partitions could be located
@@ -130,8 +131,8 @@ Partition based install method in OEM install image
 Compatibility
 -------------
 
-The legacy KIWI version can be installed and used together with the next
-generation KIWI.
+The {kiwi-legacy} version can be installed and used together with
+{kiwi}.
 
 .. note:: Automatic Link Creation for :command:`kiwi` Command
 
@@ -141,15 +142,15 @@ generation KIWI.
    already exists on your system, the alternative setup will skip the
    creation of the link target because it already exists.
 
-From an appliance description perspective, both KIWI versions are fully
+From an appliance description perspective, both versions are fully
 compatible. Users can build their appliances with both versions and the
 same appliance description. If the appliance description uses features
-the next generation KIWI does not provide, the build will fail with an
+{kiwi} does not provide, the build will fail with an
 exception early. If the appliance description uses next generation
 features like the selection of the initrd system, it's not possible to
-build that with the legacy KIWI, unless the appliance description
+build that with the {kiwi-legacy}, unless the appliance description
 properly encapsulates the differences into a profile.
 
-The next generation KIWI also provides the `--compat` option and
+{kiwi} also provides the `--compat` option and
 the :command:`kiwicompat` tool to be able to use the same commandline
-as provided with the legacy KIWI version.
+as provided with the {kiwi-legacy} version.

--- a/doc/source/working_with_kiwi/runtime_configuration.rst
+++ b/doc/source/working_with_kiwi/runtime_configuration.rst
@@ -3,12 +3,12 @@
 The Runtime Configuration File
 ------------------------------
 
-KIWI supports an additional configuration file for runtime specific
+{kiwi} supports an additional configuration file for runtime specific
 settings that do not belong into the image description but which are
 persistent and would be unsuitable for command line parameters.
 
 The runtime configuration file must adhere to the `YAML
-<https://yaml.org/>`_ syntax. KIWI searches for the runtime configuration
+<https://yaml.org/>`_ syntax. {kiwi} searches for the runtime configuration
 file in the following locations:
 
 1. :file:`~/.config/kiwi/config.yml`

--- a/doc/source/working_with_kiwi/shell_scripts.rst
+++ b/doc/source/working_with_kiwi/shell_scripts.rst
@@ -11,7 +11,7 @@ User Defined Scripts
    description alone.
 
 
-KIWI supports up to two user defined scripts that it runs in the change
+{kiwi} supports up to two user defined scripts that it runs in the change
 root environment (chroot) containing your new appliance:
 
 1. :file:`config.sh` runs the end of the :ref:`prepare step <prepare-step>`
@@ -24,7 +24,7 @@ root environment (chroot) containing your new appliance:
    built for a specific hardware, unnecessary kernel drivers can be removed
    using this script.
 
-KIWI will execute both scripts via the operating system if their executable
+{kiwi} will execute both scripts via the operating system if their executable
 bit is set (in that case a shebang is mandatory) otherwise they will be
 invoked via the BASH.
 
@@ -33,7 +33,7 @@ invoked via the BASH.
 Image Customization via the ``config.sh`` Shell Script
 ------------------------------------------------------
 
-The KIWI image description allows to have an :file:`config.sh` script in
+The {kiwi} image description allows to have an :file:`config.sh` script in
 place. It can be used for changes appropriate for all images to be created
 from a given unpacked image (:file:`config.sh` runs prior to the *create
 step*). The script should add operating system configuration files which
@@ -44,7 +44,7 @@ for a firstboot workflow, etc.
 The :file:`config.sh` script is called at the end of the :ref:`prepare step
 <prepare-step>` (after users have been set and the *overlay tree directory*
 has been applied). If :file:`config.sh` exits with a non-zero exit code
-then KIWI will report the failure and abort the image creation.
+then {kiwi} will report the failure and abort the image creation.
 
 Find a common template for `config.sh` script below:
 
@@ -74,7 +74,7 @@ Configuration Tips
   Machine ID files are created and set (:file:`/etc/machine-id`,
   :file:`/var/lib/dbus/machine-id`) during the image package installation
   when *systemd* and/or *dbus* are installed. Those UUIDs are intended to
-  be unique and set only once in each deployment. KIWI follows the `systemd
+  be unique and set only once in each deployment. {kiwi} follows the `systemd
   recommendations
   <https://www.freedesktop.org/software/systemd/man/machine-id.html>`_ and
   wipes any :file:`/etc/machine-id` content, leaving it as an empty file.
@@ -119,7 +119,7 @@ Configuration Tips
 Image Customization via the ``images.sh`` Shell Script
 ------------------------------------------------------
 
-The KIWI image description allows to have an optional :file:`images.sh`
+The {kiwi} image description allows to have an optional :file:`images.sh`
 bash script in place. It can be used for changes appropriate for certain
 images/image types on a case-by-case basis (since it runs at beginning of
 :ref:`create step <create-step>`).
@@ -137,7 +137,7 @@ additional packages or configurations then that can be handled in
 changes performed beforehand do not interfere in a negative way if another
 image type is created from the same unpacked image root tree.
 
-If :file:`images.sh` exits with a non-zero exit code, then KIWI will report
+If :file:`images.sh` exits with a non-zero exit code, then {kiwi} will report
 an error and abort the image creation.
 
 See below a common template for :file:`images.sh` script:
@@ -166,10 +166,10 @@ See below a common template for :file:`images.sh` script:
    exit 0
 
 
-Functions and Variables Provided by KIWI
-----------------------------------------
+Functions and Variables Provided by {kiwi}
+-------------------------------------------
 
-KIWI creates the :file:`.kconfig` and :file:`.profile` files to be sourced
+{kiwi} creates the :file:`.kconfig` and :file:`.profile` files to be sourced
 by the shell scripts :file:`config.sh` and :file:`images.sh`.
 :file:`.kconfig` contains various helper functions which can be used to
 simplify the image configuration and :file:`.profile` contains environment
@@ -315,14 +315,14 @@ The following list describes all functions provided by :file:`.kconfig`:
 Functions for Custom non-dracut Based Boot
 ''''''''''''''''''''''''''''''''''''''''''
 
-KIWI also provides the following functions (mostly for compatibility
+{kiwi} also provides the following functions (mostly for compatibility
 reasons) which can be used to customize the boot process when using the
 custom boot option (see
 :ref:`working-with-kiwi-customizing-the-boot-process`):
 
 ``baseStripInitrd``
   Removes various tools binaries and libraries which
-  are not required to boot a SUSE system with KIWI. This function is not
+  are not required to boot a SUSE system with {kiwi}. This function is not
   required when using the dracut initrd system and is kept for
   compatibility reasons.
 
@@ -369,7 +369,7 @@ custom boot option (see
 Profile Environment Variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :file:`.profile` environment file is created by KIWI and contains a
+The :file:`.profile` environment file is created by {kiwi} and contains a
 specific set of variables which are listed below.
 
 ``$kiwi_compressed``

--- a/doc/source/working_with_kiwi/xml_description.rst
+++ b/doc/source/working_with_kiwi/xml_description.rst
@@ -4,7 +4,7 @@ The Image Description
 =====================
 
 The image description is a XML file that defines properties of the
-appliance that will be build by KIWI, for example:
+appliance that will be build by {kiwi}, for example:
 
 - image type (e.g. QEMU disk image, PXE bootable image, Vagrant box, etc.)
 - partition layout
@@ -56,7 +56,7 @@ above example):
 
 - `name`: A name for this image that must not contain spaces or `/`.
 
-- `schemaversion`: The used version of the [KIWI] RNG schema. KIWI will
+- `schemaversion`: The used version of the RNG schema. {kiwi} will
   automatically convert your image description from an older schema
   version to the most recent one (it will perform this only internally and
   won't modify your :file:`config.xml`).
@@ -100,7 +100,7 @@ image:
 
 The `description` element must always contain a `type` attribute. This
 attribute accepts the values `system` or `boot`. The value `boot` is used
-by the KIWI developers and is not relevant for the end user, thus `type`
+by the {kiwi} developers and is not relevant for the end user, thus `type`
 should be always set to `system`.
 
 `description` allows the following optional children:
@@ -128,7 +128,7 @@ in the section :ref:`build-types`.
 Build Types
 -----------
 
-A build type defines the type of an appliance that is produced by KIWI, for
+A build type defines the type of an appliance that is produced by {kiwi}, for
 instance, a live ISO image or a virtual machine disk.
 
 For example, a live ISO image is specified as follows:
@@ -181,10 +181,10 @@ a virtual machine disk of the same appliance:
    </image>
 
 Note the additional attribute `primary` in the Live ISO image build
-type. KIWI will by default build the image which `primary` attribute is set
+type. {kiwi} will by default build the image which `primary` attribute is set
 to `true`.
 
-KIWI supports the following values for the `image` attribute (further
+{kiwi} supports the following values for the `image` attribute (further
 attributes of the `type` element are documented inside the referenced
 sections):
 
@@ -197,7 +197,7 @@ sections):
 
 - `docker`, `oci`: container images, see :ref:`building-docker-build`
 
-- `btrfs`, `ext2`, `ext3`, `ext4`, `xfs`: KIWI will convert the
+- `btrfs`, `ext2`, `ext3`, `ext4`, `xfs`: {kiwi} will convert the
   image into a mountable filesystem of the specified type.
 
 - `squashfs`, `clicfs`: creates the image as a filesystem that can be used
@@ -219,7 +219,7 @@ above, `oemconfig` is a subelement of `<type image="oem" ...>`):
 
 - `pxedeploy`: settings for PXE booting, see :ref:`build_pxe`
 
-- `vagrantconfig`: instructs KIWI to build a Vagrant box instead of a
+- `vagrantconfig`: instructs {kiwi} to build a Vagrant box instead of a
   standard virtual machine image, see :ref:`setup_vagrant`
 
 - `systemdisk`: used to define LVM or Btrfs (sub)volumens, see
@@ -252,18 +252,18 @@ build types and will be covered here:
   makes sense to set this value to `0` for images intended to be started
   non-interactively (e.g. virtual machines).
 
-- `bootpartition`: Boolean parameter notifying KIWI whether an extra boot
+- `bootpartition`: Boolean parameter notifying {kiwi} whether an extra boot
   partition should be used or not (the default depends on the current
-  layout). This will override KIWI's default layout.
+  layout). This will override {kiwi}'s default layout.
 
 - `btrfs_quota_groups`: Boolean parameter to activate filesystem quotas if
   the filesystem is `btrfs`. By default quotas are inactive.
 
-- `btrfs_root_is_snapshot`: Boolean parameter that tells KIWI to install
+- `btrfs_root_is_snapshot`: Boolean parameter that tells {kiwi} to install
   the system into a btrfs snapshot. The snapshot layout is compatible with
   snapper. By default snapshots are turned off.
 
-- `btrfs_root_is_readonly_snapshot`: Boolean parameter notifying KIWI that
+- `btrfs_root_is_readonly_snapshot`: Boolean parameter notifying {kiwi} that
   the btrfs root filesystem snapshot has to made read-only. if this option
   is set to true, the root filesystem snapshot it will be turned into
   read-only mode, once all data has been placed to it. The option is only
@@ -304,7 +304,7 @@ build types and will be covered here:
   :file:`/etc/fstab`.
 
 - `fscreateoptions`: Specifies the filesystem options used to create the
-  filesystem. In KIWI the filesystem utility to create a filesystem is
+  filesystem. In {kiwi} the filesystem utility to create a filesystem is
   called without any custom options. The default options are filesystem
   specific and are provided along with the package that provides the
   filesystem utility. For the Linux `ext[234]` filesystem, the default
@@ -314,7 +314,7 @@ build types and will be covered here:
   :command:`man mke2fs`. With the `fscreateoptions` attribute it's possible
   to directly influence how the filesystem will be created. The options
   provided as a string are passed to the command that creates the
-  filesystem without any further validation by KIWI. For example, to turn
+  filesystem without any further validation by {kiwi}. For example, to turn
   off the journal on creation of an ext4 filesystem the following option
   would be required:
 
@@ -330,7 +330,7 @@ build types and will be covered here:
   password. Note that the password must be entered when booting the
   appliance!
 
-- `primary`: Boolean option, KIWI will by default build the image which
+- `primary`: Boolean option, {kiwi} will by default build the image which
   `primary` attribute is set to `true`.
 
 - `target_blocksize`: Specifies the image blocksize in bytes which has to
@@ -357,7 +357,7 @@ remaining child-elements of `preferences`:
 - `packagemanager`: Specify the package manager that will be used to download
   and install the packages for your appliance. Currently the following package
   managers are supported: ``apt-get``, ``zypper`` and ``dnf``. Note that the
-  package manager must be installed on the system **calling** KIWI, it is
+  package manager must be installed on the system **calling** {kiwi}, it is
   **not** sufficient to install it inside the appliance.
 
 - `locale`: Specify the locale that the resulting appliance will use.
@@ -419,11 +419,11 @@ attribute `image`.
 
 In certain cases this is undesirable, for instance when building multiple
 very similar virtual machine disks. Then one would have to duplicate the
-whole :file:`config.xml` for each virtual machine. KIWI supports *profiles*
+whole :file:`config.xml` for each virtual machine. {kiwi} supports *profiles*
 to work around this issue.
 
 A *profile* is a namespace for additional settings that can be applied by
-KIWI on top of the default settings (or other profiles), thereby allowing
+{kiwi} on top of the default settings (or other profiles), thereby allowing
 to build multiple appliances with the same build type but with different
 configurations.
 
@@ -455,10 +455,10 @@ format).
 Each profile is declared via the element `profile`, which itself must be a
 child of `profiles` and must contain the `name` and `description`
 attributes. The `description` is only present for documentation purposes,
-`name` on the other hand is used to instruct KIWI which profile to build
+`name` on the other hand is used to instruct {kiwi} which profile to build
 via the command line. Additionally, one can provide the boolean attribute
 `import`, which defines whether this profile should be used by default when
-KIWI is invoked via the command line.
+{kiwi} is invoked via the command line.
 
 A profile inherits the default settings which do not belong to any
 profile. It applies only to elements that contain the profile in their
@@ -487,7 +487,7 @@ Profiles can furthermore inherit settings from another profile via the
 The profile `QEMU` would inherit the settings from `VM` in the above
 example.
 
-We cover the usage of *profiles* when invoking KIWI and when building in
+We cover the usage of *profiles* when invoking {kiwi} and when building in
 the Open Build Service in :ref:`building-build-with-profiles`.
 
 .. _adding-users:
@@ -588,16 +588,16 @@ Defining Repositories and Adding or Removing Packages
 =====================================================
 
 A crucial part of each appliance is the package and repository
-selection. KIWI allows the end user to completely customize the selection
+selection. {kiwi} allows the end user to completely customize the selection
 of repositories and packages via the `repository` and `packages` elements.
 
 
 Adding repositories
 -------------------
 
-KIWI installs packages into your appliance from the repositories defined in
+{kiwi} installs packages into your appliance from the repositories defined in
 the image description. Therefore at least one repository **must** be
-defined, as KIWI will otherwise not be able to fetch any packages.
+defined, as {kiwi} will otherwise not be able to fetch any packages.
 
 A repository is added to the description via the `repository` element,
 which is a child of the top-level `image` element:
@@ -616,7 +616,7 @@ which is a child of the top-level `image` element:
 
 In the above snippet we defined two repositories:
 
-1. The repository belonging to the KIWI project:
+1. The repository belonging to the {kiwi} project:
    *{exc_kiwi_repo}* at the Open Build Service (OBS)
 
 2. The RPM repository belonging to the OS project:
@@ -645,7 +645,7 @@ following optional attributes:
 
 - `alias`: Name to be used for this repository, it will appear as the
   repository's name in the image, which is visible via ``zypper repos`` or
-  ``dnf repolist``. KIWI will construct an alias from the path in the
+  ``dnf repolist``. {kiwi} will construct an alias from the path in the
   `source` child element (replacing each `/` with a `_`), if no value is
   given.
 
@@ -670,7 +670,7 @@ Supported repository paths
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The actual location of a repository is specified in the `source` child
-element of `repository` via its only attribute `path`. KIWI supports the
+element of `repository` via its only attribute `path`. {kiwi} supports the
 following paths types:
 
 - `http://URL` or `https://URL` or `ftp://URL`: a URL to the repository
@@ -678,7 +678,7 @@ following paths types:
 
 - `obs://$PROJECT/$REPOSITORY`: evaluates to the repository `$REPOSITORY`
   of the project `$PROJECT` available on the Open Build Service (OBS). By
-  default KIWI will look for projects on `build.opensuse.org
+  default {kiwi} will look for projects on `build.opensuse.org
   <https://build.opensuse.org>`_, but this can be overridden using the
   runtime configuration file (see :ref:`runtime_config`).
   Note that it is not possible to add repositories using the `obs://` path
@@ -687,7 +687,7 @@ following paths types:
 
 - `obsrepositories:/`: special path only available for builds using the
   Open Build Service. The repositories configured for the OBS project in
-  which the KIWI image resides will be available inside the appliance. This
+  which the {kiwi} image resides will be available inside the appliance. This
   allows you to configure the repositories of your image from OBS itself
   and not having to modify the image description.
 
@@ -696,7 +696,7 @@ following paths types:
   appliance.
 
 - `iso:///path/to/image.iso`: the specified ISO image will be mounted
-  during the build of the KIWI image and a repository will be created
+  during the build of the {kiwi} image and a repository will be created
   pointing to the mounted ISO.
 
 
@@ -726,7 +726,7 @@ removed via individual `package` child elements:
    </image>
 
 The `packages` element provides a collection of different child elements
-that instruct KIWI when and how to perform package installation or
+that instruct {kiwi} when and how to perform package installation or
 removal. Each `packages` element acts as a group, whose behavior can be
 configured via the following attributes:
 
@@ -743,7 +743,7 @@ configured via the following attributes:
   image, for details see :ref:`uninstall-system-packages`.
 
   And packages which belong to a build type are only installed when that
-  specific build type is currently processed by KIWI.
+  specific build type is currently processed by {kiwi}.
 
 - `profiles`: a list of profiles to which this package selection applies
   (see :ref:`image-profiles`).
@@ -792,11 +792,11 @@ capability (e.g. `Provides: /usr/bin/my-binary`) via:
 
 Whether this works depends on the package manager and on the environment
 that is being used. In the Open Build Service, certain `Provides` either
-are not visible or cannot be properly extracted from the KIWI
+are not visible or cannot be properly extracted from the {kiwi}
 description. Therefore, relying on `Provides` is not recommended.
 
 Packages can also be included only on specific architectures via the `arch`
-attribute. KIWI compares the `arch` attributes value with the output of
+attribute. {kiwi} compares the `arch` attributes value with the output of
 `uname -m`.
 
 .. code:: xml
@@ -820,9 +820,9 @@ The `archive` element
 ^^^^^^^^^^^^^^^^^^^^^
 
 It is sometimes necessary to include additional packages into the image
-which are not available in the package manager's native format. KIWI
+which are not available in the package manager's native format. {kiwi}
 supports the inclusion of ordinary archives via the `archive` element,
-whose `name` attribute specifies the filename of the archive (KIWI looks
+whose `name` attribute specifies the filename of the archive ({kiwi} looks
 for the archive in the image description folder).
 
 .. code:: xml
@@ -832,7 +832,7 @@ for the archive in the image description folder).
        <archive name="custom-program2.tar"/>
    </packages>
 
-KIWI will extract the archive into the root directory of the image using
+{kiwi} will extract the archive into the root directory of the image using
 `GNU tar <https://www.gnu.org/software/tar/>`_, thus only archives
 supported by it can be included. When multiple `archive` elements are
 specified then they will be applied in a top to bottom order. If a file is
@@ -844,7 +844,7 @@ it (same as with the image overlay).
 Uninstall System Packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-KIWI supports two different methods how packages can be removed from the
+{kiwi} supports two different methods how packages can be removed from the
 appliance:
 
 1. Packages present as a child element of `<packages type="uninstall">`
@@ -930,7 +930,7 @@ connection.
 The `product` and `namedCollection` element
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-KIWI supports the inclusion of openSUSE products or of namedCollections
+{kiwi} supports the inclusion of openSUSE products or of namedCollections
 (*patterns* in SUSE based distributions or *groups* for RedHat based
 distributions). These can be added via the `product` and `namedCollection`
 child elements, which both take the mandatory `name` attribute and the


### PR DESCRIPTION
There is the legacy kiwi version and there is this kiwi(next generation).
From a documentation perspective there are several inconsistencies that
could confuse users. This commit makes the name for KIWI-NG consistent
across the entire documentation. At places where we point to older
documentation we use the term Legacy KIWI and a link to the documentation
that covers this part. All this is needed in preparation to cleanup the
documentation situation for the SUSE documentation but with respect to
the upstream doc sources, their layout and markup.

