### PR TITLE
Use GPT table for Power ofw firmware

### DIFF
--- a/kiwi/firmware.py
+++ b/kiwi/firmware.py
@@ -70,10 +70,7 @@ class FirmWare:
             else:
                 return 'msdos'
         elif 'ppc64' in self.arch:
-            if self.opal_mode():
-                return 'gpt'
-            else:
-                return 'msdos'
+            return 'gpt'
         elif self.efi_mode():
             default_efi_table = Defaults.get_default_efi_partition_table_type()
             return self.efi_partition_table or default_efi_table

--- a/kiwi/partitioner/gpt.py
+++ b/kiwi/partitioner/gpt.py
@@ -45,7 +45,8 @@ class PartitionerGpt(PartitionerBase):
             't.swap': '8200',
             't.lvm': '8E00',
             't.raid': 'FD00',
-            't.efi': 'EF00'
+            't.efi': 'EF00',
+            't.prep': '4100'
         }
 
     def create(self, name, mbsize, type_name, flags=None):

--- a/test/unit/firmware_test.py
+++ b/test/unit/firmware_test.py
@@ -70,7 +70,7 @@ class TestFirmWare:
         assert self.firmware_s390_scsi.get_partition_table_type() == 'msdos'
 
     def test_get_partition_table_type_ppc_ofw_mode(self):
-        assert self.firmware_ofw.get_partition_table_type() == 'msdos'
+        assert self.firmware_ofw.get_partition_table_type() == 'gpt'
 
     def test_get_partition_table_type_ppc_opal_mode(self):
         assert self.firmware_opal.get_partition_table_type() == 'gpt'
@@ -97,9 +97,11 @@ class TestFirmWare:
 
     def test_ofw_mode(self):
         assert self.firmware_ofw.ofw_mode() is True
+        assert self.firmware_bios.ofw_mode() is False
 
     def test_opal_mode(self):
         assert self.firmware_opal.opal_mode() is True
+        assert self.firmware_bios.opal_mode() is False
 
     def test_get_legacy_bios_partition_size(self):
         assert self.firmware_bios.get_legacy_bios_partition_size() == 0


### PR DESCRIPTION
GPT partition table should be preferred for power systems these days

