### PR TITLE
Enhance OEM ppc integration test for 4k/512b disks

### DIFF
--- a/build-tests/ppc/suse/test-image-oem/appliance.kiwi
+++ b/build-tests/ppc/suse/test-image-oem/appliance.kiwi
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-Profiles: @BUILD_FLAVOR@ -->
+
 <image schemaversion="7.1" name="OEM-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
         <specification>oem disk test build</specification>
     </description>
+    <profiles>
+        <profile name="PhysicalBSZ_4096" description="Image for physical 4k storage disk"/>
+        <profile name="PhysicalBSZ_512" description="Image for 512byte storage disk"/>
+    </profiles>
     <preferences>
         <version>1.15.1</version>
         <packagemanager>zypper</packagemanager>
@@ -16,7 +22,12 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
+    </preferences>
+    <preferences profiles="PhysicalBSZ_4096">
         <type image="oem" filesystem="ext4" initrd_system="dracut" bootloader="grub2" bootloader_console="serial" kernelcmdline="console=ttyS0 splash" firmware="ofw" installiso="true" installboot="install" target_blocksize="4096"/>
+    </preferences>
+    <preferences profiles="PhysicalBSZ_512">
+        <type image="oem" filesystem="ext4" initrd_system="dracut" bootloader="grub2" bootloader_console="serial" kernelcmdline="console=ttyS0 splash" firmware="ofw" installiso="true" installboot="install"/>
     </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>


### PR DESCRIPTION
Add profile section to build one image for storage disks with
4k physical blocksize and one image for disks using 512byte
blocksize. Related to Issue #1325

