### PR TITLE
Make squashfs compression configurable

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -435,7 +435,11 @@ class DiskBuilder:
         if self.root_filesystem_is_overlay:
             squashed_root_file = NamedTemporaryFile()
             squashed_root = FileSystemSquashFs(
-                device_provider=None, root_dir=self.root_dir
+                device_provider=None, root_dir=self.root_dir,
+                custom_args={
+                    'compression':
+                        self.xml_state.build_type.get_squashfscompression()
+                }
             )
             squashed_root.create_on_file(
                 filename=squashed_root_file.name,
@@ -748,7 +752,11 @@ class DiskBuilder:
             log.info('--> creating readonly root partition')
             squashed_root_file = NamedTemporaryFile()
             squashed_root = FileSystemSquashFs(
-                device_provider=None, root_dir=self.root_dir
+                device_provider=None, root_dir=self.root_dir,
+                custom_args={
+                    'compression':
+                        self.xml_state.build_type.get_squashfscompression()
+                }
             )
             squashed_root.create_on_file(
                 filename=squashed_root_file.name,

--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -75,6 +75,10 @@ class FileSystemBuilder:
             'mount_options': xml_state.get_fs_mount_option_list(),
             'create_options': xml_state.get_fs_create_option_list()
         }
+        if self.requested_filesystem == 'squashfs':
+            self.filesystem_custom_parameters['compression'] = \
+                xml_state.build_type.get_squashfscompression()
+
         self.system_setup = SystemSetup(
             xml_state=xml_state, root_dir=self.root_dir
         )

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -181,7 +181,8 @@ class InstallImageBuilder:
             device_provider=None,
             root_dir=self.squashed_contents,
             custom_args={
-                'create_options': self.xml_state.get_fs_create_option_list()
+                'compression':
+                    self.xml_state.build_type.get_squashfscompression()
             }
         )
         squashed_image.create_on_file(squashed_image_file)

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -254,7 +254,11 @@ class LiveImageBuilder:
         live_container_image = FileSystem(
             name='squashfs',
             device_provider=None,
-            root_dir=self.live_container_dir
+            root_dir=self.live_container_dir,
+            custom_args={
+                'compression':
+                    self.xml_state.build_type.get_squashfscompression()
+            }
         )
         container_image = NamedTemporaryFile()
         live_container_image.create_on_file(

--- a/kiwi/filesystem/squashfs.py
+++ b/kiwi/filesystem/squashfs.py
@@ -37,19 +37,28 @@ class FileSystemSquashFs(FileSystemBase):
         :param list exclude: list of exclude dirs/files
         """
         exclude_options = []
+        compression = self.custom_args.get('compression')
+        if compression is None or compression == 'xz':
+            if '-comp' not in self.custom_args['create_options']:
+                self.custom_args['create_options'].append('-comp')
+                self.custom_args['create_options'].append('xz')
 
-        if '-comp' not in self.custom_args['create_options']:
-            self.custom_args['create_options'].append('-comp')
-            self.custom_args['create_options'].append('xz')
-
-        if '-Xbcj' not in self.custom_args['create_options']:
-            host_architecture = platform.machine()
-            if '86' in host_architecture:
-                self.custom_args['create_options'].append('-Xbcj')
-                self.custom_args['create_options'].append('x86')
-            if 'ppc' in host_architecture:
-                self.custom_args['create_options'].append('-Xbcj')
-                self.custom_args['create_options'].append('powerpc')
+            if '-Xbcj' not in self.custom_args['create_options']:
+                host_architecture = platform.machine()
+                if '86' in host_architecture:
+                    self.custom_args['create_options'].append('-Xbcj')
+                    self.custom_args['create_options'].append('x86')
+                if 'ppc' in host_architecture:
+                    self.custom_args['create_options'].append('-Xbcj')
+                    self.custom_args['create_options'].append('powerpc')
+        elif compression != 'uncompressed':
+            if '-comp' not in self.custom_args['create_options']:
+                self.custom_args['create_options'].append('-comp')
+                self.custom_args['create_options'].append(compression)
+        else:
+            for flag in ['-noI', '-noD', '-noF', '-noX']:
+                if flag not in self.custom_args['create_options']:
+                    self.custom_args['create_options'].append(flag)
 
         if exclude:
             exclude_options.extend(['-wildcards', '-e'])

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1388,6 +1388,15 @@ div {
             sch:param [ name = "attr" value = "filesystem" ]
             sch:param [ name = "types" value = "vmx oem pxe" ]
         ]
+	k.type.squashfscompression.attribute = 
+        ## Specifies the compression type for mksquashfs
+        attribute squashfscompression {
+            "uncompressed" | "gzip" | "lzo" | "lz4" | "xz" | "zstd"
+        }
+        >> sch:pattern [ id = "squashfscompression" is-a = "image_type"
+            sch:param [ name = "attr" value = "squashfscompression" ]
+            sch:param [ name = "types" value = "vmx oem pxe iso" ]
+        ]
     k.type.overlayroot.attribute =
         ## Specifies to use an overlay root system consisting
         ## out of a squashfs compressed read-only root system
@@ -1747,6 +1756,7 @@ div {
         k.type.formatoptions.attribute? &
         k.type.fsmountoptions.attribute? &
         k.type.fscreateoptions.attribute? &
+        k.type.squashfscompression.attribute? &
         k.type.gcelicense.attribute? &
         k.type.hybridpersistent.attribute? &
         k.type.hybridpersistent_filesystem.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2078,6 +2078,23 @@ structure</a:documentation>
         <sch:param name="types" value="vmx oem pxe"/>
       </sch:pattern>
     </define>
+    <define name="k.type.squashfscompression.attribute">
+      <attribute name="squashfscompression">
+        <a:documentation>Specifies the compression type for mksquashfs</a:documentation>
+        <choice>
+          <value>uncompressed</value>
+          <value>gzip</value>
+          <value>lzo</value>
+          <value>lz4</value>
+          <value>xz</value>
+          <value>zstd</value>
+        </choice>
+      </attribute>
+      <sch:pattern id="squashfscompression" is-a="image_type">
+        <sch:param name="attr" value="squashfscompression"/>
+        <sch:param name="types" value="vmx oem pxe iso"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.overlayroot.attribute">
       <attribute name="overlayroot">
         <a:documentation>Specifies to use an overlay root system consisting
@@ -2625,6 +2642,9 @@ default.</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.fscreateoptions.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.squashfscompression.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.gcelicense.attribute"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.29.24.
-# Python 3.6.9 (default, Oct 29 2019, 10:39:36) [GCC]
+# Python 3.6.10 (default, Jan 16 2020, 09:12:04) [GCC]
 #
 # Command line options:
 #   ('-f', '')
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/ms/Project/kiwi/.tox/3.6/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/david/work/kiwi/.env3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -2566,7 +2566,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, boottimeout=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, boottimeout=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2594,6 +2594,7 @@ class type_(GeneratedsSuper):
         self.formatoptions = _cast(None, formatoptions)
         self.fsmountoptions = _cast(None, fsmountoptions)
         self.fscreateoptions = _cast(None, fscreateoptions)
+        self.squashfscompression = _cast(None, squashfscompression)
         self.gcelicense = _cast(None, gcelicense)
         self.hybridpersistent = _cast(bool, hybridpersistent)
         self.hybridpersistent_filesystem = _cast(None, hybridpersistent_filesystem)
@@ -2748,6 +2749,8 @@ class type_(GeneratedsSuper):
     def set_fsmountoptions(self, fsmountoptions): self.fsmountoptions = fsmountoptions
     def get_fscreateoptions(self): return self.fscreateoptions
     def set_fscreateoptions(self, fscreateoptions): self.fscreateoptions = fscreateoptions
+    def get_squashfscompression(self): return self.squashfscompression
+    def set_squashfscompression(self, squashfscompression): self.squashfscompression = squashfscompression
     def get_gcelicense(self): return self.gcelicense
     def set_gcelicense(self, gcelicense): self.gcelicense = gcelicense
     def get_hybridpersistent(self): return self.hybridpersistent
@@ -2969,6 +2972,9 @@ class type_(GeneratedsSuper):
         if self.fscreateoptions is not None and 'fscreateoptions' not in already_processed:
             already_processed.add('fscreateoptions')
             outfile.write(' fscreateoptions=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.fscreateoptions), input_name='fscreateoptions')), ))
+        if self.squashfscompression is not None and 'squashfscompression' not in already_processed:
+            already_processed.add('squashfscompression')
+            outfile.write(' squashfscompression=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.squashfscompression), input_name='squashfscompression')), ))
         if self.gcelicense is not None and 'gcelicense' not in already_processed:
             already_processed.add('gcelicense')
             outfile.write(' gcelicense=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.gcelicense), input_name='gcelicense')), ))
@@ -3260,6 +3266,11 @@ class type_(GeneratedsSuper):
         if value is not None and 'fscreateoptions' not in already_processed:
             already_processed.add('fscreateoptions')
             self.fscreateoptions = value
+        value = find_attr_value_('squashfscompression', node)
+        if value is not None and 'squashfscompression' not in already_processed:
+            already_processed.add('squashfscompression')
+            self.squashfscompression = value
+            self.squashfscompression = ' '.join(self.squashfscompression.split())
         value = find_attr_value_('gcelicense', node)
         if value is not None and 'gcelicense' not in already_processed:
             already_processed.add('gcelicense')

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -539,8 +539,13 @@ class TestDiskBuilder:
             self.disk_builder.create_disk()
 
         assert mock_squashfs.call_args_list == [
-            call(device_provider=None, root_dir='root_dir'),
-            call(device_provider=None, root_dir='root_dir')
+            call(
+                custom_args={'compression': None},
+                device_provider=None, root_dir='root_dir'
+            ), call(
+                custom_args={'compression': None},
+                device_provider=None, root_dir='root_dir'
+            )
         ]
         assert squashfs.create_on_file.call_args_list == [
             call(exclude=['var/cache/kiwi'], filename='tempname'),

--- a/test/unit/builder/filesystem_test.py
+++ b/test/unit/builder/filesystem_test.py
@@ -51,6 +51,10 @@ class TestFileSystemBuilder:
             return_value=4096
         )
 
+        self.xml_state.build_type.get_squashfscompression = Mock(
+            return_value='gzip'
+        )
+
         self.fs_setup = Mock()
         self.fs_setup.get_size_mbytes = Mock(
             return_value=42
@@ -139,7 +143,8 @@ class TestFileSystemBuilder:
         mock_fs.assert_called_once_with(
             'squashfs', provider, 'root_dir', {
                 'mount_options': ['async'],
-                'create_options': ['-O', 'option']
+                'create_options': ['-O', 'option'],
+                'compression': 'gzip'
             }
         )
         self.filesystem.create_on_file.assert_called_once_with(

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -150,6 +150,10 @@ class TestInstallImageBuilder:
             call('IMAGE="result-image.raw"\n'),
             call('IMAGE="result-image.raw"\n')
         ]
+        kiwi.builder.install.FileSystemSquashFs.assert_called_once_with(
+            custom_args={'compression': mock.ANY},
+            device_provider=None, root_dir='temp-squashfs'
+        )
         self.squashed_image.create_on_file.assert_called_once_with(
             'target_dir/result-image.raw.squashfs'
         )

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -86,6 +86,9 @@ class TestLiveImageBuilder:
         self.xml_state.build_type.get_flags = mock.Mock(
             return_value=None
         )
+        self.xml_state.build_type.get_squashfscompression = mock.Mock(
+            return_value='lzo'
+        )
         self.xml_state.get_image_version = mock.Mock(
             return_value='1.2.3'
         )
@@ -187,7 +190,8 @@ class TestLiveImageBuilder:
             ),
             call(
                 device_provider=None, name='squashfs',
-                root_dir='temp-squashfs'
+                root_dir='temp-squashfs',
+                custom_args={'compression': 'lzo'}
             )
         ]
 

--- a/test/unit/filesystem/squashfs_test.py
+++ b/test/unit/filesystem/squashfs_test.py
@@ -46,3 +46,29 @@ class TestFileSystemSquashfs:
                 '-noappend', '-b', '1M', '-comp', 'xz'
             ]
         )
+
+    @patch('kiwi.filesystem.squashfs.Command.run')
+    def test_create_on_file_gzip(self, mock_command):
+        self.squashfs.custom_args = {
+            'compression': 'gzip', 'create_options': []
+        }
+        self.squashfs.create_on_file('myimage', 'label')
+        mock_command.assert_called_once_with(
+            [
+                'mksquashfs', 'root_dir', 'myimage',
+                '-noappend', '-b', '1M', '-comp', 'gzip'
+            ]
+        )
+
+    @patch('kiwi.filesystem.squashfs.Command.run')
+    def test_create_on_file_no_compression(self, mock_command):
+        self.squashfs.custom_args = {
+            'compression': 'uncompressed', 'create_options': []
+        }
+        self.squashfs.create_on_file('myimage', 'label')
+        mock_command.assert_called_once_with(
+            [
+                'mksquashfs', 'root_dir', 'myimage', '-noappend',
+                '-b', '1M', '-noI', '-noD', '-noF', '-noX'
+            ]
+        )


### PR DESCRIPTION
This commit adds the `squashfscompression` attribute in type element. It
can take `gzip`, `xz`, `lzo`, `lz4` or `none`. The default is `xz`.

Fixes #1315
