### PR TITLE
Fixed handling of fillup templates

### DIFF
--- a/kiwi/system/root_init.py
+++ b/kiwi/system/root_init.py
@@ -23,7 +23,6 @@ import os
 
 # project
 from kiwi.utils.sync import DataSync
-from kiwi.command import Command
 from kiwi.path import Path
 from kiwi.defaults import Defaults
 
@@ -63,8 +62,8 @@ class RootInit:
         for the purpose of building a system image from it. This
         includes the following setup:
 
-        * create static core device nodes
         * create core system paths
+        * create static core device nodes
 
         On success the contents of the temporary location are
         synced to the specified root_dir and the temporary location
@@ -79,7 +78,6 @@ class RootInit:
         try:
             self._create_base_directories(root)
             self._create_base_links(root)
-            self._setup_config_templates(root)
             data = DataSync(root + '/', self.root_dir)
             data.sync_data(
                 options=['-a', '--ignore-existing']
@@ -95,17 +93,6 @@ class RootInit:
             )
         finally:
             rmtree(root, ignore_errors=True)
-
-    def _setup_config_templates(self, root):
-        group_template = '/var/adm/fillup-templates/group.aaa_base'
-        passwd_template = '/var/adm/fillup-templates/passwd.aaa_base'
-        proxy_template = '/var/adm/fillup-templates/sysconfig.proxy'
-        if os.path.exists(group_template):
-            Command.run(['cp', group_template, root + '/etc/group'])
-        if os.path.exists(passwd_template):
-            Command.run(['cp', passwd_template, root + '/etc/passwd'])
-        if os.path.exists(proxy_template):
-            Command.run(['cp', proxy_template, root + '/etc/sysconfig/proxy'])
 
     def _create_base_directories(self, root):
         """

--- a/test/unit/system/root_init_test.py
+++ b/test/unit/system/root_init_test.py
@@ -28,9 +28,9 @@ class TestRootInit:
     @patch('shutil.rmtree')
     @patch('kiwi.system.root_init.DataSync')
     @patch('kiwi.system.root_init.mkdtemp')
-    @patch('kiwi.system.root_init.Command.run')
+    @patch('kiwi.system.root_init.Path.create')
     def test_create_raises_error(
-        self, mock_command, mock_temp, mock_data_sync, mock_rmtree,
+        self, mock_Path_create, mock_temp, mock_data_sync, mock_rmtree,
         mock_symlink, mock_chwon, mock_makedirs, mock_path
     ):
         mock_path.return_value = False
@@ -50,17 +50,19 @@ class TestRootInit:
     @patch('kiwi.system.root_init.rmtree')
     @patch('kiwi.system.root_init.DataSync')
     @patch('kiwi.system.root_init.mkdtemp')
-    @patch('kiwi.system.root_init.Command.run')
+    @patch('kiwi.system.root_init.Path.create')
     def test_create(
-        self, mock_command, mock_temp, mock_data_sync, mock_rmtree, mock_copy,
-        mock_create, mock_makedev, mock_symlink, mock_chwon, mock_makedirs,
+        self, mock_Path_create, mock_temp, mock_data_sync,
+        mock_rmtree, mock_copy, mock_create, mock_makedev,
+        mock_symlink, mock_chwon, mock_makedirs,
         mock_path
     ):
         data_sync = Mock()
         mock_data_sync.return_value = data_sync
         mock_makedev.return_value = 'makedev'
         mock_path_return = [
-            True, True, True, True, False, False, False, False, False, False, False
+            True, True, True, True, False, False,
+            False, False, False, False, False
         ]
 
         def path_exists(self):
@@ -96,23 +98,6 @@ class TestRootInit:
             call('fd/0', 'tmpdir/dev/stdin'),
             call('fd/1', 'tmpdir/dev/stdout'),
             call('/run', 'tmpdir/var/run')
-        ]
-        assert mock_command.call_args_list == [
-            call([
-                'cp',
-                '/var/adm/fillup-templates/group.aaa_base',
-                'tmpdir/etc/group'
-            ]),
-            call([
-                'cp',
-                '/var/adm/fillup-templates/passwd.aaa_base',
-                'tmpdir/etc/passwd'
-            ]),
-            call([
-                'cp',
-                '/var/adm/fillup-templates/sysconfig.proxy',
-                'tmpdir/etc/sysconfig/proxy'
-            ])
         ]
         mock_data_sync.assert_called_once_with(
             'tmpdir/', 'root_dir'


### PR DESCRIPTION
Systems using a template tool to generate config files
might not be effective when they see the intermediate
config files we need from the host to let certain package
managers work correctly. Therefore the cleanup code in
kiwi takes care to restore from an optionally existing
template file if no other custom variant is present.
This Fixes bsc#1163978


