### PR TITLE
Refactor plugin architecture

### DIFF
--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -11,6 +11,7 @@ Contributing
    :maxdepth: 1
 
    development/kiwi_from_python
+   development/kiwi_plugin_architecture
    development/schema_extensions.rst
 
 The Basics

--- a/doc/source/development/kiwi_plugin_architecture.rst
+++ b/doc/source/development/kiwi_plugin_architecture.rst
@@ -1,0 +1,108 @@
+Plugin Architecture
+===================
+
+Each command provided by {kiwi} is written as a task plugin under
+the **kiwi.tasks** namespace. As a developer you can extend {kiwi}
+with custom task plugins if the following conventions are taken
+into account:
+
+Naming Conventions
+------------------
+
+Task Plugin File Name
+  The file name of a task plugin must follow the pattern
+  :file:`<service>_<command>.py`. This allows to invoke the task
+  with :command:`kiwi-ng service command ...`
+
+Task Plugin Option Handling
+  {kiwi} uses the docopt module to handle options. Each task plugin
+  must use docopt to allow option handling.
+
+Task Plugin Class
+  The implementation of the plugin must be a class that matches
+  the naming convention: :class:`<Service><Command>Task`. The class
+  must inherit from the :class:`CliTask` base class. On startup of
+  the plugin, {kiwi} expects an implementation of the
+  :file:`process` method.
+
+Task Plugin Entry Point
+  Registration of the plugin must be done in :file:`setup.py`
+  using the ``entry_points`` concept from Python's setuptools.
+
+  .. code:: python
+
+      'entry_points': {
+          'kiwi.tasks': [
+              'service_command=kiwi.tasks.service_command'
+          ]
+      }
+
+Example Plugin
+--------------
+
+.. note::
+
+   The following example assumes an existing Python project
+   which was set up according to the Python project rules
+   and standards.
+
+1. Create the task plugin directory :file:`kiwi/tasks`
+
+2. Create the entry point in :command:`setup.py`.
+
+   Assuming we want to create the service named **relax** providing
+   the command **justdoit** this would be the following entry point
+   definition in :file:`setup.py`:
+
+   .. code:: python
+
+      'entry_points': {
+          'kiwi.tasks': [
+              'relax_justdoit=kiwi.tasks.relax_justdoit'
+          ]
+      }
+
+3. Create the plugin code in the file :file:`kiwi/tasks/relax_justdoit.py`
+   with the following content:
+
+   .. code:: python
+
+       """
+       usage: kiwi-ng relax justdoit -h | --help
+              kiwi-ng relax justdoit --now
+       
+       commands:
+           justdoit
+               time to relax
+
+       options:
+           --now
+               right now. For more details about docopt
+               see: http://docopt.org
+       """
+       # These imports requires kiwi to be part of your environment
+       # It can be either installed from pip into a virtual development
+       # environment or from the distribution package manager
+       from kiwi.tasks.base import CliTask
+       from kiwi.help import Help
+
+       class RelaxJustDoItTask(CliTask):
+           def process(self):
+               self.manual = Help()
+               if self.command_args.get('help') is True:
+                   # The following will invoke man to show the man page
+                   # for the requested command. Thus for the call to
+                   # succeed a manual page needs to be written and
+                   # installed by the plugin
+                   return self.manual.show('kiwi::relax::justdoit')
+
+               print(
+                   'https://genius.com/Frankie-goes-to-hollywood-relax-lyrics'
+               )
+
+4. Test the plugin
+
+   .. code:: bash
+
+       $ ./setup.py develop
+       $ kiwi-ng relax justdoit --now

--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -66,24 +66,20 @@ global options for services: image, system
         build type will be used
 """
 import sys
-import glob
-import re
 import os
-import importlib
+import pkg_resources
 from docopt import docopt
 
 # project
-from .exceptions import (
+from kiwi.exceptions import (
     KiwiUnknownServiceName,
-    KiwiCommandNotFound,
     KiwiCommandNotLoaded,
     KiwiLoadCommandUndefined,
     KiwiCompatError
 )
-from .path import Path
-from .defaults import Defaults
-from .version import __version__
-from .help import Help
+from kiwi.path import Path
+from kiwi.version import __version__
+from kiwi.help import Help
 
 
 class Cli:
@@ -150,7 +146,7 @@ class Cli:
 
         :param list compat_args: legacy kiwi command arguments
         """
-        kiwicompat = self._lookup_kiwicompat()
+        kiwicompat = Path.which('kiwicompat', access_mode=os.X_OK)
         try:
             os.execvp(kiwicompat, ['kiwicompat'] + compat_args)
         except Exception as e:
@@ -209,53 +205,46 @@ class Cli:
         """
         Loads task class plugin according to service and command name
 
-        :return: importlib loaded module
+        :return: loaded task module
 
         :rtype: object
         """
-        command = self.get_command()
+        discovered_tasks = {
+            entry_point.name: entry_point.load()
+            for entry_point in pkg_resources.iter_entry_points('kiwi.tasks')
+        }
         service = self.get_servicename()
+        command = self.get_command()
+
         if service == 'compat':
             compat_arguments = self.all_args['<legacy_args>']
             if '--' in compat_arguments:
                 compat_arguments.remove('--')
             return self.invoke_kiwicompat(compat_arguments)
+
         if not command:
             raise KiwiLoadCommandUndefined(
-                'No command specified for %s service' % service
+                'No command specified for {0} service'.format(service)
             )
-        command_source_file = Defaults.project_file(
-            'tasks/' + service + '_' + command + '.py'
-        )
-        if not os.path.exists(command_source_file):
-            prefix = 'usage:'
-            for service_command in self._get_command_implementations(service):
-                print(
-                    '{0} kiwi {1}'.format(prefix, service_command)
-                )
-                prefix = '      '
-            raise SystemExit(1)
-        self.command_loaded = importlib.import_module(
-            'kiwi.tasks.' + service + '_' + command
-        )
-        return self.command_loaded
 
-    def _get_command_implementations(self, service):
-        command_implementations = []
-        glob_match = Defaults.project_file('/') + 'tasks/*.py'
-        for source_file in glob.iglob(glob_match):
-            with open(source_file, 'r') as source:
-                for line in source:
-                    if re.search('usage: (.*)', line):
-                        command_path = os.path.basename(
-                            source_file
-                        ).replace('.py', '').split('_')
-                        if command_path[0] == service:
-                            command_implementations.append(
-                                ' '.join(command_path)
-                            )
-                        break
-        return command_implementations
+        self.command_loaded = discovered_tasks.get(
+            service + '_' + command
+        )
+        if not self.command_loaded:
+            prefix = 'usage:'
+            discovered_tasks_for_service = ''
+            for task in discovered_tasks:
+                if task.startswith(service):
+                    discovered_tasks_for_service += '{0} kiwi-ng {1}\n'.format(
+                        prefix, task.replace('_', ' ')
+                    )
+                    prefix = '      '
+            raise KiwiCommandNotLoaded(
+                'Command "{0}" not found\n\n{1}'.format(
+                    command, discovered_tasks_for_service
+                )
+            )
+        return self.command_loaded
 
     def _load_command_args(self):
         try:
@@ -267,10 +256,3 @@ class Cli:
             raise KiwiCommandNotLoaded(
                 '%s command not loaded' % self.get_command()
             )
-
-    def _lookup_kiwicompat(self):
-        for kiwicompat_name in ['kiwicompat-3', 'kiwicompat-2']:
-            kiwicompat = Path.which(kiwicompat_name, access_mode=os.X_OK)
-            if kiwicompat:
-                return kiwicompat
-        raise KiwiCommandNotFound('kiwicompat not found')

--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,9 @@ config = {
     'description': 'KIWI - Appliance Builder (next generation)',
     'author': 'Marcus Schaefer',
     'url': 'https://osinside.github.io/kiwi',
-    'download_url': 'https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder',
+    'download_url':
+        'https://download.opensuse.org/repositories/'
+        'Virtualization:/Appliances:/Builder',
     'author_email': 'ms@suse.com',
     'version': __version__,
     'license' : 'GPLv3+',
@@ -199,6 +201,16 @@ config = {
         'clean': clean
     },
     'entry_points': {
+        'kiwi.tasks': [
+            'image_info=kiwi.tasks.image_info',
+            'image_resize=kiwi.tasks.image_resize',
+            'result_bundle=kiwi.tasks.result_bundle',
+            'result_list=kiwi.tasks.result_list',
+            'system_build=kiwi.tasks.system_build',
+            'system_create=kiwi.tasks.system_create',
+            'system_prepare=kiwi.tasks.system_prepare',
+            'system_update=kiwi.tasks.system_update'
+        ],
         'console_scripts': [
             'kiwi-ng=kiwi.kiwi:main',
             'kiwicompat=kiwi.kiwi_compat:main'
@@ -210,7 +222,8 @@ config = {
        # classifier: http://pypi.python.org/pypi?%3Aaction=list_classifiers
        'Development Status :: 5 - Production/Stable',
        'Intended Audience :: Developers',
-       'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
+       'License :: OSI Approved :: '
+       'GNU General Public License v3 or later (GPLv3+)',
        'Operating System :: POSIX :: Linux',
        'Programming Language :: Python :: 3.6',
        'Programming Language :: Python :: 3.7',

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -8,7 +8,6 @@ from .test_helper import argv_kiwi_tests
 from kiwi.cli import Cli
 from kiwi.exceptions import (
     KiwiCompatError,
-    KiwiCommandNotFound,
     KiwiLoadCommandUndefined,
     KiwiCommandNotLoaded,
     KiwiUnknownServiceName
@@ -150,16 +149,10 @@ class TestCli:
         with raises(KiwiCompatError):
             self.cli.invoke_kiwicompat([])
 
-    @patch('kiwi.cli.Path.which')
-    def test_invoke_kiwicompat_not_found(self, mock_which):
-        mock_which.return_value = None
-        with raises(KiwiCommandNotFound):
-            self.cli.invoke_kiwicompat([])
-
     def test_load_command_unknown(self):
         self.cli.loaded = False
         self.cli.all_args['<command>'] = 'foo'
-        with raises(SystemExit):
+        with raises(KiwiCommandNotLoaded):
             self.cli.load_command()
 
     def test_load_command_undefined(self):


### PR DESCRIPTION
Set kiwi.tasks to be the plugin entry point and register
existing task plugins in setup.py. Change the code in
cli.py to auto register plugins using the iter_entry_points
method from the pkg_resources class. This allows for easier
writing of external kiwi plugins.


