### PR TITLE
Consistency kiwi binary name

### DIFF
--- a/doc/source/commands/image_info.rst
+++ b/doc/source/commands/image_info.rst
@@ -1,5 +1,5 @@
-kiwi image info
-===============
+kiwi-ng image info
+==================
 
 .. _db_image_info_synopsis:
 
@@ -8,14 +8,14 @@ SYNOPSIS
 
 .. code:: bash
 
-   kiwi [global options] service <command> [<args>]
+   kiwi-ng [global options] service <command> [<args>]
 
-   kiwi image info -h | --help
-   kiwi image info --description=<directory>
+   kiwi-ng image info -h | --help
+   kiwi-ng image info --description=<directory>
        [--resolve-package-list]
        [--ignore-repos]
        [--add-repo=<source,type,alias,priority>...]
-   kiwi image info help
+   kiwi-ng image info help
 
 .. _db_image_info_desc:
 

--- a/doc/source/commands/image_resize.rst
+++ b/doc/source/commands/image_resize.rst
@@ -1,7 +1,7 @@
 .. _db_kiwi_image_resize:
 
-kiwi image resize
-=================
+kiwi-ng image resize
+====================
 
 .. _db_kiwi_image_resize_synopsis:
 
@@ -10,12 +10,12 @@ SYNOPSIS
 
 .. code:: bash
 
-   kiwi [global options] service <command> [<args>]
+   kiwi-ng [global options] service <command> [<args>]
 
-   kiwi image resize -h | --help
-   kiwi image resize --target-dir=<directory> --size=<size>
+   kiwi-ng image resize -h | --help
+   kiwi-ng image resize --target-dir=<directory> --size=<size>
        [--root=<directory>]
-   kiwi image resize help
+   kiwi-ng image resize help
 
 .. _db_kiwi_image_resize_desc:
 

--- a/doc/source/commands/kiwi.rst
+++ b/doc/source/commands/kiwi.rst
@@ -1,5 +1,5 @@
-kiwi
-====
+kiwi-ng
+=======
 
 .. _db_commands_kiwi_synopsis:
 
@@ -8,28 +8,28 @@ SYNOPSIS
 
 .. code:: bash
 
-   kiwi [global options] service <command> [<args>]
+   kiwi-ng [global options] service <command> [<args>]
 
-   kiwi -h | --help
-   kiwi [--profile=<name>...]
-        [--type=<build_type>]
-        [--logfile=<filename>]
-        [--debug]
-        [--color-output]
+   kiwi-ng -h | --help
+   kiwi-ng [--profile=<name>...]
+           [--type=<build_type>]
+           [--logfile=<filename>]
+           [--debug]
+           [--color-output]
        image <command> [<args>...]
-   kiwi [--debug]
+   kiwi-ng [--debug]
            [--color-output]
        result <command> [<args>...]
-   kiwi [--profile=<name>...]
+   kiwi-ng [--profile=<name>...]
            [--shared-cache-dir=<directory>]
            [--type=<build_type>]
            [--logfile=<filename>]
            [--debug]
            [--color-output]
        system <command> [<args>...]
-   kiwi compat <legacy_args>...
-   kiwi -v | --version
-   kiwi help
+   kiwi-ng compat <legacy_args>...
+   kiwi-ng -v | --version
+   kiwi-ng help
 
 .. _db_commands_kiwi_desc:
 

--- a/doc/source/commands/result_bundle.rst
+++ b/doc/source/commands/result_bundle.rst
@@ -1,5 +1,5 @@
-kiwi result bundle
-==================
+kiwi-ng result bundle
+=====================
 
 .. _db_kiwi_result_bundle_synopsis:
 
@@ -8,12 +8,12 @@ SYNOPSIS
 
 .. code:: bash
 
-   kiwi [global options] service <command> [<args>]
+   kiwi-ng [global options] service <command> [<args>]
 
-   kiwi result bundle -h | --help
-   kiwi result bundle --target-dir=<directory> --id=<bundle_id> --bundle-dir=<directory>
+   kiwi-ng result bundle -h | --help
+   kiwi-ng result bundle --target-dir=<directory> --id=<bundle_id> --bundle-dir=<directory>
        [--zsync_source=<download_location>]
-   kiwi result bundle help
+   kiwi-ng result bundle help
 
 .. _db_kiwi_result_bundle_desc:
 

--- a/doc/source/commands/result_list.rst
+++ b/doc/source/commands/result_list.rst
@@ -1,5 +1,5 @@
-kiwi result list
-================
+kiwi-ng result list
+===================
 
 .. _db_kiwi_result_list_synopsis:
 
@@ -8,11 +8,11 @@ SYNOPSIS
 
 .. code:: bash
 
-   kiwi [global options] service <command> [<args>]
+   kiwi-ng [global options] service <command> [<args>]
 
-   kiwi result list -h | --help
-   kiwi result list --target-dir=<directory>
-   kiwi result list help
+   kiwi-ng result list -h | --help
+   kiwi-ng result list --target-dir=<directory>
+   kiwi-ng result list help
 
 .. _db_kiwi_result_list_desc:
 

--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -1,5 +1,5 @@
-kiwi system build
-=================
+kiwi-ng system build
+====================
 
 .. _db_kiwi_system_build_synopsis:
 
@@ -8,10 +8,10 @@ SYNOPSIS
 
 .. code:: bash
 
-   kiwi [global options] service <command> [<args>]
+   kiwi-ng [global options] service <command> [<args>]
 
-   kiwi system build -h | --help
-   kiwi system build --description=<directory> --target-dir=<directory>
+   kiwi-ng system build -h | --help
+   kiwi-ng system build --description=<directory> --target-dir=<directory>
        [--allow-existing-root]
        [--clear-cache]
        [--ignore-repos]
@@ -22,7 +22,7 @@ SYNOPSIS
        [--add-bootstrap-package=<name>...]
        [--delete-package=<name>...]
        [--signing-key=<key-file>...]
-   kiwi system build help
+   kiwi-ng system build help
 
 .. _db_kiwi_system_build_desc:
 

--- a/doc/source/commands/system_create.rst
+++ b/doc/source/commands/system_create.rst
@@ -1,5 +1,5 @@
-kiwi system create
-==================
+kiwi-ng system create
+=====================
 
 .. _db_kiwi_system_create_synopsis:
 
@@ -8,12 +8,12 @@ SYNOPSIS
 
 .. code:: bash
 
-   kiwi [global options] service <command> [<args>]
+   kiwi-ng [global options] service <command> [<args>]
 
-   kiwi system create -h | --help
-   kiwi system create --root=<directory> --target-dir=<directory>
+   kiwi-ng system create -h | --help
+   kiwi-ng system create --root=<directory> --target-dir=<directory>
        [--signing-key=<key-file>...]
-   kiwi system create help
+   kiwi-ng system create help
 
 .. _db_kiwi_system_create_desc:
 

--- a/doc/source/commands/system_prepare.rst
+++ b/doc/source/commands/system_prepare.rst
@@ -1,5 +1,5 @@
-kiwi system prepare
-===================
+kiwi-ng system prepare
+======================
 
 .. _db_kiwi_system_prepare_synopsis:
 
@@ -8,10 +8,10 @@ SYNOPSIS
 
 .. code:: bash
 
-   kiwi [global options] service <command> [<args>]
+   kiwi-ng [global options] service <command> [<args>]
 
-   kiwi system prepare -h | --help
-   kiwi system prepare --description=<directory> --root=<directory>
+   kiwi-ng system prepare -h | --help
+   kiwi-ng system prepare --description=<directory> --root=<directory>
        [--allow-existing-root]
        [--clear-cache]
        [--ignore-repos]
@@ -22,7 +22,7 @@ SYNOPSIS
        [--add-bootstrap-package=<name>...]
        [--delete-package=<name>...]
        [--signing-key=<key-file>...]
-   kiwi system prepare help
+   kiwi-ng system prepare help
 
 .. _db_kiwi_system_prepare_desc:
 

--- a/doc/source/commands/system_update.rst
+++ b/doc/source/commands/system_update.rst
@@ -1,5 +1,5 @@
-kiwi system update
-==================
+kiwi-ng system update
+=====================
 
 .. _db_kiwi_system_update_synopsis:
 
@@ -8,13 +8,13 @@ SYNOPSIS
 
 .. code:: bash
 
-   kiwi [global options] service <command> [<args>]
+   kiwi-ng [global options] service <command> [<args>]
 
-   kiwi system update -h | --help
-   kiwi system update --root=<directory>
+   kiwi-ng system update -h | --help
+   kiwi-ng system update --root=<directory>
        [--add-package=<name>...]
        [--delete-package=<name>...]
-   kiwi system update help
+   kiwi-ng system update help
 
 .. _db_kiwi_system_update_desc:
 

--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -16,27 +16,27 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 """
-usage: kiwi -h | --help
-       kiwi [--profile=<name>...]
-            [--type=<build_type>]
-            [--logfile=<filename>]
-            [--debug]
-            [--color-output]
+usage: kiwi-ng -h | --help
+       kiwi-ng [--profile=<name>...]
+               [--type=<build_type>]
+               [--logfile=<filename>]
+               [--debug]
+               [--color-output]
            image <command> [<args>...]
-       kiwi [--debug]
-            [--color-output]
+       kiwi-ng [--debug]
+               [--color-output]
            result <command> [<args>...]
-       kiwi [--profile=<name>...]
-            [--shared-cache-dir=<directory>]
-            [--type=<build_type>]
-            [--logfile=<filename>]
-            [--debug]
-            [--color-output]
+       kiwi-ng [--profile=<name>...]
+               [--shared-cache-dir=<directory>]
+               [--type=<build_type>]
+               [--logfile=<filename>]
+               [--debug]
+               [--color-output]
            system <command> [<args>...]
-       kiwi compat <legacy_args>...
-       kiwi --compat <legacy_args>...
-       kiwi -v | --version
-       kiwi help
+       kiwi-ng compat <legacy_args>...
+       kiwi-ng --compat <legacy_args>...
+       kiwi-ng -v | --version
+       kiwi-ng help
 
 global options:
     --color-output

--- a/kiwi/kiwi.py
+++ b/kiwi/kiwi.py
@@ -93,7 +93,7 @@ def usage(command_usage):
     data now always consists out of:
 
     1. the generic call
-       kiwi [global options] service <command> [<args>]
+       kiwi-ng [global options] service <command> [<args>]
 
     2. the command specific usage defined by the docopt string
        short form by default, long form with -h | --help
@@ -115,7 +115,7 @@ def usage(command_usage):
         if process_lines:
             global_options += format(line)
 
-    print('usage: kiwi [global options] service <command> [<args>]\n')
+    print('usage: kiwi-ng [global options] service <command> [<args>]\n')
     print(format(command_usage).replace('usage:', '      '))
     if 'global options' not in format(command_usage):
         print(format(global_options))

--- a/kiwi/tasks/image_info.py
+++ b/kiwi/tasks/image_info.py
@@ -16,12 +16,12 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 """
-usage: kiwi image info -h | --help
-       kiwi image info --description=<directory>
+usage: kiwi-ng image info -h | --help
+       kiwi-ng image info --description=<directory>
            [--resolve-package-list]
            [--ignore-repos]
            [--add-repo=<source,type,alias,priority>...]
-       kiwi image info help
+       kiwi-ng image info help
 
 commands:
     info

--- a/kiwi/tasks/image_resize.py
+++ b/kiwi/tasks/image_resize.py
@@ -16,10 +16,10 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 """
-usage: kiwi image resize -h | --help
-       kiwi image resize --target-dir=<directory> --size=<size>
+usage: kiwi-ng image resize -h | --help
+       kiwi-ng image resize --target-dir=<directory> --size=<size>
            [--root=<directory>]
-       kiwi image resize help
+       kiwi-ng image resize help
 
 commands:
     resize

--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -16,10 +16,10 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 """
-usage: kiwi result bundle -h | --help
-       kiwi result bundle --target-dir=<directory> --id=<bundle_id> --bundle-dir=<directory>
+usage: kiwi-ng result bundle -h | --help
+       kiwi-ng result bundle --target-dir=<directory> --id=<bundle_id> --bundle-dir=<directory>
            [--zsync-source=<download_location>]
-       kiwi result bundle help
+       kiwi-ng result bundle help
 
 commands:
     bundle

--- a/kiwi/tasks/result_list.py
+++ b/kiwi/tasks/result_list.py
@@ -16,9 +16,9 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 """
-usage: kiwi result list -h | --help
-       kiwi result list --target-dir=<directory>
-       kiwi result list help
+usage: kiwi-ng result list -h | --help
+       kiwi-ng result list --target-dir=<directory>
+       kiwi-ng result list help
 
 commands:
     list

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -16,8 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 """
-usage: kiwi system build -h | --help
-       kiwi system build --description=<directory> --target-dir=<directory>
+usage: kiwi-ng system build -h | --help
+       kiwi-ng system build --description=<directory> --target-dir=<directory>
            [--allow-existing-root]
            [--clear-cache]
            [--ignore-repos]
@@ -31,7 +31,7 @@ usage: kiwi system build -h | --help
            [--set-container-tag=<name>]
            [--add-container-label=<label>...]
            [--signing-key=<key-file>...]
-       kiwi system build help
+       kiwi-ng system build help
 
 commands:
     build

--- a/kiwi/tasks/system_create.py
+++ b/kiwi/tasks/system_create.py
@@ -16,10 +16,10 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 """
-usage: kiwi system create -h | --help
-       kiwi system create --root=<directory> --target-dir=<directory>
+usage: kiwi-ng system create -h | --help
+       kiwi-ng system create --root=<directory> --target-dir=<directory>
            [--signing-key=<key-file>...]
-       kiwi system create help
+       kiwi-ng system create help
 
 commands:
     create

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -16,8 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 """
-usage: kiwi system prepare -h | --help
-       kiwi system prepare --description=<directory> --root=<directory>
+usage: kiwi-ng system prepare -h | --help
+       kiwi-ng system prepare --description=<directory> --root=<directory>
            [--allow-existing-root]
            [--clear-cache]
            [--ignore-repos]
@@ -31,7 +31,7 @@ usage: kiwi system prepare -h | --help
            [--set-container-tag=<name>]
            [--add-container-label=<label>...]
            [--signing-key=<key-file>...]
-       kiwi system prepare help
+       kiwi-ng system prepare help
 
 commands:
     prepare

--- a/kiwi/tasks/system_update.py
+++ b/kiwi/tasks/system_update.py
@@ -16,11 +16,11 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 """
-usage: kiwi system update -h | --help
-       kiwi system update --root=<directory>
+usage: kiwi-ng system update -h | --help
+       kiwi-ng system update --root=<directory>
            [--add-package=<name>...]
            [--delete-package=<name>...]
-       kiwi system update help
+       kiwi-ng system update help
 
 commands:
     update


### PR DESCRIPTION
Fixed docopt strings to use correct binary name
    
The kiwi binary from the entry_point configuration is
kiwi-ng. The docopt strings should use this name for
consistency. The alternative binary name kiwi is just
a symlink created on the rpm packaging level and is
not guaranteed to exist depending on how kiwi was
installed
