### PR TITLE
Turn xorriso requirement into a recommend

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -139,7 +139,15 @@ Requires:       gdisk
 %endif
 Requires:       dosfstools
 Requires:       e2fsprogs
+%if 0%{?rhel} && 0%{?rhel} < 8
 Requires:       xorriso
+%else
+%ifarch %{ix86} x86_64
+Requires:       xorriso
+%else
+Recommends:     xorriso
+%endif
+%endif
 Requires:       grub2
 Requires:       kiwi-tools
 Requires:       lvm2


### PR DESCRIPTION
xorriso was set required on the master python3-kiwi package.
This is not needed since it is only required if an ISO target
will be built. Especially on non x86 architectures the ISO
target is used rarely. Therefore this commit turns xorriso
into a recommended package on non x86 architectures. This is
related to Issue #1325


