### PR TITLE
Make sure it properly validate the size of the partitions in the conf…

### DIFF
--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -4065,7 +4065,7 @@ class volume(GeneratedsSuper):
             if not self.gds_validate_simple_patterns(
                     self.validate_volume_size_type_patterns_, value):
                 warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_volume_size_type_patterns_, ))
-    validate_volume_size_type_patterns_ = [['^\\d+|\\d+M|\\d+G|all$']]
+    validate_volume_size_type_patterns_ = [['^(\\d+|\\d+M|\\d+G|all)$']]
     def hasContent_(self):
         if (
 


### PR DESCRIPTION
…ig xml

Fixes # .
When using the following xml:

`<volume mountpoint="/home" name="LVhome" size="512M" />`

you get a warning in the log:

`/usr/lib/python3.6/site-packages/kiwi/xml_parse.py:4056: UserWarning: Value "b'512M'" does not match xsd pattern restrictions: [['^\\d+\|\\d+M\|\\d+G\|all$'`
