### PR TITLE
Fix container labels setup in OBS

### DIFF
--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -171,8 +171,8 @@ class ContainerImageOCI:
                 if line.startswith('BUILD_DISTURL') and '=' in line:
                     disturl = line.split('=')[1].lstrip('\'\"').rstrip('\n\'\"')
                     if disturl:
-                        self.oci_config['labels'] = {
-                            'org.openbuildservice.disturl': disturl
-                        }
+                        self.oci_config['labels'].update(
+                            {'org.openbuildservice.disturl': disturl}
+                        )
                         return
             log.warning('Could not find BUILD_DISTURL inside .buildenv')

--- a/test/unit/container/image_oci_test.py
+++ b/test/unit/container/image_oci_test.py
@@ -72,7 +72,9 @@ class TestContainerImageOCI:
         with patch('builtins.open', m_open, create=True):
             m_open.return_value.__iter__ = lambda _:\
                 iter(['BUILD_DISTURL=obs://build.opensuse.org/some:project'])
-            container = ContainerImageOCI('root_dir', 'oci-archive')
+            container = ContainerImageOCI(
+                'root_dir', 'oci-archive', {'labels': {}}
+            )
 
         m_open.assert_called_once_with('/.buildenv')
         assert container.oci_config['labels'] == {


### PR DESCRIPTION
This commits fixes the containers label setup in OBS, ensuring that
adding the 'org.openbuildservice.disturl' label does not clear any
other label.

Fixes #1338