### PR TITLE
Build and push SUSE documentation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,8 @@
 stages:
   - test
-  - package
+  - documentation
+  - sourcepackage
+  - packages
 
 variables:
   LANG: en_US.UTF-8
@@ -8,39 +10,41 @@ variables:
   TUMBLEWEED_BUILD: buildenv-tumbleweed
   FEDORA_BUILD: buildenv-fedora
 
-.install_and_build_src_package: &install_and_build_system_src_package
-  before_script:
-    - groupadd -f -g 135 -r mock # workaround RHBZ#1740545
-    - 'sed -i "s|build: clean tox|build:|" Makefile'
-    - make build
-    - mv dist/python-kiwi.spec .
-    - rm dist/python-kiwi.changes
-    - >
-      mock
-      --old-chroot -r /etc/mock/fedora-30-x86_64.cfg
-      --buildsrpm --sources ./dist
-      --spec ./python-kiwi.spec 2>&1 | tee srpm_build_out
-    - "export SRC_RPM=$(ls $(grep 'INFO: Results ' srpm_build_out | awk -F ':' '{print $3}')/*.src.rpm)"
-    - mv $SRC_RPM .
-
-code_style_plus_unit_test:
+code_style:
   image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
+  stage: test
   script:
-    # Flake
     - tox -e check
-    # Python 3.6
+  cache:
+    key: "$CI_JOB_NAME"
+    paths:
+      - .tox/3
+
+unit_py36:
+  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
+  stage: test
+  script:
     - export PYTHON=python3.6
     - tox -e unit_py3_6 "-n $(nproc)"
-    # Python 3.7
+  cache:
+    key: "$CI_JOB_NAME"
+    paths:
+      - .tox/3.6
+
+unit_py37:
+  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
+  stage: test
+  script:
     - export PYTHON=python3.7
     - tox -e unit_py3_7 "-n $(nproc)"
   cache:
     key: "$CI_JOB_NAME"
     paths:
-      - .tox
+      - .tox/3.7
 
 build_doc:
   image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$TUMBLEWEED_BUILD
+  stage: documentation
   script:
     - tox -e packagedoc
   artifacts:
@@ -51,38 +55,87 @@ build_doc:
     paths:
       - doc/build
 
-rpm_fedora_30:
-  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
-  stage: package
-  <<: *install_and_build_system_src_package
+build_and_push_suse_doc:
+  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$TUMBLEWEED_BUILD
+  stage: documentation
   script:
+    - "export GIT_SSH=$(pwd)/run_ssh"
+    - "export ID_DOC_SUSE=$(pwd)/id_doc_suse"
+    - echo 'exec ssh -o StrictHostKeyChecking=no -i $ID_DOC_SUSE "$@"' > run_ssh
+    - chmod u+x run_ssh
+    - base64 --decode "$DOC_SUSE_SECRET" > id_doc_suse
+    - chmod 600 id_doc_suse
+    - git clone git@github.com:OSInside/kiwi-suse-doc.git /tmp/kiwi-suse-doc
+    - tox -e doc_suse
+    - cp doc/DC-kiwi /tmp/kiwi-suse-doc/doc/build
+    - cp doc/source/.images/* /tmp/kiwi-suse-doc/doc/build/build/.images/color
+    - cp doc/build/xml/book.xml /tmp/kiwi-suse-doc/doc/build/xml
+    - git config --global user.email "kiwi-internal@suse.de"
+    - git config --global user.name "SUSE KIWI Team"
+    - cd /tmp/kiwi-suse-doc
+    - git add .
+    - git commit -a -m "upstream sync" && git push || true
+  artifacts:
+    paths:
+      - doc/build/
+
+rpm_source_package:
+  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
+  stage: sourcepackage
+  script:
+    - groupadd -f -g 135 -r mock # workaround RHBZ#1740545
+    - 'sed -i "s|build: clean tox|build:|" Makefile'
+    - make build
+    - mv dist/python-kiwi.spec .
+    - rm dist/python-kiwi.changes
     - >
       mock
-      --old-chroot
-      --resultdir $(pwd)/mock-result
+      --isolation=simple -r /etc/mock/fedora-30-x86_64.cfg
+      --buildsrpm --sources ./dist
+      --resultdir $(pwd)/mock-result-srpm
+      --spec ./python-kiwi.spec 2>&1 | tee srpm_build_out
+  artifacts:
+    when: always
+    paths:
+      - srpm_build_out
+      - mock-result-srpm
+    expire_in: 1 week
+
+rpm_fedora_30:
+  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
+  stage: packages
+  script:
+    - "export SRC_RPM=$(ls mock-result-srpm/*kiwi*)"
+    - cp $SRC_RPM .
+    - >
+      mock
+      --isolation=simple
+      --resultdir $(pwd)/mock-result-fedora
       -r /etc/mock/fedora-30-x86_64.cfg $(basename $SRC_RPM)
   artifacts:
     when: always
     paths:
-      - mock-result
+      - mock-result-fedora
     expire_in: 1 week
   dependencies:
-    - build_doc
+    - rpm_source_package
 
 rpm_suse_TW:
   image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
-  stage: package
-  <<: *install_and_build_system_src_package
+  stage: packages
   script:
+    - "export SRC_RPM=$(ls mock-result-srpm/*kiwi*)"
+    - cp $SRC_RPM .
     - >
       mock
-      --old-chroot
-      --resultdir $(pwd)/mock-result
+      --isolation=simple
+      --resultdir $(pwd)/mock-result-tw
       -r /etc/mock/opensuse-tumbleweed-x86_64.cfg $(basename $SRC_RPM)
   artifacts:
     when: always
     paths:
-      - mock-result
+      - mock-result-tw
     expire_in: 1 week
+  allow_failure: true
   dependencies:
-    - build_doc
+    - rpm_source_package

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,9 +55,20 @@ build_doc:
     paths:
       - doc/build
 
-build_and_push_suse_doc:
+build_suse_doc:
   image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$TUMBLEWEED_BUILD
   stage: documentation
+  script:
+    - tox -e doc_suse
+  artifacts:
+    paths:
+      - doc/build/
+
+push_suse_doc:
+  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$TUMBLEWEED_BUILD
+  stage: documentation
+  only:
+    - master
   script:
     - "export GIT_SSH=$(pwd)/run_ssh"
     - "export ID_DOC_SUSE=$(pwd)/id_doc_suse"
@@ -66,7 +77,6 @@ build_and_push_suse_doc:
     - base64 --decode "$DOC_SUSE_SECRET" > id_doc_suse
     - chmod 600 id_doc_suse
     - git clone git@github.com:OSInside/kiwi-suse-doc.git /tmp/kiwi-suse-doc
-    - tox -e doc_suse
     - cp doc/DC-kiwi /tmp/kiwi-suse-doc/doc/build
     - cp doc/source/.images/* /tmp/kiwi-suse-doc/doc/build/build/.images/color
     - cp doc/build/xml/book.xml /tmp/kiwi-suse-doc/doc/build/xml
@@ -75,9 +85,6 @@ build_and_push_suse_doc:
     - cd /tmp/kiwi-suse-doc
     - git add .
     - git commit -a -m "upstream sync" && git push || true
-  artifacts:
-    paths:
-      - doc/build/
 
 rpm_source_package:
   image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD


### PR DESCRIPTION
On any pull request also build the suse documentation and
push changes to the OSInside/kiwi-suse-doc git repository.
The SUSE documentation team needs a repo with docbook sources
for the publishing procedure. In addition change the gitlab
pipeline to run in three stages: Test, Documentation and
Package. Let the style and unit tests run in parallel and
cleanup the dependency setup

