### PR TITLE
Fix a regression for container builds in OBS

### DIFF
--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -171,8 +171,10 @@ class ContainerImageOCI:
                 if line.startswith('BUILD_DISTURL') and '=' in line:
                     disturl = line.split('=')[1].lstrip('\'\"').rstrip('\n\'\"')
                     if disturl:
-                        self.oci_config['labels'].update(
-                            {'org.openbuildservice.disturl': disturl}
-                        )
+                        label = {'org.openbuildservice.disturl': disturl}
+                        if self.oci_config.get('labels'):
+                            self.oci_config['labels'].update(label)
+                        else:
+                            self.oci_config['labels'] = label
                         return
             log.warning('Could not find BUILD_DISTURL inside .buildenv')

--- a/test/unit/container/image_oci_test.py
+++ b/test/unit/container/image_oci_test.py
@@ -73,11 +73,26 @@ class TestContainerImageOCI:
             m_open.return_value.__iter__ = lambda _:\
                 iter(['BUILD_DISTURL=obs://build.opensuse.org/some:project'])
             container = ContainerImageOCI(
-                'root_dir', 'oci-archive', {'labels': {}}
+                'root_dir', 'oci-archive'
             )
 
         m_open.assert_called_once_with('/.buildenv')
         assert container.oci_config['labels'] == {
+            'org.openbuildservice.disturl':
+            'obs://build.opensuse.org/some:project'
+        }
+
+        m_open = mock_open()
+        with patch('builtins.open', m_open, create=True):
+            m_open.return_value.__iter__ = lambda _:\
+                iter(['BUILD_DISTURL=obs://build.opensuse.org/some:project'])
+            container = ContainerImageOCI(
+                'root_dir', 'oci-archive', {'labels': {'label': 'value'}}
+            )
+
+        m_open.assert_called_once_with('/.buildenv')
+        assert container.oci_config['labels'] == {
+            'label': 'value',
             'org.openbuildservice.disturl':
             'obs://build.opensuse.org/some:project'
         }


### PR DESCRIPTION
This commit fixes a regression introduced in 12d84be2. We need to ensure
that `labels` item exist in oci image configuration dict before updating
it and creating it in case it doesn't exist.
