### PR TITLE
Fixed file name for config.bootoptions file

### DIFF
--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -337,7 +337,7 @@ class InstallImageBuilder:
         # create pxe image bound boot config file, contents can be
         # changed but presence is required.
         log.info('Creating pxe install boot options file')
-        configname = 'pxeboot.{0}.config.bootoptions'.format(self.pxename)
+        configname = '{0}.config.bootoptions'.format(self.pxename)
         shutil.copy(
             os.sep.join([self.root_dir, 'config.bootoptions']),
             os.sep.join([self.pxe_dir, configname])

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -382,7 +382,7 @@ class TestInstallImageBuilder:
             ),
             call(
                 'root_dir/config.bootoptions',
-                'tmpdir/pxeboot.result-image.x86_64-1.2.3.config.bootoptions'
+                'tmpdir/result-image.x86_64-1.2.3.config.bootoptions'
             )
         ]
         assert mock_chmod.call_args_list == [


### PR DESCRIPTION
The dracut code in 90kiwi-dump/kiwi-dump-image.sh looks for a
file matching ${image_uri}.config.bootoptions but the install
code packs a file named pxeboot.${image_uri}.config.bootoptions
into the tarball. Thus without renaming the file it won't
be found. Also the documentation mentions the file to be
named ${image_uri}.config.bootoptions. This commit fixes the
install code to match the dracut boot code and the documentation


