### PR TITLE
Add kpartx dependency on dracut-kiwi-oem-dump package

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -284,6 +284,7 @@ BuildRequires:  dracut
 Requires:       dracut-kiwi-lib
 Requires:       kexec-tools
 Requires:       gawk
+Requires:       kpartx
 License:        GPL-3.0-or-later
 Group:          %{sysgroup}
 


### PR DESCRIPTION
This commit adds a missing dependency on dracut-kiwi-oem-dump
package. In images where The `kpartx` tool is missing the
dracut-kiwi-oem-dump was not applied for the initrd.

Fixes #1364