### PR TITLE
Skip nodev devices for size calculations

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -221,6 +221,22 @@ class Defaults:
         ]
         return exclude_list
 
+    def get_exclude_list_for_non_physical_devices():
+        """
+        Provides the list of folders that are not associated
+        with a physical device. KIWI returns the basename of
+        the folders typically used as mountpoint for those
+        devices.
+
+        :return: list of file and directory names
+
+        :rtype: list
+        """
+        exclude_list = [
+            'proc', 'sys', 'dev'
+        ]
+        return exclude_list
+
     @staticmethod
     def get_failsafe_kernel_options():
         """

--- a/kiwi/system/size.py
+++ b/kiwi/system/size.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import os
+
 # project
 from kiwi.command import Command
 from kiwi.defaults import Defaults
@@ -72,6 +74,11 @@ class SystemSize:
         :rtype: int
         """
         exclude_options = []
+        for nodev in Defaults.get_exclude_list_for_non_physical_devices():
+            exclude_options.append('--exclude')
+            exclude_options.append(
+                os.sep.join([self.source_dir, nodev])
+            )
         if exclude:
             for item in exclude:
                 exclude_options.append('--exclude')

--- a/test/unit/system/size_test.py
+++ b/test/unit/system/size_test.py
@@ -27,6 +27,9 @@ class TestSystemSize:
         mock_command.assert_called_once_with(
             [
                 'du', '-s', '--apparent-size', '--block-size', '1',
+                '--exclude', 'directory/proc',
+                '--exclude', 'directory/sys',
+                '--exclude', 'directory/dev',
                 '--exclude', '/foo', 'directory'
             ]
         )


### PR DESCRIPTION
Added a static list of mountpoints used for devices that
are not associated with a physical device like /proc and
use that information in the exclude list for calculating
the image byte size. This Fixes #1363

