### PR TITLE
Fix order in fstab

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -876,6 +876,18 @@ class DiskBuilder:
             device_map['root'].get_device(), '/',
             custom_root_mount_args, fs_check_interval
         )
+        if device_map.get('boot'):
+            if self.bootloader == 'grub2_s390x_emu':
+                boot_mount_point = '/boot/zipl'
+            else:
+                boot_mount_point = '/boot'
+            self._add_generic_fstab_entry(
+                device_map['boot'].get_device(), boot_mount_point
+            )
+        if device_map.get('efi'):
+            self._add_generic_fstab_entry(
+                device_map['efi'].get_device(), '/boot/efi'
+            )
         if self.volume_manager_name:
             volume_fstab_entries = self.system.get_fstab(
                 self.persistency_type, self.requested_filesystem
@@ -897,18 +909,6 @@ class DiskBuilder:
                 self._add_generic_fstab_entry(
                     device_map['swap'].get_device(), 'swap'
                 )
-        if device_map.get('boot'):
-            if self.bootloader == 'grub2_s390x_emu':
-                boot_mount_point = '/boot/zipl'
-            else:
-                boot_mount_point = '/boot'
-            self._add_generic_fstab_entry(
-                device_map['boot'].get_device(), boot_mount_point
-            )
-        if device_map.get('efi'):
-            self._add_generic_fstab_entry(
-                device_map['efi'].get_device(), '/boot/efi'
-            )
         setup.create_fstab(
             self.generic_fstab_entries
         )

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -756,19 +756,19 @@ class TestDiskBuilder:
         self.setup.create_fstab.assert_called_once_with(
             [
                 'UUID=blkid_result / blkid_result_fs ro 0 0',
-                'fstab_volume_entries',
-                '/dev/systemVG/LVSwap swap swap defaults 0 0',
                 'UUID=blkid_result /boot blkid_result_fs defaults 0 0',
-                'UUID=blkid_result /boot/efi blkid_result_fs defaults 0 0'
+                'UUID=blkid_result /boot/efi blkid_result_fs defaults 0 0',
+                'fstab_volume_entries',
+                '/dev/systemVG/LVSwap swap swap defaults 0 0'
             ]
         )
         self.boot_image_task.setup.create_fstab.assert_called_once_with(
             [
                 'UUID=blkid_result / blkid_result_fs ro 0 0',
-                'fstab_volume_entries',
-                '/dev/systemVG/LVSwap swap swap defaults 0 0',
                 'UUID=blkid_result /boot blkid_result_fs defaults 0 0',
-                'UUID=blkid_result /boot/efi blkid_result_fs defaults 0 0'
+                'UUID=blkid_result /boot/efi blkid_result_fs defaults 0 0',
+                'fstab_volume_entries',
+                '/dev/systemVG/LVSwap swap swap defaults 0 0'
             ]
         )
 


### PR DESCRIPTION
Any mount point directly under / should be just right after the root
mountpoint and before the custom mountpoints based on user's subvolume
configuration.

Fixes #1349 and bsc#1164310
