### PR TITLE
Better fstab handling

### DIFF
--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -32,6 +32,7 @@ from kiwi.system.root_init import RootInit
 from kiwi.command import Command
 from kiwi.command_process import CommandProcess
 from kiwi.utils.sync import DataSync
+from kiwi.utils.fstab import Fstab
 from kiwi.defaults import Defaults
 from kiwi.system.users import Users
 from kiwi.system.shell import Shell
@@ -633,6 +634,13 @@ class SystemSetup:
                 ['chroot', self.root_dir, '/etc/fstab.script']
             )
             Path.wipe(fstab_script_file)
+
+        # rewrite fstab after initial creation and after all
+        # optional modifications to make sure the canonical
+        # mount order is correct and no garbage exists.
+        fstab_final = Fstab()
+        fstab_final.read(fstab_file)
+        fstab_final.export(fstab_file)
 
     def create_init_link_from_linuxrc(self):
         """

--- a/kiwi/utils/fstab.py
+++ b/kiwi/utils/fstab.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2020 SUSE Software Solutions Germany GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+from collections import namedtuple
+
+# project
+from kiwi.path import Path
+
+
+class Fstab:
+    """
+    **Managing fstab values**
+    """
+    def __init__(self):
+        self.fstab = []
+        self.fstab_entry_type = namedtuple(
+            'fstab_entry_type', [
+                'fstype', 'mountpoint', 'device_spec', 'device_path', 'options'
+            ]
+        )
+
+    def read(self, filename):
+        """
+        Import specified fstab file
+
+        :param string filename: path to a fstab file
+        """
+        self.fstab = []
+        with open(filename) as fstab:
+            for line in fstab.readlines():
+                mount_record = line.split()
+                if not mount_record or mount_record[0].startswith('#'):
+                    continue
+                device = mount_record[0]
+                mountpoint = mount_record[1]
+                fstype = mount_record[2]
+                options = mount_record[3]
+                if device.startswith('UUID'):
+                    device_path = ''.join(
+                        ['/dev/disk/by-uuid/', device.split('=')[1]]
+                    )
+                elif device.startswith('LABEL'):
+                    device_path = ''.join(
+                        ['/dev/disk/by-label/', device.split('=')[1]]
+                    )
+                elif device.startswith('PARTUUID'):
+                    device_path = ''.join(
+                        ['/dev/disk/by-partuuid/', device.split('=')[1]]
+                    )
+                else:
+                    device_path = device
+
+                self.fstab.append(
+                    self.fstab_entry_type(
+                        fstype=fstype,
+                        mountpoint=mountpoint,
+                        device_path=device_path,
+                        device_spec=device,
+                        options=options
+                    )
+                )
+
+    def get_devices(self):
+        return self.fstab
+
+    def export(self, filename):
+        """
+        Export entries, respect canonical mount order
+
+        :param string filename: path to file name
+        """
+        fstab_entries_by_path = {}
+        for entry in self.fstab:
+            fstab_entries_by_path[entry.mountpoint] = entry
+
+        with open(filename, 'w') as fstab:
+            for device_path in Path.sort_by_hierarchy(
+                sorted(fstab_entries_by_path.keys())
+            ):
+                entry = fstab_entries_by_path[device_path]
+                fstab.write(
+                    '{0} {1} {2} {3} 0 0{4}'.format(
+                        entry.device_spec, entry.mountpoint,
+                        entry.fstype, entry.options,
+                        os.linesep
+                    )
+                )

--- a/test/data/fstab
+++ b/test/data/fstab
@@ -1,0 +1,9 @@
+UUID=bd604632-663b-4d4c-b5b0-8d8686267ea2  /          ext4  acl,user_xattr  0  1
+UUID=daa5a8c3-5c72-4343-a1d4-bb74ec4e586e  swap       swap  defaults        0  0
+UUID=FCF7-B051                             /boot/efi  vfat  defaults        0  0
+LABEL=BOOT                                 /boot      xfs   defaults        0  0
+LABEL=foo  /home      ext4  defaults        0  0
+PARTUUID=3c8bd108-01 /bar ext4 defaults 0 0
+/dev/mynode /foo ext4 defaults 0 0
+
+# this comment line and the line above should be ignored by the parser

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -692,7 +692,12 @@ class TestSystemSetup:
     @patch('os.path.exists')
     @patch('kiwi.system.setup.Path.wipe')
     @patch('kiwi.command.Command.run')
-    def test_create_fstab(self, mock_command, mock_wipe, mock_exists):
+    @patch('kiwi.system.setup.Fstab')
+    def test_create_fstab(
+        self, mock_Fstab, mock_command, mock_wipe, mock_exists
+    ):
+        fstab_final = Mock()
+        mock_Fstab.return_value = fstab_final
         mock_exists.return_value = True
 
         m_open = mock_open(read_data='append_entry')
@@ -716,6 +721,8 @@ class TestSystemSetup:
             call('root_dir/etc/fstab.patch'),
             call('root_dir/etc/fstab.script')
         ]
+        fstab_final.read.assert_called_once_with('root_dir/etc/fstab')
+        fstab_final.export.assert_called_once_with('root_dir/etc/fstab')
 
     @patch('kiwi.command.Command.run')
     @patch('kiwi.system.setup.NamedTemporaryFile')

--- a/test/unit/utils/fstab_test.py
+++ b/test/unit/utils/fstab_test.py
@@ -1,0 +1,90 @@
+import io
+from unittest.mock import (
+    MagicMock, patch, call
+)
+from kiwi.utils.fstab import Fstab
+
+
+class TestFstab(object):
+    def setup(self):
+        self.fstab = Fstab()
+        self.fstab.read('../data/fstab')
+
+    def test_get_devices(self):
+        assert self.fstab.get_devices() == [
+            self.fstab.fstab_entry_type(
+                fstype='ext4',
+                mountpoint='/',
+                device_path='/dev/disk/'
+                'by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2',
+                device_spec='UUID=bd604632-663b-4d4c-b5b0-8d8686267ea2',
+                options='acl,user_xattr'
+            ),
+            self.fstab.fstab_entry_type(
+                fstype='swap',
+                mountpoint='swap',
+                device_path='/dev/disk/'
+                'by-uuid/daa5a8c3-5c72-4343-a1d4-bb74ec4e586e',
+                device_spec='UUID=daa5a8c3-5c72-4343-a1d4-bb74ec4e586e',
+                options='defaults'
+            ),
+            self.fstab.fstab_entry_type(
+                fstype='vfat',
+                mountpoint='/boot/efi',
+                device_path='/dev/disk/by-uuid/FCF7-B051',
+                device_spec='UUID=FCF7-B051',
+                options='defaults'
+            ),
+            self.fstab.fstab_entry_type(
+                fstype='xfs',
+                mountpoint='/boot',
+                device_path='/dev/disk/by-label/BOOT',
+                device_spec='LABEL=BOOT',
+                options='defaults'
+            ),
+            self.fstab.fstab_entry_type(
+                fstype='ext4',
+                mountpoint='/home',
+                device_path='/dev/disk/by-label/foo',
+                device_spec='LABEL=foo',
+                options='defaults'
+            ),
+            self.fstab.fstab_entry_type(
+                fstype='ext4',
+                mountpoint='/bar',
+                device_path='/dev/disk/by-partuuid/3c8bd108-01',
+                device_spec='PARTUUID=3c8bd108-01',
+                options='defaults'
+            ),
+            self.fstab.fstab_entry_type(
+                fstype='ext4',
+                mountpoint='/foo',
+                device_path='/dev/mynode',
+                device_spec='/dev/mynode',
+                options='defaults'
+            )
+        ]
+
+    def test_export_and_canonical_order(self):
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            self.fstab.export('filename')
+            file_handle = mock_open.return_value.__enter__.return_value
+            mock_open.assert_called_once_with(
+                'filename', 'w'
+            )
+            assert file_handle.write.call_args_list == [
+                call(
+                    'UUID=daa5a8c3-5c72-4343-a1d4-bb74ec4e586e swap '
+                    'swap defaults 0 0\n'
+                ),
+                call(
+                    'UUID=bd604632-663b-4d4c-b5b0-8d8686267ea2 / '
+                    'ext4 acl,user_xattr 0 0\n'
+                ),
+                call('PARTUUID=3c8bd108-01 /bar ext4 defaults 0 0\n'),
+                call('LABEL=BOOT /boot xfs defaults 0 0\n'),
+                call('/dev/mynode /foo ext4 defaults 0 0\n'),
+                call('LABEL=foo /home ext4 defaults 0 0\n'),
+                call('UUID=FCF7-B051 /boot/efi vfat defaults 0 0\n')
+            ]


### PR DESCRIPTION
This pull request is two fold

**Added Fstab class**
    
Handling of fstab should be done in its own namespace and class. The current handling of fstab entries is spread at several places. There should be only one code that writes the fstab entries and that code should also care for the correct canonical order of the mountpoints

**Validate and order final fstab file**
    
On write of the final fstab file read, validate and order the entries. This is related to Issue #1349
