### PR TITLE
Complete refactoring of fstab handling

### DIFF
--- a/test/data/fstab
+++ b/test/data/fstab
@@ -5,5 +5,8 @@ LABEL=BOOT                                 /boot      xfs   defaults        0  0
 LABEL=foo  /home      ext4  defaults        0  0
 PARTUUID=3c8bd108-01 /bar ext4 defaults 0 0
 /dev/mynode /foo ext4 defaults 0 0
+# entry with the same mountpoint, expected to be skipped
+LABEL=bar  /home      xfs  defaults        0  0
+
 
 # this comment line and the line above should be ignored by the parser

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -692,24 +692,23 @@ class TestSystemSetup:
     @patch('os.path.exists')
     @patch('kiwi.system.setup.Path.wipe')
     @patch('kiwi.command.Command.run')
-    @patch('kiwi.system.setup.Fstab')
     def test_create_fstab(
-        self, mock_Fstab, mock_command, mock_wipe, mock_exists
+        self, mock_command, mock_wipe, mock_exists
     ):
-        fstab_final = Mock()
-        mock_Fstab.return_value = fstab_final
+        fstab = Mock()
         mock_exists.return_value = True
 
         m_open = mock_open(read_data='append_entry')
         with patch('builtins.open', m_open, create=True):
-            self.setup.create_fstab(['fstab_entry'])
+            self.setup.create_fstab(fstab)
+
+        fstab.export.assert_called_once_with('root_dir/etc/fstab')
 
         assert m_open.call_args_list == [
-            call('root_dir/etc/fstab', 'w'),
+            call('root_dir/etc/fstab', 'a'),
             call('root_dir/etc/fstab.append', 'r')
         ]
         assert m_open.return_value.write.call_args_list == [
-            call('fstab_entry\n'),
             call('append_entry')
         ]
         assert mock_command.call_args_list == [
@@ -721,8 +720,6 @@ class TestSystemSetup:
             call('root_dir/etc/fstab.patch'),
             call('root_dir/etc/fstab.script')
         ]
-        fstab_final.read.assert_called_once_with('root_dir/etc/fstab')
-        fstab_final.export.assert_called_once_with('root_dir/etc/fstab')
 
     @patch('kiwi.command.Command.run')
     @patch('kiwi.system.setup.NamedTemporaryFile')


### PR DESCRIPTION
With the new Fstab class from prior pull request there is an
opportunity to handle all fstab related actions to be done
by that class. This commit extends the Fstab class with an
add_entry method such that we can avoid the extra lists
holding raw fstab lines in e.g the disk builder. In the end
all fstab related data is stored in an instance of the Fstab
class. This also extends the KIWI api by an fstab management
class. Related to #1329 and #1349


