### PR TITLE
Update centos integration test

### DIFF
--- a/build-tests/x86/centos/test-image-iso-oem-vmx/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-iso-oem-vmx/appliance.kiwi
@@ -27,7 +27,7 @@
         <type image="iso" flags="overlay" firmware="uefi" hybridpersistent_filesystem="ext4" hybridpersistent="true"/>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="vmx" primary="true" filesystem="ext4" kernelcmdline="rhgb console=ttyS0" bootloader="grub2" firmware="uefi" format="qcow2"/>
+        <type image="vmx" primary="true" filesystem="ext4" kernelcmdline="rhgb console=ttyS0" bootloader="grub2" firmware="msdos" format="qcow2"/>
     </preferences>
     <preferences profiles="Disk">
         <type image="oem" initrd_system="dracut" filesystem="ext4" installiso="true" bootloader="grub2" firmware="uefi">
@@ -59,6 +59,8 @@
     </repository>
     <packages type="image">
         <package name="syslinux"/>
+        <package name="gdisk"/>
+        <package name="util-linux"/>
         <package name="grub2"/>
         <package name="kernel"/>
         <package name="plymouth-theme-charge"/>


### PR DESCRIPTION
There is no testing of centos disk images that uses the
old msdos partition table. All tests were done with GPT
table layout.

