### PR TITLE
Changed concept for checking oem resize to be done

### DIFF
--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -234,8 +234,8 @@ mask_fsck_root_service
 # initialize for disk repartition
 initialize
 
-if ! disk_has_unallocated_space "${disk}";then
-    # already resized or disk has not received any geometry change
+if ! is_initial_deployment "${disk}"; then
+    # already resized
     return
 fi
 

--- a/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
@@ -149,3 +149,23 @@ function bool {
         echo "false"
     fi
 }
+
+function is_initial_deployment {
+    # """
+    # reads label names from filesystems on given disk
+    # and checks if their name contains the id string
+    # added during build time of the image. If such
+    # label is found the assumption is made that this
+    # is the first time the image got deployed on the
+    # given disk device. During resize of the disk
+    # kiwi changes the label name and deletes the id
+    # string
+    # """
+    local disk=$1
+    for label in $(lsblk --fs -o LABEL "${disk}");do
+        if [[ "${label}" == *"_IMG" ]];then
+            return 0
+        fi
+    done
+    return 1
+}

--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -307,17 +307,6 @@ function relocate_gpt_at_end_of_disk {
     fi
 }
 
-function disk_has_unallocated_space {
-    local disk_device=$1
-    local pt_table_type
-    pt_table_type=$(get_partition_table_type "${disk_device}")
-    if [ "${pt_table_type}" = "dos" ];then
-        sfdisk --verify "${disk_device}" 2>&1 | grep -q "unallocated"
-    else
-        sgdisk --verify "${disk_device}" 2>&1 | grep -q "end of the disk"
-    fi
-}
-
 function activate_boot_partition {
     local disk_device=$1
     local boot_partition_id=$2

--- a/dracut/modules.d/99kiwi-lib/module-setup.sh
+++ b/dracut/modules.d/99kiwi-lib/module-setup.sh
@@ -18,8 +18,8 @@ install() {
         blkid blockdev parted dd mkdir rmdir \
         grep cut tail head tr bc \
         basename partprobe sfdisk sgdisk mkswap readlink lsblk \
-        btrfs xfs_growfs resize2fs \
-        e2fsck btrfsck xfs_repair \
+        btrfs xfs_growfs resize2fs tune2fs \
+        e2fsck btrfsck xfs_repair xfs_admin \
         vgs vgchange lvextend lvcreate lvresize pvresize \
         mdadm cryptsetup dialog \
         pv curl xz \

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -24,6 +24,7 @@ namespace db  = "http://docbook.org/ns/docbook"
 namespace sch = "http://purl.oclc.org/dsdl/schematron"
 namespace nul = ""
 
+label-name = xsd:token {pattern = "[a-zA-Z]{1,8}"}
 safe-posix-name = xsd:token {pattern = "[a-zA-Z0-9_\-\.]+"}
 safe-posix-short-name = xsd:token {pattern = "[a-zA-Z0-9_\-\.]{1,32}"}
 locale-name = xsd:token {pattern = "(POSIX|[a-z]{2,3}_[A-Z]{2})(,[a-z]{2,3}_[A-Z]{2})*"}
@@ -1657,7 +1658,7 @@ div {
         ]
     k.type.rootfs_label.attribute =
         ## label to set for the root filesystem. By default ROOT is used
-        attribute rootfs_label { text }
+        attribute rootfs_label { label-name }
         >> sch:pattern [ id = "rootfs_label" is-a = "image_type"
             sch:param [ name = "attr" value = "rootfs_label" ]
             sch:param [ name = "types" value = "oem vmx pxe docker" ]

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -21,6 +21,11 @@
   ****************
 -->
 <grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:db="http://docbook.org/ns/docbook" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="label-name">
+    <data type="token">
+      <param name="pattern">[a-zA-Z]{1,8}</param>
+    </data>
+  </define>
   <define name="safe-posix-name">
     <data type="token">
       <param name="pattern">[a-zA-Z0-9_\-\.]+</param>
@@ -2467,6 +2472,7 @@ will force any COW action to happen in RAM</a:documentation>
     <define name="k.type.rootfs_label.attribute">
       <attribute name="rootfs_label">
         <a:documentation>label to set for the root filesystem. By default ROOT is used</a:documentation>
+        <ref name="label-name"/>
       </attribute>
       <sch:pattern id="rootfs_label" is-a="image_type">
         <sch:param name="attr" value="rootfs_label"/>

--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -225,8 +225,19 @@ class DiskSetup:
         :rtype: str
         """
         root_label = self.xml_state.build_type.get_rootfs_label()
+        image_type = self.xml_state.get_build_type_name()
         if not root_label:
             root_label = 'ROOT'
+        if image_type == 'oem':
+            # For the oem image type we append an ID string to
+            # the label of the root filesystem. This information is
+            # used in the kiwi dracut repart module to check for
+            # the initial deployment of the oem image. On resize
+            # the label gets rewritten by the dracut code without
+            # containing the ID string. Subsequent boots of that
+            # deployed machine will now no longer run the resize
+            # code again.
+            root_label += '_IMG'
         return root_label
 
     def get_efi_label(self):

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/ms/Project/kiwi/.tox/3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/ms/Project/kiwi/.tox/3.6/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -2832,6 +2832,13 @@ class type_(GeneratedsSuper):
                     self.validate_grub_console_patterns_, value):
                 warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_grub_console_patterns_, ))
     validate_grub_console_patterns_ = [['^(console|gfxterm|serial)( (console|gfxterm|serial))*$']]
+    def validate_label_name(self, value):
+        # Validate type label-name, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_label_name_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_label_name_patterns_, ))
+    validate_label_name_patterns_ = [['^[a-zA-Z]{1,8}$']]
     def validate_partition_size_type(self, value):
         # Validate type partition-size-type, a restriction on xs:token.
         if value is not None and Validate_simpletypes_:
@@ -3040,7 +3047,7 @@ class type_(GeneratedsSuper):
             outfile.write(' ramonly="%s"' % self.gds_format_boolean(self.ramonly, input_name='ramonly'))
         if self.rootfs_label is not None and 'rootfs_label' not in already_processed:
             already_processed.add('rootfs_label')
-            outfile.write(' rootfs_label=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.rootfs_label), input_name='rootfs_label')), ))
+            outfile.write(' rootfs_label=%s' % (quote_attrib(self.rootfs_label), ))
         if self.spare_part is not None and 'spare_part' not in already_processed:
             already_processed.add('spare_part')
             outfile.write(' spare_part=%s' % (quote_attrib(self.spare_part), ))
@@ -3425,6 +3432,8 @@ class type_(GeneratedsSuper):
         if value is not None and 'rootfs_label' not in already_processed:
             already_processed.add('rootfs_label')
             self.rootfs_label = value
+            self.rootfs_label = ' '.join(self.rootfs_label.split())
+            self.validate_label_name(self.rootfs_label)    # validate type label-name
         value = find_attr_value_('spare_part', node)
         if value is not None and 'spare_part' not in already_processed:
             already_processed.add('spare_part')

--- a/test/unit/storage/setup_test.py
+++ b/test/unit/storage/setup_test.py
@@ -228,10 +228,11 @@ class TestDiskSetup:
         assert self.setup.get_efi_label() == 'EFI'
 
     def test_get_default_root_label(self):
-        assert self.setup.get_root_label() == 'ROOT'
+        assert self.setup_root_volume.get_root_label() == 'ROOT'
+        assert self.setup.get_root_label() == 'ROOT_IMG'
 
     def test_get_custom_root_label(self):
-        assert self.setup_ppc.get_root_label() == 'MYLABEL'
+        assert self.setup_ppc.get_root_label() == 'MYLABEL_IMG'
 
     def _init_bootpart_check(self):
         self.setup.root_filesystem_is_overlay = None


### PR DESCRIPTION
The former implementation was based on checking for unallocated space on the disk compared to the current disk geometry used in the partition table. This actually is a clean way to check
the condition if the image got already resized to the real disk geometry. The tools used to check this condition were sfdisk and sgdisk. The problem is they are different in behavior and functionality compared across the distributions we support with kiwi. Thus there was a big risk that the check for unallocated space failed depending on the target distribution and release. Therefore I changed the concept to detect the condition and added an ID string to the root filesystem label.
If the ID string is present we consider it as an initial deployment, if not we consider the machine deployed and will not run the resize operation again. On resize kiwi's dracut code will rewrite the label and remove the ID. Users can re-activate the resize operation if they stick with the kiwi
oem dracut modules and append the _IMG id string to the rootfs label.

