### PR TITLE
Make disk allocation check more robust

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -312,9 +312,15 @@ function disk_has_unallocated_space {
     local pt_table_type
     pt_table_type=$(get_partition_table_type "${disk_device}")
     if [ "${pt_table_type}" = "dos" ];then
-        sfdisk --verify "${disk_device}" 2>&1 | grep -q "unallocated"
-    else
+        # we can't distinguish from 'intentional free space left'
+        # and the 'already resized' condition. Thus assume it's
+        # not fully allocated to allow for resize
+        true
+    elif [ "${pt_table_type}" = "gpt" ];then
         sgdisk --verify "${disk_device}" 2>&1 | grep -q "end of the disk"
+    else
+        # assume it's not fully allocated and allow for resize
+        true
     fi
 }
 

--- a/dracut/modules.d/99kiwi-lib/module-setup.sh
+++ b/dracut/modules.d/99kiwi-lib/module-setup.sh
@@ -16,7 +16,7 @@ install() {
     declare moddir=${moddir}
     inst_multiple \
         blkid blockdev parted dd mkdir rmdir \
-        grep cut tail head tr bc \
+        grep cut tail head tr bc true false \
         basename partprobe sfdisk sgdisk mkswap readlink lsblk \
         btrfs xfs_growfs resize2fs \
         e2fsck btrfsck xfs_repair \


### PR DESCRIPTION
**Make disk allocation check more robust**
    
The tools used to check the disk allocation condition are sfdisk and sgdisk. The problem is that at least sfdisk is different in behavior and functionality compared across the distributions we support with kiwi. In addition the verification for the msdos table cannot be used to distinguish between intentionaly wanted free space on disk and a disk that has not yet been resized. Thus  this commit changes two parts:
    
* always report unallocated space available for the msdos  table to allow to run kiwi's resize code
    
* make sure the table type is taken into consideration It's important to run the verification based on the table type (DOS, GPT) where we know the tools to work. In any  other case we report the disk to have unallocated space  and give the resize code a chance

