### PR TITLE
No default boot partition for btrfs_root_is_snapshot

### DIFF
--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -189,10 +189,10 @@ class DiskSetup:
             return False
         if self.mdraid:
             return True
-        if self.volume_manager:
+        if self.volume_manager == 'lvm':
             return True
-        if self.filesystem == 'btrfs':
-            return True
+        if self.volume_manager == 'btrfs':
+            return False
         if self.filesystem == 'xfs':
             return True
         if self.root_filesystem_is_overlay:

--- a/test/unit/storage/setup_test.py
+++ b/test/unit/storage/setup_test.py
@@ -105,8 +105,8 @@ class TestDiskSetup:
 
     def test_need_boot_partition_btrfs(self):
         self._init_bootpart_check()
-        self.setup.filesystem = 'btrfs'
-        assert self.setup.need_boot_partition() is True
+        self.setup.volume_manager = 'btrfs'
+        assert self.setup.need_boot_partition() is False
 
     def test_need_boot_partition_xfs(self):
         self._init_bootpart_check()
@@ -134,7 +134,6 @@ class TestDiskSetup:
 
     def test_get_disksize_mbytes_with_ppc_prep_partition(self):
         assert self.setup_ppc.get_disksize_mbytes() == \
-            Defaults.get_default_boot_mbytes() + \
             Defaults.get_default_prep_mbytes() + \
             self.size.accumulate_mbyte_file_sizes.return_value
 
@@ -143,7 +142,6 @@ class TestDiskSetup:
         assert self.setup_arm.get_disksize_mbytes() == \
             configured_spare_part_size + \
             Defaults.get_default_efi_boot_mbytes() + \
-            Defaults.get_default_boot_mbytes() + \
             self.size.accumulate_mbyte_file_sizes.return_value
 
     def test_get_disksize_mbytes_configured_additive(self):
@@ -155,7 +153,6 @@ class TestDiskSetup:
         assert self.setup.get_disksize_mbytes() == \
             Defaults.get_default_legacy_bios_mbytes() + \
             Defaults.get_default_efi_boot_mbytes() + \
-            Defaults.get_default_boot_mbytes() + \
             Defaults.get_swapsize_mbytes() + \
             root_size + 42 + \
             200 * 1.7


### PR DESCRIPTION
This commit ensures no boot partition is used when root is set to be
a btrfs snapshot unless this is explicitly required by the user.

Fixes #1351