### PR TITLE
Added new oem-resize-once element

### DIFF
--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -234,8 +234,8 @@ mask_fsck_root_service
 # initialize for disk repartition
 initialize
 
-if ! disk_has_unallocated_space "${disk}";then
-    # already resized or disk has not received any geometry change
+# check if repart/resize is wanted
+if ! resize_wanted "${root_device}" "${disk}"; then
     return
 fi
 

--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -88,7 +88,9 @@ class BootImageKiwi(BootImageBase):
         self.setup = SystemSetup(
             self.boot_xml_state, self.boot_root_directory
         )
-        self.setup.import_shell_environment(profile)
+        profile.create(
+            Defaults.get_profile_file(self.boot_root_directory)
+        )
         self.setup.import_description()
         self.setup.import_overlay_files(
             follow_links=True

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -367,6 +367,9 @@ class DiskBuilder:
                 label='SWAP'
             )
 
+        # store root partition uuid for profile
+        self._preserve_root_partition_uuid(device_map)
+
         # create a random image identifier
         self.mbrid = SystemIdentifier()
         self.mbrid.calculate_id()
@@ -940,6 +943,16 @@ class DiskBuilder:
             ]
         )
         self.fstab.add_entry(fstab_entry)
+
+    def _preserve_root_partition_uuid(self, device_map):
+        block_operation = BlockID(
+            device_map['root'].get_device()
+        )
+        partition_uuid = block_operation.get_blkid('PARTUUID')
+        if partition_uuid:
+            self.xml_state.set_root_partition_uuid(
+                partition_uuid
+            )
 
     def _write_image_identifier_to_system_image(self):
         log.info('Creating image identifier: %s', self.mbrid.get_id())

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1495,6 +1495,12 @@ class Defaults:
         if key in self.defaults:
             return self.defaults[key]
 
+    def get_profile_file(root_dir):
+        """
+        Return name of profile file for given root directory
+        """
+        return root_dir + '/.profile'
+
     def to_profile(self, profile):
         """
         Implements method to add list of profile keys and their values

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -385,6 +385,24 @@ div {
 }
 
 #==========================================
+# common element <oem-resize-once>
+#
+div {
+    k.oem-resize-once.content = xsd:boolean
+    k.oem-resize-once.attlist = empty
+    k.oem-resize-once =
+        ## For oem images: repart/resize only on first boot: true/false
+        ## By default the repart/resize happens on every reboot and
+        ## therefore also allows for disk geometry changes during the
+        ## livetime of the machine. If set to false the repart/resize
+        ## operation happens only once and then never again
+        element oem-resize-once {
+            k.oem-resize-once.attlist,
+            k.oem-resize-once.content
+        }
+}
+
+#==========================================
 # common element <oem-device-filter>
 #
 div {
@@ -2435,6 +2453,7 @@ div {
             k.oemconfig.attlist &
             k.oem-boot-title? &
             k.oem-bootwait? &
+            k.oem-resize-once? &
             k.oem-device-filter? &
             k.oem-nic-filter? &
             k.oem-inplace-recovery? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -650,6 +650,30 @@ of the OEM image</a:documentation>
   </div>
   <!--
     ==========================================
+    common element <oem-resize-once>
+    
+  -->
+  <div>
+    <define name="k.oem-resize-once.content">
+      <data type="boolean"/>
+    </define>
+    <define name="k.oem-resize-once.attlist">
+      <empty/>
+    </define>
+    <define name="k.oem-resize-once">
+      <element name="oem-resize-once">
+        <a:documentation>For oem images: repart/resize only on first boot: true/false
+By default the repart/resize happens on every reboot and
+therefore also allows for disk geometry changes during the
+livetime of the machine. If set to false the repart/resize
+operation happens only once and then never again</a:documentation>
+        <ref name="k.oem-resize-once.attlist"/>
+        <ref name="k.oem-resize-once.content"/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
     common element <oem-device-filter>
     
   -->
@@ -3759,6 +3783,9 @@ and setup the system disk.</a:documentation>
           </optional>
           <optional>
             <ref name="k.oem-bootwait"/>
+          </optional>
+          <optional>
+            <ref name="k.oem-resize-once"/>
           </optional>
           <optional>
             <ref name="k.oem-device-filter"/>

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -151,21 +151,6 @@ class SystemSetup:
                 repo_sourcetype
             )
 
-    def import_shell_environment(self, profile):
-        """
-        Create profile environment to let scripts consume
-        information from the XML description.
-
-        :param object profile: instance of :class:`Profile`
-        """
-        profile_file = self.root_dir + '/.profile'
-        log.info('Creating .profile environment')
-        profile_environment = profile.create()
-        with open(profile_file, 'w') as profile:
-            for line in profile_environment:
-                profile.write(line + '\n')
-                log.debug('--> %s', line)
-
     def import_cdroot_files(self, target_dir):
         """
         Copy cdroot files from the image description to the

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -218,11 +218,13 @@ class SystemBuildTask(CliTask):
 
         defaults = Defaults()
         defaults.to_profile(profile)
+        profile.create(
+            Defaults.get_profile_file(image_root)
+        )
 
         setup = SystemSetup(
             self.xml_state, image_root
         )
-        setup.import_shell_environment(profile)
 
         setup.import_description()
         setup.import_overlay_files()

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -207,7 +207,10 @@ class SystemPrepareTask(CliTask):
         setup = SystemSetup(
             self.xml_state, abs_root_path
         )
-        setup.import_shell_environment(profile)
+
+        profile.create(
+            Defaults.get_profile_file(abs_root_path)
+        )
 
         setup.import_description()
         setup.import_overlay_files()

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -5742,7 +5742,7 @@ class oemconfig(GeneratedsSuper):
     which are used to repartition and setup the system disk."""
     subclass = None
     superclass = None
-    def __init__(self, oem_boot_title=None, oem_bootwait=None, oem_device_filter=None, oem_nic_filter=None, oem_inplace_recovery=None, oem_kiwi_initrd=None, oem_multipath_scan=None, oem_vmcp_parmfile=None, oem_partition_install=None, oem_reboot=None, oem_reboot_interactive=None, oem_recovery=None, oem_recoveryID=None, oem_recovery_part_size=None, oem_shutdown=None, oem_shutdown_interactive=None, oem_silent_boot=None, oem_silent_install=None, oem_silent_verify=None, oem_skip_verify=None, oem_swap=None, oem_swapsize=None, oem_systemsize=None, oem_unattended=None, oem_unattended_id=None):
+    def __init__(self, oem_boot_title=None, oem_bootwait=None, oem_resize_once=None, oem_device_filter=None, oem_nic_filter=None, oem_inplace_recovery=None, oem_kiwi_initrd=None, oem_multipath_scan=None, oem_vmcp_parmfile=None, oem_partition_install=None, oem_reboot=None, oem_reboot_interactive=None, oem_recovery=None, oem_recoveryID=None, oem_recovery_part_size=None, oem_shutdown=None, oem_shutdown_interactive=None, oem_silent_boot=None, oem_silent_install=None, oem_silent_verify=None, oem_skip_verify=None, oem_swap=None, oem_swapsize=None, oem_systemsize=None, oem_unattended=None, oem_unattended_id=None):
         self.original_tagname_ = None
         if oem_boot_title is None:
             self.oem_boot_title = []
@@ -5752,6 +5752,10 @@ class oemconfig(GeneratedsSuper):
             self.oem_bootwait = []
         else:
             self.oem_bootwait = oem_bootwait
+        if oem_resize_once is None:
+            self.oem_resize_once = []
+        else:
+            self.oem_resize_once = oem_resize_once
         if oem_device_filter is None:
             self.oem_device_filter = []
         else:
@@ -5865,6 +5869,11 @@ class oemconfig(GeneratedsSuper):
     def add_oem_bootwait(self, value): self.oem_bootwait.append(value)
     def insert_oem_bootwait_at(self, index, value): self.oem_bootwait.insert(index, value)
     def replace_oem_bootwait_at(self, index, value): self.oem_bootwait[index] = value
+    def get_oem_resize_once(self): return self.oem_resize_once
+    def set_oem_resize_once(self, oem_resize_once): self.oem_resize_once = oem_resize_once
+    def add_oem_resize_once(self, value): self.oem_resize_once.append(value)
+    def insert_oem_resize_once_at(self, index, value): self.oem_resize_once.insert(index, value)
+    def replace_oem_resize_once_at(self, index, value): self.oem_resize_once[index] = value
     def get_oem_device_filter(self): return self.oem_device_filter
     def set_oem_device_filter(self, oem_device_filter): self.oem_device_filter = oem_device_filter
     def add_oem_device_filter(self, value): self.oem_device_filter.append(value)
@@ -5984,6 +5993,7 @@ class oemconfig(GeneratedsSuper):
         if (
             self.oem_boot_title or
             self.oem_bootwait or
+            self.oem_resize_once or
             self.oem_device_filter or
             self.oem_nic_filter or
             self.oem_inplace_recovery or
@@ -6045,6 +6055,9 @@ class oemconfig(GeneratedsSuper):
         for oem_bootwait_ in self.oem_bootwait:
             showIndent(outfile, level, pretty_print)
             outfile.write('<oem-bootwait>%s</oem-bootwait>%s' % (self.gds_format_boolean(oem_bootwait_, input_name='oem-bootwait'), eol_))
+        for oem_resize_once_ in self.oem_resize_once:
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<oem-resize-once>%s</oem-resize-once>%s' % (self.gds_format_boolean(oem_resize_once_, input_name='oem-resize-once'), eol_))
         for oem_device_filter_ in self.oem_device_filter:
             showIndent(outfile, level, pretty_print)
             outfile.write('<oem-device-filter>%s</oem-device-filter>%s' % (self.gds_encode(self.gds_format_string(quote_xml(oem_device_filter_), input_name='oem-device-filter')), eol_))
@@ -6138,6 +6151,16 @@ class oemconfig(GeneratedsSuper):
                 raise_parse_error(child_, 'requires boolean')
             ival_ = self.gds_validate_boolean(ival_, node, 'oem_bootwait')
             self.oem_bootwait.append(ival_)
+        elif nodeName_ == 'oem-resize-once':
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_resize_once')
+            self.oem_resize_once.append(ival_)
         elif nodeName_ == 'oem-device-filter':
             oem_device_filter_ = child_.text
             oem_device_filter_ = self.gds_validate_string(oem_device_filter_, node, 'oem_device_filter')

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -46,6 +46,7 @@ class XMLState:
     :param object build_type: build <type> section reference
     """
     def __init__(self, xml_data, profiles=None, build_type=None):
+        self.root_partition_uuid = None
         self.host_architecture = platform.machine()
         self.xml_data = xml_data
         self.profiles = self._used_profiles(profiles)
@@ -1807,6 +1808,20 @@ class XMLState:
                 type section
             ''')
             log.warning(message.format(uri))
+
+    def set_root_partition_uuid(self, uuid):
+        """
+        Store PARTUUID provided in uuid as state information
+
+        :param string uuid: PARTUUID
+        """
+        self.root_partition_uuid = uuid
+
+    def get_root_partition_uuid(self):
+        """
+        Return preserved PARTUUID
+        """
+        return self.root_partition_uuid
 
     def _used_profiles(self, profiles=None):
         """

--- a/test/unit/boot/image/builtin_kiwi_test.py
+++ b/test/unit/boot/image/builtin_kiwi_test.py
@@ -68,8 +68,8 @@ class TestBootImageKiwi:
         assert self.profile.add.call_args_list[0] == call(
             'kiwi_initrdname', 'initrd-oemboot-suse-13.2'
         )
-        self.setup.import_shell_environment.assert_called_once_with(
-            self.profile
+        self.profile.create.assert_called_once_with(
+            'boot-root-directory/.profile'
         )
         self.setup.import_description.assert_called_once_with()
         self.setup.import_overlay_files.assert_called_once_with(

--- a/test/unit/boot/image/dracut_test.py
+++ b/test/unit/boot/image/dracut_test.py
@@ -32,15 +32,10 @@ class TestBootImageKiwi:
         ])
 
     @patch('kiwi.boot.image.dracut.SystemSetup')
-    @patch('kiwi.boot.image.dracut.Profile')
-    def test_prepare(self, mock_profile, mock_setup):
+    def test_prepare(self, mock_setup):
         setup = Mock()
-        profile = Mock()
-        profile.dot_profile = dict()
-        mock_profile.return_value = profile
         mock_setup.return_value = setup
         self.boot_image.prepare()
-        setup.import_shell_environment.assert_called_once_with(profile)
         setup.setup_machine_id.assert_called_once_with()
         assert self.boot_image.dracut_options == [
             '--install', '/.profile'
@@ -115,9 +110,13 @@ class TestBootImageKiwi:
     @patch('kiwi.boot.image.dracut.Kernel')
     @patch('kiwi.boot.image.dracut.Command.run')
     @patch('kiwi.boot.image.base.BootImageBase.is_prepared')
+    @patch('kiwi.boot.image.dracut.Profile')
     def test_create_initrd(
-        self, mock_prepared, mock_command, mock_kernel
+        self, mock_Profile, mock_prepared, mock_command, mock_kernel
     ):
+        profile = Mock()
+        profile.dot_profile = dict()
+        mock_Profile.return_value = profile
         kernel = Mock()
         kernel_details = Mock()
         kernel_details.version = '1.2.3'
@@ -130,6 +129,9 @@ class TestBootImageKiwi:
         self.boot_image.include_module('foo')
         self.boot_image.omit_module('bar')
         self.boot_image.create_initrd()
+        profile.create.assert_called_once_with(
+            'system-directory/.profile'
+        )
         assert mock_command.call_args_list == [
             call([
                 'chroot', 'system-directory',

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -380,6 +380,9 @@ class TestDiskBuilder:
             call(['cp', 'root_dir/recovery.partition.size', 'boot_dir']),
             call(['mv', 'initrd', 'root_dir/boot/initrd.vmx']),
         ]
+        self.block_operation.get_blkid.assert_has_calls(
+            [call('PARTUUID')]
+        )
         self.setup.export_package_list.assert_called_once_with(
             'target_dir'
         )
@@ -497,6 +500,9 @@ class TestDiskBuilder:
             call(['cp', 'root_dir/recovery.partition.size', 'boot_dir']),
             call(['mv', 'initrd', 'root_dir/boot/initramfs-1.2.3.img'])
         ]
+        self.block_operation.get_blkid.assert_has_calls(
+            [call('PARTUUID')]
+        )
         self.setup.export_package_list.assert_called_once_with(
             'target_dir'
         )

--- a/test/unit/system/profile_test.py
+++ b/test/unit/system/profile_test.py
@@ -13,6 +13,7 @@ class TestProfile:
     def setup(self):
         self.tmpfile = mock.Mock()
         self.tmpfile.name = 'tmpfile'
+        self.profile_file = 'tmpfile.profile'
         description = XMLDescription('../data/example_dot_profile_config.xml')
         self.profile = Profile(
             XMLState(description.load())
@@ -23,8 +24,9 @@ class TestProfile:
     def test_create(self, mock_which, mock_temp):
         mock_which.return_value = 'cp'
         mock_temp.return_value = self.tmpfile
-        result = self.profile.create()
+        self.profile.create(self.profile_file)
         os.remove(self.tmpfile.name)
+        os.remove(self.profile_file)
         assert self.profile.dot_profile == {
             'kiwi_Volume_1': 'usr_lib|size:1024|usr/lib',
             'kiwi_Volume_2': 'LVRoot|freespace:500|',
@@ -70,6 +72,7 @@ class TestProfile:
             'kiwi_oemrecoveryPartSize': None,
             'kiwi_oemrootMB': 2048,
             'kiwi_oemshutdowninteractive': None,
+            'kiwi_oemresizeonce': None,
             'kiwi_oemshutdown': None,
             'kiwi_oemsilentboot': None,
             'kiwi_oemsilentinstall': None,
@@ -98,38 +101,9 @@ class TestProfile:
             'kiwi_vga': None,
             'kiwi_startsector': 2048,
             'kiwi_wwid_wait_timeout': None,
-            'kiwi_xendomain': 'dom0'
+            'kiwi_xendomain': 'dom0',
+            'kiwi_rootpartuuid': None
         }
-        assert result == [
-            "kiwi_Volume_1='usr_lib|size:1024|usr/lib'",
-            "kiwi_Volume_2='LVRoot|freespace:500|'",
-            "kiwi_Volume_3='etc_volume|freespace:30|etc'",
-            "kiwi_Volume_4='bin_volume|size:all|/usr/bin'",
-            "kiwi_Volume_5='usr_bin|freespace:30|usr/bin'",
-            "kiwi_Volume_6='LVSwap|size:128|'",
-            "kiwi_bootloader='grub2'",
-            "kiwi_cmdline='splash'",
-            "kiwi_displayname='schäfer'",
-            "kiwi_firmware='efi'",
-            "kiwi_iname='LimeJeOS-openSUSE-13.2'",
-            "kiwi_initrd_system='kiwi'",
-            "kiwi_install_volid='INSTALL'",
-            "kiwi_iversion='1.13.2'",
-            "kiwi_keytable='us.map.gz'",
-            "kiwi_language='en_US'",
-            "kiwi_loader_theme='openSUSE'",
-            "kiwi_lvm='true'",
-            "kiwi_lvmgroup='systemVG'",
-            "kiwi_oemrootMB='2048'",
-            "kiwi_oemskipverify='true'",
-            "kiwi_oemtitle='schäfer'",
-            "kiwi_ramonly='true'",
-            "kiwi_splash_theme='openSUSE'",
-            "kiwi_startsector='2048'",
-            "kiwi_timezone='Europe/Berlin'",
-            "kiwi_type='oem'",
-            "kiwi_xendomain='dom0'"
-        ]
 
     @patch('kiwi.system.profile.NamedTemporaryFile')
     @patch('kiwi.path.Path.which')
@@ -140,9 +114,11 @@ class TestProfile:
         profile = Profile(
             XMLState(description.load())
         )
-        profile.create()
+        profile.create(self.profile_file)
         os.remove(self.tmpfile.name)
-        assert profile.dot_profile['kiwi_displayname'] == 'LimeJeOS-openSUSE-13.2'
+        os.remove(self.profile_file)
+        assert profile.dot_profile['kiwi_displayname'] == \
+            'LimeJeOS-openSUSE-13.2'
 
     @patch('kiwi.system.profile.NamedTemporaryFile')
     @patch('kiwi.path.Path.which')
@@ -153,9 +129,11 @@ class TestProfile:
         profile = Profile(
             XMLState(description.load(), None, 'cpio')
         )
-        profile.create()
+        profile.create(self.profile_file)
         os.remove(self.tmpfile.name)
-        assert profile.dot_profile['kiwi_cpio_name'] == 'LimeJeOS-openSUSE-13.2'
+        os.remove(self.profile_file)
+        assert profile.dot_profile['kiwi_cpio_name'] == \
+            'LimeJeOS-openSUSE-13.2'
 
     def test_add(self):
         self.profile.add('foo', 'bar')

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -185,20 +185,6 @@ class TestSystemSetup:
             ['rm', '-r', '-f', '/.kconfig', '/image']
         )
 
-    def test_import_shell_environment(self):
-        mock_profile = MagicMock()
-        mock_profile.create = Mock(
-            return_value=['a']
-        )
-
-        m_open = mock_open()
-        with patch('builtins.open', m_open, create=True):
-            self.setup.import_shell_environment(mock_profile)
-
-        mock_profile.create.assert_called_once_with()
-        m_open.assert_called_once_with('root_dir/.profile', 'w')
-        m_open.return_value.write.assert_called_once_with('a\n')
-
     @patch('kiwi.system.setup.ArchiveTar')
     @patch('kiwi.system.setup.glob.iglob')
     def test_import_cdroot_files(self, mock_iglob, mock_ArchiveTar):

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -160,8 +160,8 @@ class TestSystemBuildTask:
         self.system_prepare.install_system.assert_called_once_with(
             self.manager
         )
-        self.setup.import_shell_environment.assert_called_once_with(
-            self.profile
+        self.profile.create.assert_called_once_with(
+            self.abs_target_dir + '/build/image-root/.profile'
         )
         self.setup.import_description.assert_called_once_with()
         self.setup.import_overlay_files.assert_called_once_with()

--- a/test/unit/tasks/system_prepare_test.py
+++ b/test/unit/tasks/system_prepare_test.py
@@ -150,8 +150,8 @@ class TestSystemPrepareTask:
         self.system_prepare.install_system.assert_called_once_with(
             self.manager
         )
-        self.setup.import_shell_environment.assert_called_once_with(
-            self.profile
+        self.profile.create.assert_called_once_with(
+            self.abs_root_dir + '/.profile'
         )
         self.setup.import_description.assert_called_once_with()
         self.setup.import_overlay_files.assert_called_once_with()

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -817,3 +817,8 @@ class TestXMLState:
         assert self.state.get_rpm_locale() == [
             'POSIX', 'C', 'C.UTF-8', 'en_US', 'de_DE'
         ]
+
+    def test_set_root_partition_uuid(self):
+        assert self.state.get_root_partition_uuid() is None
+        self.state.set_root_partition_uuid('some-id')
+        assert self.state.get_root_partition_uuid() == 'some-id'


### PR DESCRIPTION
The new element controls the behavior of the repart/resize code
in the oem-repart dracut module.

```xml
<oemconfig>
    <oem-resize-once>true</oem-resize-once>
</oemconfig>
```

By default the repart/resize happens on every reboot and therefore also allows for disk geometry changes during the livetime of the machine. If the element is set to false the repart/resize operation happens only once and then never again. To check for this condition a new profile environment variable kiwi_rootpartuuid which holds the PARTUUID of the root partition has been added to the disk builder.



