### PR TITLE
Add SECURE_BOOT parameter for grub2 in efi mode

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -483,6 +483,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         * LOADER_LOCATION
         * DEFAULT_APPEND
         * FAILSAFE_APPEND
+        * SECURE_BOOT
         """
         sysconfig_bootloader_entries = {
             'LOADER_TYPE':
@@ -490,6 +491,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             'LOADER_LOCATION':
                 'none' if self.firmware.efi_mode() else 'mbr'
         }
+        if self.firmware.efi_mode() == 'uefi':
+            sysconfig_bootloader_entries['SECURE_BOOT'] = 'yes'
         if self.cmdline:
             sysconfig_bootloader_entries['DEFAULT_APPEND'] = '"{0}"'.format(
                 self.cmdline

--- a/kiwi/firmware.py
+++ b/kiwi/firmware.py
@@ -97,9 +97,9 @@ class FirmWare:
         """
         Check if EFI mode is requested
 
-        :return: True or False
+        :return: The requested EFI mode or None if no EFI mode requested
 
-        :rtype: bool
+        :rtype: str
         """
         if self.firmware in Defaults.get_efi_capable_firmware_names():
             return self.firmware

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -371,7 +371,7 @@ class TestBootLoaderConfigGrub2:
             call('LOADER_TYPE', 'grub2')
         ]
         self.firmware.efi_mode = Mock(
-            return_value=True
+            return_value='uefi'
         )
         sysconfig_bootloader.__setitem__.reset_mock()
         self.bootloader._setup_sysconfig_bootloader()
@@ -382,7 +382,8 @@ class TestBootLoaderConfigGrub2:
                 '"some-cmdline root=UUID=foo failsafe-options"'
             ),
             call('LOADER_LOCATION', 'none'),
-            call('LOADER_TYPE', 'grub2-efi')
+            call('LOADER_TYPE', 'grub2-efi'),
+            call('SECURE_BOOT', 'yes')
         ]
 
     def test_setup_live_image_config_multiboot(self):


### PR DESCRIPTION
This commit adds the SECURE_BOOT parameter on bootloader sysconfig
for grub2.

Fixes bsc#1167746
