### PR TITLE
Make build of filesystem image optional for pxe

### DIFF
--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1405,7 +1405,7 @@ div {
         >> sch:pattern [
             id = "filesystem_mandatory" is-a = "image_type_requirement"
             sch:param [ name = "attr" value = "filesystem" ]
-            sch:param [ name = "types" value = "vmx oem pxe" ]
+            sch:param [ name = "types" value = "vmx oem" ]
         ]
 	k.type.squashfscompression.attribute = 
         ## Specifies the compression type for mksquashfs

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2104,7 +2104,7 @@ structure</a:documentation>
       </sch:pattern>
       <sch:pattern id="filesystem_mandatory" is-a="image_type_requirement">
         <sch:param name="attr" value="filesystem"/>
-        <sch:param name="types" value="vmx oem pxe"/>
+        <sch:param name="types" value="vmx oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.squashfscompression.attribute">


### PR DESCRIPTION
Allow to build a kernel/initrd pair without a root
filesystem image. Related to Issue #1388

