### PR TITLE
Allow overlay directories for profiles

### DIFF
--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -61,9 +61,12 @@ Overlay Files
    A directory structure with files and subdirectories stored as part
    of the Image Description. This directory structure is packaged as
    a file :file:`root.tar.gz` or stored inside a directory named
-   :file:`root`. The content of the directory structure is copied on top of
-   the the existing file system (overlayed) of the appliance root.
-   This also includes permissions and attributes as a supplement.
+   :file:`root`. Additional overlay directories for selected profiles
+   are supported too and are taken into account if the directory
+   name matches the name of the profile. The content of each of the
+   directory structures is copied on top of the the existing file
+   system (overlayed) of the appliance root. This also includes
+   permissions and attributes as a supplement.
 
 {kiwi}
    An OS appliance builder.

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -264,6 +264,31 @@ class TestSystemSetup:
             'root_dir'
         )
 
+    @patch('kiwi.system.setup.DataSync')
+    @patch('os.path.exists')
+    def test_import_overlay_files_from_profile(
+        self, mock_os_path, mock_DataSync
+    ):
+        exists_results = [True, False, False]
+
+        def side_effect(arg):
+            return exists_results.pop()
+
+        data = Mock()
+        mock_DataSync.return_value = data
+        mock_os_path.side_effect = side_effect
+        self.xml_state.profiles = ['profile_root']
+        self.setup.import_overlay_files()
+        mock_DataSync.assert_called_once_with(
+            'description_dir/profile_root/', 'root_dir'
+        )
+        data.sync_data.assert_called_once_with(
+            options=[
+                '-r', '-p', '-t', '-D', '-H', '-X', '-A',
+                '--one-file-system', '--links'
+            ]
+        )
+
     @patch('kiwi.system.setup.Shell.run_common_function')
     @patch('kiwi.system.setup.Command.run')
     @patch('os.path.exists')


### PR DESCRIPTION
In addition to the existing root/ overlay directory which
applies always there can now also be profile specific overlay
directories. If an overlay directory should be applied for
a specific profile this can now be done by placing this data
in a directory that is named the same as the profile name.

