### PR TITLE
Create qcow2 images in two steps

### DIFF
--- a/kiwi/storage/subformat/qcow2.py
+++ b/kiwi/storage/subformat/qcow2.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
-
+from tempfile import NamedTemporaryFile
 
 # project
 from kiwi.storage.subformat.base import DiskFormatBase
@@ -40,11 +40,19 @@ class DiskFormatQcow2(DiskFormatBase):
         """
         Create qcow2 disk format
         """
+        intermediate = NamedTemporaryFile()
         Command.run(
             [
-                'qemu-img', 'convert', '-c', '-f', 'raw', self.diskname,
+                'qemu-img', 'convert', '-f', 'raw', self.diskname,
                 '-O', self.image_format
             ] + self.options + [
+                intermediate.name
+            ]
+        )
+        Command.run(
+            [
+                'qemu-img', 'convert', '-c', '-f', self.image_format,
+                intermediate.name, '-O', self.image_format,
                 self.get_target_file_path_for_format(self.image_format)
             ]
         )

--- a/test/unit/storage/subformat/qcow2_test.py
+++ b/test/unit/storage/subformat/qcow2_test.py
@@ -1,6 +1,6 @@
-from mock import patch
-
-import mock
+from mock import (
+    patch, Mock, call
+)
 
 from kiwi.storage.subformat.qcow2 import DiskFormatQcow2
 
@@ -9,13 +9,13 @@ class TestDiskFormatQcow2:
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'
-        xml_data = mock.Mock()
-        xml_data.get_name = mock.Mock(
+        xml_data = Mock()
+        xml_data.get_name = Mock(
             return_value='some-disk-image'
         )
-        self.xml_state = mock.Mock()
+        self.xml_state = Mock()
         self.xml_state.xml_data = xml_data
-        self.xml_state.get_image_version = mock.Mock(
+        self.xml_state.get_image_version = Mock(
             return_value='1.2.3'
         )
         self.disk_format = DiskFormatQcow2(
@@ -27,18 +27,33 @@ class TestDiskFormatQcow2:
         assert self.disk_format.options == ['-o', 'option=value']
 
     @patch('kiwi.storage.subformat.qcow2.Command.run')
-    def test_create_image_format(self, mock_command):
+    @patch('kiwi.storage.subformat.qcow2.NamedTemporaryFile')
+    def test_create_image_format(self, mock_NamedTemporaryFile, mock_command):
+        tmpfile = Mock()
+        tmpfile.name = 'tmpfile'
+        mock_NamedTemporaryFile.return_value = tmpfile
         self.disk_format.create_image_format()
-        mock_command.assert_called_once_with(
-            [
-                'qemu-img', 'convert', '-c', '-f', 'raw',
-                'target_dir/some-disk-image.x86_64-1.2.3.raw', '-O', 'qcow2',
-                'target_dir/some-disk-image.x86_64-1.2.3.qcow2'
-            ]
-        )
+        assert mock_command.call_args_list == [
+            call(
+                [
+                    'qemu-img', 'convert', '-f', 'raw',
+                    'target_dir/some-disk-image.x86_64-1.2.3.raw',
+                    '-O', 'qcow2',
+                    'tmpfile'
+                ]
+            ),
+            call(
+                [
+                    'qemu-img', 'convert', '-c', '-f', 'qcow2',
+                    'tmpfile',
+                    '-O', 'qcow2',
+                    'target_dir/some-disk-image.x86_64-1.2.3.qcow2'
+                ]
+            )
+        ]
 
     def test_store_to_result(self):
-        result = mock.Mock()
+        result = Mock()
         self.disk_format.store_to_result(result)
         result.add.assert_called_once_with(
             compress=False,


### PR DESCRIPTION
The creation of the qcow2 format was done in one qemu-img
convert call. That call instructs qemu to compress and
convert in one call. The downside of this approach is that
not all qcow2 options can be used. For example the setup
of:

```xml
<type ... formatoptions="preallocation=metadata"/>
```

failed the build with an error message that compression and
preallocation is not possible at the same time. Thus this patch
changes the way the qcow2 image is created to be done in two
steps. The first step converts the format without compression
and therefore allows for any format option to be used. The
second call only applies the compression and leads to the
final result.


