### PR TITLE
Validate use of GRUB_USE_LINUXEFI

### DIFF
--- a/kiwi/utils/command_capabilities.py
+++ b/kiwi/utils/command_capabilities.py
@@ -103,10 +103,11 @@ class CommandCapabilities:
         try:
             command = Command.run(arguments)
             for line in command.output.splitlines():
-                match = re.search('[0-9]+(\.[0-9]+)*', line)
-                if match:
+                matches = re.findall(r'([0-9]+(\.[0-9]+)*)', line)
+                if matches:
+                    match = max([m[0] for m in matches], key=len)
                     version_info = tuple(
-                        int(elt) for elt in match.group(0).split('.')
+                        int(elt) for elt in match.split('.')
                     )
                     break
             if version_info is None:

--- a/test/unit/utils/command_capabilities_test.py
+++ b/test/unit/utils/command_capabilities_test.py
@@ -95,6 +95,15 @@ class TestCommandCapabilities:
         ])
 
     @patch('kiwi.command.Command.run')
+    def test_check_version_complex_pattern(self, mock_run):
+        command_type = namedtuple('command', ['output'])
+        mock_run.return_value = command_type(
+            output="grub2-mkconfig (GRUB2) 2.02\n"
+        )
+        assert CommandCapabilities.check_version('command', (2, 2)) is True
+        assert CommandCapabilities.check_version('command', (2, 4)) is False
+
+    @patch('kiwi.command.Command.run')
     def test_check_version_no_match(self, mock_run):
         command_type = namedtuple('command', ['output'])
         mock_run.return_value = command_type(


### PR DESCRIPTION
Validate use of GRUB_USE_LINUXEFI
    
On systems that uses GRUB_USE_LINUXEFI with grub2 version
less than 2.04 there is no support for dynamic EFI
environment checking. In this condition we extend the grub
setup to add this support. The change kiwi does is as
follows:
    
* Apply only on grub < 2.04
   1. Modify 10_linux to set linux/initrd as variables
   2. Write hybrid setup as 01_efihybrid
    
This Fixes bsc#1165960