### PR TITLE
Fixed check for grub mkconfig capabilities

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -575,7 +575,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 use_linuxefi_implemented = Command.run(
                     [
                         'grep', '-q', 'GRUB_USE_LINUXEFI',
-                        Defaults.get_grub_config_tool()
+                        self._get_grub2_mkconfig_tool()
                     ], raise_on_error=False
                 )
                 if use_linuxefi_implemented.returncode == 0:
@@ -589,7 +589,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         enable_blscfg_implemented = Command.run(
             [
                 'grep', '-q', 'GRUB_ENABLE_BLSCFG',
-                Defaults.get_grub_config_tool()
+                self._get_grub2_mkconfig_tool()
             ], raise_on_error=False
         )
         if enable_blscfg_implemented.returncode == 0:

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -369,20 +369,6 @@ class Defaults:
             return 'grub'
 
     @staticmethod
-    def get_grub_config_tool():
-        """
-        Provides full qualified path name to grub mkconfig utility
-
-        :return: file path name
-
-        :rtype: str
-        """
-        for grub_mkconfig_tool in ['grub2-mkconfig', 'grub-mkconfig']:
-            grub_mkconfig_tool_file_path = Path.which(grub_mkconfig_tool)
-            if grub_mkconfig_tool_file_path:
-                return grub_mkconfig_tool_file_path
-
-    @staticmethod
     def get_grub_basic_modules(multiboot):
         """
         Provides list of basic grub modules


### PR DESCRIPTION
The check for the capabilities of the tool were applied to
the tool installed on the host but the later call of the
tool will be done with the tool inside the image root

