### PR TITLE
Fixed return value from _get_grub2_mkconfig_tool

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -233,7 +233,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         Command.run(
             [
                 'chroot', self.root_mount.mountpoint,
-                self._get_grub2_mkconfig_tool(), '-o',
+                os.path.basename(self._get_grub2_mkconfig_tool()), '-o',
                 config_file.replace(self.root_mount.mountpoint, '')
             ]
         )
@@ -875,8 +875,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
 
     def _get_grub2_mkconfig_tool(self):
         for grub_mkconfig_tool in ['grub2-mkconfig', 'grub-mkconfig']:
-            if Path.which(grub_mkconfig_tool, root_dir=self.root_dir):
-                return grub_mkconfig_tool
+            return Path.which(grub_mkconfig_tool, root_dir=self.root_dir)
 
     def _get_grub2_boot_path(self):
         return self.boot_dir + '/boot/' + self.boot_directory_name

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -414,10 +414,12 @@ class TestBootLoaderConfigGrub2:
     @patch.object(BootLoaderConfigGrub2, '_mount_system')
     @patch.object(BootLoaderConfigGrub2, '_copy_grub_config_to_efi_path')
     @patch('kiwi.bootloader.config.grub2.Command.run')
+    @patch('kiwi.bootloader.config.grub2.Path.which')
     def test_setup_disk_image_config(
-        self, mock_Command_run, mock_copy_grub_config_to_efi_path,
-        mock_mount_system
+        self, mock_Path_which, mock_Command_run,
+        mock_copy_grub_config_to_efi_path, mock_mount_system
     ):
+        mock_Path_which.return_value = '/path/to/grub2-mkconfig'
         self.firmware.efi_mode = Mock(
             return_value='uefi'
         )
@@ -456,10 +458,13 @@ class TestBootLoaderConfigGrub2:
     @patch.object(BootLoaderConfigGrub2, '_copy_grub_config_to_efi_path')
     @patch('kiwi.bootloader.config.grub2.Command.run')
     @patch('kiwi.bootloader.config.grub2.CommandCapabilities.check_version')
+    @patch('kiwi.bootloader.config.grub2.Path.which')
     def test_setup_disk_image_config_validate_linuxefi(
-        self, mock_CommandCapabilities_check_version, mock_Command_run,
-        mock_copy_grub_config_to_efi_path, mock_mount_system
+        self, mock_Path_which, mock_CommandCapabilities_check_version,
+        mock_Command_run, mock_copy_grub_config_to_efi_path,
+        mock_mount_system
     ):
+        mock_Path_which.return_value = '/path/to/grub2-mkconfig'
         mock_CommandCapabilities_check_version.return_value = False
         self.firmware.efi_mode = Mock(
             return_value='uefi'


### PR DESCRIPTION
The method returned the basename of the tool if it could
be found by Path.which(). But the method's scope has been
changed in a way that the return value of the method must
be the result from Path.which() to allow working on the
full path name.


