### PR TITLE
Increase spare space on disk repart

### DIFF
--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -74,15 +74,15 @@ function repart_standard_disk {
         local disk_have_root_system_mbytes=$((
             disk_root_mbytes + disk_free_mbytes
         ))
-        local min_additional_mbytes=5
+        local min_additional_mbytes=10
     else
         local disk_have_root_system_mbytes=${kiwi_oemrootMB}
         local min_additional_mbytes=$((
             kiwi_oemrootMB - disk_root_mbytes
         ))
     fi
-    if [ "${min_additional_mbytes}" -lt 5 ];then
-        min_additional_mbytes=5
+    if [ "${min_additional_mbytes}" -lt 10 ];then
+        min_additional_mbytes=10
     fi
     # check if we can repart this disk
     if ! check_repart_possible \
@@ -124,7 +124,7 @@ function repart_lvm_disk {
         local disk_have_root_system_mbytes=$((
             disk_root_mbytes + disk_free_mbytes
         ))
-        local min_additional_mbytes=5
+        local min_additional_mbytes=10
     else
         local disk_have_root_system_mbytes=$((
             kiwi_oemrootMB
@@ -133,8 +133,8 @@ function repart_lvm_disk {
             kiwi_oemrootMB - disk_root_mbytes
         ))
     fi
-    if [ "${min_additional_mbytes}" -lt 5 ];then
-        min_additional_mbytes=5
+    if [ "${min_additional_mbytes}" -lt 10 ];then
+        min_additional_mbytes=10
     fi
     # check if we can repart this disk
     if ! check_repart_possible \


### PR DESCRIPTION
The sizing of the virtual cylinders in parted seems to be unfavorable,
as with some disks and SD cards here the device size is not a multiple
of the cylinder size, so the last incomplete cylinder is wasted.
If this wasted space is more than 5MiB, kiwi tries to resize indefinitely.
Therefore min_additional_mbytes gets increased to prevent running
into this situation. This Fixes bsc#1165823

