### PR TITLE
Added check_syslinux_installed_if_isolinux_is_used

### DIFF
--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -87,7 +87,8 @@ class CliTask:
             'check_dracut_module_for_disk_oem_in_package_list': [],
             'check_dracut_module_for_oem_install_in_package_list': [],
             'check_architecture_supports_iso_firmware_setup': [],
-            'check_appx_naming_conventions_valid': []
+            'check_appx_naming_conventions_valid': [],
+            'check_syslinux_installed_if_isolinux_is_used': []
         }
         self.checks_after_command_args = {
             'check_repositories_configured': [],

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -321,5 +321,25 @@ class TestRuntimeChecker:
         with raises(KiwiRuntimeError):
             runtime_checker.check_architecture_supports_iso_firmware_setup()
 
+    @patch('platform.machine')
+    @patch('kiwi.runtime_checker.Path.which')
+    def test_check_syslinux_installed_if_isolinux_is_used(
+        self, mock_Path_which, mock_machine
+    ):
+        mock_Path_which.return_value = None
+        mock_machine.return_value = 'x86_64'
+        xml_state = XMLState(
+            self.description.load(), ['vmxFlavour'], 'iso'
+        )
+        runtime_checker = RuntimeChecker(xml_state)
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_syslinux_installed_if_isolinux_is_used()
+        xml_state = XMLState(
+            self.description.load(), ['xenFlavour'], 'oem'
+        )
+        runtime_checker = RuntimeChecker(xml_state)
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_syslinux_installed_if_isolinux_is_used()
+
     def teardown(self):
         sys.argv = argv_kiwi_tests


### PR DESCRIPTION
ISO images that are configured to use isolinux requires the host
to provide a set of syslinux binaries. The runtime check makes
sure to check for this condition early including a proper message.
This Fixes #1376

