### PR TITLE
Disable AudioAdapter for vagrant

### DIFF
--- a/kiwi/storage/subformat/template/virtualbox_ovf.py
+++ b/kiwi/storage/subformat/template/virtualbox_ovf.py
@@ -53,6 +53,11 @@ class VirtualboxOvfTemplate:
       <Description>${vm_description}</Description>
       <vbox:OSType ovf:required="false">Linux_64</vbox:OSType>
     </OperatingSystemSection>
+    <vbox:Machine ovf:required="false">
+      <Hardware>
+        <AudioAdapter enabled="false"/>
+      </Hardware>
+    </vbox:Machine>
     <VirtualHardwareSection>
       <Info>Virtual hardware requirements for a virtual machine</Info>
       <System>

--- a/test/data/vagrant_virtualbox.ovf
+++ b/test/data/vagrant_virtualbox.ovf
@@ -20,6 +20,11 @@
       <Description>OpenSUSE Leap 15.0</Description>
       <vbox:OSType ovf:required="false">Linux_64</vbox:OSType>
     </OperatingSystemSection>
+    <vbox:Machine ovf:required="false">
+      <Hardware>
+        <AudioAdapter enabled="false"/>
+      </Hardware>
+    </vbox:Machine>
     <VirtualHardwareSection>
       <Info>Virtual hardware requirements for a virtual machine</Info>
       <System>


### PR DESCRIPTION
The kiwi template for vagrant images assumes the box files to
be used in non graphics mode and for the purpose of automation
or server deployment. Thus by default we disable Audio.
For details see the API reference:

* https://www.virtualbox.org/sdkref/interface_i_audio_adapter.html

This Fixes #1322

