### PR TITLE
Add flags and argument separator for zypper

### DIFF
--- a/kiwi/package_manager/zypper.py
+++ b/kiwi/package_manager/zypper.py
@@ -105,7 +105,7 @@ class PackageManagerZypper(PackageManagerBase):
         command = ['zypper'] + self.zypper_args + [
             '--root', self.root_dir,
             'install', '--auto-agree-with-licenses'
-        ] + self.custom_args + self._install_items()
+        ] + self.custom_args + ['--'] + self._install_items()
         return Command.call(
             command, self.command_env
         )
@@ -136,7 +136,7 @@ class PackageManagerZypper(PackageManagerBase):
         return Command.call(
             ['chroot', self.root_dir, 'zypper'] + self.chroot_zypper_args + [
                 'install', '--auto-agree-with-licenses'
-            ] + self.custom_args + self._install_items(),
+            ] + self.custom_args + ['--'] + self._install_items(),
             self.chroot_command_env
         )
 

--- a/test/unit/package_manager/zypper_test.py
+++ b/test/unit/package_manager/zypper_test.py
@@ -57,7 +57,7 @@ class TestPackageManagerZypper:
                 'zypper', '--reposd-dir', 'root-dir/my/repos',
                 '--root', 'root-dir',
                 'install', '--auto-agree-with-licenses'
-            ] + self.manager.custom_args + ['vim'], self.command_env
+            ] + self.manager.custom_args + ['--', 'vim'], self.command_env
         )
 
     @patch('kiwi.command.Command.call')
@@ -80,7 +80,7 @@ class TestPackageManagerZypper:
         mock_call.assert_called_once_with(
             ['chroot', 'root-dir', 'zypper'] + self.chroot_zypper_args + [
                 'install', '--auto-agree-with-licenses'
-            ] + self.manager.custom_args + ['vim'], self.chroot_command_env
+            ] + self.manager.custom_args + ['--', 'vim'], self.chroot_command_env
         )
 
     @patch('kiwi.command.Command.call')


### PR DESCRIPTION
This commits adds a `--` argument in zypper install calls right after
the flags and before the arguments (in this case packages) list.

Fixes #1407
