### PR TITLE
Added new build type kis

### DIFF
--- a/doc/source/api/kiwi.builder.rst
+++ b/doc/source/api/kiwi.builder.rst
@@ -54,10 +54,10 @@ Submodules
     :undoc-members:
     :show-inheritance:
 
-`kiwi.builder.pxe` Module
+`kiwi.builder.kis` Module
 -------------------------
 
-.. automodule:: kiwi.builder.pxe
+.. automodule:: kiwi.builder.kis
     :members:
     :undoc-members:
     :show-inheritance:

--- a/kiwi/builder/__init__.py
+++ b/kiwi/builder/__init__.py
@@ -21,7 +21,7 @@ from kiwi.builder.filesystem import FileSystemBuilder
 from kiwi.builder.container import ContainerBuilder
 from kiwi.builder.disk import DiskBuilder
 from kiwi.builder.live import LiveImageBuilder
-from kiwi.builder.pxe import PxeBuilder
+from kiwi.builder.kis import KisBuilder
 from kiwi.defaults import Defaults
 
 from kiwi.exceptions import (
@@ -47,8 +47,8 @@ class ImageBuilder:
             return LiveImageBuilder(
                 xml_state, target_dir, root_dir, custom_args
             )
-        elif requested_image_type in Defaults.get_network_image_types():
-            return PxeBuilder(
+        elif requested_image_type in Defaults.get_kis_image_types():
+            return KisBuilder(
                 xml_state, target_dir, root_dir, custom_args
             )
         elif requested_image_type in Defaults.get_archive_image_types():

--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -62,7 +62,7 @@ class FileSystemBuilder:
         self.root_dir = root_dir
         self.target_dir = target_dir
         self.requested_image_type = xml_state.get_build_type_name()
-        if self.requested_image_type == 'pxe':
+        if self.requested_image_type in Defaults.get_kis_image_types():
             self.requested_filesystem = xml_state.build_type.get_filesystem()
         else:
             self.requested_filesystem = self.requested_image_type

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1208,15 +1208,15 @@ class Defaults:
         return ['iso']
 
     @staticmethod
-    def get_network_image_types():
+    def get_kis_image_types():
         """
-        Provides supported pxe image types
+        Provides supported kis image types
 
-        :return: pxe image type names
+        :return: kis image type names
 
         :rtype: list
         """
-        return ['pxe']
+        return ['kis', 'pxe']
 
     @staticmethod
     def get_boot_image_description_path():

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -494,10 +494,10 @@ class KiwiProfileNotFound(KiwiError):
     """
 
 
-class KiwiPxeBootImageError(KiwiError):
+class KiwiKisBootImageError(KiwiError):
     """
     Exception raised if a required boot file e.g the kernel could
-    not be found in the process of building a pxe image.
+    not be found in the process of building a kis image.
     """
 
 

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -430,7 +430,7 @@ div {
         ## operator. Interface names matching the rule will be skipped. All
         ## other interface names stay in the list. It is also possible to
         ## pass the variable kiwi_oemnicfilter as kernel command
-        ## line in a PXE deployment
+        ## line in a netboot deployment
         element oem-nic-filter {
             k.oem-nic-filter.attlist,
             k.oem-nic-filter.content
@@ -1358,16 +1358,16 @@ div {
         attribute boottimeout { xsd:nonNegativeInteger }
         >> sch:pattern [ id = "boottimeout" is-a = "image_type"
             sch:param [ name = "attr" value = "boottimeout" ]
-            sch:param [ name = "types" value = "oem vmx iso pxe" ]
+            sch:param [ name = "types" value = "oem vmx iso pxe kis" ]
         ]
     k.type.compressed.attribute =
         ## Specifies whether the image output file should be
         ## compressed or not. This makes only sense for filesystem
-        ## only images respectively for the pxe or cpio type
+        ## only images.
         attribute compressed { xsd:boolean }
         >> sch:pattern [ id = "compressed" is-a = "image_type"
             sch:param [ name = "attr" value = "compressed" ]
-            sch:param [ name = "types" value = "pxe" ]
+            sch:param [ name = "types" value = "pxe kis" ]
         ]
     k.type.devicepersistency.attribute =
         ## Specifies which method to use in order to get persistent
@@ -1400,7 +1400,7 @@ div {
         }
         >> sch:pattern [ id = "filesystem" is-a = "image_type"
             sch:param [ name = "attr" value = "filesystem" ]
-            sch:param [ name = "types" value = "vmx oem pxe" ]
+            sch:param [ name = "types" value = "vmx oem pxe kis" ]
         ]
         >> sch:pattern [
             id = "filesystem_mandatory" is-a = "image_type_requirement"
@@ -1414,7 +1414,7 @@ div {
         }
         >> sch:pattern [ id = "squashfscompression" is-a = "image_type"
             sch:param [ name = "attr" value = "squashfscompression" ]
-            sch:param [ name = "types" value = "vmx oem pxe iso" ]
+            sch:param [ name = "types" value = "vmx oem pxe kis iso" ]
         ]
     k.type.overlayroot.attribute =
         ## Specifies to use an overlay root system consisting
@@ -1643,7 +1643,7 @@ div {
         attribute kernelcmdline { text }
         >> sch:pattern [ id = "kernelcmdline" is-a = "image_type"
             sch:param [ name = "attr" value = "kernelcmdline" ]
-            sch:param [ name = "types" value = "oem vmx iso pxe" ]
+            sch:param [ name = "types" value = "oem vmx iso pxe kis" ]
         ]
     k.type.luks.attribute =
         ## Setup cryptographic volume along with the given filesystem
@@ -1653,7 +1653,7 @@ div {
         attribute luks { text }
         >> sch:pattern [ id = "luks" is-a = "image_type"
             sch:param [ name = "attr" value = "luks" ]
-            sch:param [ name = "types" value = "oem vmx iso pxe" ]
+            sch:param [ name = "types" value = "oem vmx iso pxe kis" ]
         ]
     k.type.luksOS.attribute =
         ## With the luksOS value a predefined set of ciper, keysize
@@ -1665,7 +1665,7 @@ div {
         }
         >> sch:pattern [ id = "luksOS" is-a = "image_type"
             sch:param [ name = "attr" value = "luksOS" ]
-            sch:param [ name = "types" value = "oem vmx iso pxe" ]
+            sch:param [ name = "types" value = "oem vmx iso pxe kis" ]
         ]
     k.type.mdraid.attribute =
         ## Setup software raid in degraded mode with one disk
@@ -1693,7 +1693,7 @@ div {
         attribute rootfs_label { text }
         >> sch:pattern [ id = "rootfs_label" is-a = "image_type"
             sch:param [ name = "attr" value = "rootfs_label" ]
-            sch:param [ name = "types" value = "oem vmx pxe docker" ]
+            sch:param [ name = "types" value = "oem vmx pxe kis docker" ]
         ] 
     k.type.vga.attribute =
         ## Specifies the kernel framebuffer mode. More information
@@ -1702,7 +1702,7 @@ div {
         attribute vga { text }
         >> sch:pattern [ id = "vga" is-a = "image_type"
             sch:param [ name = "attr" value = "vga" ]
-            sch:param [ name = "types" value = "oem vmx pxe iso" ]
+            sch:param [ name = "types" value = "oem vmx pxe kis iso" ]
         ]
     k.type.gcelicense.attribute =
         ## Specifies the license tag in a GCE format
@@ -2621,7 +2621,7 @@ div {
         ## packages are only installed if this build type is requested.
         attribute type {
             "bootstrap" | "delete" | "docker" | "image" |
-            "iso" | "oem" | "pxe" | "vmx" | "oci" |
+            "iso" | "oem" | "pxe" | "kis" | "vmx" | "oci" |
             "uninstall"
         }
     k.packages.profiles.attribute = k.profiles.attribute

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -713,7 +713,7 @@ regular expression. The expression is handled by the bash regexp
 operator. Interface names matching the rule will be skipped. All
 other interface names stay in the list. It is also possible to
 pass the variable kiwi_oemnicfilter as kernel command
-line in a PXE deployment</a:documentation>
+line in a netboot deployment</a:documentation>
         <ref name="k.oem-nic-filter.attlist"/>
         <ref name="k.oem-nic-filter.content"/>
       </element>
@@ -2036,19 +2036,19 @@ to 10sec</a:documentation>
       </attribute>
       <sch:pattern id="boottimeout" is-a="image_type">
         <sch:param name="attr" value="boottimeout"/>
-        <sch:param name="types" value="oem vmx iso pxe"/>
+        <sch:param name="types" value="oem vmx iso pxe kis"/>
       </sch:pattern>
     </define>
     <define name="k.type.compressed.attribute">
       <attribute name="compressed">
         <a:documentation>Specifies whether the image output file should be
 compressed or not. This makes only sense for filesystem
-only images respectively for the pxe or cpio type</a:documentation>
+only images.</a:documentation>
         <data type="boolean"/>
       </attribute>
       <sch:pattern id="compressed" is-a="image_type">
         <sch:param name="attr" value="compressed"/>
-        <sch:param name="types" value="pxe"/>
+        <sch:param name="types" value="pxe kis"/>
       </sch:pattern>
     </define>
     <define name="k.type.devicepersistency.attribute">
@@ -2100,7 +2100,7 @@ structure</a:documentation>
       </attribute>
       <sch:pattern id="filesystem" is-a="image_type">
         <sch:param name="attr" value="filesystem"/>
-        <sch:param name="types" value="vmx oem pxe"/>
+        <sch:param name="types" value="vmx oem pxe kis"/>
       </sch:pattern>
       <sch:pattern id="filesystem_mandatory" is-a="image_type_requirement">
         <sch:param name="attr" value="filesystem"/>
@@ -2121,7 +2121,7 @@ structure</a:documentation>
       </attribute>
       <sch:pattern id="squashfscompression" is-a="image_type">
         <sch:param name="attr" value="squashfscompression"/>
-        <sch:param name="types" value="vmx oem pxe iso"/>
+        <sch:param name="types" value="vmx oem pxe kis iso"/>
       </sch:pattern>
     </define>
     <define name="k.type.overlayroot.attribute">
@@ -2450,7 +2450,7 @@ kernel command line options</a:documentation>
       </attribute>
       <sch:pattern id="kernelcmdline" is-a="image_type">
         <sch:param name="attr" value="kernelcmdline"/>
-        <sch:param name="types" value="oem vmx iso pxe"/>
+        <sch:param name="types" value="oem vmx iso pxe kis"/>
       </sch:pattern>
     </define>
     <define name="k.type.luks.attribute">
@@ -2462,7 +2462,7 @@ mount that filesystem while booting</a:documentation>
       </attribute>
       <sch:pattern id="luks" is-a="image_type">
         <sch:param name="attr" value="luks"/>
-        <sch:param name="types" value="oem vmx iso pxe"/>
+        <sch:param name="types" value="oem vmx iso pxe kis"/>
       </sch:pattern>
     </define>
     <define name="k.type.luksOS.attribute">
@@ -2475,7 +2475,7 @@ distribution</a:documentation>
       </attribute>
       <sch:pattern id="luksOS" is-a="image_type">
         <sch:param name="attr" value="luksOS"/>
-        <sch:param name="types" value="oem vmx iso pxe"/>
+        <sch:param name="types" value="oem vmx iso pxe kis"/>
       </sch:pattern>
     </define>
     <define name="k.type.mdraid.attribute">
@@ -2515,7 +2515,7 @@ will force any COW action to happen in RAM</a:documentation>
       </attribute>
       <sch:pattern id="rootfs_label" is-a="image_type">
         <sch:param name="attr" value="rootfs_label"/>
-        <sch:param name="types" value="oem vmx pxe docker"/>
+        <sch:param name="types" value="oem vmx pxe kis docker"/>
       </sch:pattern>
     </define>
     <define name="k.type.vga.attribute">
@@ -2526,7 +2526,7 @@ hwinfo --framebuffer or in /usr/src/linux/Documentation/fb/vesafb.txt</a:documen
       </attribute>
       <sch:pattern id="vga" is-a="image_type">
         <sch:param name="attr" value="vga"/>
-        <sch:param name="types" value="oem vmx pxe iso"/>
+        <sch:param name="types" value="oem vmx pxe kis iso"/>
       </sch:pattern>
     </define>
     <define name="k.type.gcelicense.attribute">
@@ -4111,6 +4111,7 @@ packages are only installed if this build type is requested.</a:documentation>
           <value>iso</value>
           <value>oem</value>
           <value>pxe</value>
+          <value>kis</value>
           <value>vmx</value>
           <value>oci</value>
           <value>uninstall</value>

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -136,8 +136,8 @@ class XMLState:
 
         :rtype: str
         """
-        if self.get_build_type_name() in ['vmx', 'iso']:
-            # vmx and iso image types always use dracut as initrd system
+        if self.get_build_type_name() in ['vmx', 'iso', 'kis']:
+            # vmx, iso and kis image types always use dracut as initrd system
             initrd_system = 'dracut'
         elif self.get_build_type_name() in ['oem', 'pxe']:
             # pxe and oem image types default to kiwi if unset

--- a/test/unit/builder/init_test.py
+++ b/test/unit/builder/init_test.py
@@ -41,9 +41,17 @@ class TestImageBuilder:
             xml_state, 'target_dir', 'root_dir', None
         )
 
-    @patch('kiwi.builder.PxeBuilder')
-    def test_pxe_builder(self, mock_builder):
+    @patch('kiwi.builder.KisBuilder')
+    def test_kis_builder(self, mock_builder):
         xml_state = Mock()
+        xml_state.get_build_type_name = Mock(
+            return_value='kis'
+        )
+        ImageBuilder(xml_state, 'target_dir', 'root_dir')
+        mock_builder.assert_called_once_with(
+            xml_state, 'target_dir', 'root_dir', None
+        )
+        mock_builder.reset_mock()
         xml_state.get_build_type_name = Mock(
             return_value='pxe'
         )


### PR DESCRIPTION
KIS is an abbreviation for Kernel, Initrd, System and defines a
highly customizable image consisting out of these components.
This commit performs the changes documented in #1414 and
introduces the new kis type. From an image build perspective
kis is currently the same as pxe with restrictions for kis
on the schema level. A kis build uses dracut and does not allow
to use the legacy netboot initrd. The pxe type will therefore be
exclusively used to built for the legacy netboot infrastructure
and is on its way to deprecation in the future.
This Fixes #1346


