### PR TITLE
Do not set GRUB_DISTRIBUTOR

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -574,13 +574,11 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         * GRUB_CMDLINE_LINUX_DEFAULT
         * GRUB_GFXMODE
         * GRUB_TERMINAL
-        * GRUB_DISTRIBUTOR
         """
         grub_default_entries = {
             'GRUB_TIMEOUT': self.timeout,
             'GRUB_GFXMODE': self.gfxmode,
-            'GRUB_TERMINAL': '"{0}"'.format(self.terminal),
-            'GRUB_DISTRIBUTOR': '"{0}"'.format(self.get_menu_entry_title())
+            'GRUB_TERMINAL': '"{0}"'.format(self.terminal)
         }
         if self.cmdline:
             grub_default_entries['GRUB_CMDLINE_LINUX_DEFAULT'] = '"{0}"'.format(

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -338,7 +338,6 @@ class TestBootLoaderConfigGrub2:
                 '/boot/grub2/themes/openSUSE/background.png'
             ),
             call('GRUB_CMDLINE_LINUX_DEFAULT', '"some-cmdline"'),
-            call('GRUB_DISTRIBUTOR', '"Bob"'),
             call('GRUB_ENABLE_BLSCFG', 'true'),
             call('GRUB_ENABLE_CRYPTODISK', 'y'),
             call('GRUB_GFXMODE', '800x600'),


### PR DESCRIPTION
grub mkconfig creates a proper string based on /etc/os-release
if GRUB_DISTRIBUTOR is not set. We assume this to be true
for all distributions. This Fixes #1416

