### PR TITLE
Use auto video mode as default for grub

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -299,6 +299,7 @@ class Defaults:
             '0x319': video_type(grub2='1280x1024', isolinux='1280 1024'),
             '0x31a': video_type(grub2='1280x1024', isolinux='1280 1024'),
             '0x31b': video_type(grub2='1280x1024', isolinux='1280 1024'),
+            'auto': video_type(grub2='auto', isolinux='800 600')
         }
 
     @staticmethod
@@ -337,13 +338,15 @@ class Defaults:
     @staticmethod
     def get_default_video_mode():
         """
-        Provides 800x600 default video mode as hex value for the kernel
+        Uses auto mode for default video. See get_video_mode_map
+        for details on the value depending which bootloader is
+        used
 
-        :return: vesa video kernel hex value
+        :return: auto
 
         :rtype: str
         """
-        return '0x303'
+        return 'auto'
 
     @staticmethod
     def get_grub_boot_directory_name(lookup_path):

--- a/test/unit/bootloader/config/base_test.py
+++ b/test/unit/bootloader/config/base_test.py
@@ -261,7 +261,7 @@ class TestBootLoaderConfigBase:
     def test_get_gfxmode_default(self, mock_get_vga):
         mock_get_vga.return_value = None
         assert self.bootloader.get_gfxmode('isolinux') == '800 600'
-        assert self.bootloader.get_gfxmode('grub2') == '800x600'
+        assert self.bootloader.get_gfxmode('grub2') == 'auto'
 
     @patch('kiwi.xml_parse.type_.get_vga')
     def test_get_gfxmode(self, mock_get_vga):


### PR DESCRIPTION
An explicit video mode 800x600 was used for grub if no
video mode setup exists in the XML description. For grub
this should better result in the auto mode. Related to
bsc#1165730

