### PR TITLE
Clean AnonymousUniqueId from the image

### DIFF
--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -205,6 +205,15 @@ class PackageManagerBase:
         """
         return True if returncode != 0 else False
 
+    def clean_leftovers(self):
+        """
+        Cleans package manager related data not needed in the
+        resulting image such as custom macros
+
+        Implementation in specialized package manager class
+        """
+        pass
+
     def cleanup_requests(self):
         """
         Cleanup request queues

--- a/kiwi/package_manager/dnf.py
+++ b/kiwi/package_manager/dnf.py
@@ -20,9 +20,11 @@ import re
 # project
 from kiwi.command import Command
 from kiwi.utils.rpm_database import RpmDataBase
+from kiwi.utils.rpm import Rpm
 from kiwi.package_manager.base import PackageManagerBase
 from kiwi.path import Path
 from kiwi.exceptions import KiwiRequestError
+from kiwi.defaults import Defaults
 
 
 class PackageManagerDnf(PackageManagerBase):
@@ -264,3 +266,12 @@ class PackageManagerDnf(PackageManagerBase):
         rpmdb = RpmDataBase(self.root_dir)
         if rpmdb.has_rpm():
             rpmdb.set_database_to_image_path()
+
+    def clean_leftovers(self):
+        """
+        Cleans package manager related data not needed in the
+        resulting image such as custom macros
+        """
+        Rpm(
+            self.root_dir, Defaults.get_custom_rpm_image_macro_name()
+        ).wipe_config()

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -453,6 +453,18 @@ class SystemPrepare:
                 )
             )
 
+    def clean_package_manager_leftovers(self):
+        """
+        This methods cleans some package manager artifacts created
+        at run time such as macros
+        """
+        package_manager = self.xml_state.get_package_manager()
+        manager = PackageManager(
+            Repository(self.root_bind, package_manager),
+            package_manager
+        )
+        manager.clean_leftovers()
+
     def _install_archives(self, archive_list):
         log.info("Installing archives")
         for archive in archive_list:

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -100,7 +100,6 @@ from kiwi.system.profile import Profile
 from kiwi.defaults import Defaults
 from kiwi.privileges import Privileges
 from kiwi.path import Path
-from kiwi.utils.rpm import Rpm
 
 log = logging.getLogger('kiwi')
 
@@ -253,9 +252,7 @@ class SystemBuildTask(CliTask):
         system.pinch_system(force=True)
 
         # delete any custom rpm macros created
-        Rpm(
-            image_root, Defaults.get_custom_rpm_image_macro_name()
-        ).wipe_config()
+        system.clean_package_manager_leftovers()
 
         # make sure system instance is cleaned up now
         del system

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -96,7 +96,6 @@ from kiwi.system.prepare import SystemPrepare
 from kiwi.system.setup import SystemSetup
 from kiwi.defaults import Defaults
 from kiwi.system.profile import Profile
-from kiwi.utils.rpm import Rpm
 
 log = logging.getLogger('kiwi')
 
@@ -239,9 +238,7 @@ class SystemPrepareTask(CliTask):
         system.pinch_system(force=True)
 
         # delete any custom rpm macros created
-        Rpm(
-            abs_root_path, Defaults.get_custom_rpm_image_macro_name()
-        ).wipe_config()
+        system.clean_package_manager_leftovers()
 
         # make sure system instance is cleaned up now
         del system

--- a/test/unit/package_manager/base_test.py
+++ b/test/unit/package_manager/base_test.py
@@ -83,3 +83,6 @@ class TestPackageManagerBase:
         assert self.manager.product_requests == []
         assert self.manager.collection_requests == []
         assert self.manager.exclude_requests == []
+
+    def test_clean_leftovers(self):
+        self.manager.clean_leftovers()

--- a/test/unit/package_manager/dnf_test.py
+++ b/test/unit/package_manager/dnf_test.py
@@ -148,3 +148,12 @@ class TestPackageManagerDnf:
         mock_RpmDataBase.return_value = rpmdb
         self.manager.post_process_install_requests_bootstrap()
         rpmdb.set_database_to_image_path.assert_called_once_with()
+
+    @patch('kiwi.package_manager.dnf.Rpm')
+    def test_clean_leftovers(self, mock_rpm):
+        mock_rpm.return_value = mock.Mock()
+        self.manager.clean_leftovers()
+        mock_rpm.assert_called_once_with(
+            '/root-dir', 'macros.kiwi-image-config'
+        )
+        mock_rpm.return_value.wipe_config.assert_called_once_with()

--- a/test/unit/package_manager/zypper_test.py
+++ b/test/unit/package_manager/zypper_test.py
@@ -160,3 +160,21 @@ class TestPackageManagerZypper:
         assert self.manager.has_failed(1) is True
         assert self.manager.has_failed(4) is True
         assert self.manager.has_failed(-42) is True
+
+    @patch('kiwi.package_manager.zypper.os.unlink')
+    @patch('kiwi.package_manager.zypper.os.path.exists')
+    @patch('kiwi.package_manager.zypper.Rpm')
+    def test_clean_leftovers(self, mock_rpm, mock_exists, mock_unlink):
+        mock_exists.return_value = True
+        mock_rpm.return_value = mock.Mock()
+        self.manager.clean_leftovers()
+        mock_rpm.assert_called_once_with(
+            'root-dir', 'macros.kiwi-image-config'
+        )
+        mock_rpm.return_value.wipe_config.assert_called_once_with()
+        mock_exists.assert_called_once_with(
+            'root-dir/var/lib/zypp/AnonymousUniqueId'
+        )
+        mock_unlink.assert_called_once_with(
+            'root-dir/var/lib/zypp/AnonymousUniqueId'
+        )

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -388,6 +388,13 @@ class TestSystemPrepare:
         self.system.__del__()
         self.system.root_bind.cleanup.assert_called_once_with()
 
+    @patch('kiwi.system.prepare.Repository')
+    @patch('kiwi.system.prepare.PackageManager')
+    def test_clean_package_manager_leftovers(self, mock_manager, mock_repo):
+        self.system.clean_package_manager_leftovers()
+        assert mock_repo.called
+        assert mock_manager.called
+
     def test_destructor_raising(self):
         self.system.root_bind = mock.Mock()
         self.system.root_bind.cleanup.side_effect = ValueError("nothing")

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -53,11 +53,6 @@ class TestSystemBuildTask:
             return_value=self.system_prepare
         )
 
-        self.rpm = mock.Mock()
-        kiwi.tasks.system_build.Rpm = mock.Mock(
-            return_value=self.rpm
-        )
-
         self.setup = mock.Mock()
         kiwi.tasks.system_build.SystemSetup = mock.Mock(
             return_value=self.setup
@@ -179,7 +174,7 @@ class TestSystemBuildTask:
         self.system_prepare.pinch_system.assert_has_calls(
             [call(force=False), call(force=True)]
         )
-        self.rpm.wipe_config.assert_called_once_with()
+        assert self.system_prepare.clean_package_manager_leftovers.called
         self.setup.call_image_script.assert_called_once_with()
         self.builder.create.assert_called_once_with()
         self.result.print_results.assert_called_once_with()

--- a/test/unit/tasks/system_prepare_test.py
+++ b/test/unit/tasks/system_prepare_test.py
@@ -49,11 +49,6 @@ class TestSystemPrepareTask:
             return_value=self.manager
         )
 
-        self.rpm = mock.Mock()
-        kiwi.tasks.system_prepare.Rpm = mock.Mock(
-            return_value=self.rpm
-        )
-
         self.setup = mock.Mock()
         kiwi.tasks.system_prepare.SystemSetup = mock.Mock(
             return_value=self.setup
@@ -170,7 +165,7 @@ class TestSystemPrepareTask:
         self.system_prepare.pinch_system.assert_has_calls(
             [call(force=False), call(force=True)]
         )
-        self.rpm.wipe_config.assert_called_once_with()
+        assert self.system_prepare.clean_package_manager_leftovers.called
 
     def test_process_system_prepare_add_package(self):
         self._init_command_args()


### PR DESCRIPTION
This commit is two fold.

For one side does a small refactor to move the deletion of custom RPM
macros to package manager level inside a cleaning method. This way only
RPM based package managers run RPM specific code and each package manager
can apply its own specific logic.

On the other hand for the zypper package manager the deletion of
/var/lib/zypp/AnonymousUniqueId file has been added as part of the
new cleaning method.

Fixes #1396