### PR TITLE
Clean AnonymousUniqueId

### DIFF
--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -1112,8 +1112,6 @@ function suseCleanup {
     # the final target system
     # ----
     baseCleanup
-    # zypper id
-    rm -f /var/lib/zypp/AnonymousUniqueId
 }
 
 #======================================


### PR DESCRIPTION
This is a follow up commit for 469f71144. There is not need to remove
the `/var/lib/zypp/AnonymousUniqueId` file from the clean up method
since this has been already integrated inside the python code base
and this is not needed anymore as a helper function.