### PR TITLE
Fix support for multiple dracut modules (v2)

### DIFF
--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -185,15 +185,16 @@ class LiveImageBuilder:
 
         # create dracut initrd for live image
         log.info('Creating live ISO boot image')
-        live_dracut_module = Defaults.get_live_dracut_module_from_flag(
+        live_dracut_modules = Defaults.get_live_dracut_modules_from_flag(
             self.live_type
         )
-        self.boot_image.include_module('pollcdrom')
-        self.boot_image.include_module(live_dracut_module)
+        live_dracut_modules.append('pollcdrom')
+        for dracut_module in live_dracut_modules:
+            self.boot_image.include_module(dracut_module)
         self.boot_image.omit_module('multipath')
         self.boot_image.write_system_config_file(
             config={
-                'modules': ['pollcdrom', live_dracut_module],
+                'modules': live_dracut_modules,
                 'omit_modules': ['multipath']
             },
             config_file=self.root_dir + '/etc/dracut.conf.d/02-livecd.conf'

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1138,25 +1138,25 @@ class Defaults:
         return '/etc/dracut.conf.d/02-kiwi.conf'
 
     @staticmethod
-    def get_live_dracut_module_from_flag(flag_name):
+    def get_live_dracut_modules_from_flag(flag_name):
         """
-        Provides flag_name to dracut module name map
+        Provides flag_name to dracut modules name map
 
         Depending on the value of the flag attribute in the KIWI image
-        description a specific dracut module needs to be selected
+        description specific dracut modules need to be selected
 
-        :return: dracut module name
+        :return: dracut module names as list
 
-        :rtype: str
+        :rtype: list
         """
         live_modules = {
-            'overlay': 'kiwi-live',
-            'dmsquash': 'dmsquash-live livenet'
+            'overlay': ['kiwi-live'],
+            'dmsquash': ['dmsquash-live', 'livenet']
         }
         if flag_name in live_modules:
             return live_modules[flag_name]
         else:
-            return 'kiwi-live'
+            return ['kiwi-live']
 
     @staticmethod
     def get_default_live_iso_root_filesystem():

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -212,12 +212,12 @@ class TestLiveImageBuilder:
         )
 
         assert self.boot_image_task.include_module.call_args_list == [
-            call('pollcdrom'), call('kiwi-live')
+            call('kiwi-live'), call('pollcdrom')
         ]
         self.boot_image_task.omit_module.assert_called_once_with('multipath')
         self.boot_image_task.write_system_config_file.assert_called_once_with(
             config={
-                'modules': ['pollcdrom', 'kiwi-live'],
+                'modules': ['kiwi-live', 'pollcdrom'],
                 'omit_modules': ['multipath']
             },
             config_file='root_dir/etc/dracut.conf.d/02-livecd.conf'

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -64,13 +64,13 @@ class TestDefaults:
             lookup_path='lookup_path'
         ) == 'grub'
 
-    def test_get_live_dracut_module_from_flag(self):
-        assert Defaults.get_live_dracut_module_from_flag('foo') == \
-            'kiwi-live'
-        assert Defaults.get_live_dracut_module_from_flag('overlay') == \
-            'kiwi-live'
-        assert Defaults.get_live_dracut_module_from_flag('dmsquash') == \
-            'dmsquash-live livenet'
+    def test_get_live_dracut_modules_from_flag(self):
+        assert Defaults.get_live_dracut_modules_from_flag('foo') == \
+            ['kiwi-live']
+        assert Defaults.get_live_dracut_modules_from_flag('overlay') == \
+            ['kiwi-live']
+        assert Defaults.get_live_dracut_modules_from_flag('dmsquash') == \
+            ['dmsquash-live', 'livenet']
 
     @patch('platform.machine')
     def test_get_iso_boot_path(self, mock_machine):


### PR DESCRIPTION
Passing the dmsquash flag adds dmsquash-live and livenet modules to
dracut. This broke when adding a check to only add modules that dracut
reports as available. Use a list instead of a string to represent the
modules to add.

Fixes: 07ea23a4