### PR TITLE
Refactor xml bootloader settings format

### DIFF
--- a/build-tests/arm/fedora/test-image-iso/appliance.kiwi
+++ b/build-tests/arm/fedora/test-image-iso/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="ISO-Fedora">
+<image schemaversion="7.2" name="ISO-Fedora">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/arm/suse/test-image-iso/appliance.kiwi
+++ b/build-tests/arm/suse/test-image-iso/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="ISO-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="ISO-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -21,8 +21,8 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="bind-utils"/>

--- a/build-tests/arm/suse/test-image-rpi-oem/appliance.kiwi
+++ b/build-tests/arm/suse/test-image-rpi-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="OEM-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="OEM-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -15,7 +15,8 @@
         <keytable>us</keytable>
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
-        <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" bootloader="grub2" firmware="efi" kernelcmdline="plymouth.enable=0 swiotlb=512 cma=64M console=ttyS0,115200n8 console=tty" bootpartition="false" devicepersistency="by-label" btrfs_root_is_snapshot="true" efipartsize="16" editbootinstall="editbootinstall_rpi.sh">
+        <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 swiotlb=512 cma=64M console=ttyS0,115200n8 console=tty" bootpartition="false" devicepersistency="by-label" btrfs_root_is_snapshot="true" efipartsize="16" editbootinstall="editbootinstall_rpi.sh">
+            <bootloader name="grub2"/>
             <systemdisk name="RaspberryPi">
                 <volume name="home"/>
                 <volume name="root"/>
@@ -36,8 +37,8 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-openSUSE-base"/>

--- a/build-tests/ppc/fedora/test-image-vmx/appliance.kiwi
+++ b/build-tests/ppc/fedora/test-image-vmx/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="VMX-Fedora-30.0">
+<image schemaversion="7.2" name="VMX-Fedora-30.0">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -15,13 +15,15 @@
         <keytable>us</keytable>
         <timezone>UTC</timezone>
         <rpm-check-signatures>false</rpm-check-signatures>
-        <type image="vmx" filesystem="ext4" bootloader="grub2" kernelcmdline="console=ttyS0 splash" firmware="ofw" bootloader_console="serial" format="qcow2"/>
+        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0 splash" firmware="ofw" format="qcow2">
+            <bootloader name="grub2" console="serial"/>
+        </type>
     </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="grub2"/>

--- a/build-tests/ppc/sle12/test-image-vmx-oem/appliance.kiwi
+++ b/build-tests/ppc/sle12/test-image-vmx-oem/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.1" name="SLE12">
+<image schemaversion="7.2" name="SLE12">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -23,19 +23,25 @@
         <rpm-check-signatures>false</rpm-check-signatures>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="vmx" filesystem="ext4" bootloader="grub2" kernelcmdline="console=ttyS0 splash" firmware="ofw" bootloader_console="serial" format="qcow2"/>
+        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0 splash" firmware="ofw" format="qcow2">
+            <bootloader name="grub2" console="serial"/>
+        </type>
     </preferences>
     <preferences profiles="PhysicalBSZ_4096">
-        <type image="oem" filesystem="ext4" initrd_system="dracut" bootloader="grub2" bootloader_console="serial" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install" target_blocksize="4096"/>
+        <type image="oem" filesystem="ext4" initrd_system="dracut" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install" target_blocksize="4096">
+            <bootloader name="grub2" console="serial"/>
+        </type>
     </preferences>
     <preferences profiles="PhysicalBSZ_512">
-        <type image="oem" filesystem="ext4" initrd_system="dracut" bootloader="grub2" bootloader_console="serial" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install"/>
+        <type image="oem" filesystem="ext4" initrd_system="dracut" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install">
+            <bootloader name="grub2" console="serial"/>
+        </type>
     </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-sles-Minimal"/>

--- a/build-tests/ppc/sle15/test-image-vmx-oem/appliance.kiwi
+++ b/build-tests/ppc/sle15/test-image-vmx-oem/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.1" name="SLE15">
+<image schemaversion="7.2" name="SLE15">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -23,19 +23,25 @@
         <rpm-check-signatures>false</rpm-check-signatures>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="vmx" filesystem="ext4" bootloader="grub2" kernelcmdline="console=ttyS0 splash" firmware="ofw" bootloader_console="serial" format="qcow2"/>
+        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0 splash" firmware="ofw" format="qcow2">
+            <bootloader name="grub2" console="serial"/>
+        </type>
     </preferences>
     <preferences profiles="PhysicalBSZ_4096">
-        <type image="oem" filesystem="ext4" initrd_system="dracut" bootloader="grub2" bootloader_console="serial" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install" target_blocksize="4096"/>
+        <type image="oem" filesystem="ext4" initrd_system="dracut" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install" target_blocksize="4096">
+            <bootloader name="grub2" console="serial"/>
+        </type>
     </preferences>
     <preferences profiles="PhysicalBSZ_512">
-        <type image="oem" filesystem="ext4" initrd_system="dracut" bootloader="grub2" bootloader_console="serial" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install"/>
+        <type image="oem" filesystem="ext4" initrd_system="dracut" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install">
+            <bootloader name="grub2" console="serial"/>
+        </type>
     </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>

--- a/build-tests/ppc/suse/test-image-oem/appliance.kiwi
+++ b/build-tests/ppc/suse/test-image-oem/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.1" name="OEM-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="OEM-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -24,16 +24,20 @@
         <bootloader-theme>openSUSE</bootloader-theme>
     </preferences>
     <preferences profiles="PhysicalBSZ_4096">
-        <type image="oem" filesystem="ext4" initrd_system="dracut" bootloader="grub2" bootloader_console="serial" kernelcmdline="console=ttyS0 splash" firmware="ofw" installiso="true" installboot="install" target_blocksize="4096"/>
+        <type image="oem" filesystem="ext4" initrd_system="dracut" kernelcmdline="console=ttyS0 splash" firmware="ofw" installiso="true" installboot="install" target_blocksize="4096">
+            <bootloader name="grub2" console="serial"/>
+        </type>
     </preferences>
     <preferences profiles="PhysicalBSZ_512">
-        <type image="oem" filesystem="ext4" initrd_system="dracut" bootloader="grub2" bootloader_console="serial" kernelcmdline="console=ttyS0 splash" firmware="ofw" installiso="true" installboot="install"/>
+        <type image="oem" filesystem="ext4" initrd_system="dracut" kernelcmdline="console=ttyS0 splash" firmware="ofw" installiso="true" installboot="install">
+            <bootloader name="grub2" console="serial"/>
+        </type>
     </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>

--- a/build-tests/ppc/suse/test-image-vmx/appliance.kiwi
+++ b/build-tests/ppc/suse/test-image-vmx/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="VMX-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="VMX-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -16,13 +16,15 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext4" bootloader="grub2" kernelcmdline="console=ttyS0 splash" firmware="ofw" bootloader_console="serial" format="qcow2"/>
+        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0 splash" firmware="ofw" format="qcow2">
+            <bootloader name="grub2" console="serial"/>
+        </type>
     </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>

--- a/build-tests/s390/suse/test-image-oem/appliance.kiwi
+++ b/build-tests/s390/suse/test-image-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="OEM-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="OEM-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>
@@ -14,7 +14,8 @@
         <locale>en_US</locale>
         <keytable>us</keytable>
         <timezone>Europe/Berlin</timezone>
-        <type image="oem" filesystem="xfs" initrd_system="dracut" bootloader="grub2_s390x_emu" zipl_targettype="FBA" kernelcmdline="cio_ignore=all,!ipldev,!condev" bootloader_console="serial">
+        <type image="oem" filesystem="xfs" initrd_system="dracut" kernelcmdline="cio_ignore=all,!ipldev,!condev">
+            <bootloader name="grub2_s390x_emu" console="serial" targettype="FBA"/>
             <systemdisk>
                 <volume name="home"/>
             </systemdisk>
@@ -27,8 +28,8 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>

--- a/build-tests/s390/suse/test-image-vmx/appliance.kiwi
+++ b/build-tests/s390/suse/test-image-vmx/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="VMX-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="VMX-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -14,13 +14,15 @@
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
-        <type image="vmx" filesystem="ext4" bootloader="grub2_s390x_emu" kernelcmdline="console=ttyS0" bootloader_console="serial" zipl_targettype="SCSI" format="qcow2"/>
+        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0" format="qcow2">
+            <bootloader name="grub2_s390x_emu" console="serial" targettype="SCSI"/>
+        </type>
     </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>

--- a/build-tests/x86/centos/test-image-iso-oem-vmx/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-iso-oem-vmx/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.1" name="LimeJeOS-CentOS-07.0">
+<image schemaversion="7.2" name="LimeJeOS-CentOS-07.0">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>
@@ -27,10 +27,13 @@
         <type image="iso" flags="overlay" firmware="uefi" hybridpersistent_filesystem="ext4" hybridpersistent="true"/>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="vmx" primary="true" filesystem="ext4" kernelcmdline="rhgb console=ttyS0" bootloader="grub2" firmware="bios" format="qcow2"/>
+        <type image="vmx" primary="true" filesystem="ext4" kernelcmdline="rhgb console=ttyS0" firmware="bios" format="qcow2">
+            <bootloader name="grub2"/>
+        </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" initrd_system="dracut" filesystem="ext4" installiso="true" bootloader="grub2" firmware="uefi">
+        <type image="oem" initrd_system="dracut" filesystem="ext4" installiso="true" firmware="uefi">
+            <bootloader name="grub2"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-swap>true</oem-swap>

--- a/build-tests/x86/fedora/test-image-iso-oem-vmx/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-iso-oem-vmx/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.1" name="VMX-Fedora-30.0">
+<image schemaversion="7.2" name="VMX-Fedora-30.0">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>
@@ -28,10 +28,13 @@
         <type image="iso" flags="overlay" firmware="uefi" hybridpersistent_filesystem="ext4" hybridpersistent="true"/>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="vmx" filesystem="ext4" bootloader="grub2" kernelcmdline="console=ttyS0 splash" bootloader_console="serial console"/>
+        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0 splash">
+            <bootloader name="grub2" console="serial console"/>
+        </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" initrd_system="dracut" filesystem="ext4" installiso="true" bootloader="grub2" firmware="uefi">
+        <type image="oem" initrd_system="dracut" filesystem="ext4" installiso="true" firmware="uefi">
+            <bootloader name="grub2"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-swap>true</oem-swap>

--- a/build-tests/x86/suse/test-image-MicroOS/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-MicroOS/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="MicroOS-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="MicroOS-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -16,24 +16,8 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type
-            image="vmx"
-            filesystem="btrfs"
-            format="qcow2"
-            bootloader="grub2"
-            bootloader_console="gfxterm"
-            firmware="uefi"
-            kernelcmdline="plymouth.enable=0 console=ttyS0,115200 console=tty0 net.ifnames=0 swapaccount=1"
-            bootpartition="false"
-            bootkernel="custom"
-            btrfs_root_is_snapshot="true"
-            btrfs_root_is_readonly_snapshot="true"
-            btrfs_quota_groups="false"
-            spare_part="5G"
-            spare_part_mountpoint="/var"
-            spare_part_fs="ext4"
-            spare_part_is_last="true"
-        >
+        <type image="vmx" filesystem="btrfs" format="qcow2" firmware="uefi" kernelcmdline="plymouth.enable=0 console=ttyS0,115200 console=tty0 net.ifnames=0 swapaccount=1" bootpartition="false" bootkernel="custom" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true" btrfs_quota_groups="false" spare_part="5G" spare_part_mountpoint="/var" spare_part_fs="ext4" spare_part_is_last="true">
+            <bootloader name="grub2" console="gfxterm"/>
             <systemdisk>
                 <volume name="home"/>
                 <volume name="root"/>
@@ -50,8 +34,8 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>

--- a/build-tests/x86/suse/test-image-azure/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-azure/appliance.kiwi
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="Azure-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="Azure-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>
         <specification>azure test build</specification>
     </description>
     <preferences>
-        <type image="vmx" filesystem="xfs" bootloader="grub2" kernelcmdline="USE_BY_UUID_DEVICE_NAMES=1 earlyprintk=ttyS0 console=ttyS0 rootdelay=300 net.ifnames=0 dis_ucode_ldr" devicepersistency="by-uuid" formatoptions="force_size" format="vhd-fixed" vhdfixedtag="22222222-3333-4444-5555-666666666666" bootpartition="true" bootpartsize="1024" bootloader_console="serial">
+        <type image="vmx" filesystem="xfs" kernelcmdline="USE_BY_UUID_DEVICE_NAMES=1 earlyprintk=ttyS0 console=ttyS0 rootdelay=300 net.ifnames=0 dis_ucode_ldr" devicepersistency="by-uuid" formatoptions="force_size" format="vhd-fixed" vhdfixedtag="22222222-3333-4444-5555-666666666666" bootpartition="true" bootpartsize="1024">
+            <bootloader name="grub2" console="serial"/>
             <size unit="M">30720</size>
         </type>
         <version>1.0.5</version>
@@ -20,8 +21,8 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>

--- a/build-tests/x86/suse/test-image-docker-derived/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-docker-derived/appliance.kiwi
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="docker-builder-image">
+<image schemaversion="7.2" name="docker-builder-image">
     <description type="system">
         <author>David Cassany</author>
         <contact>dcassany@suse.de</contact>
         <specification>Builder image based on Tumbleweed</specification>
     </description>
     <preferences>
-        <type image="docker" derived_from="obs://openSUSE:Containers:Tumbleweed/containers/opensuse/tumbleweed#latest"> 
+        <type image="docker" derived_from="obs://openSUSE:Containers:Tumbleweed/containers/opensuse/tumbleweed#latest">
             <containerconfig name="builder" tag="1.0" additionaltags="latest"/>
         </type>
         <version>1.0</version>
         <packagemanager>zypper</packagemanager>
         <rpm-excludedocs>true</rpm-excludedocs>
     </preferences>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="python3-kiwi"/>

--- a/build-tests/x86/suse/test-image-docker/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-docker/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="Docker-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="Docker-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -23,8 +23,8 @@
     <users>
         <user name="vagrant" password="vh4vw1N4alxKQ" home="/home/vagrant" groups="vagrant"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="grub"/>

--- a/build-tests/x86/suse/test-image-ec2/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-ec2/appliance.kiwi
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="EC2-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="EC2-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>
         <specification>ec2 test build</specification>
     </description>
     <preferences>
-        <type image="vmx" filesystem="ext4" bootloader="grub2" kernelcmdline="console=ttyS0 multipath=off net.ifnames=0" boottimeout="1" devicepersistency="by-label" firmware="ec2">
+        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0 multipath=off net.ifnames=0" devicepersistency="by-label" firmware="ec2">
+            <bootloader name="grub2" timeout="1"/>
             <size unit="M">10240</size>
             <machine xen_loader="pvgrub"/>
         </type>
@@ -21,8 +22,8 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image" patternType="plusRecommended">
         <package name="patterns-base-minimal_base"/>

--- a/build-tests/x86/suse/test-image-gce/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-gce/appliance.kiwi
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="GCE-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="GCE-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>
         <specification>GCE test build</specification>
     </description>
     <preferences>
-        <type image="vmx" filesystem="ext4" boottimeout="1" kernelcmdline="console=ttyS0,38400n8 net.ifnames=0 NON_PERSISTENT_DEVICE_NAMES=1 dis_ucode_ldr" format="gce" gcelicense="1111111111111111111" bootloader="grub2" firmware="efi">
+        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0,38400n8 net.ifnames=0 NON_PERSISTENT_DEVICE_NAMES=1 dis_ucode_ldr" format="gce" gcelicense="1111111111111111111" firmware="efi">
+            <bootloader name="grub2" timeout="1"/>
             <size unit="M">10240</size>
         </type>
         <version>1.0.17</version>
@@ -20,8 +21,8 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>

--- a/build-tests/x86/suse/test-image-iso/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-iso/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="ISO-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="ISO-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -21,8 +21,8 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="bind-utils"/>

--- a/build-tests/x86/suse/test-image-luks/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-luks/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="VMX-LUKS-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="VMX-LUKS-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -16,13 +16,15 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext4" bootloader="grub2" kernelcmdline="console=ttyS0 splash" firmware="uefi" luks="linux" bootpartition="false"/>
+        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0 splash" firmware="uefi" luks="linux" bootpartition="false">
+            <bootloader name="grub2"/>
+        </type>
     </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>

--- a/build-tests/x86/suse/test-image-oem-legacy/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-oem-legacy/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="OEM-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="OEM-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -16,7 +16,8 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" initrd_system="kiwi" boot="oemboot/suse-tumbleweed" bootloader="grub2" kernelcmdline="splash" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true" installboot="install">
+        <type image="oem" filesystem="btrfs" initrd_system="kiwi" boot="oemboot/suse-tumbleweed" kernelcmdline="splash" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true" installboot="install">
+            <bootloader name="grub2"/>
             <oemconfig>
                 <oem-swapsize>1024</oem-swapsize>
                 <oem-multipath-scan>false</oem-multipath-scan>
@@ -29,8 +30,8 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-openSUSE-base"/>

--- a/build-tests/x86/suse/test-image-oem/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="OEM-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="OEM-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -16,7 +16,8 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" initrd_system="dracut" bootloader="grub2" bootloader_console="serial" kernelcmdline="console=ttyS0 splash" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true" installboot="install">
+        <type image="oem" filesystem="btrfs" initrd_system="dracut" kernelcmdline="console=ttyS0 splash" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true" installboot="install">
+            <bootloader name="grub2" console="serial"/>
             <oemconfig>
                 <oem-unattended>true</oem-unattended>
                 <oem-swapsize>1024</oem-swapsize>
@@ -30,8 +31,8 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-openSUSE-base"/>

--- a/build-tests/x86/suse/test-image-orthos-oem/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-orthos-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="factory-kiwi">
+<image schemaversion="7.2" name="factory-kiwi">
     <description type="system">
         <author>Julian Wolf</author>
         <contact>juwolf@suse.de</contact>
@@ -13,15 +13,16 @@
         <keytable>us</keytable>
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
-        <type image="oem" initrd_system="dracut" filesystem="btrfs" kernelcmdline="root=/dev/vda4 console=ttyS0,115200 sysrq_always_enabled linemode=1 panic=100 ignore_loglevel unknown_nmi_panici crashkernel=512M-2G:128M,2G-64G:256M,64G-:512M" format="qcow2" bootloader="grub2" firmware="efi" installpxe="true">
+        <type image="oem" initrd_system="dracut" filesystem="btrfs" kernelcmdline="root=/dev/vda4 console=ttyS0,115200 sysrq_always_enabled linemode=1 panic=100 ignore_loglevel unknown_nmi_panici crashkernel=512M-2G:128M,2G-64G:256M,64G-:512M" format="qcow2" firmware="efi" installpxe="true">
+            <bootloader name="grub2"/>
             <size unit="G">10</size>
         </type>
     </preferences>
     <users>
         <user name="root" password="linux" pwdformat="plain" home="/root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image" patternType="plusRecommended">
         <package name="patterns-openSUSE-base"/>

--- a/build-tests/x86/suse/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-overlayroot/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="VMX-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="VMX-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -16,15 +16,16 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext3" bootloader="grub2" kernelcmdline="console=ttyS0 splash" firmware="efi" format="vmdk" overlayroot="true">
+        <type image="vmx" filesystem="ext3" kernelcmdline="console=ttyS0 splash" firmware="efi" format="vmdk" overlayroot="true">
+            <bootloader name="grub2"/>
             <size unit="G">4</size>
         </type>
     </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>

--- a/build-tests/x86/suse/test-image-pxe/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-pxe/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.1" name="PXE-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="PXE-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -33,8 +33,8 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-openSUSE-base"/>

--- a/build-tests/x86/suse/test-image-qcow-openstack/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-qcow-openstack/appliance.kiwi
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="TW-OpenStack">
+<image schemaversion="7.2" name="TW-OpenStack">
     <description type="system">
         <author>KIWI Team</author>
         <contact>kiwi-images@googlegroups.com</contact>
         <specification>SUSE Tumbleweed guest image for OpenStack</specification>
     </description>
     <preferences>
-        <type image="vmx" filesystem="ext4" format="qcow2" kernelcmdline="console=tty1 console=ttyS0 net.ifnames=0" boottimeout="1" bootloader="grub2">
+        <type image="vmx" filesystem="ext4" format="qcow2" kernelcmdline="console=tty1 console=ttyS0 net.ifnames=0">
+            <bootloader name="grub2" timeout="1"/>
             <size unit="M">10240</size>
         </type>
         <version>0.3.10</version>
@@ -20,8 +21,8 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-openSUSE-base"/>

--- a/build-tests/x86/suse/test-image-tbz/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-tbz/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="TBZ-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="TBZ-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -11,8 +11,8 @@
         <packagemanager>zypper</packagemanager>
         <type image="tbz"/>
     </preferences>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="bootstrap">
         <package name="vim"/>

--- a/build-tests/x86/suse/test-image-vagrant/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-vagrant/appliance.kiwi
@@ -4,7 +4,7 @@
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 <!-- OBS-ExclusiveArch: x86_64 -->
 
-<image schemaversion="7.1" name="Tumbleweed">
+<image schemaversion="7.2" name="Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -28,20 +28,22 @@
         <bootloader-theme>openSUSE</bootloader-theme>
     </preferences>
     <preferences profiles="libvirt">
-        <type image="vmx" filesystem="ext4" format="vagrant" boottimeout="0" bootloader="grub2" firmware="efi" kernelcmdline="net.ifnames=0">
+        <type image="vmx" filesystem="ext4" format="vagrant" firmware="efi" kernelcmdline="net.ifnames=0">
+            <bootloader name="grub2" timeout="0"/>
             <vagrantconfig provider="libvirt" virtualsize="42"/>
             <size unit="G">42</size>
         </type>
     </preferences>
     <preferences profiles="virtualbox">
-        <type image="vmx" filesystem="ext4" format="vagrant" boottimeout="0" bootloader="grub2" kernelcmdline="net.ifnames=0">
+        <type image="vmx" filesystem="ext4" format="vagrant" kernelcmdline="net.ifnames=0">
+            <bootloader name="grub2" timeout="0"/>
             <vagrantconfig provider="virtualbox" virtualbox_guest_additions_present="true" virtualsize="42"/>
             <size unit="G">42</size>
         </type>
     </preferences>
     <users>
-        <user password="vagrant" home="/root" name="root" groups="root" pwdformat="plain" />
-        <user password="vagrant" home="/home/vagrant" name="vagrant" groups="vagrant" pwdformat="plain" />
+        <user password="vagrant" home="/root" name="root" groups="root" pwdformat="plain"/>
+        <user password="vagrant" home="/home/vagrant" name="vagrant" groups="vagrant" pwdformat="plain"/>
     </users>
     <repository>
         <source path="obsrepositories:/"/>

--- a/build-tests/x86/suse/test-image-vmx-lvm/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-vmx-lvm/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="VMX-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="VMX-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -16,7 +16,8 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext3" bootloader="grub2" kernelcmdline="console=ttyS0 splash" firmware="uefi" format="vmdk">
+        <type image="vmx" filesystem="ext3" kernelcmdline="console=ttyS0 splash" firmware="uefi" format="vmdk">
+            <bootloader name="grub2"/>
             <systemdisk>
                 <volume name="home"/>
             </systemdisk>
@@ -25,8 +26,8 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>

--- a/build-tests/x86/suse/test-image-vmx/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-vmx/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="VMX-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="VMX-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -16,13 +16,15 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext3" bootloader="grub2" kernelcmdline="console=ttyS0 splash" firmware="uefi" format="vmdk"/>
+        <type image="vmx" filesystem="ext3" kernelcmdline="console=ttyS0 splash" firmware="uefi" format="vmdk">
+            <bootloader name="grub2"/>
+        </type>
     </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>

--- a/build-tests/x86/suse/test-image-wsl/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-wsl/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="WSL-openSUSE-Tumbleweed">
+<image schemaversion="7.2" name="WSL-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -15,20 +15,15 @@
         <keytable>us</keytable>
         <type image="appx" metadata_path="/usr/share/wsl-appx">
             <containerconfig name="Tumbleweed">
-                <history
-                    author="KIWI-Team"
-                    application_id="tumbleweed"
-                    package_version="2003.12.0.0"
-                    launcher="openSUSE-Tumbleweed.exe"
-                >Tumbleweed JeOS text based</history>
+                <history author="KIWI-Team" application_id="tumbleweed" package_version="2003.12.0.0" launcher="openSUSE-Tumbleweed.exe">Tumbleweed JeOS text based</history>
             </containerconfig>
         </type>
     </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" >
-        <source path='obsrepositories:/'/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="grub"/>

--- a/build-tests/x86/ubuntu/test-image-iso-oem-vmx/appliance.kiwi
+++ b/build-tests/x86/ubuntu/test-image-iso-oem-vmx/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.1" name="LimeJeOS-Ubuntu-18.04">
+<image schemaversion="7.2" name="LimeJeOS-Ubuntu-18.04">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>
@@ -28,10 +28,13 @@
         <type image="iso" flags="overlay" hybridpersistent_filesystem="ext4" hybridpersistent="true"/>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="vmx" filesystem="ext4" bootloader="grub2" kernelcmdline="console=ttyS0 splash"/>
+        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0 splash">
+            <bootloader name="grub2"/>
+        </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" filesystem="ext4" initrd_system="dracut" bootloader="grub2" installiso="true">
+        <type image="oem" filesystem="ext4" initrd_system="dracut" installiso="true">
+            <bootloader name="grub2"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-device-filter>/dev/ram</oem-device-filter>
@@ -43,10 +46,10 @@
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
     <repository type="apt-deb" alias="kiwi-next-generation" priority="1" repository_gpgcheck="false">
-       <source path="obs://Virtualization:Appliances:Staging/xUbuntu_18.04"/>
+        <source path="obs://Virtualization:Appliances:Staging/xUbuntu_18.04"/>
     </repository>
     <repository type="apt-deb" alias="Ubuntu-Bionic-Universe" distribution="bionic" components="main multiverse restricted universe" repository_gpgcheck="false">
-       <source path="obs://Ubuntu:18.04/universe"/>
+        <source path="obs://Ubuntu:18.04/universe"/>
     </repository>
     <repository type="apt-deb" alias="Ubuntu-Bionic" distribution="bionic" components="main multiverse restricted universe" repository_gpgcheck="false">
         <source path="obs://Ubuntu:18.04/standard"/>
@@ -80,9 +83,7 @@
         <package name="dracut-kiwi-oem-dump"/>
     </packages>
     <packages type="bootstrap">
-        <!-- not added by default on OBS -->
         <package name="mawk"/>
-        <!-- comptibility package for /usr/lib paths -->
         <package name="usrmerge"/>
     </packages>
 </image>

--- a/doc/source/building/build_vmx_disk.rst
+++ b/doc/source/building/build_vmx_disk.rst
@@ -22,12 +22,11 @@ interface is shown below:
 
 .. code:: xml
 
-   <image schemaversion="7.1" name="JeOS-Tumbleweed">
+   <image schemaversion="7.2" name="JeOS-Tumbleweed">
      <!-- snip -->
      <preferences>
-       <type image="vmx" filesystem="ext4"
-             format="vmdk" boottimeout="0"
-             bootloader="grub2">
+       <type image="vmx" filesystem="ext4" format="vmdk">
+         <bootloader name="grub2" timeout="0"/>
          <size unit="G">42</size>
          <machine memory="512" guestOS="suse" HWversion="4">
            <vmdisk id="0" controller="ide"/>
@@ -99,7 +98,7 @@ added to the virtual machine image of which 5 GB are left unpartitioned:
 
 .. code:: xml
 
-   <image schemaversion="7.1" name="JeOS-Tumbleweed">
+   <image schemaversion="7.2" name="JeOS-Tumbleweed">
      <!-- snip -->
      <preferences>
        <type image="vmx" format="vmdk">
@@ -195,11 +194,11 @@ The following example adds the two entries `numvcpus = "4"` and
 
 .. code:: xml
 
-   <image schemaversion="7.1" name="openSUSE-15.1" displayname="Bob">
+   <image schemaversion="7.2" name="openSUSE-15.1" displayname="Bob">
      <preferences>
        <type image="vmx" filesystem="ext4" format="vmdk"
-             bootloader="grub2" kernelcmdline="splash"
-             bootpartition="false">
+             kernelcmdline="splash" bootpartition="false">
+         <bootloader name="grub2"/>
          <machine memory="512" guestOS="suse" HWversion="4">
            <vmconfig-entry>numvcpus = "4"</vmconfig-entry>
            <vmconfig-entry>cpuid.coresPerSocket = "2"</vmconfig-entry>
@@ -223,10 +222,10 @@ In the following example we add a bridged network interface using the
 
 .. code:: xml
 
-   <image schemaversion="7.1" name="openSUSE-15.1" displayname="Bob">
+   <image schemaversion="7.2" name="openSUSE-15.1" displayname="Bob">
      <preferences>
-       <type image="vmx" filesystem="btrfs"
-             bootloader="grub2" kernelcmdline="splash">
+       <type image="vmx" filesystem="btrfs" kernelcmdline="splash">
+         <bootloader name="grub2"/>
          <machine memory="4096" guestOS="suse" HWversion="4">
            <vmnic driver="e1000" interface="0" mode="bridged"/>
          </machine>
@@ -262,11 +261,11 @@ The following example adds a disk with the ID 0 using an IDE controller:
 
 .. code:: xml
 
-   <image schemaversion="7.1" name="openSUSE-15.1" displayname="Bob">
+   <image schemaversion="7.2" name="openSUSE-15.1" displayname="Bob">
      <preferences>
        <type image="vmx" filesystem="ext4" format="vmdk"
-             bootloader="grub2" kernelcmdline="splash"
-             bootpartition="false">
+             kernelcmdline="splash" bootpartition="false">
+         <bootloader name="grub2"/>
          <machine memory="512" guestOS="suse" HWversion="4">
            <vmdisk id="0" controller="ide"/>
          </machine>
@@ -303,10 +302,10 @@ IDE controller:
 
 .. code:: xml
 
-   <image schemaversion="7.1" name="openSUSE-15.1" displayname="Bob">
+   <image schemaversion="7.2" name="openSUSE-15.1" displayname="Bob">
      <preferences>
-       <type bootloader="grub2" filesystem="ext4"
-             image="vmx" kernelcmdline="splash">
+       <type image="vmx" filesystem="ext4" kernelcmdline="splash">
+         <bootloader name="grub2"/>
          <machine memory="512" xen_loader="hvmloader">
            <vmdvd id="0" controller="scsi"/>
            <vmdvd id="1" controller="ide"/>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -73,7 +73,7 @@ prolog_replacements = {
     '{exc_repo}': 'obs://openSUSE:Leap:15.1/standard',
     '{exc_kiwi_repo}':
         'obs://Virtualization:Appliances:Builder/openSUSE_Leap_15.1',
-    '{schema_version}': '7.1',
+    '{schema_version}': '7.2',
     '{kiwi}': 'KIWI NG',
     '{kiwi-product}': 'KIWI Next Generation (KIWI NG)',
     '{kiwi-legacy}': 'KIWI Legacy'

--- a/doc/source/working_with_images/build_in_buildservice.rst
+++ b/doc/source/working_with_images/build_in_buildservice.rst
@@ -100,7 +100,7 @@ The notable differences to running {kiwi} locally include:
 
         <!-- OBS-Profiles: foo_profile bar_profile -->
 
-        <image schemaversion="7.1" name="openSUSE-Leap-15.1">
+        <image schemaversion="7.2" name="openSUSE-Leap-15.1">
           <!-- image description with the profiles foo_profile and bar_profile
         </image>
 
@@ -118,7 +118,7 @@ The notable differences to running {kiwi} locally include:
 
      <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-     <image schemaversion="7.1" name="openSUSE-Leap-15.1">
+     <image schemaversion="7.2" name="openSUSE-Leap-15.1">
        <!-- image description with the profiles foo_profile and bar_profile
      </image>
 

--- a/doc/source/working_with_images/custom_volumes.rst
+++ b/doc/source/working_with_images/custom_volumes.rst
@@ -19,7 +19,7 @@ elements of the `systemdisk` element:
 
 .. code:: xml
 
-   <image schemaversion="7.1" name="openSUSE-Leap-15.1">
+   <image schemaversion="7.2" name="openSUSE-Leap-15.1">
      <type image="oem" filesystem="btrfs" preferlvm="true">
        <systemdisk name="vgroup">
          <volume name="usr/lib" size="1G" label="library"/>

--- a/doc/source/working_with_images/oem_ramdisk_deployment.rst
+++ b/doc/source/working_with_images/oem_ramdisk_deployment.rst
@@ -20,7 +20,8 @@ oem type definition:
 
 .. code:: xml
 
-    <type image="oem" filesystem="ext4" installiso="true" bootloader="grub2" initrd_system="dracut" installboot="install" boottimeout="1" kernelcmdline="rd.kiwi.ramdisk ramdisk_size=2048000">
+    <type image="oem" filesystem="ext4" installiso="true" initrd_system="dracut" installboot="install" kernelcmdline="rd.kiwi.ramdisk ramdisk_size=2048000">
+        <bootloader name="grub2" timeout="1"/>
         <oemconfig>
             <oem-skip-verify>true</oem-skip-verify>
             <oem-unattended>true</oem-unattended>

--- a/doc/source/working_with_images/vmx_setup_for_azure.rst
+++ b/doc/source/working_with_images/vmx_setup_for_azure.rst
@@ -45,14 +45,13 @@ description as follows:
 
       <type image="vmx"
             filesystem="ext4"
-            boottimeout="1"
             kernelcmdline="console=ttyS0 rootdelay=300 net.ifnames=0"
             devicepersistency="by-uuid"
             format="vhd-fixed"
             formatoptions="force_size"
-            bootloader="grub2"
             bootpartition="true"
             bootpartsize="1024">
+        <bootloader name="grub2" timeout="1"/>
         <size unit="M">30720</size>
       </type>
 

--- a/doc/source/working_with_images/vmx_setup_for_ec2.rst
+++ b/doc/source/working_with_images/vmx_setup_for_ec2.rst
@@ -51,11 +51,10 @@ description as follows:
 
       <type image="vmx"
             filesystem="ext4"
-            bootloader="grub2"
             kernelcmdline="console=xvc0 multipath=off net.ifnames=0"
-            boottimeout="1"
             devicepersistency="by-label"
             firmware="ec2">
+        <bootloader name="grub2" timeout="1"/>
         <size unit="M">10240</size>
         <machine xen_loader="hvmloader"/>
       </type>

--- a/doc/source/working_with_images/vmx_setup_for_google.rst
+++ b/doc/source/working_with_images/vmx_setup_for_google.rst
@@ -54,10 +54,10 @@ description as follows:
 
       <type image="oem"
             initrd_system="dracut"
-            filesystem="ext4" boottimeout="1"
+            filesystem="ext4"
             kernelcmdline="console=ttyS0,38400n8 net.ifnames=0"
-            format="gce"
-            bootloader="grub2">
+            format="gce">
+        <bootloader name="grub2" timeout="1"/>
         <size unit="M">10240</size>
         <oemconfig>
             <oem-swap>false</oem-swap>

--- a/doc/source/working_with_images/vmx_setup_for_luks.rst
+++ b/doc/source/working_with_images/vmx_setup_for_luks.rst
@@ -49,7 +49,6 @@ Update the {kiwi} image description as follows:
         <type image="vmx"
             image="vmx"
             filesystem="ext4"
-            bootloader="grub2"
             luks="linux"
             bootpartition="false">
         </type>
@@ -60,7 +59,6 @@ Update the {kiwi} image description as follows:
         <type image="vmx"
             image="vmx"
             filesystem="ext4"
-            bootloader="grub2"
             luks="linux"
             bootpartition="true">
         </type>

--- a/doc/source/working_with_images/vmx_vagrant_setup.rst
+++ b/doc/source/working_with_images/vmx_vagrant_setup.rst
@@ -42,7 +42,8 @@ required:
 
    .. code:: xml
 
-      <type image="vmx" filesystem="ext4" format="vagrant" boottimeout="0">
+      <type image="vmx" filesystem="ext4" format="vagrant">
+          <bootloader name="grub2" timeout="0"/>
           <vagrantconfig provider="libvirt" virtualsize="42"/>
           <size unit="G">42</size>
       </type>
@@ -57,7 +58,8 @@ required:
 
    .. code:: xml
 
-      <type image="vmx" filesystem="ext4" format="vagrant" boottimeout="0">
+      <type image="vmx" filesystem="ext4" format="vagrant">
+          <bootloader name="grub2" timeout="0"/>
           <vagrantconfig
             provider="virtualbox"
             virtualbox_guest_additions_present="true"
@@ -225,7 +227,8 @@ description directory next to :file:`config.sh`):
 
 .. code:: xml
 
-   <type image="vmx" filesystem="ext4" format="vagrant" boottimeout="0">
+   <type image="vmx" filesystem="ext4" format="vagrant">
+       <bootloader name="grub2" timeout="0"/>
        <vagrantconfig
          provider="libvirt"
          virtualsize="42"
@@ -258,9 +261,8 @@ customized one (the libvirt profile in the following example):
        <type
          image="vmx"
          filesystem="ext4"
-         format="vagrant"
-         boottimeout="0"
-         bootloader="grub2">
+         format="vagrant">
+           <bootloader name="grub2" timeout="0"/>
            <vagrantconfig
              provider="libvirt"
              virtualsize="42"
@@ -273,9 +275,8 @@ customized one (the libvirt profile in the following example):
         <type
           image="vmx"
           filesystem="ext4"
-          format="vagrant"
-          boottimeout="0"
-          bootloader="grub2">
+          format="vagrant">
+            <bootloader name="grub2" timeout="0"/>
             <vagrantconfig
               provider="virtualbox"
               virtualbox_guest_additions_present="true"

--- a/doc/source/working_with_kiwi/xml_description.rst
+++ b/doc/source/working_with_kiwi/xml_description.rst
@@ -47,7 +47,7 @@ children, for example:
 
    <?xml version="1.0" encoding="utf-8"?>
 
-   <image schemaversion="7.1" name="{exc_image_base_name}">
+   <image schemaversion="7.2" name="{exc_image_base_name}">
        <!-- all settings belong here -->
    </image>
 
@@ -162,10 +162,10 @@ a virtual machine disk of the same appliance:
            <type image="iso" primary="true" flags="overlay" hybridpersistent_filesystem="ext4" hybridpersistent="true"/>
 
            <!-- Virtual machine -->
-           <type image="vmx" filesystem="ext4" bootloader="grub2" kernelcmdline="splash" firmware="efi"/>
+           <type image="vmx" filesystem="ext4" kernelcmdline="splash" firmware="efi"/>
 
            <!-- OEM installation image -->
-           <type image="oem" filesystem="ext4" initrd_system="dracut" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi">
+           <type image="oem" filesystem="ext4" initrd_system="dracut" installiso="true" kernelcmdline="splash" firmware="efi">
                <oemconfig>
                    <oem-systemsize>2048</oem-systemsize>
                    <oem-swap>true</oem-swap>
@@ -235,18 +235,6 @@ The `type` element supports a plethora of optional attributes, some of
 these are only relevant for certain build types and will be covered in the
 appropriate place. Certain attributes are however useful for nearly all
 build types and will be covered here:
-
-- `bootloader`: Specifies the bootloader used for booting the image. At
-  the moment `grub2`, `zipl` and `grub2_s390x_emu` (a combination of zipl
-  and a userspace GRUB2) are supported.
-  The special `custom` entry allows to skip the bootloader configuration
-  and installation and leaves this up to the user which can be done by
-  using the `editbootinstall` and `editbootconfig` custom scripts.
-
-- `boottimeout`: Specifies the boot timeout in seconds prior to launching
-  the default boot option. By default the timeout is set to 10 seconds. It
-  makes sense to set this value to `0` for images intended to be started
-  non-interactively (e.g. virtual machines).
 
 - `bootpartition`: Boolean parameter notifying {kiwi} whether an extra boot
   partition should be used or not (the default depends on the current
@@ -338,6 +326,24 @@ build types and will be covered here:
 
      blockdev --report $DEVICE
 
+Common attributes of the `bootloader` element
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `bootloader` element is used to select the bootloader. At
+the moment `grub2`, `isolinux`, `zipl` and `grub2_s390x_emu`
+(a combination of zipl and a userspace GRUB2) are supported.
+The special `custom` entry allows to skip the bootloader configuration
+and installation and leaves this up to the user which can be done by
+using the `editbootinstall` and `editbootconfig` custom scripts.
+
+- `timeout`: Specifies the boot timeout in seconds prior to launching
+  the default boot option. By default the timeout is set to 10 seconds. It
+  makes sense to set this value to `0` for images intended to be started
+  non-interactively (e.g. virtual machines).
+
+- `targettype`: Specifies the device type of the disk zipl should boot.
+  On zFCP devices use `SCSI`, on DASD devices use `CDL` or `LDL` on
+  emulated DASD devices use `FBA`
 
 Common Elements
 ---------------
@@ -396,7 +402,7 @@ An example excerpt from a image description using these child-elements of
            <rpm-check-signatures>false</rpm-check-signatures>
            <bootsplash-theme>openSUSE</bootsplash-theme>
            <bootloader-theme>openSUSE</bootloader-theme>
-           <type image="vmx" filesystem="ext4" format="qcow2" boottimeout="0" bootloader="grub2">
+           <type image="vmx" filesystem="ext4" format="qcow2">
        </preferences>
        <!-- snip -->
    </image>
@@ -440,10 +446,10 @@ format).
            <packagemanager>zypper</packagemanager>
        </preferences>
        <preferences profiles="QEMU">
-           <type image="vmx" format="qcow2" filesystem="ext4" bootloader="grub2">
+           <type image="vmx" format="qcow2" filesystem="ext4">
        </preferences>
        <preferences profiles="VMWare">
-           <type image="vmx" format="vmdk" filesystem="ext4" bootloader="grub2">
+           <type image="vmx" format="vmdk" filesystem="ext4">
        </preferences>
        <!-- snip -->
    </image>

--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -331,10 +331,7 @@ class BootImageBase:
         )
         type_attributes = [
             'bootkernel',
-            'bootloader',
-            'bootloader_console',
             'bootprofile',
-            'boottimeout',
             'btrfs_root_is_snapshot',
             'gpt_hybrid_mbr',
             'devicepersistency',
@@ -354,6 +351,9 @@ class BootImageBase:
         ]
         self.xml_state.copy_build_type_attributes(
             type_attributes, self.boot_xml_state
+        )
+        self.xml_state.copy_bootloader_section(
+            self.boot_xml_state
         )
         self.xml_state.copy_systemdisk_section(
             self.boot_xml_state

--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -229,7 +229,7 @@ class BootLoaderConfigBase:
 
         :rtype: int
         """
-        timeout_seconds = self.xml_state.build_type.get_boottimeout()
+        timeout_seconds = self.xml_state.get_build_type_bootloader_timeout()
         if timeout_seconds is None:
             timeout_seconds = Defaults.get_default_boot_timeout_seconds()
         return timeout_seconds

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -85,7 +85,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         else:
             self.boot_directory_name = 'grub'
 
-        self.terminal = self.xml_state.build_type.get_bootloader_console() \
+        self.terminal = self.xml_state.get_build_type_bootloader_console() \
             or 'gfxterm'
         self.gfxmode = self.get_gfxmode('grub2')
         self.theme = self.get_boot_theme()

--- a/kiwi/bootloader/config/isolinux.py
+++ b/kiwi/bootloader/config/isolinux.py
@@ -72,7 +72,7 @@ class BootLoaderConfigIsoLinux(BootLoaderConfigBase):
                     self.xml_state.build_type.get_hybridpersistent_filesystem()
                 )
 
-        self.terminal = self.xml_state.build_type.get_bootloader_console()
+        self.terminal = self.xml_state.get_build_type_bootloader_console()
         self.gfxmode = self.get_gfxmode('isolinux')
         # isolinux counts the timeout in units of 1/10 sec
         self.timeout = self.get_boot_timeout_seconds() * 10

--- a/kiwi/bootloader/config/zipl.py
+++ b/kiwi/bootloader/config/zipl.py
@@ -72,11 +72,13 @@ class BootLoaderConfigZipl(BootLoaderConfigBase):
         self.cmdline_failsafe = ' '.join(
             [self.cmdline, Defaults.get_failsafe_kernel_options()]
         )
-        self.target_blocksize = self.xml_state.build_type.get_target_blocksize()
+        self.target_blocksize = \
+            self.xml_state.build_type.get_target_blocksize()
         if not self.target_blocksize:
             self.target_blocksize = Defaults.get_s390_disk_block_size()
 
-        self.target_type = self.xml_state.build_type.get_zipl_targettype()
+        self.target_type = \
+            self.xml_state.get_build_type_bootloader_targettype()
         if not self.target_type:
             self.target_type = Defaults.get_s390_disk_type()
 

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -102,7 +102,7 @@ class DiskBuilder:
         self.requested_filesystem = xml_state.build_type.get_filesystem()
         self.requested_boot_filesystem = \
             xml_state.build_type.get_bootfilesystem()
-        self.bootloader = xml_state.build_type.get_bootloader()
+        self.bootloader = xml_state.get_build_type_bootloader_name()
         self.initrd_system = xml_state.get_initrd_system()
         self.target_removable = xml_state.build_type.get_target_removable()
         self.root_filesystem_is_multipath = \

--- a/kiwi/config/strip.xml
+++ b/kiwi/config/strip.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="initrd-strip-metadata">
+<image schemaversion="7.2" name="initrd-strip-metadata">
     <description type="boot">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -349,6 +349,17 @@ class Defaults:
         return 'auto'
 
     @staticmethod
+    def get_default_bootloader():
+        """
+        Return default bootloader name which is grub2
+
+        :return: bootloader name
+
+        :rtype: str
+        """
+        return 'grub2'
+
+    @staticmethod
     def get_grub_boot_directory_name(lookup_path):
         """
         Provides grub2 data directory name in boot/ directory

--- a/kiwi/firmware.py
+++ b/kiwi/firmware.py
@@ -38,7 +38,8 @@ class FirmWare:
     """
     def __init__(self, xml_state):
         self.arch = platform.machine()
-        self.zipl_target_type = xml_state.build_type.get_zipl_targettype()
+        self.zipl_target_type = \
+            xml_state.get_build_type_bootloader_targettype()
         self.firmware = xml_state.build_type.get_firmware()
         self.efipart_mbytes = xml_state.build_type.get_efipartsize()
         self.efi_partition_table = xml_state.build_type.get_efiparttable()

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -62,7 +62,7 @@ div {
         attribute xsi:schemaLocation { xsd:anyURI }
     k.image.schemaversion.attribute =
         ## The allowed Schema version (fixed value)
-        attribute schemaversion { "7.1" }
+        attribute schemaversion { "7.2" }
     k.image.id =
         ## An identification number which is represented in a file
         ## named /etc/ImageID
@@ -1170,29 +1170,6 @@ div {
         ## image description. When kiwi builds the boot image the
         ## information is passed as add-profile option
         attribute bootkernel { text }
-    k.type.bootloader.attribute =
-        ## Specifies the bootloader used for booting the image.
-        ## At the moment grub2, zipl and the combination of zipl plus
-        ## userspace grub2 are supported. The special custom entry
-        ## allows to skip the bootloader configuration and installation
-        ## and leaves this up to the user which can be done by using
-        ## the editbootinstall and editbootconfig custom scripts
-        attribute bootloader {
-            "grub2" | "zipl" | "grub2_s390x_emu" | "custom"
-        }
-        >> sch:pattern [ id = "bootloader" is-a = "image_type"
-            sch:param [ name = "attr" value = "bootloader" ]
-            sch:param [ name = "types" value = "oem vmx" ]
-        ]
-    k.type.bootloader_console.attribute =
-        ## Specifies the bootloader console.
-        ## The value only has an effect for the grub bootloader.
-        ## By default a graphics console setup is used
-        attribute bootloader_console { grub_console }
-        >> sch:pattern [ id = "bootloader_console" is-a = "image_type"
-            sch:param [ name = "attr" value = "bootloader_console" ]
-            sch:param [ name = "types" value = "oem vmx iso" ]
-        ]
     k.type.xen_server.attribute =
         ## Specify the image is a Xen dom0 (Xen Server) image
         ## The information is used to create a correct bootloader
@@ -1304,17 +1281,6 @@ div {
             sch:param [ name = "attr" value = "spare_part_is_last" ]
             sch:param [ name = "types" value = "vmx" ]
         ]
-    k.type.zipl_targettype.attribute =
-        ## The device type of the disk zipl should boot. On zFCP
-        ## devices use SCSI, on DASD devices use CDL or LDL on
-        ## emulated DASD devices use FBA
-        attribute zipl_targettype {
-            "CDL" | "LDL" | "FBA" | "SCSI"
-        }
-        >> sch:pattern [ id = "zipl_targettype" is-a = "image_type"
-            sch:param [ name = "attr" value = "zipl_targettype" ]
-            sch:param [ name = "types" value = "oem vmx" ]
-        ]
     k.type.bootpartsize.attribute =
         ## For images with a separate boot partition this attribute
         ## specifies the size in MB. If not set the min bootpart
@@ -1350,15 +1316,6 @@ div {
         >> sch:pattern [ id = "bootprofile" is-a = "image_type"
             sch:param [ name = "attr" value = "bootprofile" ]
             sch:param [ name = "types" value = "oem vmx iso pxe cpio" ]
-        ]
-    k.type.boottimeout.attribute =
-        ## Specifies the boot timeout in seconds prior to launching
-        ## the default boot option. By default the timeout is set
-        ## to 10sec
-        attribute boottimeout { xsd:nonNegativeInteger }
-        >> sch:pattern [ id = "boottimeout" is-a = "image_type"
-            sch:param [ name = "attr" value = "boottimeout" ]
-            sch:param [ name = "types" value = "oem vmx iso pxe kis" ]
         ]
     k.type.compressed.attribute =
         ## Specifies whether the image output file should be
@@ -1590,7 +1547,7 @@ div {
         ]
     k.type.install_continue_on_timeout.attribute =
         ## Specifies the boot timeout handling for the KIWI
-        ## install image. If set to "true" the configured boottimeout
+        ## install image. If set to "true" the configured timeout
         ## or its default value applies. If set to "false" no
         ## timeout applies in the boot menu of the install image.
         attribute install_continue_on_timeout { xsd:boolean }
@@ -1767,15 +1724,11 @@ div {
         k.type.bootfilesystem.attribute? &
         k.type.firmware.attribute? &
         k.type.bootkernel.attribute? &
-        k.type.bootloader.attribute? &
-        k.type.bootloader_console.attribute? &
-        k.type.zipl_targettype.attribute? &
         k.type.bootpartition.attribute? &
         k.type.bootpartsize.attribute? &
         k.type.efipartsize.attribute? &
         k.type.efiparttable.attribute? &
         k.type.bootprofile.attribute? &
-        k.type.boottimeout.attribute? &
         k.type.btrfs_quota_groups.attribute? &
         k.type.btrfs_root_is_snapshot.attribute? &
         k.type.btrfs_root_is_readonly_snapshot.attribute? &
@@ -1832,6 +1785,7 @@ div {
         ## The Image Type of the Logical Extend
         element type { 
             k.type.attlist &
+            k.bootloader? &
             k.containerconfig? &
             k.machine? &
             k.oemconfig? &
@@ -2114,6 +2068,92 @@ div {
         element strip {
             k.strip.attlist &
             k.file+
+        }
+}
+
+#==========================================
+# main block: <bootloader>
+#
+div {
+    sch:pattern [
+        abstract = "true"
+        id = "bootloader_image_type"
+        sch:rule [
+            context = "bootloader[@$attr]"
+            sch:assert [
+                test = "contains('$types', ../@image)"
+                "bootloader($attr) is only available for the following "
+                "image types: $types"
+            ]
+        ]
+    ]
+    sch:pattern [
+        abstract = "true"
+        id = "bootloader_name_type"
+        sch:rule [
+            context = "bootloader[@$attr]"
+            sch:assert [
+                test = "contains('$types', @name)"
+                "bootloader($attr) attribute is only available for the following "
+                "bootloader types: $types"
+            ]
+        ]
+    ]
+    k.bootloader.name.attribute =
+        ## Specifies the bootloader used for booting the image.
+        ## At the moment grub2, isolinux, zipl and the combination of
+        ## zipl plus userspace grub2 are supported. The special custom
+        ## entry allows to skip the bootloader configuration and installation
+        ## and leaves this up to the user which can be done by using
+        ## the editbootinstall and editbootconfig custom scripts
+        attribute name {
+            "grub2" | "isolinux" | "zipl" | "grub2_s390x_emu" | "custom"
+        }
+        >> sch:pattern [ id = "loader_name" is-a = "bootloader_image_type"
+            sch:param [ name = "attr" value = "name" ]
+            sch:param [ name = "types" value = "oem vmx iso" ]
+        ]
+    k.bootloader.console.attribute =
+        ## Specifies the bootloader console.
+        ## The value is available for grub and isolinux bootloader
+        ## types. By default a graphics console setup is used
+        attribute console { grub_console }
+        >> sch:pattern [ id = "loader_console" is-a = "bootloader_name_type"
+            sch:param [ name = "attr" value = "console" ]
+            sch:param [ name = "types" value = "grub2 isolinux grub2_s390x_emu" ]
+        ]
+    k.bootloader.timeout.attribute =
+        ## Specifies the boot timeout in seconds prior to launching
+        ## the default boot option. By default the timeout is set
+        ## to 10sec
+        attribute timeout { xsd:nonNegativeInteger }
+        >> sch:pattern [ id = "timeout" is-a = "bootloader_name_type"
+            sch:param [ name = "attr" value = "timeout" ]
+            sch:param [ name = "types" value = "grub2 isolinux zipl grub2_s390x_emu" ]
+        ]
+    k.bootloader.targettype.attribute =
+        ## The device type of the disk zipl should boot. On zFCP
+        ## devices use SCSI, on DASD devices use CDL or LDL on
+        ## emulated DASD devices use FBA
+        attribute targettype {
+            "CDL" | "LDL" | "FBA" | "SCSI"
+        }
+        >> sch:pattern [ id = "targettype" is-a = "bootloader_name_type"
+            sch:param [ name = "attr" value = "targettype" ]
+            sch:param [ name = "types" value = "zipl" ]
+        ]
+    k.bootloader.attlist =
+        k.bootloader.name.attribute &
+        k.bootloader.console.attribute? &
+        k.bootloader.timeout.attribute? &
+        k.bootloader.targettype.attribute?
+
+    k.bootloader =
+        ## The bootloader section is used to select the bootloader
+        ## and to provide configuration parameters for it
+        element bootloader {
+            k.bootloader.attlist &
+            empty
         }
 }
 

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -130,7 +130,7 @@ second the location of the XSD Schema
     <define name="k.image.schemaversion.attribute">
       <attribute name="schemaversion">
         <a:documentation>The allowed Schema version (fixed value)</a:documentation>
-        <value>7.1</value>
+        <value>7.2</value>
       </attribute>
     </define>
     <define name="k.image.id">
@@ -1781,38 +1781,6 @@ image description. When kiwi builds the boot image the
 information is passed as add-profile option</a:documentation>
       </attribute>
     </define>
-    <define name="k.type.bootloader.attribute">
-      <attribute name="bootloader">
-        <a:documentation>Specifies the bootloader used for booting the image.
-At the moment grub2, zipl and the combination of zipl plus
-userspace grub2 are supported. The special custom entry
-allows to skip the bootloader configuration and installation
-and leaves this up to the user which can be done by using
-the editbootinstall and editbootconfig custom scripts</a:documentation>
-        <choice>
-          <value>grub2</value>
-          <value>zipl</value>
-          <value>grub2_s390x_emu</value>
-          <value>custom</value>
-        </choice>
-      </attribute>
-      <sch:pattern id="bootloader" is-a="image_type">
-        <sch:param name="attr" value="bootloader"/>
-        <sch:param name="types" value="oem vmx"/>
-      </sch:pattern>
-    </define>
-    <define name="k.type.bootloader_console.attribute">
-      <attribute name="bootloader_console">
-        <a:documentation>Specifies the bootloader console.
-The value only has an effect for the grub bootloader.
-By default a graphics console setup is used</a:documentation>
-        <ref name="grub_console"/>
-      </attribute>
-      <sch:pattern id="bootloader_console" is-a="image_type">
-        <sch:param name="attr" value="bootloader_console"/>
-        <sch:param name="types" value="oem vmx iso"/>
-      </sch:pattern>
-    </define>
     <define name="k.type.xen_server.attribute">
       <attribute name="xen_server">
         <a:documentation>Specify the image is a Xen dom0 (Xen Server) image
@@ -1960,23 +1928,6 @@ attribute that setup can be toggled.</a:documentation>
         <sch:param name="types" value="vmx"/>
       </sch:pattern>
     </define>
-    <define name="k.type.zipl_targettype.attribute">
-      <attribute name="zipl_targettype">
-        <a:documentation>The device type of the disk zipl should boot. On zFCP
-devices use SCSI, on DASD devices use CDL or LDL on
-emulated DASD devices use FBA</a:documentation>
-        <choice>
-          <value>CDL</value>
-          <value>LDL</value>
-          <value>FBA</value>
-          <value>SCSI</value>
-        </choice>
-      </attribute>
-      <sch:pattern id="zipl_targettype" is-a="image_type">
-        <sch:param name="attr" value="zipl_targettype"/>
-        <sch:param name="types" value="oem vmx"/>
-      </sch:pattern>
-    </define>
     <define name="k.type.bootpartsize.attribute">
       <attribute name="bootpartsize">
         <a:documentation>For images with a separate boot partition this attribute
@@ -2025,18 +1976,6 @@ information is passed as add-profile option</a:documentation>
       <sch:pattern id="bootprofile" is-a="image_type">
         <sch:param name="attr" value="bootprofile"/>
         <sch:param name="types" value="oem vmx iso pxe cpio"/>
-      </sch:pattern>
-    </define>
-    <define name="k.type.boottimeout.attribute">
-      <attribute name="boottimeout">
-        <a:documentation>Specifies the boot timeout in seconds prior to launching
-the default boot option. By default the timeout is set
-to 10sec</a:documentation>
-        <data type="nonNegativeInteger"/>
-      </attribute>
-      <sch:pattern id="boottimeout" is-a="image_type">
-        <sch:param name="attr" value="boottimeout"/>
-        <sch:param name="types" value="oem vmx iso pxe kis"/>
       </sch:pattern>
     </define>
     <define name="k.type.compressed.attribute">
@@ -2380,7 +2319,7 @@ only evaluated for grub and ext|syslinux</a:documentation>
     <define name="k.type.install_continue_on_timeout.attribute">
       <attribute name="install_continue_on_timeout">
         <a:documentation>Specifies the boot timeout handling for the KIWI
-install image. If set to "true" the configured boottimeout
+install image. If set to "true" the configured timeout
 or its default value applies. If set to "false" no
 timeout applies in the boot menu of the install image.</a:documentation>
         <data type="boolean"/>
@@ -2624,15 +2563,6 @@ default.</a:documentation>
           <ref name="k.type.bootkernel.attribute"/>
         </optional>
         <optional>
-          <ref name="k.type.bootloader.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.type.bootloader_console.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.type.zipl_targettype.attribute"/>
-        </optional>
-        <optional>
           <ref name="k.type.bootpartition.attribute"/>
         </optional>
         <optional>
@@ -2646,9 +2576,6 @@ default.</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.bootprofile.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.type.boottimeout.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.btrfs_quota_groups.attribute"/>
@@ -2811,6 +2738,9 @@ default.</a:documentation>
         <a:documentation>The Image Type of the Logical Extend</a:documentation>
         <interleave>
           <ref name="k.type.attlist"/>
+          <optional>
+            <ref name="k.bootloader"/>
+          </optional>
           <optional>
             <ref name="k.containerconfig"/>
           </optional>
@@ -3302,6 +3232,109 @@ references file names in linux lib directories to keep.</a:documentation>
           <oneOrMore>
             <ref name="k.file"/>
           </oneOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <bootloader>
+    
+  -->
+  <div>
+    <sch:pattern abstract="true" id="bootloader_image_type">
+      <sch:rule context="bootloader[@$attr]">
+        <sch:assert test="contains('$types', ../@image)">bootloader($attr) is only available for the following image types: $types</sch:assert>
+      </sch:rule>
+    </sch:pattern>
+    <sch:pattern abstract="true" id="bootloader_name_type">
+      <sch:rule context="bootloader[@$attr]">
+        <sch:assert test="contains('$types', @name)">bootloader($attr) attribute is only available for the following bootloader types: $types</sch:assert>
+      </sch:rule>
+    </sch:pattern>
+    <define name="k.bootloader.name.attribute">
+      <attribute name="name">
+        <a:documentation>Specifies the bootloader used for booting the image.
+At the moment grub2, isolinux, zipl and the combination of
+zipl plus userspace grub2 are supported. The special custom
+entry allows to skip the bootloader configuration and installation
+and leaves this up to the user which can be done by using
+the editbootinstall and editbootconfig custom scripts</a:documentation>
+        <choice>
+          <value>grub2</value>
+          <value>isolinux</value>
+          <value>zipl</value>
+          <value>grub2_s390x_emu</value>
+          <value>custom</value>
+        </choice>
+      </attribute>
+      <sch:pattern id="loader_name" is-a="bootloader_image_type">
+        <sch:param name="attr" value="name"/>
+        <sch:param name="types" value="oem vmx iso"/>
+      </sch:pattern>
+    </define>
+    <define name="k.bootloader.console.attribute">
+      <attribute name="console">
+        <a:documentation>Specifies the bootloader console.
+The value is available for grub and isolinux bootloader
+types. By default a graphics console setup is used</a:documentation>
+        <ref name="grub_console"/>
+      </attribute>
+      <sch:pattern id="loader_console" is-a="bootloader_name_type">
+        <sch:param name="attr" value="console"/>
+        <sch:param name="types" value="grub2 isolinux grub2_s390x_emu"/>
+      </sch:pattern>
+    </define>
+    <define name="k.bootloader.timeout.attribute">
+      <attribute name="timeout">
+        <a:documentation>Specifies the boot timeout in seconds prior to launching
+the default boot option. By default the timeout is set
+to 10sec</a:documentation>
+        <data type="nonNegativeInteger"/>
+      </attribute>
+      <sch:pattern id="timeout" is-a="bootloader_name_type">
+        <sch:param name="attr" value="timeout"/>
+        <sch:param name="types" value="grub2 isolinux zipl grub2_s390x_emu"/>
+      </sch:pattern>
+    </define>
+    <define name="k.bootloader.targettype.attribute">
+      <attribute name="targettype">
+        <a:documentation>The device type of the disk zipl should boot. On zFCP
+devices use SCSI, on DASD devices use CDL or LDL on
+emulated DASD devices use FBA</a:documentation>
+        <choice>
+          <value>CDL</value>
+          <value>LDL</value>
+          <value>FBA</value>
+          <value>SCSI</value>
+        </choice>
+      </attribute>
+      <sch:pattern id="targettype" is-a="bootloader_name_type">
+        <sch:param name="attr" value="targettype"/>
+        <sch:param name="types" value="zipl"/>
+      </sch:pattern>
+    </define>
+    <define name="k.bootloader.attlist">
+      <interleave>
+        <ref name="k.bootloader.name.attribute"/>
+        <optional>
+          <ref name="k.bootloader.console.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.bootloader.timeout.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.bootloader.targettype.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="k.bootloader">
+      <element name="bootloader">
+        <a:documentation>The bootloader section is used to select the bootloader
+and to provide configuration parameters for it</a:documentation>
+        <interleave>
+          <ref name="k.bootloader.attlist"/>
+          <empty/>
         </interleave>
       </element>
     </define>

--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -49,7 +49,7 @@ class DiskSetup:
         self.mdraid = xml_state.build_type.get_mdraid()
         self.luks = xml_state.build_type.get_luks()
         self.volume_manager = xml_state.get_volume_management()
-        self.bootloader = xml_state.build_type.get_bootloader()
+        self.bootloader = xml_state.get_build_type_bootloader_name()
         self.oemconfig = xml_state.get_build_type_oemconfig_section()
         self.volumes = xml_state.get_volumes()
 

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -295,7 +295,7 @@ class Profile:
         self.dot_profile['kiwi_compressed'] = \
             type_section.get_compressed()
         self.dot_profile['kiwi_boot_timeout'] = \
-            type_section.get_boottimeout()
+            self.xml_state.get_build_type_bootloader_timeout()
         self.dot_profile['kiwi_wwid_wait_timeout'] = \
             type_section.get_wwid_wait_timeout()
         self.dot_profile['kiwi_hybridpersistent'] = \
@@ -315,9 +315,9 @@ class Profile:
         self.dot_profile['kiwi_firmware'] = \
             type_section.get_firmware()
         self.dot_profile['kiwi_bootloader'] = \
-            type_section.get_bootloader()
+            self.xml_state.get_build_type_bootloader_name()
         self.dot_profile['kiwi_bootloader_console'] = \
-            type_section.get_bootloader_console()
+            self.xml_state.get_build_type_bootloader_console()
         self.dot_profile['kiwi_btrfs_root_is_snapshot'] = \
             type_section.get_btrfs_root_is_snapshot()
         self.dot_profile['kiwi_gpt_hybrid_mbr'] = \

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2566,21 +2566,17 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, boottimeout=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
         self.firmware = _cast(None, firmware)
         self.bootkernel = _cast(None, bootkernel)
-        self.bootloader = _cast(None, bootloader)
-        self.bootloader_console = _cast(None, bootloader_console)
-        self.zipl_targettype = _cast(None, zipl_targettype)
         self.bootpartition = _cast(bool, bootpartition)
         self.bootpartsize = _cast(int, bootpartsize)
         self.efipartsize = _cast(int, efipartsize)
         self.efiparttable = _cast(None, efiparttable)
         self.bootprofile = _cast(None, bootprofile)
-        self.boottimeout = _cast(int, boottimeout)
         self.btrfs_quota_groups = _cast(bool, btrfs_quota_groups)
         self.btrfs_root_is_snapshot = _cast(bool, btrfs_root_is_snapshot)
         self.btrfs_root_is_readonly_snapshot = _cast(bool, btrfs_root_is_readonly_snapshot)
@@ -2633,6 +2629,10 @@ class type_(GeneratedsSuper):
         self.xen_server = _cast(bool, xen_server)
         self.publisher = _cast(None, publisher)
         self.disk_start_sector = _cast(int, disk_start_sector)
+        if bootloader is None:
+            self.bootloader = []
+        else:
+            self.bootloader = bootloader
         if containerconfig is None:
             self.containerconfig = []
         else:
@@ -2668,6 +2668,11 @@ class type_(GeneratedsSuper):
         else:
             return type_(*args_, **kwargs_)
     factory = staticmethod(factory)
+    def get_bootloader(self): return self.bootloader
+    def set_bootloader(self, bootloader): self.bootloader = bootloader
+    def add_bootloader(self, value): self.bootloader.append(value)
+    def insert_bootloader_at(self, index, value): self.bootloader.insert(index, value)
+    def replace_bootloader_at(self, index, value): self.bootloader[index] = value
     def get_containerconfig(self): return self.containerconfig
     def set_containerconfig(self, containerconfig): self.containerconfig = containerconfig
     def add_containerconfig(self, value): self.containerconfig.append(value)
@@ -2706,12 +2711,6 @@ class type_(GeneratedsSuper):
     def set_firmware(self, firmware): self.firmware = firmware
     def get_bootkernel(self): return self.bootkernel
     def set_bootkernel(self, bootkernel): self.bootkernel = bootkernel
-    def get_bootloader(self): return self.bootloader
-    def set_bootloader(self, bootloader): self.bootloader = bootloader
-    def get_bootloader_console(self): return self.bootloader_console
-    def set_bootloader_console(self, bootloader_console): self.bootloader_console = bootloader_console
-    def get_zipl_targettype(self): return self.zipl_targettype
-    def set_zipl_targettype(self, zipl_targettype): self.zipl_targettype = zipl_targettype
     def get_bootpartition(self): return self.bootpartition
     def set_bootpartition(self, bootpartition): self.bootpartition = bootpartition
     def get_bootpartsize(self): return self.bootpartsize
@@ -2722,8 +2721,6 @@ class type_(GeneratedsSuper):
     def set_efiparttable(self, efiparttable): self.efiparttable = efiparttable
     def get_bootprofile(self): return self.bootprofile
     def set_bootprofile(self, bootprofile): self.bootprofile = bootprofile
-    def get_boottimeout(self): return self.boottimeout
-    def set_boottimeout(self, boottimeout): self.boottimeout = boottimeout
     def get_btrfs_quota_groups(self): return self.btrfs_quota_groups
     def set_btrfs_quota_groups(self, btrfs_quota_groups): self.btrfs_quota_groups = btrfs_quota_groups
     def get_btrfs_root_is_snapshot(self): return self.btrfs_root_is_snapshot
@@ -2828,13 +2825,6 @@ class type_(GeneratedsSuper):
     def set_publisher(self, publisher): self.publisher = publisher
     def get_disk_start_sector(self): return self.disk_start_sector
     def set_disk_start_sector(self, disk_start_sector): self.disk_start_sector = disk_start_sector
-    def validate_grub_console(self, value):
-        # Validate type grub_console, a restriction on xs:token.
-        if value is not None and Validate_simpletypes_:
-            if not self.gds_validate_simple_patterns(
-                    self.validate_grub_console_patterns_, value):
-                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_grub_console_patterns_, ))
-    validate_grub_console_patterns_ = [['^(console|gfxterm|serial)( (console|gfxterm|serial))*$']]
     def validate_partition_size_type(self, value):
         # Validate type partition-size-type, a restriction on xs:token.
         if value is not None and Validate_simpletypes_:
@@ -2865,6 +2855,7 @@ class type_(GeneratedsSuper):
     validate_safe_posix_short_name_patterns_ = [['^[a-zA-Z0-9_\\-\\.]{1,32}$']]
     def hasContent_(self):
         if (
+            self.bootloader or
             self.containerconfig or
             self.machine or
             self.oemconfig or
@@ -2909,15 +2900,6 @@ class type_(GeneratedsSuper):
         if self.bootkernel is not None and 'bootkernel' not in already_processed:
             already_processed.add('bootkernel')
             outfile.write(' bootkernel=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bootkernel), input_name='bootkernel')), ))
-        if self.bootloader is not None and 'bootloader' not in already_processed:
-            already_processed.add('bootloader')
-            outfile.write(' bootloader=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bootloader), input_name='bootloader')), ))
-        if self.bootloader_console is not None and 'bootloader_console' not in already_processed:
-            already_processed.add('bootloader_console')
-            outfile.write(' bootloader_console=%s' % (quote_attrib(self.bootloader_console), ))
-        if self.zipl_targettype is not None and 'zipl_targettype' not in already_processed:
-            already_processed.add('zipl_targettype')
-            outfile.write(' zipl_targettype=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.zipl_targettype), input_name='zipl_targettype')), ))
         if self.bootpartition is not None and 'bootpartition' not in already_processed:
             already_processed.add('bootpartition')
             outfile.write(' bootpartition="%s"' % self.gds_format_boolean(self.bootpartition, input_name='bootpartition'))
@@ -2933,9 +2915,6 @@ class type_(GeneratedsSuper):
         if self.bootprofile is not None and 'bootprofile' not in already_processed:
             already_processed.add('bootprofile')
             outfile.write(' bootprofile=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bootprofile), input_name='bootprofile')), ))
-        if self.boottimeout is not None and 'boottimeout' not in already_processed:
-            already_processed.add('boottimeout')
-            outfile.write(' boottimeout="%s"' % self.gds_format_integer(self.boottimeout, input_name='boottimeout'))
         if self.btrfs_quota_groups is not None and 'btrfs_quota_groups' not in already_processed:
             already_processed.add('btrfs_quota_groups')
             outfile.write(' btrfs_quota_groups="%s"' % self.gds_format_boolean(self.btrfs_quota_groups, input_name='btrfs_quota_groups'))
@@ -3097,6 +3076,8 @@ class type_(GeneratedsSuper):
             eol_ = '\n'
         else:
             eol_ = ''
+        for bootloader_ in self.bootloader:
+            bootloader_.export(outfile, level, namespaceprefix_, name_='bootloader', pretty_print=pretty_print)
         for containerconfig_ in self.containerconfig:
             containerconfig_.export(outfile, level, namespaceprefix_, name_='containerconfig', pretty_print=pretty_print)
         for machine_ in self.machine:
@@ -3135,22 +3116,6 @@ class type_(GeneratedsSuper):
         if value is not None and 'bootkernel' not in already_processed:
             already_processed.add('bootkernel')
             self.bootkernel = value
-        value = find_attr_value_('bootloader', node)
-        if value is not None and 'bootloader' not in already_processed:
-            already_processed.add('bootloader')
-            self.bootloader = value
-            self.bootloader = ' '.join(self.bootloader.split())
-        value = find_attr_value_('bootloader_console', node)
-        if value is not None and 'bootloader_console' not in already_processed:
-            already_processed.add('bootloader_console')
-            self.bootloader_console = value
-            self.bootloader_console = ' '.join(self.bootloader_console.split())
-            self.validate_grub_console(self.bootloader_console)    # validate type grub_console
-        value = find_attr_value_('zipl_targettype', node)
-        if value is not None and 'zipl_targettype' not in already_processed:
-            already_processed.add('zipl_targettype')
-            self.zipl_targettype = value
-            self.zipl_targettype = ' '.join(self.zipl_targettype.split())
         value = find_attr_value_('bootpartition', node)
         if value is not None and 'bootpartition' not in already_processed:
             already_processed.add('bootpartition')
@@ -3187,15 +3152,6 @@ class type_(GeneratedsSuper):
         if value is not None and 'bootprofile' not in already_processed:
             already_processed.add('bootprofile')
             self.bootprofile = value
-        value = find_attr_value_('boottimeout', node)
-        if value is not None and 'boottimeout' not in already_processed:
-            already_processed.add('boottimeout')
-            try:
-                self.boottimeout = int(value)
-            except ValueError as exp:
-                raise_parse_error(node, 'Bad integer attribute: %s' % exp)
-            if self.boottimeout < 0:
-                raise_parse_error(node, 'Invalid NonNegativeInteger')
         value = find_attr_value_('btrfs_quota_groups', node)
         if value is not None and 'btrfs_quota_groups' not in already_processed:
             already_processed.add('btrfs_quota_groups')
@@ -3533,7 +3489,12 @@ class type_(GeneratedsSuper):
             except ValueError as exp:
                 raise_parse_error(node, 'Bad integer attribute: %s' % exp)
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
-        if nodeName_ == 'containerconfig':
+        if nodeName_ == 'bootloader':
+            obj_ = bootloader.factory()
+            obj_.build(child_)
+            self.bootloader.append(obj_)
+            obj_.original_tagname_ = 'bootloader'
+        elif nodeName_ == 'containerconfig':
             obj_ = containerconfig.factory()
             obj_.build(child_)
             self.containerconfig.append(obj_)
@@ -4498,6 +4459,123 @@ class strip(GeneratedsSuper):
             self.file.append(obj_)
             obj_.original_tagname_ = 'file'
 # end class strip
+
+
+class bootloader(GeneratedsSuper):
+    """The bootloader section is used to select the bootloader and to
+    provide configuration parameters for it"""
+    subclass = None
+    superclass = None
+    def __init__(self, name=None, console=None, timeout=None, targettype=None):
+        self.original_tagname_ = None
+        self.name = _cast(None, name)
+        self.console = _cast(None, console)
+        self.timeout = _cast(int, timeout)
+        self.targettype = _cast(None, targettype)
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, bootloader)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if bootloader.subclass:
+            return bootloader.subclass(*args_, **kwargs_)
+        else:
+            return bootloader(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_name(self): return self.name
+    def set_name(self, name): self.name = name
+    def get_console(self): return self.console
+    def set_console(self, console): self.console = console
+    def get_timeout(self): return self.timeout
+    def set_timeout(self, timeout): self.timeout = timeout
+    def get_targettype(self): return self.targettype
+    def set_targettype(self, targettype): self.targettype = targettype
+    def validate_grub_console(self, value):
+        # Validate type grub_console, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_grub_console_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_grub_console_patterns_, ))
+    validate_grub_console_patterns_ = [['^(console|gfxterm|serial)( (console|gfxterm|serial))*$']]
+    def hasContent_(self):
+        if (
+
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', name_='bootloader', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('bootloader')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='bootloader')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='bootloader', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='bootloader'):
+        if self.name is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
+        if self.console is not None and 'console' not in already_processed:
+            already_processed.add('console')
+            outfile.write(' console=%s' % (quote_attrib(self.console), ))
+        if self.timeout is not None and 'timeout' not in already_processed:
+            already_processed.add('timeout')
+            outfile.write(' timeout="%s"' % self.gds_format_integer(self.timeout, input_name='timeout'))
+        if self.targettype is not None and 'targettype' not in already_processed:
+            already_processed.add('targettype')
+            outfile.write(' targettype=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.targettype), input_name='targettype')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='bootloader', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('name', node)
+        if value is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            self.name = value
+            self.name = ' '.join(self.name.split())
+        value = find_attr_value_('console', node)
+        if value is not None and 'console' not in already_processed:
+            already_processed.add('console')
+            self.console = value
+            self.console = ' '.join(self.console.split())
+            self.validate_grub_console(self.console)    # validate type grub_console
+        value = find_attr_value_('timeout', node)
+        if value is not None and 'timeout' not in already_processed:
+            already_processed.add('timeout')
+            try:
+                self.timeout = int(value)
+            except ValueError as exp:
+                raise_parse_error(node, 'Bad integer attribute: %s' % exp)
+            if self.timeout < 0:
+                raise_parse_error(node, 'Invalid NonNegativeInteger')
+        value = find_attr_value_('targettype', node)
+        if value is not None and 'targettype' not in already_processed:
+            already_processed.add('targettype')
+            self.targettype = value
+            self.targettype = ' '.join(self.targettype.split())
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        pass
+# end class bootloader
 
 
 class containerconfig(GeneratedsSuper):
@@ -7553,6 +7631,7 @@ if __name__ == '__main__':
 __all__ = [
     "archive",
     "argument",
+    "bootloader",
     "containerconfig",
     "description",
     "drivers",

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -759,6 +759,68 @@ class XMLState:
 
         return []
 
+    def get_build_type_bootloader_section(self):
+        """
+        First bootloader section from the build type section
+
+        :return: <bootloader> section reference
+
+        :rtype: xml_parse::bootloader
+        """
+        bootloader_sections = self.build_type.get_bootloader()
+        if bootloader_sections:
+            return bootloader_sections[0]
+
+    def get_build_type_bootloader_name(self):
+        """
+        Return bootloader name for selected build type
+
+        :return: bootloader name
+
+        :rtype: string
+        """
+        bootloader = self.get_build_type_bootloader_section()
+        return bootloader.get_name() if bootloader else \
+            Defaults.get_default_bootloader()
+
+    def get_build_type_bootloader_console(self):
+        """
+        Return bootloader console setting for selected build type
+
+        :return: console string
+
+        :rtype: string
+        """
+        bootloader = self.get_build_type_bootloader_section()
+        if bootloader:
+            return bootloader.get_console()
+
+    def get_build_type_bootloader_timeout(self):
+        """
+        Return bootloader timeout setting for selected build type
+
+        :return: timeout string
+
+        :rtype: string
+        """
+        bootloader = self.get_build_type_bootloader_section()
+        if bootloader:
+            return bootloader.get_timeout()
+
+    def get_build_type_bootloader_targettype(self):
+        """
+        Return bootloader target type setting. Only relevant for
+        the zipl bootloader because zipl is installed differently
+        depending on the storage target it runs later
+
+        :return: target type string
+
+        :rtype: string
+        """
+        bootloader = self.get_build_type_bootloader_section()
+        if bootloader:
+            return bootloader.get_targettype()
+
     def get_build_type_oemconfig_section(self):
         """
         First oemconfig section from the build type section
@@ -1518,6 +1580,18 @@ class XMLState:
         if machine_section:
             target_state.build_type.set_machine(
                 [machine_section]
+            )
+
+    def copy_bootloader_section(self, target_state):
+        """
+        Copy bootloader section from this xml state to the target xml state
+
+        :param object target_state: XMLState instance
+        """
+        bootloader_section = self.get_build_type_bootloader_section()
+        if bootloader_section:
+            target_state.build_type.set_bootloader(
+                [bootloader_section]
             )
 
     def copy_oemconfig_section(self, target_state):

--- a/kiwi/xsl/convert44to45.xsl
+++ b/kiwi/xsl/convert44to45.xsl
@@ -35,7 +35,7 @@
     </xsl:choose>
 </xsl:template>
 
-<!-- remove compressed element -->
+<!-- remove patternPackageType attribute -->
 <para xmlns="http://docbook.org/ns/docbook">
     Remove patternPackageType attribute, it's no longer used
 </para>

--- a/kiwi/xsl/convert62to63.xsl
+++ b/kiwi/xsl/convert62to63.xsl
@@ -12,7 +12,6 @@
 </xsl:template>
 
 <!-- version update -->
-<!-- remove inherit attribute from image -->
 <para xmlns="http://docbook.org/ns/docbook">
     Changed attribute <tag class="attribute">schemaversion</tag>
     to <tag class="attribute">schemaversion</tag> from
@@ -27,7 +26,7 @@
         <!-- otherwise apply templates -->
         <xsl:otherwise>
             <image schemaversion="6.3">
-                <xsl:copy-of select="@*[local-name() != 'schemaversion' and local-name() != 'inherit']"/>
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
                 <xsl:apply-templates  mode="conv62to63"/>  
             </image>
         </xsl:otherwise>

--- a/kiwi/xsl/convert63to64.xsl
+++ b/kiwi/xsl/convert63to64.xsl
@@ -12,7 +12,6 @@
 </xsl:template>
 
 <!-- version update -->
-<!-- remove inherit attribute from image -->
 <para xmlns="http://docbook.org/ns/docbook">
     Changed attribute <tag class="attribute">schemaversion</tag>
     to <tag class="attribute">schemaversion</tag> from
@@ -27,7 +26,7 @@
         <!-- otherwise apply templates -->
         <xsl:otherwise>
             <image schemaversion="6.4">
-                <xsl:copy-of select="@*[local-name() != 'schemaversion' and local-name() != 'inherit']"/>
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
                 <xsl:apply-templates  mode="conv63to64"/>  
             </image>
         </xsl:otherwise>

--- a/kiwi/xsl/convert64to65.xsl
+++ b/kiwi/xsl/convert64to65.xsl
@@ -12,7 +12,6 @@
 </xsl:template>
 
 <!-- version update -->
-<!-- remove inherit attribute from image -->
 <para xmlns="http://docbook.org/ns/docbook">
     Changed attribute <tag class="attribute">schemaversion</tag>
     to <tag class="attribute">schemaversion</tag> from
@@ -27,7 +26,7 @@
         <!-- otherwise apply templates -->
         <xsl:otherwise>
             <image schemaversion="6.5">
-                <xsl:copy-of select="@*[local-name() != 'schemaversion' and local-name() != 'inherit']"/>
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
                 <xsl:apply-templates  mode="conv64to65"/>  
             </image>
         </xsl:otherwise>

--- a/kiwi/xsl/convert65to66.xsl
+++ b/kiwi/xsl/convert65to66.xsl
@@ -12,7 +12,6 @@
 </xsl:template>
 
 <!-- version update -->
-<!-- remove inherit attribute from image -->
 <para xmlns="http://docbook.org/ns/docbook">
     Changed attribute <tag class="attribute">schemaversion</tag>
     to <tag class="attribute">schemaversion</tag> from
@@ -27,7 +26,7 @@
         <!-- otherwise apply templates -->
         <xsl:otherwise>
             <image schemaversion="6.6">
-                <xsl:copy-of select="@*[local-name() != 'schemaversion' and local-name() != 'inherit']"/>
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
                 <xsl:apply-templates  mode="conv65to66"/>  
             </image>
         </xsl:otherwise>

--- a/kiwi/xsl/convert67to68.xsl
+++ b/kiwi/xsl/convert67to68.xsl
@@ -12,7 +12,6 @@
 </xsl:template>
 
 <!-- version update -->
-<!-- remove kiwirevision attribute from image -->
 <para xmlns="http://docbook.org/ns/docbook">
     Changed attribute <tag class="attribute">schemaversion</tag>
     to <tag class="attribute">schemaversion</tag> from
@@ -27,7 +26,7 @@
         <!-- otherwise apply templates -->
         <xsl:otherwise>
             <image schemaversion="6.8">
-                <xsl:copy-of select="@*[local-name() != 'schemaversion' and local-name() != 'kiwirevision']"/>
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
                 <xsl:apply-templates  mode="conv67to68"/>
             </image>
         </xsl:otherwise>

--- a/kiwi/xsl/convert68to69.xsl
+++ b/kiwi/xsl/convert68to69.xsl
@@ -12,7 +12,6 @@
 </xsl:template>
 
 <!-- version update -->
-<!-- remove kiwirevision attribute from image -->
 <para xmlns="http://docbook.org/ns/docbook">
     Changed attribute <tag class="attribute">schemaversion</tag>
     to <tag class="attribute">schemaversion</tag> from
@@ -27,7 +26,7 @@
         <!-- otherwise apply templates -->
         <xsl:otherwise>
             <image schemaversion="6.9">
-                <xsl:copy-of select="@*[local-name() != 'schemaversion' and local-name() != 'kiwirevision']"/>
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
                 <xsl:apply-templates  mode="conv68to69"/>  
             </image>
         </xsl:otherwise>

--- a/kiwi/xsl/convert69to70.xsl
+++ b/kiwi/xsl/convert69to70.xsl
@@ -12,7 +12,6 @@
 </xsl:template>
 
 <!-- version update -->
-<!-- remove kiwirevision attribute from image -->
 <para xmlns="http://docbook.org/ns/docbook">
     Changed attribute <tag class="attribute">schemaversion</tag>
     to <tag class="attribute">schemaversion</tag> from
@@ -27,7 +26,7 @@
         <!-- otherwise apply templates -->
         <xsl:otherwise>
             <image schemaversion="7.0">
-                <xsl:copy-of select="@*[local-name() != 'schemaversion' and local-name() != 'kiwirevision']"/>
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
                 <xsl:apply-templates  mode="conv69to70"/>  
             </image>
         </xsl:otherwise>

--- a/kiwi/xsl/convert70to71.xsl
+++ b/kiwi/xsl/convert70to71.xsl
@@ -12,7 +12,6 @@
 </xsl:template>
 
 <!-- version update -->
-<!-- remove kiwirevision attribute from image -->
 <para xmlns="http://docbook.org/ns/docbook">
     Changed attribute <tag class="attribute">schemaversion</tag>
     to <tag class="attribute">schemaversion</tag> from
@@ -27,7 +26,7 @@
         <!-- otherwise apply templates -->
         <xsl:otherwise>
             <image schemaversion="7.1">
-                <xsl:copy-of select="@*[local-name() != 'schemaversion' and local-name() != 'kiwirevision']"/>
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
                 <xsl:apply-templates  mode="conv70to71"/>
             </image>
         </xsl:otherwise>

--- a/kiwi/xsl/convert71to72.xsl
+++ b/kiwi/xsl/convert71to72.xsl
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv71to72">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv71to72"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>7.1</literal> to <literal>7.2</literal>.
+</para>
+<xsl:template match="image" mode="conv71to72">
+    <xsl:choose>
+        <!-- nothing to do if already at 7.2 -->
+        <xsl:when test="@schemaversion > 7.1">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="7.2">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv71to72"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<para xmlns="http://docbook.org/ns/docbook">
+    Move bootloader, bootloader_console, boottimeout
+    and zipl_targettype attributes from types into a new
+    bootloader subsection
+</para>
+<xsl:template match="type" mode="conv71to72">
+    <type>
+        <xsl:copy-of select="@*[not(local-name(.) = 'bootloader') and not(local-name(.) = 'bootloader_console') and not(local-name(.) = 'boottimeout') and not(local-name(.) = 'zipl_targettype')]"/>
+        <xsl:variable name="loadername" select="@bootloader"/>
+        <xsl:variable name="loaderconsole" select="@bootloader_console"/>
+        <xsl:variable name="loadertime" select="@boottimeout"/>
+        <xsl:variable name="loadertarget" select="@zipl_targettype"/>
+        <xsl:choose>
+            <xsl:when test="@bootloader!=''">
+                <bootloader>
+                    <xsl:attribute name="name">
+                        <xsl:value-of select="$loadername"/>
+                    </xsl:attribute>
+                    <xsl:choose>
+                        <xsl:when test="@bootloader_console!=''">
+                            <xsl:attribute name="console">
+                                <xsl:value-of select="$loaderconsole"/>
+                            </xsl:attribute>
+                        </xsl:when>
+                    </xsl:choose>
+                    <xsl:choose>
+                        <xsl:when test="@boottimeout!=''">
+                            <xsl:attribute name="timeout">
+                                <xsl:value-of select="$loadertime"/>
+                            </xsl:attribute>
+                        </xsl:when>
+                    </xsl:choose>
+                    <xsl:choose>
+                        <xsl:when test="@zipl_targettype!=''">
+                            <xsl:attribute name="targettype">
+                                <xsl:value-of select="$loadertarget"/>
+                            </xsl:attribute>
+                        </xsl:when>
+                    </xsl:choose>
+                </bootloader>
+            </xsl:when>
+        </xsl:choose>
+        <xsl:apply-templates mode="conv71to72"/>
+    </type>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/kiwi/xsl/master.xsl
+++ b/kiwi/xsl/master.xsl
@@ -42,6 +42,7 @@
 <xsl:import href="convert68to69.xsl"/>
 <xsl:import href="convert69to70.xsl"/>
 <xsl:import href="convert70to71.xsl"/>
+<xsl:import href="convert71to72.xsl"/>
 <xsl:import href="pretty.xsl"/>
 
 
@@ -196,8 +197,12 @@
         <xsl:apply-templates select="exslt:node-set($v70)" mode="conv70to71"/>
     </xsl:variable>
 
+    <xsl:variable name="v72">
+        <xsl:apply-templates select="exslt:node-set($v71)" mode="conv71to72"/>
+    </xsl:variable>
+
     <xsl:apply-templates
-        select="exslt:node-set($v71)" mode="pretty"
+        select="exslt:node-set($v72)" mode="pretty"
     />
 </xsl:template>
 

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -44,7 +44,7 @@
 
 Name:           python-kiwi
 Version:        %%VERSION
-Provides:       kiwi-schema = 7.1
+Provides:       kiwi-schema = 7.2
 Release:        0
 Url:            https://github.com/OSInside/kiwi
 Summary:        KIWI - Appliance Builder Next Generation

--- a/test/data/example_arm_disk_size_config.xml
+++ b/test/data/example_arm_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" bootloader="grub2" spare_part="42M"/>
+        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" spare_part="42M"/>
     </preferences>
     <repository>
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_btrfs_config.xml
+++ b/test/data/example_btrfs_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi">
+        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" kernelcmdline="splash" firmware="efi">
             <systemdisk/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>
@@ -40,7 +40,7 @@
         <rpm-locale-filtering>true</rpm-locale-filtering>
     </preferences>
     <preferences>
-        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" fscreateoptions="-O ^has_journal" btrfs_root_is_snapshot="true" spare_part="200M" spare_part_fs_attributes="no-copy-on-write" xen_server="true" formatoptions="force_size,super=man" filesystem="ext4">
+        <type image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" fscreateoptions="-O ^has_journal" btrfs_root_is_snapshot="true" spare_part="200M" spare_part_fs_attributes="no-copy-on-write" xen_server="true" formatoptions="force_size,super=man" filesystem="ext4">
             <size unit="G" additive="true">1</size>
             <systemdisk name="mydisk"/>
             <machine memory="512" xen_loader="hvmloader">
@@ -67,17 +67,17 @@
         <bootloader-theme>openSUSE</bootloader-theme>
     </preferences>
     <preferences profiles="ec2Flavour">
-        <type image="vmx" filesystem="ext3" bootprofile="ec2" bootkernel="ec2k" bootloader="grub2" kernelcmdline="xencons=xvc0 console=xvc0 multipath=off splash" firmware="ec2"/>
+        <type image="vmx" filesystem="ext3" bootprofile="ec2" bootkernel="ec2k" kernelcmdline="xencons=xvc0 console=xvc0 multipath=off splash" firmware="ec2"/>
     </preferences>
     <preferences profiles="xenFlavour">
-        <type image="vmx" filesystem="ext3" bootprofile="xen" bootkernel="xenk" bootloader="grub2" kernelcmdline="splash">
+        <type image="vmx" filesystem="ext3" bootprofile="xen" bootkernel="xenk" kernelcmdline="splash">
             <machine memory="512" xen_loader="hvmloader">
                 <vmdisk id="0" device="/dev/xvda" controller="ide"/>
                 <vmnic interface=""/>
             </machine>
             <size>10</size>
         </type>
-        <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" bootprofile="xen" bootkernel="xenk" installiso="true" bootloader="grub2" kernelcmdline="splash">
+        <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" bootprofile="xen" bootkernel="xenk" installiso="true" kernelcmdline="splash">
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-swap>true</oem-swap>
@@ -86,7 +86,7 @@
         <type image="docker"/>
     </preferences>
     <preferences profiles="vmxFlavour">
-        <type image="vmx" filesystem="ext3" format="vmdk" bootloader="grub2" kernelcmdline="splash" bootpartition="false">
+        <type image="vmx" filesystem="ext3" format="vmdk" kernelcmdline="splash" bootpartition="false">
             <size unit="G" unpartitioned="1">4</size>
             <systemdisk name="systemVG"/>
             <machine memory="512" guestOS="suse" HWversion="4">
@@ -96,7 +96,7 @@
                 <vmconfig-entry>cpuid.coresPerSocket = "2"</vmconfig-entry>
             </machine>
         </type>
-        <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" installiso="true" bootloader="grub2" kernelcmdline="splash">
+        <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" installiso="true" kernelcmdline="splash">
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-swap>true</oem-swap>

--- a/test/data/example_disk_config.xml
+++ b/test/data/example_disk_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true">
+        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" kernelcmdline="splash" firmware="efi" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true">
             <oemconfig>
                 <oem-multipath-scan>false</oem-multipath-scan>
                 <oem-swap>true</oem-swap>

--- a/test/data/example_disk_size_config.xml
+++ b/test/data/example_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi">
+        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" kernelcmdline="splash" firmware="efi">
             <oemconfig>
                 <oem-inplace-recovery>true</oem-inplace-recovery>
                 <oem-recovery-part-size>200</oem-recovery-part-size>

--- a/test/data/example_disk_size_empty_vol_config.xml
+++ b/test/data/example_disk_size_empty_vol_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext3" bootloader="grub2" kernelcmdline="splash" firmware="efi">
+        <type image="vmx" filesystem="ext3" kernelcmdline="splash" firmware="efi">
             <systemdisk/>
         </type>
     </preferences>

--- a/test/data/example_disk_size_oem_volume_config.xml
+++ b/test/data/example_disk_size_oem_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext3" boot="oemboot/suse-13.2" bootloader="grub2" kernelcmdline="splash" firmware="efi">
+        <type image="oem" filesystem="ext3" boot="oemboot/suse-13.2" kernelcmdline="splash" firmware="efi">
             <systemdisk>
                 <volume name="usr/lib" size="1G"/>
                 <volume name="usr/bin" size="5"/>

--- a/test/data/example_disk_size_vol_root_config.xml
+++ b/test/data/example_disk_size_vol_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext3" bootloader="grub2" kernelcmdline="splash" firmware="efi">
+        <type image="vmx" filesystem="ext3" kernelcmdline="splash" firmware="efi">
             <systemdisk>
                 <volume name="@root" size="5M"/>
             </systemdisk>

--- a/test/data/example_disk_size_volume_config.xml
+++ b/test/data/example_disk_size_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext3" bootloader="grub2" kernelcmdline="splash" firmware="efi">
+        <type image="vmx" filesystem="ext3" kernelcmdline="splash" firmware="efi">
             <systemdisk>
                 <volume name="usr/lib" size="1G"/>
                 <volume name="usr/bin" size="5"/>

--- a/test/data/example_dot_profile_config.xml
+++ b/test/data/example_dot_profile_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -19,7 +19,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" primary="true" filesystem="ext3" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi" ramonly="true" xen_server="true">
+        <type image="oem" primary="true" filesystem="ext3" boot="oemboot/suse-13.2" installiso="true" kernelcmdline="splash" firmware="efi" ramonly="true" xen_server="true">
             <systemdisk>
                 <volume name="usr/lib" size="1G"/>
                 <volume name="@root" freespace="500M"/>

--- a/test/data/example_lvm_default_config.xml
+++ b/test/data/example_lvm_default_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext3" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi">
+        <type image="oem" filesystem="ext3" boot="oemboot/suse-13.2" installiso="true" kernelcmdline="splash" firmware="efi">
             <systemdisk>
                 <volume name="usr/lib" size="1G" label="library"/>
                 <volume name="@root" freespace="500M"/>

--- a/test/data/example_lvm_no_root_config.xml
+++ b/test/data/example_lvm_no_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext3" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi">
+        <type image="oem" filesystem="ext3" boot="oemboot/suse-13.2" installiso="true" kernelcmdline="splash" firmware="efi">
             <systemdisk/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>

--- a/test/data/example_lvm_no_root_full_usr_config.xml
+++ b/test/data/example_lvm_no_root_full_usr_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext3" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi">
+        <type image="oem" filesystem="ext3" boot="oemboot/suse-13.2" installiso="true" kernelcmdline="splash" firmware="efi">
             <systemdisk>
                 <volume name="usr" size="all"/>
             </systemdisk>

--- a/test/data/example_lvm_preferred_config.xml
+++ b/test/data/example_lvm_preferred_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi">
+        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" kernelcmdline="splash" firmware="efi">
             <systemdisk preferlvm="true"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>

--- a/test/data/example_multiple_users_config.xml
+++ b/test/data/example_multiple_users_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -23,7 +23,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="btrfs" bootloader="grub2" kernelcmdline="splash" firmware="efi"/>
+        <type image="vmx" filesystem="btrfs" kernelcmdline="splash" firmware="efi"/>
     </preferences>
     <users>
         <user pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>

--- a/test/data/example_no_default_type.xml
+++ b/test/data/example_no_default_type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -26,7 +26,7 @@
         <bootloader-theme>openSUSE</bootloader-theme>
     </preferences>
     <preferences profiles="vmxFlavor">
-        <type image="vmx" filesystem="btrfs" bootloader="grub2" kernelcmdline="splash" firmware="efi"/>
+        <type image="vmx" filesystem="btrfs" kernelcmdline="splash" firmware="efi"/>
     </preferences>
     <users>
         <user pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>

--- a/test/data/example_no_image_packages_config.xml
+++ b/test/data/example_no_image_packages_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true"/>
+        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" kernelcmdline="splash" firmware="efi" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true"/>
     </preferences>
     <repository>
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_no_imageinclude_config.xml
+++ b/test/data/example_no_imageinclude_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -12,7 +12,7 @@
         <locale>de_DE</locale>
     </preferences>
     <preferences>
-        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async">
+        <type image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async">
             <size unit="G" additive="true">1</size>
             <systemdisk name="mydisk"/>
             <machine memory="512" xen_loader="pvgrub">

--- a/test/data/example_ppc_disk_size_config.xml
+++ b/test/data/example_ppc_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" bootloader="grub2" firmware="ofw" rootfs_label="MYLABEL"/>
+        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" firmware="ofw" rootfs_label="MYLABEL"/>
     </preferences>
     <repository>
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_pxe_config.xml
+++ b/test/data/example_pxe_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_boot_desc_not_found.xml
+++ b/test/data/example_runtime_checker_boot_desc_not_found.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="JeOS">
+<image schemaversion="7.2" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>
@@ -83,16 +83,16 @@
         </type>
     </preferences>
     <preferences profiles="ec2Flavour">
-        <type image="vmx" filesystem="ext3" bootprofile="ec2" bootkernel="ec2k" bootloader="grub2" kernelcmdline="xencons=xvc0 console=xvc0 multipath=off splash" firmware="ec2"/>
+        <type image="vmx" filesystem="ext3" bootprofile="ec2" bootkernel="ec2k" kernelcmdline="xencons=xvc0 console=xvc0 multipath=off splash" firmware="ec2"/>
     </preferences>
     <preferences profiles="xenFlavour">
-        <type image="vmx" filesystem="ext3" bootprofile="xen" bootkernel="xenk" bootloader="grub2" kernelcmdline="splash">
+        <type image="vmx" filesystem="ext3" bootprofile="xen" bootkernel="xenk" kernelcmdline="splash">
             <machine memory="512" xen_loader="pvgrub">
                 <vmdisk id="0" device="/dev/xvda" controller="ide"/>
                 <vmnic interface=""/>
             </machine>
         </type>
-        <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" bootprofile="xen" bootkernel="xenk" installiso="true" bootloader="grub2" kernelcmdline="splash" xen_server="true" firmware="bios">
+        <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" bootprofile="xen" bootkernel="xenk" installiso="true" kernelcmdline="splash" xen_server="true" firmware="bios">
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-swap>true</oem-swap>
@@ -100,7 +100,7 @@
         </type>
     </preferences>
     <preferences profiles="vmxFlavour">
-        <type image="vmx" filesystem="ext3" format="vmdk" bootloader="grub2" kernelcmdline="splash" bootpartition="false">
+        <type image="vmx" filesystem="ext3" format="vmdk" kernelcmdline="splash" bootpartition="false">
             <systemdisk name="systemVG">
                 <volume name="foo" label="SWAP"/>
             </systemdisk>
@@ -109,7 +109,7 @@
                 <vmnic driver="e1000" interface="0" mode="bridged"/>
             </machine>
         </type>
-        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="my_edit_boot_install" filesystem="btrfs" initrd_system="dracut" installiso="true">
+        <type image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="my_edit_boot_install" filesystem="btrfs" initrd_system="dracut" installiso="true">
             <size unit="G" additive="true">1</size>
             <systemdisk name="mydisk">
                 <volume name="root" size="6G" mountpoint="/" label="foo"/>

--- a/test/data/example_runtime_checker_no_boot_reference.xml
+++ b/test/data/example_runtime_checker_no_boot_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="JeOS">
+<image schemaversion="7.2" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/isoboot/example-distribution-no-delete-section/config.xml
+++ b/test/data/isoboot/example-distribution-no-delete-section/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="initrd-isoboot-suse-13.2">
+<image schemaversion="7.2" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/isoboot/example-distribution/config.xml
+++ b/test/data/isoboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="initrd-isoboot-suse-13.2">
+<image schemaversion="7.2" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/oemboot/example-distribution/config.xml
+++ b/test/data/oemboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.1" name="initrd-oemboot-suse-13.2">
+<image schemaversion="7.2" name="initrd-oemboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/unit/bootloader/config/base_test.py
+++ b/test/unit/bootloader/config/base_test.py
@@ -85,9 +85,11 @@ class TestBootLoaderConfigBase:
     def test_get_boot_timeout_seconds_default_applies(self):
         assert self.bootloader.get_boot_timeout_seconds() == 10
 
-    @patch('kiwi.xml_parse.type_.get_boottimeout')
-    def test_get_boot_timeout_seconds(self, mock_get_boottimeout):
-        mock_get_boottimeout.return_value = 0
+    @patch('kiwi.xml_parse.type_.get_bootloader')
+    def test_get_boot_timeout_seconds(self, mock_get_bootloader):
+        bootloader = Mock()
+        bootloader.get_timeout.return_value = 0
+        mock_get_bootloader.return_value = [bootloader]
         assert self.bootloader.get_boot_timeout_seconds() == 0
 
     @patch('kiwi.xml_parse.type_.get_installprovidefailsafe')

--- a/test/unit/bootloader/config/isolinux_test.py
+++ b/test/unit/bootloader/config/isolinux_test.py
@@ -22,7 +22,7 @@ class TestBootLoaderConfigIsoLinux:
         mock_machine.return_value = 'x86_64'
         mock_exists.return_value = True
         self.state = mock.Mock()
-        self.state.build_type.get_bootloader_console = mock.Mock(
+        self.state.get_build_type_bootloader_console = mock.Mock(
             return_value=None
         )
         self.state.build_type.get_mediacheck = mock.Mock(
@@ -40,7 +40,7 @@ class TestBootLoaderConfigIsoLinux:
         self.state.build_type.get_hybridpersistent_filesystem = mock.Mock(
             return_value=None
         )
-        self.state.build_type.get_boottimeout = mock.Mock(
+        self.state.get_build_type_bootloader_timeout = mock.Mock(
             return_value=None
         )
         self.state.build_type.get_install_continue_on_timeout = mock.Mock(

--- a/test/unit/bootloader/config/zipl_test.py
+++ b/test/unit/bootloader/config/zipl_test.py
@@ -46,13 +46,13 @@ class TestBootLoaderConfigZipl:
         self.xml_state.build_type.get_firmware = mock.Mock(
             return_value=None
         )
-        self.xml_state.build_type.get_boottimeout = mock.Mock(
+        self.xml_state.get_build_type_bootloader_timeout = mock.Mock(
             return_value='200'
         )
         self.xml_state.build_type.get_target_blocksize = mock.Mock(
             return_value=None
         )
-        self.xml_state.build_type.get_zipl_targettype = mock.Mock(
+        self.xml_state.get_build_type_bootloader_targettype = mock.Mock(
             return_value=None
         )
         self.xml_state.build_type.get_kernelcmdline = mock.Mock(

--- a/test/unit/firmware_test.py
+++ b/test/unit/firmware_test.py
@@ -34,14 +34,14 @@ class TestFirmWare:
 
         mock_platform.return_value = 's390x'
         xml_state.build_type.get_firmware.return_value = None
-        xml_state.build_type.get_zipl_targettype = mock.Mock()
-        xml_state.build_type.get_zipl_targettype.return_value = 'LDL'
+        xml_state.get_build_type_bootloader_targettype = mock.Mock()
+        xml_state.get_build_type_bootloader_targettype.return_value = 'LDL'
         self.firmware_s390_ldl = FirmWare(xml_state)
 
-        xml_state.build_type.get_zipl_targettype.return_value = 'CDL'
+        xml_state.get_build_type_bootloader_targettype.return_value = 'CDL'
         self.firmware_s390_cdl = FirmWare(xml_state)
 
-        xml_state.build_type.get_zipl_targettype.return_value = 'SCSI'
+        xml_state.get_build_type_bootloader_targettype.return_value = 'SCSI'
         self.firmware_s390_scsi = FirmWare(xml_state)
 
         mock_platform.return_value = 'ppc64le'

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1,6 +1,8 @@
 import logging
 from collections import namedtuple
-from mock import patch
+from mock import (
+    patch, Mock
+)
 from pytest import (
     raises, fixture
 )
@@ -41,6 +43,11 @@ class TestXMLState:
         self.no_image_packages_boot_state = XMLState(
             no_image_packages_description.load()
         )
+        self.bootloader = Mock()
+        self.bootloader.get_name.return_value = 'some-loader'
+        self.bootloader.get_timeout.return_value = 'some-timeout'
+        self.bootloader.get_targettype.return_value = 'some-target'
+        self.bootloader.get_console.return_value = 'some-console'
 
     def test_get_description_section(self):
         description = self.state.get_description_section()
@@ -494,6 +501,13 @@ class TestXMLState:
         systemdisk = self.boot_state.get_build_type_system_disk_section()
         assert systemdisk.get_name() == 'mydisk'
 
+    @patch('kiwi.xml_parse.type_.get_bootloader')
+    def test_copy_bootloader_section(self, mock_bootloader):
+        mock_bootloader.return_value = [self.bootloader]
+        self.state.copy_bootloader_section(self.boot_state)
+        assert self.boot_state.get_build_type_bootloader_section() == \
+            self.bootloader
+
     def test_copy_strip_sections(self):
         self.state.copy_strip_sections(self.boot_state)
         assert 'del-a' in self.boot_state.get_strip_files_to_delete()
@@ -827,3 +841,28 @@ class TestXMLState:
         assert self.state.get_root_filesystem_uuid() is None
         self.state.set_root_filesystem_uuid('some-id')
         assert self.state.get_root_filesystem_uuid() == 'some-id'
+
+    @patch('kiwi.xml_parse.type_.get_bootloader')
+    def test_get_build_type_bootloader_name(self, mock_bootloader):
+        mock_bootloader.return_value = [None]
+        assert self.state.get_build_type_bootloader_name() == 'grub2'
+        mock_bootloader.return_value = [self.bootloader]
+        assert self.state.get_build_type_bootloader_name() == 'some-loader'
+
+    @patch('kiwi.xml_parse.type_.get_bootloader')
+    def test_get_build_type_bootloader_console(self, mock_bootloader):
+        mock_bootloader.return_value = [self.bootloader]
+        assert self.state.get_build_type_bootloader_console() == \
+            'some-console'
+
+    @patch('kiwi.xml_parse.type_.get_bootloader')
+    def test_get_build_type_bootloader_timeout(self, mock_bootloader):
+        mock_bootloader.return_value = [self.bootloader]
+        assert self.state.get_build_type_bootloader_timeout() == \
+            'some-timeout'
+
+    @patch('kiwi.xml_parse.type_.get_bootloader')
+    def test_get_build_type_bootloader_targettype(self, mock_bootloader):
+        mock_bootloader.return_value = [self.bootloader]
+        assert self.state.get_build_type_bootloader_targettype() == \
+            'some-target'


### PR DESCRIPTION
The bootloader settings are handled through attributes in the type element. Over the years some attributes were added and  there are requests for more settings. Therefore the bootloader   setup deservers its own section. With this commit the schema  changes from v7.1 to v7.2 and moves bootloader, bootloader_console   boottimeout and zipl_targettype into a new bootloader subsection below type. The commit also adds an auto transformation template   such that customers don't have to change their image descriptions.  This is related to Issue #1401

The new layout looks like this:

```xml
<type ...>
    <bootloader name="..." ...
</type>
```

Of course an auto translation of the former 7.1 schema into the new 7.2 schema will be done automatically

