### PR TITLE
Fix string formatting

### DIFF
--- a/kiwi/iso_tools/cdrtools.py
+++ b/kiwi/iso_tools/cdrtools.py
@@ -70,7 +70,7 @@ class IsoToolsCdrTools(IsoToolsBase):
                 return tool_found
 
         raise KiwiIsoToolError(
-            'No iso creation tool found, searched for: %s'.format(
+            'No iso creation tool found, searched for: {}'.format(
                 iso_creation_tools
             )
         )

--- a/kiwi/iso_tools/iso.py
+++ b/kiwi/iso_tools/iso.py
@@ -314,7 +314,7 @@ class Iso:
         )
         if not os.path.exists(loader_file):
             raise KiwiIsoLoaderError(
-                'No isolinux loader %s found'.format(loader_file)
+                'No isolinux loader {} found'.format(loader_file)
             )
         try:
             Command.run(

--- a/test/unit/path_test.py
+++ b/test/unit/path_test.py
@@ -123,8 +123,10 @@ class TestPath:
         with self._caplog.at_level(logging.DEBUG):
             assert Path.which('file') is None
             print(self._caplog.text)
-            assert '"file": in paths "{0}" exists: "False" mode match: '
-            'not checked'.format(mock_env.return_value) in self._caplog.text
+            assert (
+                '"file": in paths "{0}" exists: "False" mode match: '
+                'not checked'
+            ).format(mock_env.return_value) in self._caplog.text
 
     @patch('os.access')
     @patch('os.environ.get')
@@ -137,8 +139,10 @@ class TestPath:
         mock_access.return_value = False
         with self._caplog.at_level(logging.DEBUG):
             assert Path.which('file', access_mode=os.X_OK) is None
-            assert '"file": in paths "{0}" exists: "True" mode match: '
-            '"False"'.format(mock_env.return_value) in self._caplog.text
+            assert (
+                '"file": in paths "{0}" exists: "True" mode match: '
+                '"False"'
+            ).format(mock_env.return_value) in self._caplog.text
 
     def test_access_invalid_mode(self):
         with raises(ValueError) as issue:


### PR DESCRIPTION
After a flake8 upgrade to v3.8.0 these changes were required to pass
the `tox -e check` validation.
