### PR TITLE
Fixed zypper error code validation

### DIFF
--- a/kiwi/package_manager/zypper.py
+++ b/kiwi/package_manager/zypper.py
@@ -274,14 +274,17 @@ class PackageManagerZypper(PackageManagerBase):
 
         :rtype: boolean
         """
+        error_codes = [
+            104,  # - ZYPPER_EXIT_INF_CAP_NOT_FOUND
+            105,  # - ZYPPER_EXIT_ON_SIGNAL
+            106,  # - ZYPPER_EXIT_INF_REPOS_SKIPPED
+            127   # - Command Not Found
+        ]
         if returncode == 0:
             # All is good
             return False
-        elif returncode == 104 or returncode == 105 or returncode == 106:
-            # Treat the following exit codes as error
-            # 104 - ZYPPER_EXIT_INF_CAP_NOT_FOUND
-            # 105 - ZYPPER_EXIT_ON_SIGNAL
-            # 106 - ZYPPER_EXIT_INF_REPOS_SKIPPED
+        elif returncode in error_codes:
+            # Treat matching exit code as error
             return True
         elif returncode >= 100:
             # Treat all other 100 codes as non error codes

--- a/test/unit/package_manager/zypper_test.py
+++ b/test/unit/package_manager/zypper_test.py
@@ -160,6 +160,7 @@ class TestPackageManagerZypper:
         assert self.manager.has_failed(1) is True
         assert self.manager.has_failed(4) is True
         assert self.manager.has_failed(-42) is True
+        assert self.manager.has_failed(127) is True
 
     @patch('kiwi.package_manager.zypper.os.unlink')
     @patch('kiwi.package_manager.zypper.os.path.exists')


### PR DESCRIPTION
The error code 127 - command not found, was not treated as
an error. This commit adds 127 to be an error condition
along with the other 1xx error codes from zypper that are
handled as errors. This Fixes #1430

