### PR TITLE
Cleanup use of machine platform name

### DIFF
--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -17,7 +17,6 @@
 #
 import re
 import os
-import platform
 import pickle
 import logging
 from collections import namedtuple
@@ -69,7 +68,7 @@ class BootImageBase:
         self.initrd_base_name = ''.join(
             [
                 self.xml_state.xml_data.get_name(),
-                '.' + platform.machine(),
+                '.' + Defaults.get_platform_name(),
                 '-' + self.xml_state.get_image_version(),
                 '.initrd'
             ]

--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -17,7 +17,6 @@
 #
 import os
 import logging
-import platform
 from collections import namedtuple
 
 # project
@@ -45,7 +44,7 @@ class BootLoaderConfigBase:
         self.root_dir = root_dir
         self.boot_dir = boot_dir or root_dir
         self.xml_state = xml_state
-        self.arch = platform.machine()
+        self.arch = Defaults.get_platform_name()
 
         self.volumes_mount = []
         self.root_mount = None

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -19,7 +19,6 @@ from string import Template
 import re
 import os
 import logging
-import platform
 import glob
 import shutil
 from collections import OrderedDict
@@ -62,16 +61,16 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 {'grub_directory_name': 'grub|grub2'}
         """
         self.custom_args = custom_args
-        arch = platform.machine()
+        arch = Defaults.get_platform_name()
         if arch == 'x86_64':
             # grub2 support for bios and efi systems
             self.arch = arch
         elif arch.startswith('ppc64'):
             # grub2 support for ofw and opal systems
             self.arch = arch
-        elif arch == 'i686' or arch == 'i586':
+        elif arch == 'ix86':
             # grub2 support for bios systems
-            self.arch = 'ix86'
+            self.arch = arch
         elif arch == 'aarch64' or arch.startswith('arm'):
             # grub2 support for efi systems
             self.arch = arch

--- a/kiwi/bootloader/config/isolinux.py
+++ b/kiwi/bootloader/config/isolinux.py
@@ -17,7 +17,6 @@
 #
 import os
 import logging
-import platform
 
 # project
 from kiwi.bootloader.config.base import BootLoaderConfigBase
@@ -41,9 +40,7 @@ class BootLoaderConfigIsoLinux(BootLoaderConfigBase):
         :param dict custom_args: custom isolinux config arguments
         """
         self.custom_args = custom_args
-        self.arch = platform.machine()
-        if self.arch == 'i686' or self.arch == 'i586':
-            self.arch = 'ix86'
+        self.arch = Defaults.get_platform_name()
 
         self.install_volid = self.xml_state.build_type.get_volid() or \
             Defaults.get_install_volume_id()

--- a/kiwi/bootloader/config/zipl.py
+++ b/kiwi/bootloader/config/zipl.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-import platform
 import logging
 import re
 
@@ -53,7 +52,7 @@ class BootLoaderConfigZipl(BootLoaderConfigBase):
                 {'targetbase': 'device_name'}
         """
         self.custom_args = custom_args
-        arch = platform.machine()
+        arch = Defaults.get_platform_name()
         if 's390' in arch:
             self.arch = arch
         else:

--- a/kiwi/bootloader/install/grub2.py
+++ b/kiwi/bootloader/install/grub2.py
@@ -18,7 +18,6 @@
 import glob
 import os
 import logging
-import platform
 
 # project
 from kiwi.bootloader.install.base import BootLoaderInstallBase
@@ -59,7 +58,7 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
                 }
 
         """
-        self.arch = platform.machine()
+        self.arch = Defaults.get_platform_name()
         self.custom_args = custom_args
         self.install_arguments = []
         self.firmware = None
@@ -129,7 +128,7 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
         if self.target_removable:
             self.install_arguments.append('--removable')
 
-        if self.arch == 'x86_64' or self.arch == 'i686' or self.arch == 'i586':
+        if Defaults.is_x86_arch(self.arch):
             self.target = 'i386-pc'
             self.install_device = self.device
             self.modules = ' '.join(

--- a/kiwi/builder/archive.py
+++ b/kiwi/builder/archive.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-import platform
 import logging
 
 # project
@@ -132,7 +131,7 @@ class ArchiveBuilder:
             [
                 self.target_dir, '/',
                 self.xml_state.xml_data.get_name(),
-                '.' + platform.machine(),
+                '.' + Defaults.get_platform_name(),
                 '-' + self.xml_state.get_image_version(),
                 '.', suffix
             ]

--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -16,7 +16,6 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import logging
-import platform
 import os
 
 # project
@@ -86,7 +85,7 @@ class ContainerBuilder:
             [
                 target_dir, '/',
                 xml_state.xml_data.get_name(),
-                '.' + platform.machine(),
+                '.' + Defaults.get_platform_name(),
                 '-' + xml_state.get_image_version(),
                 '.', self.requested_container_type,
                 '.tar' if self.requested_container_type != 'appx' else ''

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -17,7 +17,6 @@
 #
 import os
 import logging
-import platform
 import pickle
 from tempfile import NamedTemporaryFile
 
@@ -69,9 +68,7 @@ class DiskBuilder:
         * xz_options: string of XZ compression parameters
     """
     def __init__(self, xml_state, target_dir, root_dir, custom_args=None):
-        self.arch = platform.machine()
-        if self.arch == 'i686' or self.arch == 'i586':
-            self.arch = 'ix86'
+        self.arch = Defaults.get_platform_name()
         self.root_dir = root_dir
         self.target_dir = target_dir
         self.xml_state = xml_state

--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -16,7 +16,6 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import logging
-import platform
 import os
 
 # project
@@ -86,7 +85,7 @@ class FileSystemBuilder:
             [
                 target_dir, '/',
                 xml_state.xml_data.get_name(),
-                '.' + platform.machine(),
+                '.' + Defaults.get_platform_name(),
                 '-' + xml_state.get_image_version(),
                 '.', self.requested_filesystem
             ]

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -18,7 +18,6 @@
 import os
 import logging
 from tempfile import mkdtemp
-import platform
 import shutil
 
 # project
@@ -59,9 +58,7 @@ class InstallImageBuilder:
         self, xml_state, root_dir, target_dir, boot_image_task,
         custom_args=None
     ):
-        self.arch = platform.machine()
-        if self.arch == 'i686' or self.arch == 'i586':
-            self.arch = 'ix86'
+        self.arch = Defaults.get_platform_name()
         self.root_dir = root_dir
         self.target_dir = target_dir
         self.boot_image_task = boot_image_task

--- a/kiwi/builder/kis.py
+++ b/kiwi/builder/kis.py
@@ -17,7 +17,6 @@
 #
 import os
 import logging
-import platform
 
 # project
 from kiwi.defaults import Defaults
@@ -78,7 +77,7 @@ class KisBuilder:
             [
                 target_dir, '/',
                 xml_state.xml_data.get_name(),
-                '.' + platform.machine(),
+                '.' + Defaults.get_platform_name(),
                 '-' + xml_state.get_image_version()
             ]
         )

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -19,7 +19,6 @@ import os
 import logging
 from tempfile import mkdtemp
 from tempfile import NamedTemporaryFile
-import platform
 import shutil
 
 # project
@@ -60,9 +59,7 @@ class LiveImageBuilder:
     def __init__(self, xml_state, target_dir, root_dir, custom_args=None):
         self.media_dir = None
         self.live_container_dir = None
-        self.arch = platform.machine()
-        if self.arch == 'i686' or self.arch == 'i586':
-            self.arch = 'ix86'
+        self.arch = Defaults.get_platform_name()
         self.root_dir = root_dir
         self.target_dir = target_dir
         self.xml_state = xml_state
@@ -91,7 +88,7 @@ class LiveImageBuilder:
             [
                 target_dir, '/',
                 xml_state.xml_data.get_name(),
-                '.' + platform.machine(),
+                '.' + Defaults.get_platform_name(),
                 '-' + xml_state.get_image_version(),
                 '.iso'
             ]

--- a/kiwi/container/setup/appx.py
+++ b/kiwi/container/setup/appx.py
@@ -16,13 +16,13 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
-import platform
 from lxml import etree
 from xml.dom import minidom
 
 # project
 from kiwi.container.setup.base import ContainerSetupBase
 from kiwi.exceptions import KiwiContainerSetupError
+from kiwi.defaults import Defaults
 
 
 class ContainerSetupAppx(ContainerSetupBase):
@@ -164,4 +164,4 @@ class ContainerSetupAppx(ContainerSetupBase):
         windows = {
             'x86_64': 'x64'
         }
-        return windows.get(platform.machine())
+        return windows.get(Defaults.get_platform_name())

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -94,6 +94,13 @@ class Defaults:
         ]
 
     @staticmethod
+    def get_platform_name():
+        arch = platform.machine()
+        if arch == 'i686' or arch == 'i586':
+            arch = 'ix86'
+        return arch
+
+    @staticmethod
     def is_x86_arch(arch):
         """
         Checks if machine architecture is x86 based
@@ -104,7 +111,10 @@ class Defaults:
 
         :rtype: bool
         """
-        if arch == 'x86_64' or arch == 'i686' or arch == 'i586':
+        x86_arch_names = [
+            'x86_64', 'i686', 'i586', 'ix86'
+        ]
+        if arch in x86_arch_names:
             return True
         return False
 
@@ -441,7 +451,7 @@ class Defaults:
 
         :rtype: list
         """
-        host_architecture = platform.machine()
+        host_architecture = Defaults.get_platform_name()
         modules = Defaults.get_grub_basic_modules(multiboot) + [
             'part_gpt',
             'part_msdos',
@@ -886,6 +896,7 @@ class Defaults:
             'x86_64': ['efi', 'uefi', 'bios', 'ec2hvm', 'ec2'],
             'i586': ['bios'],
             'i686': ['bios'],
+            'ix86': ['bios'],
             'aarch64': ['efi', 'uefi'],
             'arm64': ['efi', 'uefi'],
             'armv5el': ['efi', 'uefi'],
@@ -906,7 +917,7 @@ class Defaults:
         """
         Provides default firmware for specified architecture
 
-        :param string arch: platform.machine
+        :param string arch: machine architecture name
 
         :return: firmware name
 
@@ -916,6 +927,7 @@ class Defaults:
             'x86_64': 'bios',
             'i586': 'bios',
             'i686': 'bios',
+            'ix86': 'bios',
             'ppc': 'ofw',
             'ppc64': 'ofw',
             'ppc64le': 'ofw',
@@ -962,7 +974,7 @@ class Defaults:
         Provides architecture specific EFI directory name which
         stores the EFI binaries for the desired architecture.
 
-        :param string arch: platform.machine
+        :param string arch: machine architecture name
 
         :return: directory name
 
@@ -1002,7 +1014,7 @@ class Defaults:
         """
         Provides architecture specific EFI boot binary name
 
-        :param string arch: platform.machine
+        :param string arch: machine architecture name
 
         :return: name
 
@@ -1336,10 +1348,9 @@ class Defaults:
 
         :rtype: str
         """
-        arch = platform.machine()
-        if arch == 'i686' or arch == 'i586':
-            arch = 'ix86'
-        return os.sep.join(['boot', arch])
+        return os.sep.join(
+            ['boot', Defaults.get_platform_name()]
+        )
 
     @staticmethod
     def get_iso_tool_category():

--- a/kiwi/filesystem/squashfs.py
+++ b/kiwi/filesystem/squashfs.py
@@ -14,11 +14,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
-import platform
-
+#
 # project
 from kiwi.filesystem.base import FileSystemBase
 from kiwi.command import Command
+from kiwi.defaults import Defaults
 
 
 class FileSystemSquashFs(FileSystemBase):
@@ -44,8 +44,8 @@ class FileSystemSquashFs(FileSystemBase):
                 self.custom_args['create_options'].append('xz')
 
             if '-Xbcj' not in self.custom_args['create_options']:
-                host_architecture = platform.machine()
-                if '86' in host_architecture:
+                host_architecture = Defaults.get_platform_name()
+                if Defaults.is_x86_arch(host_architecture):
                     self.custom_args['create_options'].append('-Xbcj')
                     self.custom_args['create_options'].append('x86')
                 if 'ppc' in host_architecture:

--- a/kiwi/firmware.py
+++ b/kiwi/firmware.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-import platform
 import re
 
 # project
@@ -37,7 +36,7 @@ class FirmWare:
     * :param object xml_state: instance of :class:`XMLState`
     """
     def __init__(self, xml_state):
-        self.arch = platform.machine()
+        self.arch = Defaults.get_platform_name()
         self.zipl_target_type = \
             xml_state.get_build_type_bootloader_targettype()
         self.firmware = xml_state.build_type.get_firmware()

--- a/kiwi/iso_tools/base.py
+++ b/kiwi/iso_tools/base.py
@@ -17,7 +17,6 @@
 #
 import os
 import shutil
-import platform
 import logging
 
 # project
@@ -39,7 +38,7 @@ class IsoToolsBase:
     :param str iso_loaders: list of ISO loaders to embed
     """
     def __init__(self, source_dir):
-        self.arch = platform.machine()
+        self.arch = Defaults.get_platform_name()
         self.source_dir = source_dir
 
         self.boot_path = Defaults.get_iso_boot_path()

--- a/kiwi/partitioner/__init__.py
+++ b/kiwi/partitioner/__init__.py
@@ -15,10 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-import platform
 import logging
 
 # project
+from kiwi.defaults import Defaults
 from kiwi.partitioner.gpt import PartitionerGpt
 from kiwi.partitioner.msdos import PartitionerMsDos
 from kiwi.partitioner.dasd import PartitionerDasd
@@ -38,15 +38,15 @@ class Partitioner:
     :param object storage_provider: Instance of class based on DeviceProvider
     :param int start_sector: sector number
     """
-    def __new__(self, table_type, storage_provider, start_sector=None):        # noqa: C901
-        host_architecture = platform.machine()
+    def __new__(self, table_type, storage_provider, start_sector=None):  # noqa: C901
+        host_architecture = Defaults.get_platform_name()
         if host_architecture == 'x86_64':
             if table_type == 'gpt':
                 return PartitionerGpt(storage_provider, start_sector)
             elif table_type == 'msdos':
                 return PartitionerMsDos(storage_provider, start_sector)
 
-        elif host_architecture == 'i686' or host_architecture == 'i586':
+        elif host_architecture == 'ix86':
             if table_type == 'msdos':
                 return PartitionerMsDos(storage_provider, start_sector)
 

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -17,7 +17,6 @@
 #
 import os
 import re
-import platform
 from textwrap import dedent
 
 # project
@@ -462,7 +461,9 @@ class RuntimeChecker:
             build host has the syslinux package installed.
         ''')
         firmware = FirmWare(self.xml_state)
-        if Defaults.is_x86_arch(platform.machine()) and not firmware.efi_mode():
+        if Defaults.is_x86_arch(
+            Defaults.get_platform_name()
+        ) and not firmware.efi_mode():
             image_builds_iso = False
             build_type = self.xml_state.get_build_type_name()
             if build_type == 'iso':
@@ -535,7 +536,7 @@ class RuntimeChecker:
 
             <type ... firmware="efi"/>
         ''')
-        arch = platform.machine()
+        arch = Defaults.get_platform_name()
         build_type = self.xml_state.get_build_type_name()
         firmware = self.xml_state.build_type.get_firmware() or \
             Defaults.get_default_firmware(arch)

--- a/kiwi/storage/subformat/base.py
+++ b/kiwi/storage/subformat/base.py
@@ -17,7 +17,6 @@
 #
 import os
 import logging
-import platform
 from collections import OrderedDict
 
 # project
@@ -40,14 +39,14 @@ class DiskFormatBase:
 
     :param object xml_state: Instance of XMLState
     :param string root_dir: root directory path name
-    :param string arch: platform.machine
+    :param string arch: Defaults.get_platform_name
     :param string target_dir: target directory path name
     :param dict custom_args: custom format options dictionary
     """
     def __init__(self, xml_state, root_dir, target_dir, custom_args=None):
         self.xml_state = xml_state
         self.root_dir = root_dir
-        self.arch = platform.machine()
+        self.arch = Defaults.get_platform_name()
         self.target_dir = target_dir
         self.custom_args = {}
         self.temp_image_dir = None

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -18,7 +18,6 @@
 import glob
 import os
 import logging
-import platform
 from collections import OrderedDict
 from collections import namedtuple
 from tempfile import NamedTemporaryFile
@@ -58,8 +57,7 @@ class SystemSetup:
     a minimal work environment inside of the image according to
     the desired image type.
 
-    :param str arch: platform.machine. The 32bit x86 platform is
-        handled as 'ix86'
+    :param str arch: Defaults.get_platform_name
     :param object xml_state: instance of :class:`XMLState`
     :param str description_dir: path to image description directory
     :param derived_description_dir: path to derived_description_dir
@@ -70,9 +68,7 @@ class SystemSetup:
     :param str root_dir: root directory path name
     """
     def __init__(self, xml_state, root_dir):
-        self.arch = platform.machine()
-        if self.arch == 'i686' or self.arch == 'i586':
-            self.arch = 'ix86'
+        self.arch = Defaults.get_platform_name()
         self.xml_state = xml_state
         self.description_dir = \
             xml_state.xml_data.description_dir


### PR DESCRIPTION
in kiwi we handle 32bit x86 architecture names as ix86. This is
done by checking i586 and i686 32bit arch names. However those
checks are spread over the entire kiwi code base and should be
consolidated into one method. The cleanup of those arch name
usage fixes an inconsistency between the arch name used in the
disk builder and the arch name used in the subformat image
formats. This Fixes #1438

