### PR TITLE
Fixed spec file

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -80,6 +80,9 @@ and cloud systems like Xen, KVM, VMware, EC2 and more.
 %package -n python%{python3_pkgversion}-kiwi
 Summary:        KIWI - Appliance Builder Next Generation
 Group:          Development/Languages/Python
+Obsoletes:      python2-kiwi
+Conflicts:      python2-kiwi
+Conflicts:      kiwi-man-pages < %{version}
 %if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?suse_version} || 0%{?debian} || 0%{?ubuntu}
 Recommends:     jing
 %endif


### PR DESCRIPTION
This patch is two fold. First the py2 version of kiwi was
dropped since py2 is EOL. To indicate that correctly on the
package level python3-kiwi has to obsolete python2-kiwi.
The other part of the change is a file conflict of the
files:

*  etc/bash_completion.d/kiwi-ng.sh
*  /usr/share/doc/packages/python-kiwi/README

which were provided by the kiwi-man-pages sub-package but
were moved to be provided by the main python3-kiwi package
now. On update of the package with an older version of
kiwi that maintains this files to belong to kiwi-man-pages
a file conflict at install time appears. To solve this
python3-kiwi now conflicts with kiwi-man-pages < 9.20.5
This Fixes #1413 and Fixes bsc#1168973

