### PR TITLE
Fix signing keys management for APT

### DIFF
--- a/package/python-kiwi-pkgbuild-template
+++ b/package/python-kiwi-pkgbuild-template
@@ -22,6 +22,7 @@ build() {
 
 package_python-kiwi(){
   depends=(python-docopt python-future python-lxml python-requests python-setuptools python-six python-pyxattr python-yaml grub qemu squashfs-tools gptfdisk pacman e2fsprogs xfsprogs btrfs-progs libisoburn lvm2 mtools parted multipath-tools rsync tar shadow kiwi-man-pages)
+  optdepends=('gnupg: keyring creation for APT package manager')
   cd kiwi-${pkgver}
   python setup.py install --root="${pkgdir}/" --optimize=1 --skip-build
   ln -sr "${pkgdir}/usr/bin/kiwi-ng" "${pkgdir}/usr/bin/kiwi"

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -122,10 +122,12 @@ Requires:       gdisk
 Requires:       dnf
 Provides:       kiwi-packagemanager:dnf
 Provides:       kiwi-packagemanager:yum
+Recommends:     gnupg2
 %endif
 %if 0%{?suse_version}
 # If it's available, let's pull it in
 Recommends:     dnf
+Recommends:     gpg2
 %endif
 %if 0%{?fedora} >= 26 || 0%{?suse_version}
 Requires:       zypper
@@ -136,6 +138,7 @@ Requires:       debootstrap
 Requires:       qemu-utils
 Requires:       squashfs-tools
 Requires:       gdisk
+Recommends:     gnupg
 %endif
 Requires:       dosfstools
 Requires:       e2fsprogs


### PR DESCRIPTION
This commit fixes the management of the trusted keyring for apt
repositories. It creates a `trusted.gpg` keyring with the provided
signing keys so APT can check against that the configured repositories.

Fixes #1440
