### PR TITLE
Fix default repositories for APT

### DIFF
--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -116,7 +116,7 @@ class RepositoryApt(RepositoryBase):
         self.shared_apt_get_dir['sources-dir'] = \
             os.sep.join([self.manager_base, 'sources.list.d'])
         self.shared_apt_get_dir['preferences-dir'] = \
-            os.sep.join([self.root_dir, 'preferences.d'])
+            os.sep.join([self.manager_base, 'preferences.d'])
         self._write_runtime_config(system_default=True)
 
     def runtime_config(self):

--- a/test/unit/repository/apt_test.py
+++ b/test/unit/repository/apt_test.py
@@ -57,6 +57,10 @@ class TestRepositoryApt:
         template.substitute.return_value = 'template-data'
         self.apt_conf.get_image_template.return_value = template
         self.repo.use_default_location()
+        assert self.repo.shared_apt_get_dir['sources-dir'] == \
+            '../data/etc/apt/sources.list.d'
+        assert self.repo.shared_apt_get_dir['preferences-dir'] == \
+            '../data/etc/apt/preferences.d'
         self.apt_conf.get_image_template.assert_called_once_with(
             self.exclude_docs
         )


### PR DESCRIPTION
This commit fixes the default repositories configuration for APT.

Fixes #1439