### PR TITLE
Refactor dracut disk re-partition library

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -2,39 +2,42 @@ type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 type udev_pending >/dev/null 2>&1 || . /lib/kiwi-lib.sh
 
 #======================================
-# Global exports
-#--------------------------------------
-export partedTableType
-export partedOutput
-export partedCylCount
-export partedCylKSize
-export partedStartSectors
-export partedEndSectors
-
-#======================================
 # Library Methods
 #--------------------------------------
-function create_parted_partitions {
+function create_partitions {
+    local disk_device=$1
+    local partition_setup=$2
+    local pt_table_type
+    pt_table_type=$(get_partition_table_type "${disk_device}")
+    case ${pt_table_type} in
+        "dos")
+            create_msdos_partitions "${disk_device}" "${partition_setup}"
+        ;;
+        "gpt")
+            create_gpt_partitions "${disk_device}" "${partition_setup}"
+        ;;
+        "dasd")
+            create_dasd_partitions "${disk_device}" "${partition_setup}"
+        ;;
+    esac
+    partprobe "${disk_device}"
+}
+
+function create_msdos_partitions {
     # """
-    # create partitions using parted
+    # create partitions using sfdisk (msdos table)
     # """
     local disk_device=$1
     local partition_setup=$2
-    local index=0
-    local commands
     local partid
-    local part_name
-    local part_start_cyl
-    local part_stop_cyl
-    local part_type
+    local part_size_end
     local cmd_list
     local cmd
 
-    _parted_init "${disk_device}"
-    _parted_sector_init "${disk_device}"
-
     # put partition setup in a command list(cmd_list)
     for cmd in ${partition_setup};do
+        # default values in sfdisk are used if - is provided
+        cmd=$(echo "${cmd}" | tr . -)
         cmd_list[$index]=${cmd}
         index=$((index + 1))
     done
@@ -46,100 +49,81 @@ function create_parted_partitions {
         "d")
             # delete a partition...
             partid=${cmd_list[$index + 1]}
-            partid=$((partid / 1))
-            commands="${commands} rm $partid"
-            _parted_write "${disk_device}" "${commands}"
-            unset commands
+            sfdisk --force --delete "${disk_device}" "${partid}"
         ;;
         "n")
             # create a partition...
-            part_name=${cmd_list[$index + 1]}
             partid=${cmd_list[$index + 2]}
-            partid=$((partid / 1))
-            part_start_cyl=${cmd_list[$index + 3]}
-            if [ ! "${partedTableType}" = "gpt" ];then
-                part_name=primary
-            else
-                part_name=$(echo ${part_name} | cut -f2 -d:)
-            fi
-            if [ "${part_start_cyl}" = "1" ];then
-                part_start_cyl=$(echo "${partedStartSectors}" |\
-                    cut -f ${partid} -d:
-                )
-            fi
-            if [ "${part_start_cyl}" = "." ];then
-                # start is next cylinder according to previous partition
-                part_start_cyl=$((partid - 1))
-                if [ ${part_start_cyl} -gt 0 ];then
-                    part_start_cyl=$(echo "${partedEndSectors}" |\
-                        cut -f ${part_start_cyl} -d:
-                    )
-                else
-                    part_start_cyl=$(echo "${partedStartSectors}" |\
-                        cut -f ${partid} -d:
-                    )
-                fi
-            fi
-            part_stop_cyl=${cmd_list[$index + 4]}
-            if [ "${part_stop_cyl}" = "." ];then
-                # use rest of the disk for partition end
-                part_stop_cyl=${partedCylCount}
-            elif echo "${part_stop_cyl}" | grep -qi M;then
-                # calculate stopp cylinder from size
-                part_stop_cyl=$((partid - 1))
-                if [ ${part_stop_cyl} -gt 0 ];then
-                    part_stop_cyl=$(_parted_end_cylinder ${part_stop_cyl})
-                fi
-                local part_size_mbytes
-                part_size_mbytes=$(
-                    echo "${cmd_list[$index + 4]}" | cut -f1 -dM | tr -d +
-                )
-                local part_size_cyl
-                part_size_cyl=$(
-                    _parted_mb_to_cylinder "${part_size_mbytes}"
-                )
-                part_stop_cyl=$((1 + part_stop_cyl + part_size_cyl))
-                if [ "${part_stop_cyl}" -gt "${partedCylCount}" ];then
-                    # given size is out of bounds, reduce to end of disk
-                    part_stop_cyl=${partedCylCount}
-                fi
-            fi
-            commands="${commands} mkpart ${part_name}"
-            commands="${commands} ${part_start_cyl} ${part_stop_cyl}"
-            _parted_write "${disk_device}" "${commands}"
-            _parted_sector_init "${disk_device}"
-            unset commands
+            part_size_end=${cmd_list[$index + 4]}
+            echo ",${part_size_end}" > /tmp/sfdisk.in
+            sfdisk --force -N "${partid}" "${disk_device}" <  /tmp/sfdisk.in
         ;;
         "t")
             # change a partition type...
             part_type=${cmd_list[$index + 2]}
             partid=${cmd_list[$index + 1]}
-            local flagok=1
-            if [ "${part_type}" = "82" ];then
-                # parted can not consistently set swap flag.
-                # There is no general solution to this issue.
-                # Thus swap flag setup is skipped
-                flagok=0
-            elif [ "${part_type}" = "fd" ];then
-                commands="${commands} set ${partid} raid on"
-            elif [ "${part_type}" = "8e" ];then
-                commands="${commands} set ${partid} lvm on"
-            elif [ "${part_type}" = "83" ];then
-                # default partition type set by parted is linux(83)
-                flagok=0
-            fi
-            if [ ! "${partedTableType}" = "gpt" ] && [ ${flagok} = 1 ];then
-                _parted_write "${disk_device}" "${commands}"
-            fi
-            unset commands
+            sfdisk --force --change-id "${disk_device}" "${partid}" \
+                "${part_type}"
         ;;
         esac
         index=$((index + 1))
     done
-    partprobe "${disk_device}"
 }
 
-function create_fdasd_partitions {
+function create_gpt_partitions {
+    # """
+    # create partitions using sgdisk (gpt table)
+    # """
+    local disk_device=$1
+    local partition_setup=$2
+    local partid
+    local part_name
+    local part_size_start
+    local part_size_end
+    local cmd_list
+    local cmd
+
+    # put partition setup in a command list(cmd_list)
+    for cmd in ${partition_setup};do
+        # default values in sgdisk are used if 0 is provided
+        cmd=$(echo "${cmd}" | tr . 0)
+        cmd_list[$index]=${cmd}
+        index=$((index + 1))
+    done
+
+    # operate on index based cmd_list
+    index=0
+    for cmd in ${cmd_list[*]};do
+        case ${cmd} in
+        "d")
+            # delete a partition...
+            partid=${cmd_list[$index + 1]}
+            sgdisk --delete "${partid}" "${disk_device}"
+        ;;
+        "n")
+            # create a partition...
+            part_name=$(echo "${cmd_list[$index + 1]}" | tr : .)
+            partid=${cmd_list[$index + 2]}
+            part_size_start=${cmd_list[$index + 3]}
+            part_size_end=${cmd_list[$index + 4]}
+            sgdisk --new "${partid}:${part_size_start}:${part_size_end}" \
+                "${disk_device}"
+            sgdisk --change-name "${partid}:${part_name}" \
+                "${disk_device}"
+        ;;
+        "t")
+            # change a partition type...
+            part_type=${cmd_list[$index + 2]}
+            partid=${cmd_list[$index + 1]}
+            sgdisk --typecode "${partid}:$(_to_guid "${part_type}")" \
+                "${disk_device}"
+        ;;
+        esac
+        index=$((index + 1))
+    done
+}
+
+function create_dasd_partitions {
     # """
     # create partitions using fdasd (s390)
     # """
@@ -181,10 +165,7 @@ function create_fdasd_partitions {
     done
     echo "w" >> ${partition_setup_file}
     echo "q" >> ${partition_setup_file}
-    if ! fdasd "${disk_device}" < ${partition_setup_file} 1>&2;then
-        die "Failed to create partition table"
-    fi
-    partprobe "${disk_device}"
+    fdasd "${disk_device}" < ${partition_setup_file} 1>&2
 }
 
 function get_partition_node_name {
@@ -254,7 +235,6 @@ function get_free_disk_bytes {
     pt_table_type=$(get_partition_table_type "${disk}")
     disk_bytes=$(blockdev --getsize64 "${disk}")
     # max msdos table geometry is at 2TB - 512
-    # max sector count taken from parted
     max_dos_disk=$((4294967295 * 512))
     if \
         [ "${pt_table_type}" = "dos" ] && \
@@ -335,7 +315,7 @@ function activate_boot_partition {
     pt_table_type=$(get_partition_table_type "${disk_device}")
     if [[ "$(uname -m)" =~ i.86|x86_64 ]];then
         if [ "${pt_table_type}" = "dos" ];then
-            parted "${disk_device}" set "${boot_partition_id}" boot on
+            sfdisk --activate "${disk_device}" "${boot_partition_id}"
         fi
     fi
 }
@@ -369,137 +349,6 @@ function finalize_partition_table {
     if [ "${kiwi_gpt_hybrid_mbr}" = "true" ];then
         create_hybrid_gpt "${disk_device}"
     fi
-}
-
-#======================================
-# Methods considered private
-#--------------------------------------
-function _parted_init {
-    # """
-    # initialize current partition table output
-    # as well as the number of cylinders and the
-    # cyliner size in kB for this disk
-    # """
-    local disk_device=$1
-    local IFS=""
-    local parted
-    local header
-    local ccount
-    local cksize
-    local diskhd
-    local plabel
-    parted=$(
-        parted -m -s "${disk_device}" unit cyl print | grep -v Warning:
-    )
-    header=$(echo "${parted}" | head -n 3 | tail -n 1)
-    ccount=$(
-        echo "${parted}" | grep ^"${disk_device}" | cut -f 2 -d: | tr -d cyl
-    )
-    cksize=$(echo "${header}" | cut -f4 -d: | cut -f1 -dk)
-    diskhd=$(echo "${parted}" | head -n 3 | tail -n 2 | head -n 1)
-    plabel=$(echo "${diskhd}" | cut -f6 -d:)
-    if [[ "${plabel}" =~ gpt ]];then
-        plabel=gpt
-    fi
-    export partedTableType=${plabel}
-    export partedOutput=${parted}
-    export partedCylCount=${ccount}
-    export partedCylKSize=${cksize}
-}
-
-function _parted_sector_init {
-    # """
-    # calculate aligned start/end sectors of
-    # the current table.
-    #
-    # Uses following kiwi profile values if present:
-    #
-    # kiwi_align
-    # kiwi_sectorsize
-    # kiwi_startsector
-    #
-    # """
-    declare kiwi_align=${kiwi_align}
-    declare kiwi_sectorsize=${kiwi_sectorsize}
-    declare kiwi_startsector=${kiwi_startsector}
-    local disk_device=$1
-    local s_start
-    local s_stopp
-    local align=1048576
-    local sector_size=512
-    local sector_start=2048
-    local part
-    [ -n "${kiwi_align}" ] && align=${kiwi_align}
-    [ -n "${kiwi_sectorsize}" ] && sector_size=${kiwi_sectorsize}
-    [ -n "${kiwi_startsector}" ] && sector_start=${kiwi_startsector}
-    local align=$((align / sector_size))
-
-    unset partedStartSectors
-    unset partedEndSectors
-
-    for part in $(
-        parted -m -s "${disk_device}" unit s print |\
-        grep -E "^[1-9]+:" | cut -f2-3 -d: | tr -d s
-    );do
-        s_start=$(echo "${part}" | cut -f1 -d:)
-        s_stopp=$(echo "${part}" | cut -f2 -d:)
-        if [ -z "${partedStartSectors}" ];then
-            partedStartSectors=${s_start}s
-        else
-            partedStartSectors=${partedStartSectors}:${s_start}s
-        fi
-        if [ -z "${partedEndSectors}" ];then
-            partedEndSectors=$((s_stopp/align*align+align))s
-        else
-            partedEndSectors=${partedEndSectors}:$((s_stopp/align*align+align))s
-        fi
-    done
-    # The default start sector applies for an empty disk
-    if [ -z "${partedStartSectors}" ];then
-        partedStartSectors=${sector_start}s
-    fi
-}
-
-function _parted_end_cylinder {
-    # """
-    # return end cylinder of given partition, next
-    # partition must start at return value plus 1
-    # """
-    local partition_id=$(($1 + 3))
-    local IFS=""
-    local header
-    local ccount
-    header=$(echo "${partedOutput}" | head -n "${partition_id}" | tail -n 1)
-    ccount=$(echo "${header}" | cut -f3 -d: | tr -d cyl)
-    echo "${ccount}"
-}
-
-function _parted_mb_to_cylinder {
-    # """
-    # convert partition size in MB to cylinder count
-    # """
-    local sizeBytes=$(($1 * 1048576))
-    # bc truncates to zero decimal places, which results in
-    # a partition that is slightly smaller than the requested
-    # size. Add one cylinder to compensate.
-    local required_cylinders
-    required_cylinders=$(
-        echo "scale=0; ${sizeBytes} / (${partedCylKSize} * 1000) + 1" | bc
-    )
-    echo "${required_cylinders}"
-}
-
-function _parted_write {
-    # """
-    # call parted with current command queue.
-    # and reinitialize the new table data
-    # """
-    local disk_device=$1
-    local commands=$2
-    if ! parted -a cyl -m -s "${disk_device}" unit cyl "${commands}";then
-        die "Failed to create partition table"
-    fi
-    _parted_init "${disk_device}"
 }
 
 function resize_wanted {
@@ -549,5 +398,31 @@ function resize_wanted {
         info "Disk geometry did not change"
         info "Skipping resize operation"
         return 1
+    fi
+}
+
+#======================================
+# Methods considered private
+#--------------------------------------
+function _to_guid {
+    # """
+    # convert two digit partition id to guid id
+    # """
+    local partid=$1
+    if [ "${partid}" = "83" ];then
+        # Linux filesystem
+        echo 8300
+    elif [ "${partid}" = "8e" ];then
+        # Linux LVM
+        echo 8e00
+    elif [ "${partid}" = "fd" ];then
+        # Linux RAID
+        echo fd00
+    elif [ "${partid}" = "82" ];then
+        # Linux swap
+        echo 8200
+    else
+        # Assume Linux filesystem
+        echo 8300
     fi
 }

--- a/dracut/modules.d/99kiwi-lib/module-setup.sh
+++ b/dracut/modules.d/99kiwi-lib/module-setup.sh
@@ -15,7 +15,7 @@ depends() {
 install() {
     declare moddir=${moddir}
     inst_multiple \
-        blkid blockdev parted dd mkdir rmdir \
+        blkid blockdev dd mkdir rmdir \
         grep cut tail head tr bc true false \
         basename partprobe sfdisk sgdisk mkswap readlink lsblk \
         btrfs xfs_growfs resize2fs \


### PR DESCRIPTION
The kiwi repartition code for msdos and gpt tables was based
on the parted tool. However parted requires to give start and
end addresses to describe a space in the partition table. The
numbers were calculated in kiwi based on cylinders. The mapping
into cylinders is a virtual number that plays no role under
Linux and vanished completely with newer storage technologies.
Tools like sgdisk and sfdisk are better prepared to handle
disk partitioning and also makes this a more straight forward
code in kiwi. Thus this commit refactors the re-partition code
to drop parted and use a dedicated tool depending on the
partition table type. This Fixes #1406


