### PR TITLE
Remmove any Recommends for CentOS7

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -125,7 +125,9 @@ Requires:       gdisk
 Requires:       dnf
 Provides:       kiwi-packagemanager:dnf
 Provides:       kiwi-packagemanager:yum
+%if 0%{?fedora} || 0%{?rhel} >= 8
 Recommends:     gnupg2
+%endif
 %endif
 %if 0%{?suse_version}
 # If it's available, let's pull it in


### PR DESCRIPTION
This commit fixes the package spec for CentOS 7. In CentOS 7 there is no
support for weak dependencies. In 9792cea1 a recommended dependency on
gpg tools was included for all builds and this caused a failure for
CentOS 7. With this commit, the recommended dependency, is omitted for
any pre CentOS 8 distro.
