### PR TITLE
Fixed root device setup in vendor grubenv

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -294,6 +294,21 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 with open(config_file, 'w') as grub_config_file:
                     grub_config_file.write(grub_config)
 
+                if self.firmware.efi_mode():
+                    vendor_grubenv_file = \
+                        Defaults.get_vendor_grubenv(self.efi_mount.mountpoint)
+                    if vendor_grubenv_file:
+                        with open(vendor_grubenv_file) as vendor_grubenv:
+                            grubenv = vendor_grubenv.read()
+                            grubenv = grubenv.replace(
+                                'root={0}'.format(boot_options.get(
+                                    'root_device')
+                                ),
+                                self.root_reference
+                            )
+                        with open(vendor_grubenv_file, 'w') as vendor_grubenv:
+                            vendor_grubenv.write(grubenv)
+
         if self.firmware.efi_mode():
             self._copy_grub_config_to_efi_path(
                 self.efi_mount.mountpoint, config_file

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -735,6 +735,36 @@ class Defaults:
                 return signed_grub
 
     @staticmethod
+    def get_efi_vendor_directory(efi_path):
+        """
+        Provides EFI vendor directory if present
+
+        Looks up distribution specific EFI vendor directory
+
+        :param string root_path: path to efi mountpoint
+
+        :return: directory path or None
+
+        :rtype: str
+        """
+        efi_vendor_directories = [
+            'EFI/fedora',
+            'EFI/opensuse'
+        ]
+        for efi_vendor_directory in efi_vendor_directories:
+            efi_vendor_directory = os.sep.join([efi_path, efi_vendor_directory])
+            if os.path.exists(efi_vendor_directory):
+                return efi_vendor_directory
+
+    @staticmethod
+    def get_vendor_grubenv(efi_path):
+        efi_vendor_directory = Defaults.get_efi_vendor_directory(efi_path)
+        if efi_vendor_directory:
+            grubenv = os.sep.join([efi_vendor_directory, 'grubenv'])
+            if os.path.exists(grubenv):
+                return grubenv
+
+    @staticmethod
     def get_shim_vendor_directory(root_path):
         """
         Provides shim vendor directory

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -420,10 +420,12 @@ class TestBootLoaderConfigGrub2:
     @patch.object(BootLoaderConfigGrub2, '_copy_grub_config_to_efi_path')
     @patch('kiwi.bootloader.config.grub2.Command.run')
     @patch('kiwi.bootloader.config.grub2.Path.which')
+    @patch('kiwi.defaults.Defaults.get_vendor_grubenv')
     def test_setup_disk_image_config(
-        self, mock_Path_which, mock_Command_run,
+        self, mock_get_vendor_grubenv, mock_Path_which, mock_Command_run,
         mock_copy_grub_config_to_efi_path, mock_mount_system
     ):
+        mock_get_vendor_grubenv.return_value = 'grubenv'
         mock_Path_which.return_value = '/path/to/grub2-mkconfig'
         self.firmware.efi_mode = Mock(
             return_value='uefi'
@@ -455,9 +457,10 @@ class TestBootLoaderConfigGrub2:
             mock_copy_grub_config_to_efi_path.assert_called_once_with(
                 'efi_mount_point', 'root_mount_point/boot/grub2/grub.cfg'
             )
-            file_handle.write.assert_called_once_with(
-                'root=overlay:UUID=ID'
-            )
+            assert file_handle.write.call_args_list == [
+                call('root=overlay:UUID=ID'),
+                call('root=overlay:UUID=ID')
+            ]
 
     @patch.object(BootLoaderConfigGrub2, '_mount_system')
     @patch.object(BootLoaderConfigGrub2, '_copy_grub_config_to_efi_path')

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -89,3 +89,9 @@ class TestDefaults:
     def test_is_x86_arch(self):
         assert Defaults.is_x86_arch('x86_64') is True
         assert Defaults.is_x86_arch('aarch64') is False
+
+    @patch('os.path.exists')
+    def test_get_vendor_grubenv(self, mock_path_exists):
+        mock_path_exists.return_value = True
+        assert Defaults.get_vendor_grubenv('boot/efi') == \
+            'boot/efi/EFI/fedora/grubenv'


### PR DESCRIPTION
In addition to the root device setup in grub.cfg we also
need to patch the vendor grubenv file which contains an
invalid kernelopts value written by grub2-mkconfig under
the conditions explained in Issue #1287. This Fixes
Issue #1454


