### PR TITLE
Fix scope for linuxefi grub config adaption

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -145,7 +145,6 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         self.cmdline = None
         self.iso_boot = False
         self.shim_fallback_setup = False
-        self.validate_use_of_linuxefi = False
 
     def write(self):
         """
@@ -241,11 +240,11 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             ]
         )
 
-        if self.validate_use_of_linuxefi:
-            # On systems that uses GRUB_USE_LINUXEFI with grub2 version
-            # less than 2.04 there is no support for dynamic EFI
-            # environment checking. In this condition we change the
-            # grub config to add this support as follows:
+        if self.firmware.efi_mode():
+            # On systems that are configured to use EFI with a grub2
+            # version less than 2.04 there is no support for dynamic
+            # EFI environment checking. In this condition we change
+            # the grub config to add this support as follows:
             #
             # * Apply only on grub < 2.04
             #    1. Modify grub.cfg to set linux/initrd as variables
@@ -638,7 +637,6 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 if use_linuxefi_implemented.returncode == 0:
                     grub_default_entries['GRUB_USE_LINUXEFI'] = 'true'
                     grub_default_entries['GRUB_USE_INITRDEFI'] = 'true'
-                    self.validate_use_of_linuxefi = True
         if self.xml_state.build_type.get_btrfs_root_is_snapshot():
             grub_default_entries['SUSE_BTRFS_SNAPSHOT_BOOTING'] = 'true'
         if self.custom_args.get('boot_is_crypto'):

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -419,12 +419,15 @@ class TestBootLoaderConfigGrub2:
     @patch.object(BootLoaderConfigGrub2, '_mount_system')
     @patch.object(BootLoaderConfigGrub2, '_copy_grub_config_to_efi_path')
     @patch('kiwi.bootloader.config.grub2.Command.run')
+    @patch('kiwi.bootloader.config.grub2.CommandCapabilities.check_version')
     @patch('kiwi.bootloader.config.grub2.Path.which')
     @patch('kiwi.defaults.Defaults.get_vendor_grubenv')
     def test_setup_disk_image_config(
-        self, mock_get_vendor_grubenv, mock_Path_which, mock_Command_run,
+        self, mock_get_vendor_grubenv, mock_Path_which,
+        mock_CommandCapabilities_check_version, mock_Command_run,
         mock_copy_grub_config_to_efi_path, mock_mount_system
     ):
+        mock_CommandCapabilities_check_version.return_value = True
         mock_get_vendor_grubenv.return_value = 'grubenv'
         mock_Path_which.return_value = '/path/to/grub2-mkconfig'
         self.firmware.efi_mode = Mock(
@@ -477,7 +480,6 @@ class TestBootLoaderConfigGrub2:
         self.firmware.efi_mode = Mock(
             return_value='uefi'
         )
-        self.bootloader.validate_use_of_linuxefi = True
         self.bootloader.root_mount = Mock()
         self.bootloader.root_mount.mountpoint = 'root_mount_point'
         self.bootloader.efi_mount = Mock()


### PR DESCRIPTION
In kiwi we support a one time patch for the grub config file
that changes the static use of linuxefi to be dynamic. In
grub2 >= 2.04 all this has already been fixed but for grub2
version older than this version we applied the patch. The
patch however was only applied based on the presence of a
grub setting named GRUB_USE_LINUXEFI. It has turned out that
this variable is a custom extension not part of grub upstream
which makes the test functional only on distributions that
supports this setting. The use of linuxefi however is code
that belongs to grub upstream. Therefore this patch changes
the scope of the one time patch to be only based on the
version of grub no matter if GRUB_USE_LINUXEFI is supported
by the distro or not. This Fixes #1453


