### PR TITLE
Fixed line ending of sha256 bundler file

### DIFF
--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -164,9 +164,10 @@ class ResultBundleTask(CliTask):
                     checksum = Checksum(bundle_file)
                     with open(bundle_file + '.sha256', 'w') as shasum:
                         shasum.write(
-                            '{0}  {1}'.format(
+                            '{0}  {1}{2}'.format(
                                 checksum.sha256(),
-                                os.path.basename(bundle_file)
+                                os.path.basename(bundle_file),
+                                os.linesep
                             )
                         )
 

--- a/test/unit/tasks/result_bundle_test.py
+++ b/test/unit/tasks/result_bundle_test.py
@@ -136,8 +136,8 @@ class TestResultBundleTask:
         )
         checksum.sha256.assert_called_once_with()
         m_open.return_value.write.assert_called_once_with(
-            '{0}  compressed_filename'.format(
-                checksum.sha256.return_value
+            '{0}  compressed_filename{1}'.format(
+                checksum.sha256.return_value, os.linesep
             )
         )
 


### PR DESCRIPTION
The .sha256 file does not end with a newline. This Fixes #1449


