### PR TITLE
Fixed dracut output file format detection

### DIFF
--- a/test/unit/repository/apt_test.py
+++ b/test/unit/repository/apt_test.py
@@ -26,31 +26,29 @@ class TestRepositoryApt:
         root_bind.shared_location = '/shared-dir'
 
         with patch('builtins.open', create=True):
-            self.repo = RepositoryApt(root_bind, ['exclude_docs'])
+            self.repo = RepositoryApt(
+                root_bind, custom_args=['exclude_docs']
+            )
 
-        self.exclude_docs = True
-        self.apt_conf.get_host_template.assert_called_once_with(
-            self.exclude_docs
-        )
-        template.substitute.assert_called_once_with(
-            {
-                'apt_shared_base': '/shared-dir/apt-get',
-                'unauthenticated': 'true'
-            }
-        )
+            self.exclude_docs = True
+            self.apt_conf.get_host_template.assert_called_once_with(
+                self.exclude_docs
+            )
+            template.substitute.assert_called_once_with(
+                {
+                    'apt_shared_base': '/shared-dir/apt-get',
+                    'unauthenticated': 'true'
+                }
+            )
+            repo = RepositoryApt(
+                root_bind, custom_args=['check_signatures']
+            )
+            assert repo.custom_args == []
+            assert repo.unauthenticated == 'false'
 
-    @patch('kiwi.repository.apt.NamedTemporaryFile')
-    @patch('kiwi.repository.apt.Path.create')
-    def test_post_init_no_custom_args(self, mock_path, mock_temp):
-        self.repo.post_init()
-        assert self.repo.custom_args == []
-
-    @patch('kiwi.repository.apt.NamedTemporaryFile')
-    @patch('kiwi.repository.apt.Path.create')
-    def test_post_init_with_custom_args(self, mock_path, mock_temp):
-        self.repo.post_init(['check_signatures'])
-        assert self.repo.custom_args == []
-        assert self.repo.unauthenticated == 'false'
+            repo = RepositoryApt(root_bind)
+            assert repo.custom_args == []
+            assert repo.unauthenticated == 'true'
 
     def test_use_default_location(self):
         template = mock.Mock()

--- a/test/unit/repository/pacman_test.py
+++ b/test/unit/repository/pacman_test.py
@@ -27,20 +27,29 @@ class TestRepositorPacman(object):
         with patch('builtins.open', create=True):
             self.repo = RepositoryPacman(root_bind)
 
-        assert runtime_pacman_config.set.call_args_list == [
-            call('options', 'Architecture', 'auto'),
-            call('options', 'CacheDir', '/shared-dir/pacman/cache'),
-            call('options', 'SigLevel', 'Never DatabaseNever'),
-            call('options', 'LocalFileSigLevel', 'Never DatabaseNever'),
-            call('options', 'Include', '/shared-dir/pacman/repos/*.repo')
-        ]
+            assert runtime_pacman_config.set.call_args_list == [
+                call('options', 'Architecture', 'auto'),
+                call('options', 'CacheDir', '/shared-dir/pacman/cache'),
+                call('options', 'SigLevel', 'Never DatabaseNever'),
+                call('options', 'LocalFileSigLevel', 'Never DatabaseNever'),
+                call('options', 'Include', '/shared-dir/pacman/repos/*.repo')
+            ]
 
-    @patch('kiwi.repository.pacman.NamedTemporaryFile')
-    @patch('kiwi.repository.pacman.Path.create')
-    def test_post_init_with_custom_args(self, mock_path, mock_temp):
-        self.repo.post_init(['check_signatures'])
-        assert self.repo.custom_args == []
-        assert self.repo.check_signatures
+            runtime_pacman_config.reset_mock()
+
+            RepositoryPacman(
+                root_bind, custom_args=['check_signatures']
+            )
+
+            assert runtime_pacman_config.set.call_args_list == [
+                call('options', 'Architecture', 'auto'),
+                call('options', 'CacheDir', '/shared-dir/pacman/cache'),
+                call('options', 'SigLevel', 'Required DatabaseRequired'),
+                call(
+                    'options', 'LocalFileSigLevel', 'Required DatabaseRequired'
+                ),
+                call('options', 'Include', '/shared-dir/pacman/repos/*.repo')
+            ]
 
     def test_runtime_config(self):
         assert self.repo.runtime_config()['pacman_args'] == \


### PR DESCRIPTION
The current way to detect the dracut output file format was
based on a lookup of the format used in the dracut tool itself.
However there are distributions like Ubuntu which calls dracut
and passes the name of the initrd file as options to the call.
This invalidates the checking done by kiwi. The only chance
for kiwi to do the same than the distributions does is by
looking for an initrd file pre-created by the package
installations and use the same format. Only if no such initrd
file exists the former format detection code applies. The
additional code expects any initrd file to match the glob
pattern 'init*'. This Fixes #1450

