### PR TITLE
Fix the patch applied on grub.cfg

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -261,11 +261,11 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 with open(config_file) as grub_config_file:
                     grub_config = grub_config_file.read()
                     grub_config = re.sub(
-                        r'([ \t]+)linux[efi]*([ \t]+)', r'\1$linux\2',
+                        r'([ \t]+)linux(efi|16)*([ \t]+)', r'\1$linux\3',
                         grub_config
                     )
                     grub_config = re.sub(
-                        r'([ \t]+)initrd[efi]*([ \t]+)', r'\1$initrd\2',
+                        r'([ \t]+)initrd(efi|16)*([ \t]+)', r'\1$initrd\3',
                         grub_config
                     )
                 with open(config_file, 'w') as grub_config_file:

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -491,8 +491,10 @@ class TestBootLoaderConfigGrub2:
                 [
                     '\tlinuxefi ${rel_dirname}/${basename} ...',
                     '\tlinux ${rel_dirname}/${basename} ...',
+                    '\tlinux16 ${rel_dirname}/${basename} ...',
                     '\tinitrdefi ${rel_dirname}/${initrd}',
-                    '\tinitrd ${rel_dirname}/${initrd}'
+                    '\tinitrd ${rel_dirname}/${initrd}',
+                    '\tinitrd16 ${rel_dirname}/${initrd}'
                 ]
             )
             self.bootloader.setup_disk_image_config(
@@ -515,6 +517,8 @@ class TestBootLoaderConfigGrub2:
                 call(
                     '\t$linux ${rel_dirname}/${basename} ...\n'
                     '\t$linux ${rel_dirname}/${basename} ...\n'
+                    '\t$linux ${rel_dirname}/${basename} ...\n'
+                    '\t$initrd ${rel_dirname}/${initrd}\n'
                     '\t$initrd ${rel_dirname}/${initrd}\n'
                     '\t$initrd ${rel_dirname}/${initrd}'
                 )


### PR DESCRIPTION
This commit fixes the patch applied on grub.cfg when EFI mode is
selected and grub < 2.04. There are some distros that make use of the
`linux16` command instead of `linux` in grub configuration, this commit
extends the regex to also consider `linux16` command.
