### PR TITLE
Added custom partition image integration test

### DIFF
--- a/build-tests/x86/suse/test-image-custom-partitions/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-custom-partitions/appliance.kiwi
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.8" name="LimeJeOS-TW">
+    <description type="system">
+        <author>Marcus Schaefer</author>
+        <contact>ms@suse.de</contact>
+        <specification>
+            TW JeOS, is a small text based image
+        </specification>
+    </description>
+    <preferences>
+        <version>1.15.1</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>false</rpm-check-signatures>
+        <bootsplash-theme>bgrt</bootsplash-theme>
+        <bootloader-theme>openSUSE</bootloader-theme>
+        <type image="oem" filesystem="ext4" initrd_system="dracut" firmware="uefi" spare_part="500M" editbootconfig="custom_partitions_create.sh" editbootinstall="custom_partitions_setup.sh" installiso="true" bootloader="grub2">
+            <oemconfig>
+                <oem-swap>true</oem-swap>
+                <oem-swapsize>512</oem-swapsize>
+                <oem-device-filter>/dev/ram</oem-device-filter>
+            </oemconfig>
+        </type>
+    </preferences>
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
+    </users>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-base-minimal_base"/>
+        <package name="bind-utils"/>
+        <package name="systemd"/>
+        <package name="plymouth-theme-bgrt"/>
+        <package name="grub2-branding-openSUSE"/>
+        <package name="iputils"/>
+        <package name="vim"/>
+        <package name="grub2"/>
+        <package name="grub2-x86_64-efi" arch="x86_64"/>
+        <package name="grub2-i386-pc"/>
+        <package name="syslinux"/>
+        <package name="lvm2"/>
+        <package name="plymouth"/>
+        <package name="fontconfig"/>
+        <package name="fonts-config"/>
+        <package name="tar"/>
+        <package name="parted"/>
+        <package name="openssh"/>
+        <package name="iproute2"/>
+        <package name="less"/>
+        <package name="bash-completion"/>
+        <package name="dhcp-client"/>
+        <package name="which"/>
+        <package name="kernel-default"/>
+        <package name="shim"/>
+        <package name="patch"/>
+        <package name="timezone"/>
+        <package name="dracut-kiwi-oem-repart"/>
+        <package name="dracut-kiwi-oem-dump"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+        <package name="cracklib-dict-full"/>
+        <package name="ca-certificates"/>
+        <package name="openSUSE-release"/>
+    </packages>
+</image>

--- a/build-tests/x86/suse/test-image-custom-partitions/config.sh
+++ b/build-tests/x86/suse/test-image-custom-partitions/config.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#================
+# FILE          : config.sh
+#----------------
+# PROJECT       : OpenSuSE KIWI Image System
+# COPYRIGHT     : (c) 2006 SUSE LINUX Products GmbH. All rights reserved
+#               :
+# AUTHOR        : Marcus Schaefer <ms@suse.de>
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : configuration script for SUSE based
+#               : operating systems
+#               :
+#               :
+# STATUS        : BETA
+#----------------
+#======================================
+# Functions...
+#--------------------------------------
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+#======================================
+# Greeting...
+#--------------------------------------
+echo "Configure image: [$kiwi_iname]..."
+
+#======================================
+# Setup baseproduct link
+#--------------------------------------
+suseSetupProduct
+
+#======================================
+# Activate services
+#--------------------------------------
+suseInsertService sshd
+
+#======================================
+# Setup default target, multi-user
+#--------------------------------------
+baseSetRunlevel 3
+
+#======================================
+# Create custom parts mount points
+#--------------------------------------
+mkdir -p var var/log var/audit
+
+#======================================
+# Custom partitions moves root
+#--------------------------------------
+patch -p0 < /config_partids.patch

--- a/build-tests/x86/suse/test-image-custom-partitions/custom_partitions_create.sh
+++ b/build-tests/x86/suse/test-image-custom-partitions/custom_partitions_create.sh
@@ -1,0 +1,34 @@
+image_fs=$1
+
+root_partnum=$2
+
+root_device=/dev/mapper/loop*p${root_partnum}
+
+loop_name=$(basename $root_device | cut -f 1-2 -d'p')
+
+disk_device=/dev/${loop_name}
+
+sgdisk --delete=4 $disk_device || exit 1
+
+# /var 100MB
+sgdisk --new=4:0:+100M $disk_device || exit 1
+
+# /var/log 100MB
+sgdisk --new=6:0:+100M $disk_device || exit 1
+
+# /var/audit rest of spare (500 - 200 = 300MB)
+sgdisk --new=7:0:0 $disk_device || exit 1
+
+# reread partition changes
+partprobe $disk_device || exit 1
+
+# add new partitions to map
+kpartx -a $disk_device || exit 1
+
+# create filesystems on partitions, use labels
+mkfs.ext4 -L var /dev/mapper/${loop_name}p4 || exit 1
+mkfs.ext4 -L log /dev/mapper/${loop_name}p6 || exit 1
+mkfs.ext4 -L audit /dev/mapper/${loop_name}p7 || exit 1
+
+# order partitions
+sgdisk --sort $disk_device

--- a/build-tests/x86/suse/test-image-custom-partitions/custom_partitions_setup.sh
+++ b/build-tests/x86/suse/test-image-custom-partitions/custom_partitions_setup.sh
@@ -1,0 +1,39 @@
+image_file=$1
+
+root_device=$2
+
+loop_name=$(basename $root_device | cut -f 1-2 -d'p')
+
+disk_device=/dev/${loop_name}
+
+# mount root part
+root=$(mktemp -d /tmp/rootmount-XXX)
+mount /dev/mapper/${loop_name}p5 $root || exit 1
+
+# move root part contents to individual partitions
+part=$(mktemp -d /tmp/partmount-XXX)
+log_uuid=$(blkid -s UUID -o value /dev/mapper/${loop_name}p6)
+mount /dev/mapper/${loop_name}p6 $part && mv $root/var/log/* $part/
+umount --lazy $part && rmdir $part
+
+part=$(mktemp -d /tmp/partmount-XXX)
+audit_uuid=$(blkid -s UUID -o value /dev/mapper/${loop_name}p7)
+mount /dev/mapper/${loop_name}p7 $part && mv $root/var/audit/* $part/
+umount --lazy $part && rmdir $part
+
+part=$(mktemp -d /tmp/partmount-XXX)
+var_uuid=$(blkid -s UUID -o value /dev/mapper/${loop_name}p4)
+mount /dev/mapper/${loop_name}p4 $part && mv $root/var/* $part/
+umount --lazy $part && rmdir $part
+
+echo "UUID=$var_uuid /var ext4 defaults 0 0" >> $root/etc/fstab
+echo "UUID=$log_uuid /var/log ext4 defaults 0 0" >> $root/etc/fstab
+echo "UUID=$audit_uuid /var/audit ext4 defaults 0 0" >> $root/etc/fstab
+
+# umount root part
+umount --lazy $root && rmdir $root
+
+# cleanup maps
+kpartx -d $disk_device
+
+exit 0

--- a/build-tests/x86/suse/test-image-custom-partitions/root/config_partids.patch
+++ b/build-tests/x86/suse/test-image-custom-partitions/root/config_partids.patch
@@ -1,0 +1,11 @@
+--- /usr/lib/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
++++ /usr/lib/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+@@ -23,6 +23,8 @@ function initialize {
+     import_file ${profile}
+     import_file ${partition_ids}
+ 
++    export kiwi_RootPart=7
++
+     disk=$(lookup_disk_device_from_root)
+     export disk
+ 


### PR DESCRIPTION
There are still people who like many extra static inflexible
entries in a partition table instead of using LVM or filesystem
volume capabilities for sometimes good but often questionable
reasons. In kiwi we intentionally support partition table
entries on a restricted basis but that does not mean you can't
create an image with a highly customized partition table.
However it includes some bits of custom code as part of the
image description and that's what this reference implementation
of an image with custom partitions demonstrates. The image
described here adds three extra partitions, var, var/log and
var/audit. The concept to create custom partitions is based on
specifying a spare partition which is by default created before
the root partition. The spare space can now be sliced into as
many partitions as needed and that needs to be implemented by
the author of the image description. Of course the partition
table itself comes with limitations which has to be respected
depending on the partition table type.

