### PR TITLE
Post-build config concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ __pycache__/
 *~
 *.kate-swp
 *.~
-
+*vscode/
 
 # C extensions
 *.so

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+*mypy_cache/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/kiwi/bootloader/install/grub2.py
+++ b/kiwi/bootloader/install/grub2.py
@@ -39,6 +39,7 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
     """
     **grub2 bootloader installation**
     """
+
     def post_init(self, custom_args):
         """
         grub2 post initialization method

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -19,7 +19,7 @@ import os
 import logging
 import pickle
 from tempfile import NamedTemporaryFile
-from typing import Dict, Union
+from typing import Dict
 
 # project
 from kiwi.defaults import Defaults

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -67,6 +67,7 @@ class DiskBuilder:
         * signing_keys: list of package signing keys
         * xz_options: string of XZ compression parameters
     """
+
     def __init__(self, xml_state, target_dir, root_dir, custom_args=None):
         self.arch = Defaults.get_platform_name()
         self.root_dir = root_dir

--- a/kiwi/mount_manager.py
+++ b/kiwi/mount_manager.py
@@ -38,6 +38,7 @@ class MountManager:
     * :param string device: device node name
     * :param string mountpoint: mountpoint directory name
     """
+
     def __init__(self, device, mountpoint=None):
         self.device = device
         self.mountpoint_created_by_mount_manager = False

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -934,7 +934,7 @@ class SystemSetup:
             command.append(os.path.join(sub_src, name))
             result = CommandProcess(command=Command.call(command),
                                     log_topic='Calling {} script'.format(name)).poll_and_watch()
-
+            os.unlink(script_path)
             if result.returncode != os.EX_OK:
                 raise KiwiScriptFailed('%s failed: %s' % (name, format(result.stderr)))
 

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -67,6 +67,7 @@ class SystemSetup:
         image archives, overlay files
     :param str root_dir: root directory path name
     """
+
     def __init__(self, xml_state, root_dir):
         self.arch = Defaults.get_platform_name()
         self.xml_state = xml_state

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -888,7 +888,7 @@ class SystemSetup:
             sorted(custom_scripts.items())
         )
 
-        description_target = self.root_dir + '/image/'
+        description_target = os.path.join(self.root_dir, 'image')
         need_script_helper_functions = False
 
         for name, script in list(sorted_custom_scripts.items()):
@@ -896,26 +896,17 @@ class SystemSetup:
                 if script.filepath.startswith('/'):
                     script_file = script.filepath
                 else:
-                    script_file = self.description_dir + '/' + script.filepath
+                    script_file = os.path.join(self.description_dir, script.filepath)
                 if os.path.exists(script_file):
-                    log.info('--> Importing %s script as %s', script.filepath, 'image/' + name)
-                    shutil.copy(script_file, description_target + name)
-                    # Command.run(['cp', script_file, description_target + name])
+                    log.info('--> Importing %s script as image/%s', script.filepath, name)
+                    shutil.copy(script_file, os.path.join(description_target, name))
                     need_script_helper_functions = True
                 elif script.raise_if_not_exists:
-                    raise KiwiImportDescriptionError(
-                        'Specified script %s does not exist' % script_file
-                    )
+                    raise KiwiImportDescriptionError('Specified script {} does not exist'.format(script_file))
 
         if need_script_helper_functions:
             log.info('--> Importing script helper functions')
-            Command.run(
-                [
-                    'cp',
-                    Defaults.get_common_functions_file(),
-                    self.root_dir + '/.kconfig'
-                ]
-            )
+            shutil.copy(Defaults.get_common_functions_file(), os.path.join(self.root_dir, ".kconfig"))
 
     def _call_script(self, name: str, root_dir: Optional[str] = None):
         """


### PR DESCRIPTION
This is a concept of post-build config. The basic idea is that it is as same as `config.sh`, except it is called after everything is already on the image. Mostly this is useful for the embedded. Currently this is working on "root" only, so I think should be expanded to something like `bootloader-post-build.sh`, `root-post-build.sh` etc.

Ideas/suggestions/criticism encouraged.

*Upd*: It also helps #1464

P.S. I also started slowly adding annotations, because it is easier then to work with. It also would be nice if you, guys, decide on a standard code formatter (linting), because it is pain to work with modern Python editors, those now tends to enforce code formatting in Go fashion and then [this happens](https://github.com/OSInside/kiwi/pull/1465/commits/e2759c5471a466778eb4991ceedc313cb45489df).