### PR TITLE
Allow to access disk root after sync_data

### DIFF
--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -56,8 +56,6 @@ class BootImageBase:
         self.initrd_filename = None
         self.boot_xml_state = None
         self.setup = None
-        self.temp_directories = []
-        self.call_destructor = True
         self.signing_keys = signing_keys
         self.boot_root_directory = root_dir
 
@@ -151,23 +149,10 @@ class BootImageBase:
         try:
             with open(filename, 'wb') as boot_image:
                 pickle.dump(self, boot_image)
-            self.disable_cleanup()
         except Exception as e:
             raise KiwiBootImageDumpError(
                 'Failed to pickle dump boot image: %s' % format(e)
             )
-
-    def disable_cleanup(self):
-        """
-        Deactivate cleanup(deletion) of boot root directory
-        """
-        self.call_destructor = False
-
-    def enable_cleanup(self):
-        """
-        Activate cleanup(deletion) of boot root directory
-        """
-        self.call_destructor = True
 
     def get_boot_names(self):
         """
@@ -383,6 +368,12 @@ class BootImageBase:
                     boot_description
             return boot_description
 
+    def cleanup(self):
+        """
+        Cleanup temporary boot image data if any
+        """
+        pass
+
     def _get_boot_image_output_file_format(self, kernel_version):
         """
         The initrd output file format varies between
@@ -451,10 +442,3 @@ class BootImageBase:
                 return os.path.basename(initrd_file).replace(
                     kernel_version, '{kernel_version}'
                 )
-
-    def __del__(self):
-        if self.call_destructor:
-            log.info('Cleaning up %s instance', type(self).__name__)
-            for directory in self.temp_directories:
-                if directory and os.path.exists(directory):
-                    Path.wipe(directory)

--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -49,17 +49,18 @@ class BootImageKiwi(BootImageBase):
         root filesystem which is a separate image to create
         the initrd from
         """
+        self.temp_directories = []
+
+    def prepare(self):
+        """
+        Prepare new root system suitable to create a kiwi initrd from it
+        """
         self.boot_root_directory = mkdtemp(
             prefix='kiwi_boot_root.', dir=self.target_dir
         )
         self.temp_directories.append(
             self.boot_root_directory
         )
-
-    def prepare(self):
-        """
-        Prepare new root system suitable to create a kiwi initrd from it
-        """
         self.load_boot_xml_description()
         boot_image_name = self.boot_xml_state.xml_data.get_name()
 
@@ -180,3 +181,8 @@ class BootImageKiwi(BootImageBase):
                 ['--check=crc32', '--lzma2=dict=1MiB', '--threads=0']
             )
             self.initrd_filename = compress.compressed_filename
+
+    def cleanup(self):
+        for directory in self.temp_directories:
+            if directory and os.path.exists(directory):
+                Path.wipe(directory)

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -238,6 +238,7 @@ class InstallImageBuilder:
             custom_args=self.custom_iso_args
         )
         iso_image.create_on_file(self.isoname)
+        self.boot_image_task.cleanup()
 
     def create_install_pxe_archive(self):
         """
@@ -345,6 +346,7 @@ class InstallImageBuilder:
         archive = ArchiveTar(self.pxetarball)
 
         archive.create(self.pxe_dir)
+        self.boot_image_task.cleanup()
 
     def _create_pxe_install_kernel_and_initrd(self):
         kernelname = 'pxeboot.{0}.kernel'.format(self.pxename)

--- a/kiwi/filesystem/base.py
+++ b/kiwi/filesystem/base.py
@@ -122,6 +122,19 @@ class FileSystemBase:
         """
         raise NotImplementedError
 
+    def get_mountpoint(self):
+        """
+        Provides mount point directory
+
+        Effective use of the directory is guaranteed only after sync_data
+
+        :return: directory path name
+
+        :rtype: string
+        """
+        if self.filesystem_mount:
+            return self.filesystem_mount.mountpoint
+
     def sync_data(self, exclude=None):
         """
         Copy root data tree into filesystem
@@ -150,7 +163,6 @@ class FileSystemBase:
             options=['-a', '-H', '-X', '-A', '--one-file-system'],
             exclude=exclude
         )
-        self.filesystem_mount.umount()
 
     def _apply_attributes(self):
         """

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -312,6 +312,18 @@ class VolumeManagerBase(DeviceProvider):
             )
         return mbsize
 
+    def get_mountpoint(self):
+        """
+        Provides mount point directory
+
+        Effective use of the directory is guaranteed only after sync_data
+
+        :return: directory path name
+
+        :rtype: string
+        """
+        return self.mountpoint
+
     def sync_data(self, exclude=None):
         """
         Implements sync of root directory to mounted volumes
@@ -327,7 +339,6 @@ class VolumeManagerBase(DeviceProvider):
                 options=['-a', '-H', '-X', '-A', '--one-file-system'],
                 exclude=exclude
             )
-            self.umount_volumes()
 
     def set_property_readonly_root(self):
         """
@@ -343,11 +354,3 @@ class VolumeManagerBase(DeviceProvider):
         the mounts of all volumes
         """
         self.mountpoint = mkdtemp(prefix='kiwi_volumes.')
-
-    def __del__(self):
-        """
-        Implements destructor to cleanup all volume subsystems
-        and mount processes. overwrite in specialized volume
-        management class
-        """
-        pass

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -58,6 +58,7 @@ class VolumeManagerBase(DeviceProvider):
     :raises KiwiVolumeManagerSetupError: if the given root_dir doesn't exist
     """
     def __init__(self, device_map, root_dir, volumes, custom_args=None):
+        self.temp_directories = []
         # all volumes are combined into one mountpoint. This is
         # needed at sync_data time. How to mount the volumes is
         # special to the volume management class
@@ -354,3 +355,8 @@ class VolumeManagerBase(DeviceProvider):
         the mounts of all volumes
         """
         self.mountpoint = mkdtemp(prefix='kiwi_volumes.')
+        self.temp_directories.append(self.mountpoint)
+
+    def _cleanup_tempdirs(self):
+        for directory in self.temp_directories:
+            Path.wipe(directory)

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -92,7 +92,7 @@ class VolumeManagerBtrfs(VolumeManagerBase):
         filesystem = FileSystem(
             name='btrfs',
             device_provider=MappedDevice(
-                device=self.device, device_provider=self
+                device=self.device, device_provider=self.device_provider_root
             ),
             custom_args=self.custom_filesystem_args
         )

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -423,5 +423,8 @@ class VolumeManagerBtrfs(VolumeManagerBase):
     def __del__(self):
         if self.toplevel_mount:
             log.info('Cleaning up %s instance', type(self).__name__)
-            if self.umount_volumes():
-                Path.wipe(self.mountpoint)
+            if not self.umount_volumes():
+                log.warning('Subvolumes still busy')
+                return
+            Path.wipe(self.mountpoint)
+        self._cleanup_tempdirs()

--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -81,7 +81,7 @@ class VolumeManagerLVM(VolumeManagerBase):
                 # the same key to put them on the same level
                 volume_name = 'swap'
             device_map[volume_name] = MappedDevice(
-                device=volume_node, device_provider=self
+                device=volume_node, device_provider=self.device_provider_root
             )
         return device_map
 
@@ -296,7 +296,7 @@ class VolumeManagerLVM(VolumeManagerBase):
         filesystem = FileSystem(
             name=filesystem_name,
             device_provider=MappedDevice(
-                device=device_node, device_provider=self
+                device=device_node, device_provider=self.device_provider_root
             ),
             custom_args=self.custom_filesystem_args
         )

--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -354,3 +354,5 @@ class VolumeManagerLVM(VolumeManagerBase):
                     log.warning(
                         'volume group %s still busy', self.volume_group
                     )
+                    return
+        self._cleanup_tempdirs()

--- a/test/unit/boot/image/base_test.py
+++ b/test/unit/boot/image/base_test.py
@@ -69,8 +69,7 @@ class TestBootImageBase:
                 self.boot_image.dump('filename')
 
     @patch('pickle.dump')
-    @patch('kiwi.boot.image.base.BootImageBase.disable_cleanup')
-    def test_dump(self, mock_disable_cleanup, mock_dump):
+    def test_dump(self, mock_dump):
         with patch('builtins.open', create=True) as mock_open:
             mock_open.return_value = MagicMock(spec=io.IOBase)
             file_handle = mock_open.return_value.__enter__.return_value
@@ -79,15 +78,6 @@ class TestBootImageBase:
             mock_dump.assert_called_once_with(
                 self.boot_image, file_handle
             )
-            mock_disable_cleanup.assert_called_once_with()
-
-    def test_disable_cleanup(self):
-        self.boot_image.disable_cleanup()
-        assert self.boot_image.call_destructor is False
-
-    def test_enable_cleanup(self):
-        self.boot_image.enable_cleanup()
-        assert self.boot_image.call_destructor is True
 
     @patch('os.listdir')
     def test_is_prepared(self, mock_listdir):
@@ -198,3 +188,4 @@ class TestBootImageBase:
         self.boot_image.include_module('module')
         self.boot_image.omit_module('module')
         self.boot_image.write_system_config_file({'config_key': 'value'})
+        self.boot_image.cleanup()

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -178,6 +178,7 @@ class TestInstallImageBuilder:
         self.boot_image_task.create_initrd.assert_called_once_with(
             self.mbrid, 'initrd_kiwi_install', install_initrd=True
         )
+        self.boot_image_task.cleanup.assert_called_once_with()
         self.kernel.copy_kernel.assert_called_once_with(
             'temp_media_dir/boot/x86_64/loader', '/linux'
         )
@@ -354,6 +355,7 @@ class TestInstallImageBuilder:
         self.boot_image_task.create_initrd.assert_called_once_with(
             self.mbrid, 'initrd_kiwi_install', install_initrd=True
         )
+        self.boot_image_task.cleanup.assert_called_once_with()
         assert mock_command.call_args_list[1] == call(
             [
                 'mv', 'initrd',

--- a/test/unit/filesystem/base_test.py
+++ b/test/unit/filesystem/base_test.py
@@ -36,6 +36,9 @@ class TestFileSystemBase:
         with raises(NotImplementedError):
             self.fsbase.create_on_file('myimage')
 
+    def test_get_mountpoint(self):
+        assert self.fsbase.get_mountpoint() is None
+
     @patch('kiwi.filesystem.base.MountManager')
     @patch('kiwi.filesystem.base.DataSync')
     @patch('kiwi.filesystem.base.Command.run')
@@ -66,7 +69,7 @@ class TestFileSystemBase:
             ['chattr', '+C', 'tmpdir']
         )
         filesystem_mount.mount.assert_called_once_with([])
-        filesystem_mount.umount.assert_called_once_with()
+        assert self.fsbase.get_mountpoint() == 'tmpdir'
 
     def test_destructor_valid_mountpoint(self):
         self.fsbase.filesystem_mount = mock.Mock()

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -206,13 +206,13 @@ class TestVolumeManagerBase:
         with raises(NotImplementedError):
             self.volume_manager.get_volumes()
 
+    def test_get_mountpoint(self):
+        assert self.volume_manager.get_mountpoint() is None
+
     @patch('kiwi.volume_manager.base.DataSync')
     @patch('kiwi.volume_manager.base.MountManager.is_mounted')
     @patch('kiwi.volume_manager.base.VolumeManagerBase.mount_volumes')
-    @patch('kiwi.volume_manager.base.VolumeManagerBase.umount_volumes')
-    def test_sync_data(
-        self, mock_umount_volumes, mock_mount_volumes, mock_mounted, mock_sync
-    ):
+    def test_sync_data(self, mock_mount_volumes, mock_mounted, mock_sync):
         data_sync = Mock()
         mock_sync.return_value = data_sync
         mock_mounted.return_value = False
@@ -226,7 +226,7 @@ class TestVolumeManagerBase:
             exclude=['exclude_me'],
             options=['-a', '-H', '-X', '-A', '--one-file-system']
         )
-        mock_umount_volumes.assert_called_once_with()
+        assert self.volume_manager.get_mountpoint() == 'mountpoint'
 
     @patch('kiwi.volume_manager.base.mkdtemp')
     def test_setup_mountpoint(self, mock_mkdtemp):
@@ -250,7 +250,3 @@ class TestVolumeManagerBase:
         mock_command.assert_called_once_with(
             ['chattr', '+C', 'toplevel/etc']
         )
-
-    def test_destructor(self):
-        # does nothing by default, just pass
-        self.volume_manager.__del__()

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -250,3 +250,9 @@ class TestVolumeManagerBase:
         mock_command.assert_called_once_with(
             ['chattr', '+C', 'toplevel/etc']
         )
+
+    @patch('kiwi.volume_manager.base.Path.wipe')
+    def test_cleanup_tempdirs(self, mock_Path_wipe):
+        self.volume_manager.temp_directories = ['tmpdir']
+        self.volume_manager._cleanup_tempdirs()
+        mock_Path_wipe.assert_called_once_with('tmpdir')

--- a/test/unit/volume_manager/btrfs_test.py
+++ b/test/unit/volume_manager/btrfs_test.py
@@ -153,8 +153,9 @@ class TestVolumeManagerBtrfs:
     @patch('kiwi.volume_manager.btrfs.FileSystem')
     @patch('kiwi.volume_manager.btrfs.MappedDevice')
     @patch('kiwi.volume_manager.btrfs.MountManager')
+    @patch('kiwi.volume_manager.base.mkdtemp')
     def test_setup_volume_id_not_detected(
-        self, mock_mount, mock_mapped_device, mock_fs,
+        self, mock_mkdtemp, mock_mount, mock_mapped_device, mock_fs,
         mock_command, mock_os_exists
     ):
         command_call = Mock()
@@ -531,3 +532,8 @@ class TestVolumeManagerBtrfs:
             self.volume_manager.__del__()
             mock_umount_volumes.assert_called_once_with()
             mock_wipe.assert_called_once_with(self.volume_manager.mountpoint)
+        mock_umount_volumes.reset_mock()
+        mock_umount_volumes.return_value = False
+        with self._caplog.at_level(logging.WARNING):
+            self.volume_manager.__del__()
+            mock_umount_volumes.assert_called_once_with()

--- a/test/unit/volume_manager/lvm_test.py
+++ b/test/unit/volume_manager/lvm_test.py
@@ -132,7 +132,8 @@ class TestVolumeManagerLVM:
         self.volume_manager.volume_group = None
 
     @patch('kiwi.volume_manager.lvm.Command.run')
-    def test_setup_volume_group_host_conflict(self, mock_command):
+    @patch('kiwi.volume_manager.base.mkdtemp')
+    def test_setup_volume_group_host_conflict(self, mock_mkdtemp, mock_command):
         command = Mock()
         command.output = 'some_data_about_volume_group'
         mock_command.return_value = command


### PR DESCRIPTION
In preparation to allow a chroot operation into the loop
mounted disk this commit refactors the process when filesystems
gets umounted and also fixes the canonical order for calling
the destructors. Related to Issue #1464

