### PR TITLE
Disk hook

### DIFF
--- a/build-tests/x86/suse/test-image-oem/disk.sh
+++ b/build-tests/x86/suse/test-image-oem/disk.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+env | grep kiwi

--- a/doc/source/working_with_kiwi.rst
+++ b/doc/source/working_with_kiwi.rst
@@ -175,8 +175,8 @@ The prepare step consists of the following substeps:
    At the end of the preparation stage the script :file:`config.sh` is
    executed (if present). It is run in the top level directory of the
    target root tree. The script's primary function is to complete the
-   system configuration, for example, to activate services. See
-   :ref:`image-customization-config-sh` section for further details.
+   system configuration. For more details about custom scripts
+   see :ref:`working-with-kiwi-user-defined-scripts`
 
 #. **Modify the Root Tree**
 
@@ -231,13 +231,8 @@ During the *create step* the following operations are performed by {kiwi}:
 #. **Execute the User-defined Script** :file:`images.sh`
 
    At the beginning of the image creation process the script named
-   :file:`images.sh` is executed (if present). It is run in the top level
-   directory of the unpacked root tree. The script is usually used to
-   remove files that are no needed in the final image. For example, if an
-   appliance is being built for a specific hardware, unnecessary kernel
-   drivers can be removed using this script.
-
-   See :ref:`image-customization-images-sh` for further details.
+   :file:`images.sh` is executed (if present). For more details about
+   custom scripts see :ref:`working-with-kiwi-user-defined-scripts`
 
 #. **Create the Requested Image Type**
 

--- a/doc/source/working_with_kiwi/shell_scripts.rst
+++ b/doc/source/working_with_kiwi/shell_scripts.rst
@@ -5,48 +5,54 @@ User Defined Scripts
 
 .. note:: **Abstract**
 
-   This chapter describes the usage of the user defined scripts
-   :file:`config.sh` and :file:`image.sh`, which can be used to further
-   customize an image in ways that are not possible via the image
-   description alone.
+   This chapter describes the purpose of the user defined scripts
+   :file:`config.sh`, :file:`image.sh` and :file:`disk.sh`, which can
+   be used to further customize an image in ways that are not possible
+   via the image description alone.
 
-
-{kiwi} supports up to two user defined scripts that it runs in the change
+{kiwi} supports the following optional scripts that it runs in a
 root environment (chroot) containing your new appliance:
 
-1. :file:`config.sh` runs the end of the :ref:`prepare step <prepare-step>`
-   if present. It can be used to fine tune the unpacked image.
+config.sh
+  runs at the end of the :ref:`prepare step <prepare-step>`
+  and after users have been set and the *overlay tree directory*
+  has been applied. It is usually used to apply a permanent and final
+  change of data in the root tree, such as modifying a package provided
+  config file.
 
-2. :file:`images.sh` is executed at the beginning of the :ref:`image
-   creation process <create-step>`. It is run on the top level of the
-   target root tree. The script is usually used to remove files that are
-   not needed in the final image. For example, if an appliance is being
-   built for a specific hardware, unnecessary kernel drivers can be removed
-   using this script.
+images.sh
+  is executed at the beginning of the :ref:`image
+  creation process <create-step>`. It runs in the same image root tree
+  that has been created by the prepare step but is invoked any
+  time an image should be created from that root tree. It is usually
+  used to apply image type specific changes to the root tree such as
+  a modification to a config file that should be done when building
+  a live iso but not when building a virtual disk image.
 
-{kiwi} will execute both scripts via the operating system if their executable
+disk.sh
+  is executed for the disk image types `vmx` and `oem`
+  only and runs after the synchronisation of the root tree into the
+  disk image loop file. At call time of the script the device name
+  of the currently mapped root device is passed as a parameter.
+  The chroot environment for this script call is the virtual disk
+  itself and not the root tree as with :file:`config.sh` and
+  :file:`images.sh`. :file:`disk.sh` is usually used to apply
+  changes at parts of the system that are not an element of the
+  file based root tree such as the partition table, the bootloader
+  or filesystem attributes.
+
+{kiwi} executes scripts via the operating system if their executable
 bit is set (in that case a shebang is mandatory) otherwise they will be
-invoked via the BASH.
-
-.. _image-customization-config-sh:
-
-Image Customization via the ``config.sh`` Shell Script
-------------------------------------------------------
-
-The {kiwi} image description allows to have an :file:`config.sh` script in
-place. It can be used for changes appropriate for all images to be created
-from a given unpacked image (:file:`config.sh` runs prior to the *create
-step*). The script should add operating system configuration files which
-would be otherwise added by a user driven installer, like the activation of
-services, creation of configuration files, preparation of an environment
-for a firstboot workflow, etc.
-
-The :file:`config.sh` script is called at the end of the :ref:`prepare step
-<prepare-step>` (after users have been set and the *overlay tree directory*
-has been applied). If :file:`config.sh` exits with a non-zero exit code
+invoked via the BASH. If a script exits with a non-zero exit code
 then {kiwi} will report the failure and abort the image creation.
 
-Find a common template for `config.sh` script below:
+Script Template for config.sh / images.sh
+-----------------------------------------
+
+{kiwi} provides a collection of methods and variables that supports users
+with custom operations. For details see :ref:`image-customization-methods`.
+The following template shows how to import this information in your
+script:
 
 .. code:: bash
 
@@ -56,18 +62,206 @@ Find a common template for `config.sh` script below:
    test -f /.kconfig && . /.kconfig
    test -f /.profile && . /.profile
 
-   #======================================
-   # Greeting...
-   #--------------------------------------
-   echo "Configure image: [$kiwi_iname]..."
-
-   #======================================
-   # Call configuration code/functions
-   #--------------------------------------
    ...
 
+.. warning:: Modifications of the unpacked root tree
+
+   Keep in mind that there is only one unpacked root tree the
+   script operates in. This means that all changes are permanent
+   and will not be automatically restored!
+
+
+.. _image-customization-methods:
+
+Functions and Variables Provided by {kiwi}
+-------------------------------------------
+
+{kiwi} creates the :file:`.kconfig` and :file:`.profile` files to be sourced
+by the shell scripts :file:`config.sh` and :file:`images.sh`.
+:file:`.kconfig` contains various helper functions which can be used to
+simplify the image configuration and :file:`.profile` contains environment
+variables which get populated from the settings provided in the image
+description.
+
+Functions
+^^^^^^^^^
+
+The :file:`.kconfig` file provides a common set of functions.  Functions
+specific to SUSE Linux begin with the name ``suse``, functions applicable
+to all Linux distributions start with the name ``base``.
+
+The following list describes all functions provided by :file:`.kconfig`:
+
+baseCleanMount
+  Unmount the filesystems :file:`/proc`, :file:`/dev/pts`, :file:`/sys` and
+  :file:`/proc/sys/fs/binfmt_misc`.
+
+baseGetPackagesForDeletion
+  Return the name(s) of the packages marked for deletion in the image
+  description.
+
+baseGetProfilesUsed
+  Return the name(s) of profiles used to build this image.
+
+baseSetRunlevel {value}
+  Set the default run level.
+
+baseSetupUserPermissions
+  Set the ownership of all home directories and their content to the correct
+  users and groups listed in :file:`/etc/passwd`.
+
+baseStripAndKeep {list of info-files to keep}
+  Helper function for the ``baseStrip*`` functions, reads the list of files
+  to check from stdin for removing
+  params: files which should be kept
+
+baseStripDocs {list of docu names to keep}
+  Remove all documentation files, except for the ones given as the
+  parameter.
+
+baseStripInfos {list of info-files to keep}
+  Remove all info files, except for the one given as the parameter.
+
+baseStripLocales {list of locales}
+  Remove all locales, except for the ones given as the parameter.
+
+baseStripTranslations {list of translations}
+  Remove all translations, except for the ones given as the parameter.
+
+baseStripMans {list of manpages to keep}
+  Remove all manual pages, except for the ones given as the parameter.
+
+  Example:
+
+  .. code:: bash
+
+     baseStripMans more less
+
+suseImportBuildKey
+  Add the SUSE build keys to the RPM database.
+
+baseStripUnusedLibs
+  Remove libraries which are not directly linked against applications
+  in the bin directories.
+
+baseUpdateSysConfig {filename} {variable} {value}
+  Update the contents of a sysconfig variable
+
+suseConfig
+  This function is deprecated and is a NOP.
+
+baseSystemdServiceInstalled {service}
+  Prints the path of the first found systemd unit or mount with name passed
+  as the first parameter.
+
+baseSysVServiceInstalled {service}
+  Prints the name `${service}` if a SysV init service with that name is
+  found, otherwise it prints nothing.
+
+baseSystemdCall {service_name} {args}
+  Calls `systemctl ${args} ${service_name}` if a systemd unit, a systemd
+  mount or a SysV init service with the `${service_name}` exist.
+
+baseInsertService {servicename}
+  Activate the given service via :command:`systemctl`.
+
+baseRemoveService {servicename}
+  Deactivate the given service via :command:`systemctl`.
+
+baseService {servicename} {on|off}
+  Activate or deactivate a service via :command:`systemctl`.
+  The function requires the service name and the value ``on`` or ``off`` as
+  parameters.
+
+  Example to enable the sshd service on boot:
+
+  .. code:: bash
+
+     baseService sshd on
+
+suseInsertService {servicename}
+  Calls baseInsertService and exists only for
+  compatibility reasons.
+
+suseRemoveService {servicename}
+  Calls baseRemoveService and exists only for
+  compatibility reasons.
+
+suseService {servicename} {on|off}
+  Calls baseService and exists only for compatibility
+  reasons.
+
+suseActivateDefaultServices
+  Activates the `network` and `cron` services to run at boot.
+
+suseSetupProduct
+  Creates the :file:`/etc/products.d/baseproduct` link
+  pointing to the product referenced by either :file:`/etc/SuSE-brand` or
+  :file:`/etc/os-release` or the latest `.prod` file available in
+  :file:`/etc/products.d`
+
+suseSetupProductInformation
+  Uses :command:`zypper` to search for the installed product
+  and installs all product specific packages. This function fails
+  when :command:`zypper` is not the appliances package manager.
+
+Debug {message}
+  Helper function to print the supplied message if the variable DEBUG is
+  set to 1.
+
+Echo {echo commandline}
+  Helper function to print a message to the controlling terminal.
+
+Rm {list of files}
+  Helper function to delete files and log the deletion.
+
+Rpm {rpm commandline}
+  Helper function for calling ``rpm``: forwards all commandline arguments to
+  ``rpm`` and logs the call.
+
+Profile Environment Variables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :file:`.profile` environment file is created by {kiwi} and contains a
+specific set of variables which are listed below.
+
+$kiwi_compressed
+  The value of the `compressed` attribute set in the `type` element in
+  :file:`config.xml`.
+
+$kiwi_delete
+  A list of all packages which are children of the `packages` element
+  with `type="delete"` in :file:`config.xml`.
+
+$kiwi_drivers
+  A comma separated list of the driver entries as listed in the
+  `drivers` section of the :file:`config.xml`.
+
+$kiwi_iname
+  The name of the image as listed in :file:`config.xml`.
+
+$kiwi_iversion
+  The image version as a string.
+
+$kiwi_keytable
+  The contents of the keytable setup as done in :file:`config.xml`.
+
+$kiwi_language
+  The contents of the locale setup as done in :file:`config.xml`.
+
+$kiwi_profiles
+  A comma separated list of profiles used to build this image.
+
+$kiwi_timezone
+  The contents of the timezone setup as done in :file:`config.xml`.
+
+$kiwi_type
+  The image type as extracted from the `type` element in
+  :file:`config.xml`.
+
+
 Configuration Tips
-^^^^^^^^^^^^^^^^^^
+------------------
 
 #. **Stateless systemd UUIDs:**
 
@@ -112,296 +306,3 @@ Configuration Tips
             rm /var/lib/dbus/machine-id
         fi
         ln -s /etc/machine-id /var/lib/dbus/machine-id
-
-
-.. _image-customization-images-sh:
-
-Image Customization via the ``images.sh`` Shell Script
-------------------------------------------------------
-
-The {kiwi} image description allows to have an optional :file:`images.sh`
-bash script in place. It can be used for changes appropriate for certain
-images/image types on a case-by-case basis (since it runs at beginning of
-:ref:`create step <create-step>`).
-
-.. warning:: Modifications of the unpacked root tree
-
-   Keep in mind that there is only one unpacked root tree the script
-   operates in. This means that all changes are permanent and will not be
-   automatically restored!
-
-The script should be designed to take over control of handling image type
-specific tasks. For example, if building the OEM type requires some
-additional packages or configurations then that can be handled in
-:file:`images.sh`. Additionally, the script authors tasks is to check if
-changes performed beforehand do not interfere in a negative way if another
-image type is created from the same unpacked image root tree.
-
-If :file:`images.sh` exits with a non-zero exit code, then {kiwi} will report
-an error and abort the image creation.
-
-See below a common template for :file:`images.sh` script:
-
-.. code:: bash
-
-   #======================================
-   # Include functions & variables
-   #--------------------------------------
-   test -f /.kconfig && . /.kconfig
-   test -f /.profile && . /.profile
-
-   #======================================
-   # Greeting...
-   #--------------------------------------
-   echo "Configure image: [$kiwi_iname]..."
-
-   #======================================
-   # Call configuration code/functions
-   #--------------------------------------
-   ...
-
-   #======================================
-   # Exit successfully
-   #--------------------------------------
-   exit 0
-
-
-Functions and Variables Provided by {kiwi}
--------------------------------------------
-
-{kiwi} creates the :file:`.kconfig` and :file:`.profile` files to be sourced
-by the shell scripts :file:`config.sh` and :file:`images.sh`.
-:file:`.kconfig` contains various helper functions which can be used to
-simplify the image configuration and :file:`.profile` contains environment
-variables which get populated from the settings provided in the image
-description.
-
-Provided Functions
-^^^^^^^^^^^^^^^^^^
-
-The :file:`.kconfig` file provides a common set of functions.  Functions
-specific to SUSE Linux begin with the name ``suse``, functions applicable
-to all Linux distributions start with the name ``base``.
-
-The following list describes all functions provided by :file:`.kconfig`:
-
-``baseCleanMount``
-  Unmount the filesystems :file:`/proc`, :file:`/dev/pts`, :file:`/sys` and
-  :file:`/proc/sys/fs/binfmt_misc`.
-
-``baseGetPackagesForDeletion``
-  Return the name(s) of the packages marked for deletion in the image
-  description.
-
-``baseGetProfilesUsed``
-  Return the name(s) of profiles used to build this image.
-
-``baseSetRunlevel {value}``
-  Set the default run level.
-
-``baseSetupUserPermissions``
-  Set the ownership of all home directories and their content to the correct
-  users and groups listed in :file:`/etc/passwd`.
-
-``baseStripAndKeep {list of info-files to keep}``
-  Helper function for the ``baseStrip*`` functions, reads the list of files
-  to check from stdin for removing
-  params: files which should be kept
-
-``baseStripDocs {list of docu names to keep}``
-  Remove all documentation files, except for the ones given as the
-  parameter.
-
-``baseStripInfos {list of info-files to keep}``
-  Remove all info files, except for the one given as the parameter.
-
-``baseStripLocales {list of locales}``
-  Remove all locales, except for the ones given as the parameter.
-
-``baseStripTranslations {list of translations}``
-  Remove all translations, except for the ones given as the parameter.
-
-``baseStripMans {list of manpages to keep}``
-  Remove all manual pages, except for the ones given as the parameter.
-
-  Example:
-
-  .. code:: bash
-
-     baseStripMans more less
-
-``suseImportBuildKey``
-  Add the SUSE build keys to the RPM database.
-
-``baseStripUnusedLibs``
-  Remove libraries which are not directly linked against applications
-  in the bin directories.
-
-``baseUpdateSysConfig {filename} {variable} {value}``
-  Update the contents of a sysconfig variable
-
-``suseConfig``
-  This function is deprecated and is a NOP.
-
-``baseSystemdServiceInstalled {service}``
-  Prints the path of the first found systemd unit or mount with name passed
-  as the first parameter.
-
-``baseSysVServiceInstalled {service}``
-  Prints the name `${service}` if a SysV init service with that name is
-  found, otherwise it prints nothing.
-
-``baseSystemdCall {service_name} {args}``
-  Calls `systemctl ${args} ${service_name}` if a systemd unit, a systemd
-  mount or a SysV init service with the `${service_name}` exist.
-
-``baseInsertService {servicename}``
-  Activate the given service via :command:`systemctl`.
-
-``baseRemoveService {servicename}``
-  Deactivate the given service via :command:`systemctl`.
-
-``baseService {servicename} {on|off}``
-  Activate or deactivate a service via :command:`systemctl`.
-  The function requires the service name and the value ``on`` or ``off`` as
-  parameters.
-
-  Example to enable the sshd service on boot:
-
-  .. code:: bash
-
-     baseService sshd on
-
-``suseInsertService {servicename}``
-  Calls baseInsertService and exists only for
-  compatibility reasons.
-
-``suseRemoveService {servicename}``
-  Calls baseRemoveService and exists only for
-  compatibility reasons.
-
-``suseService {servicename} {on|off}``
-  Calls baseService and exists only for compatibility
-  reasons.
-
-``suseActivateDefaultServices``
-  Activates the `network` and `cron` services to run at boot.
-
-``suseSetupProduct``
-  Creates the :file:`/etc/products.d/baseproduct` link
-  pointing to the product referenced by either :file:`/etc/SuSE-brand` or
-  :file:`/etc/os-release` or the latest `.prod` file available in
-  :file:`/etc/products.d`
-
-``suseSetupProductInformation``
-  Uses :command:`zypper` to search for the installed product
-  and installs all product specific packages. This function fails
-  when :command:`zypper` is not the appliances package manager.
-
-``Debug {message}``
-  Helper function to print the supplied message if the variable DEBUG is
-  set to 1.
-
-``Echo {echo commandline}``
-  Helper function to print a message to the controlling terminal.
-
-``Rm {list of files}``
-  Helper function to delete files and log the deletion.
-
-``Rpm {rpm commandline}``
-  Helper function for calling ``rpm``: forwards all commandline arguments to
-  ``rpm`` and logs the call.
-
-Functions for Custom non-dracut Based Boot
-''''''''''''''''''''''''''''''''''''''''''
-
-{kiwi} also provides the following functions (mostly for compatibility
-reasons) which can be used to customize the boot process when using the
-custom boot option (see
-:ref:`working-with-kiwi-customizing-the-boot-process`):
-
-``baseStripInitrd``
-  Removes various tools binaries and libraries which
-  are not required to boot a SUSE system with {kiwi}. This function is not
-  required when using the dracut initrd system and is kept for
-  compatibility reasons.
-
-``baseStripFirmware``
-  Check all kernel modules if they require a firmware and strip out all
-  firmware files which are not referenced by a kernel module
-
-``baseStripModules``
-  Search for updated modules and remove the old version which might be
-  provided by the standard kernel
-
-``baseStripKernel``
-  Strips the kernel:
-
-  1. create the :file:`vmlinux.gz` and :file:`vmlinuz` files which are used
-     as a fallback for the kernel extraction
-
-  2. handle `<strip type="delete">` requests. Because this information is
-     generic not only files of the kernel are affected but also other data
-     which are unwanted get deleted here
-
-  3. only keep kernel modules matching the `<drivers>` patterns from the
-     kiwi boot image description
-
-  4. lookup kernel module dependencies and bring back modules which were
-     removed but still required by other modules that were kept in the
-     system
-
-  5. search for duplicate kernel modules due to kernel module updates and
-     keep only the latest version
-
-  6. search for kernel firmware files and keep only those for which a
-     kernel driver is still present in the system
-
-``suseStripKernel``
-  Removes all kernel drivers which are not listed in the
-  drivers sections of :file:`config.xml`.
-
-``baseStripTools {list of toolpath} {list of tools}``
-  Helper function for suseStripInitrd
-  function parameters: toolpath, tools.
-
-
-Profile Environment Variables
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The :file:`.profile` environment file is created by {kiwi} and contains a
-specific set of variables which are listed below.
-
-``$kiwi_compressed``
-  The value of the `compressed` attribute set in the `type` element in
-  :file:`config.xml`.
-
-``$kiwi_delete``
-  A list of all packages which are children of the `packages` element
-  with `type="delete"` in :file:`config.xml`.
-
-``$kiwi_drivers``
-  A comma separated list of the driver entries as listed in the
-  `drivers` section of the :file:`config.xml`.
-
-``$kiwi_iname``
-  The name of the image as listed in :file:`config.xml`.
-
-``$kiwi_iversion``
-  The image version as a string.
-
-``$kiwi_keytable``
-  The contents of the keytable setup as done in :file:`config.xml`.
-
-``$kiwi_language``
-  The contents of the locale setup as done in :file:`config.xml`.
-
-``$kiwi_profiles``
-  A comma separated list of profiles used to build this image.
-
-``$kiwi_timezone``
-  The contents of the timezone setup as done in :file:`config.xml`.
-
-``$kiwi_type``
-  The image type as extracted from the `type` element in
-  :file:`config.xml`.

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -21,6 +21,8 @@ import pickle
 from tempfile import NamedTemporaryFile
 
 # project
+import kiwi.defaults as defaults
+
 from kiwi.defaults import Defaults
 from kiwi.bootloader.config import BootLoaderConfig
 from kiwi.bootloader.install import BootLoaderInstall
@@ -458,6 +460,17 @@ class DiskBuilder:
             self.system.sync_data(
                 self._get_exclude_list_for_root_data_sync(device_map)
             )
+
+        # run post sync script hook
+        if self.system_setup.script_exists(
+            defaults.post_disk_sync_script_name
+        ):
+            disk_system = SystemSetup(
+                self.xml_state, self.system.get_mountpoint()
+            )
+            disk_system.import_description()
+            disk_system.call_disk_script()
+            disk_system.cleanup()
 
         # install boot loader
         self._install_bootloader(device_map)

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -16,19 +16,30 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import sys
 import glob
 from collections import namedtuple
 import platform
 from pkg_resources import resource_filename
 
 # project
-from .path import Path
-from .version import (
+from kiwi.path import Path
+from kiwi.version import (
     __githash__,
     __version__
 )
 
-from .exceptions import KiwiBootLoaderGrubDataError
+from kiwi.exceptions import KiwiBootLoaderGrubDataError
+
+# Default module variables
+this = sys.modules[__name__]
+
+this.post_disk_sync_script_name = 'disk.sh'
+this.post_prepare_script_name = 'config.sh'
+this.pre_create_script_name = 'images.sh'
+this.edit_boot_config_script_name = 'edit_boot_config.sh'
+this.edit_boot_install_script_name = 'edit_boot_install.sh'
+this.image_metadata_directory = 'image'
 
 
 class Defaults:

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -795,3 +795,10 @@ class KiwiFileAccessError(KiwiError):
     """
     Exception raised if accessing a file or its metadata failed
     """
+
+
+class KiwiShellVariableValueError(KiwiError):
+    """
+    Exception raised if a given python value cannot be converted
+    into a string representation for use in shell scripts
+    """

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -53,6 +53,17 @@ class Profile:
         self._drivers_to_profile()
         self._root_partition_uuid_to_profile()
 
+    def get_settings(self):
+        """
+        Return all profile elements that has a value
+        """
+        profile = {}
+        for key, value in list(self.dot_profile.items()):
+            profile[key] = Shell.format_to_variable_value(value)
+        return collections.OrderedDict(
+            sorted(profile.items())
+        )
+
     def add(self, key, value):
         """
         Add key/value pair to profile dictionary
@@ -72,16 +83,13 @@ class Profile:
 
         :param str filename: file path name
         """
-        sorted_profile = collections.OrderedDict(
-            sorted(self.dot_profile.items())
-        )
+        sorted_profile = self.get_settings()
         temp_profile = NamedTemporaryFile()
         with open(temp_profile.name, 'w') as profile:
             for key, value in list(sorted_profile.items()):
-                if value:
-                    profile.write(
-                        format(key) + '=' + self._format(value) + '\n'
-                    )
+                profile.write(
+                    '{0}={1}{2}'.format(key, value, os.linesep)
+                )
         profile_environment = Shell.quote_key_value_file(temp_profile.name)
         with open(filename, 'w') as profile:
             for line in profile_environment:
@@ -382,13 +390,3 @@ class Profile:
                 return 'true'
             else:
                 return content
-
-    def _format(self, value):
-        """
-        Helper method to format bool profile values in the way
-        the boot code expects them
-        """
-        if value is True:
-            return 'true'
-        else:
-            return format(value)

--- a/kiwi/system/shell.py
+++ b/kiwi/system/shell.py
@@ -16,10 +16,14 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 from tempfile import NamedTemporaryFile
+from typing import Optional, Any
+from collections.abc import Iterable
 
 # project
 from kiwi.command import Command
 from kiwi.defaults import Defaults
+
+from kiwi.exceptions import KiwiShellVariableValueError
 
 
 class Shell:
@@ -84,3 +88,35 @@ class Shell:
                 )
             ]
         )
+
+    @staticmethod
+    def format_to_variable_value(value: Optional[Any]) -> str:
+        """
+        Format given variable value to return a string value
+        representation that can be sourced by shell scripts.
+        If the provided value is not representable as a string
+        (list, dict, tuple etc) an exception is raised
+
+        :param any value: a python variable
+
+        :raises KiwiShellVariableValueError: if value is an iterable
+
+        :return: string value representation
+
+        :rtype: str
+        """
+        if value is None:
+            return ''
+        if isinstance(value, bool):
+            return format(value).lower()
+        elif isinstance(value, str):
+            return value
+        elif isinstance(value, bytes):
+            return format(value.decode())
+        elif isinstance(value, Iterable):
+            # we will have a hard time to turn an iterable (list, dict ...)
+            # into a useful string
+            raise KiwiShellVariableValueError(
+                'Value cannot be {0}'.format(type(value))
+            )
+        return format(value)

--- a/test/unit/system/shell_test.py
+++ b/test/unit/system/shell_test.py
@@ -1,0 +1,18 @@
+from pytest import raises
+
+from kiwi.system.shell import Shell
+from kiwi.exceptions import KiwiShellVariableValueError
+
+
+class TestSystemShell:
+    def test_format_to_variable_value(self):
+        assert Shell.format_to_variable_value('text') == 'text'
+        assert Shell.format_to_variable_value(True) == 'true'
+        assert Shell.format_to_variable_value(False) == 'false'
+        assert Shell.format_to_variable_value('42') == '42'
+        assert Shell.format_to_variable_value(0) == '0'
+        assert Shell.format_to_variable_value(42) == '42'
+        assert Shell.format_to_variable_value(None) == ''
+        assert Shell.format_to_variable_value(b"42") == '42'
+        with raises(KiwiShellVariableValueError):
+            Shell.format_to_variable_value(['foo', 'bar'])


### PR DESCRIPTION
Added new post disk sync script hook
    
Allow to put a disk.sh script as part of the image description which is called for the disk image types `vmx` and `oem` only and runs after the synchronisation of the root tree into the  disk image loop file. At call time of the script the device name  of the currently mapped root device is passed as a parameter. The chroot environment for the call is the mounted disk itself  which makes this different from the config.sh/images.sh caller  environment. This Fixes #1464

Update user defined scripts documentation
    
Added information about new disk.sh script and reworked the entire chapter


