### PR TITLE
Fixed size of msgbox dialog

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -10,7 +10,7 @@ type fetch_file >/dev/null 2>&1 || . /lib/kiwi-net-lib.sh
 #--------------------------------------
 function report_and_quit {
     local text_message="$1"
-    run_dialog --timeout 60 --msgbox "\"${text_message}\"" 5 70
+    run_dialog --timeout 60 --msgbox "\"${text_message}\"" 5 80
     if getargbool 0 rd.debug; then
         die "${text_message}"
     else


### PR DESCRIPTION
The width of the dialog was set to a small value which
causes the message to be choped. I found this when testing
pxe deployments. The error messages on "Failed to fetch..."
were missing the interesting part

