### PR TITLE
Fixed permissions of custom boot image root dir

### DIFF
--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -132,6 +132,7 @@ class BootImageKiwi(BootImageBase):
             temp_boot_root_directory = mkdtemp(
                 prefix='kiwi_boot_root_copy.'
             )
+            os.chmod(temp_boot_root_directory, 0o755)
             self.temp_directories.append(
                 temp_boot_root_directory
             )

--- a/test/unit/boot/image/builtin_kiwi_test.py
+++ b/test/unit/boot/image/builtin_kiwi_test.py
@@ -100,8 +100,9 @@ class TestBootImageKiwi:
     @patch('kiwi.boot.image.builtin_kiwi.DataSync')
     @patch('kiwi.boot.image.base.BootImageBase.is_prepared')
     @patch('kiwi.boot.image.builtin_kiwi.mkdtemp')
+    @patch('kiwi.boot.image.builtin_kiwi.os.chmod')
     def test_create_initrd(
-        self, mock_mkdtemp, mock_prepared, mock_sync,
+        self, mock_os_chmod, mock_mkdtemp, mock_prepared, mock_sync,
         mock_wipe, mock_create, mock_compress, mock_cpio
     ):
         data = mock.Mock()
@@ -118,6 +119,9 @@ class TestBootImageKiwi:
         self.boot_image.create_initrd(mbrid)
         mock_sync.assert_called_once_with(
             'boot-root-directory/', 'temp-boot-directory'
+        )
+        mock_os_chmod.assert_called_once_with(
+            'temp-boot-directory', 0o755
         )
         data.sync_data.assert_called_once_with(options=['-a'])
         mock_cpio.assert_called_once_with(


### PR DESCRIPTION
When building a custom kiwi initrd the root directory
has the permissions of the mkdtemp created directory
but should have the permissions of a linux root dir
which is 0755. This Fixes #1394

