### PR TITLE
Only modify /etc/vimrc if it exists in config.sh

### DIFF
--- a/build-tests/x86/suse/test-image-oem/config.sh
+++ b/build-tests/x86/suse/test-image-oem/config.sh
@@ -61,12 +61,6 @@ rm -rf /usr/share/doc/manual/*
 rm -rf /opt/kde*
 
 #======================================
-# only basic version of vim is
-# installed; no syntax highlighting
-#--------------------------------------
-sed -i -e's/^syntax on/" syntax on/' /etc/vimrc
-
-#======================================
 # SuSEconfig
 #--------------------------------------
 suseConfig

--- a/build-tests/x86/suse/test-image-overlayroot/config.sh
+++ b/build-tests/x86/suse/test-image-overlayroot/config.sh
@@ -54,12 +54,6 @@ rm -rf /usr/share/doc/manual/*
 rm -rf /opt/kde*
 
 #======================================
-# only basic version of vim is
-# installed; no syntax highlighting
-#--------------------------------------
-sed -i -e's/^syntax on/" syntax on/' /etc/vimrc
-
-#======================================
 # SuSEconfig
 #--------------------------------------
 suseConfig

--- a/build-tests/x86/suse/test-image-pxe/config.sh
+++ b/build-tests/x86/suse/test-image-pxe/config.sh
@@ -59,12 +59,6 @@ rm -rf /usr/share/doc/manual/*
 rm -rf /opt/kde*
 
 #======================================
-# only basic version of vim is
-# installed; no syntax highlighting
-#--------------------------------------
-sed -i -e's/^syntax on/" syntax on/' /etc/vimrc
-
-#======================================
 # SuSEconfig
 #--------------------------------------
 suseConfig

--- a/build-tests/x86/suse/test-image-vmx-lvm/config.sh
+++ b/build-tests/x86/suse/test-image-vmx-lvm/config.sh
@@ -59,12 +59,6 @@ rm -rf /usr/share/doc/manual/*
 rm -rf /opt/kde*
 
 #======================================
-# only basic version of vim is
-# installed; no syntax highlighting
-#--------------------------------------
-sed -i -e's/^syntax on/" syntax on/' /etc/vimrc
-
-#======================================
 # SuSEconfig
 #--------------------------------------
 suseConfig

--- a/build-tests/x86/suse/test-image-vmx/config.sh
+++ b/build-tests/x86/suse/test-image-vmx/config.sh
@@ -59,12 +59,6 @@ rm -rf /usr/share/doc/manual/*
 rm -rf /opt/kde*
 
 #======================================
-# only basic version of vim is
-# installed; no syntax highlighting
-#--------------------------------------
-sed -i -e's/^syntax on/" syntax on/' /etc/vimrc
-
-#======================================
 # SuSEconfig
 #--------------------------------------
 suseConfig


### PR DESCRIPTION
An update of vim in Tumbleweed will move `/etc/vimrc` to `/usr/share/vim` as part of the /usr - /etc split. This makes the sed call fail because `/etc/vimrc` no longer exists.

However, the fix is not required anymore then, as the vim package dropped the `syntax on` line from the default vimrc.