### PR TITLE
Remove /etc/sysconfig/language support

### DIFF
--- a/doc/source/working_with_kiwi/shell_scripts.rst
+++ b/doc/source/working_with_kiwi/shell_scripts.rst
@@ -263,6 +263,30 @@ $kiwi_type
 Configuration Tips
 ------------------
 
+#. **Locale configuration:**
+
+  KIWI in order to set the locale relies on :command:`systemd-firstboot`,
+  which in turn writes the locale configuration file :file:`/etc/locale.conf`.
+  The values for the locale settings are taken from the description XML
+  file in the `<locale>` element under `<preferences>`.
+
+  KIWI assumes systemd adoption to handle these locale settings, in case the
+  build distribution does not honor `/etc/locale.conf` this is likely to not
+  produce any effect on the locale settings. As an example, in SLE12
+  distribution the locale configuration is already possible by using the
+  systemd toolchain, however this approach overlaps with SUSE specific
+  managers such as YaST. In that case using :command:`systemd-firstboot`
+  is only effective if locales in :file:`/etc/sysconfig/language` are
+  not set or if the file does not exist at all. In SLE12
+  :file:`/etc/sysconfig/language` has precendence over
+  :file:`/etc/locale.conf` for compatibility reasons and management tools
+  could still relay on `sysconfig` files for locale settings.
+
+  In any case the configuration is still possible in KIWI by using
+  any distribution specific way to configure the locale setting inside the
+  :file:`config.sh` script or by adding any additional configuration file
+  as part of the overlay root-tree.
+
 #. **Stateless systemd UUIDs:**
 
   Machine ID files are created and set (:file:`/etc/machine-id`,

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -338,13 +338,6 @@ class SystemSetup:
                     'chroot', self.root_dir, 'systemd-firstboot',
                     '--locale=' + locale
                 ])
-            if os.path.exists(self.root_dir + '/etc/sysconfig/language'):
-                Shell.run_common_function(
-                    'baseUpdateSysConfig', [
-                        self.root_dir + '/etc/sysconfig/language',
-                        'RC_LANG', locale
-                    ]
-                )
 
     def setup_timezone(self):
         """

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -394,11 +394,10 @@ class TestSystemSetup:
             self.setup.setup_keyboard_map()
 
     @patch('kiwi.system.setup.CommandCapabilities.has_option_in_help')
-    @patch('kiwi.system.setup.Shell.run_common_function')
     @patch('kiwi.system.setup.Command.run')
     @patch('os.path.exists')
     def test_setup_locale(
-        self, mock_path, mock_run, mock_shell, mock_caps
+        self, mock_path, mock_run, mock_caps
     ):
         mock_caps.return_valure = True
         mock_path.return_value = True
@@ -411,24 +410,22 @@ class TestSystemSetup:
                 '--locale=locale1.UTF-8'
             ])
         ])
-        mock_shell.assert_called_once_with(
-            'baseUpdateSysConfig', [
-                'root_dir/etc/sysconfig/language', 'RC_LANG', 'locale1.UTF-8'
-            ]
-        )
 
-    @patch('kiwi.system.setup.Shell.run_common_function')
+    @patch('kiwi.system.setup.CommandCapabilities.has_option_in_help')
     @patch('kiwi.system.setup.Command.run')
     @patch('os.path.exists')
-    def test_setup_locale_POSIX(self, mock_path, mock_run, mock_shell):
+    def test_setup_locale_POSIX(self, mock_path, mock_run, mock_caps):
+        mock_caps.return_valure = True
         mock_path.return_value = True
         self.setup.preferences['locale'] = 'POSIX,locale2'
         self.setup.setup_locale()
-        mock_shell.assert_called_once_with(
-            'baseUpdateSysConfig', [
-                'root_dir/etc/sysconfig/language', 'RC_LANG', 'POSIX'
-            ]
-        )
+        mock_run.assert_has_calls([
+            call(['rm', '-r', '-f', 'root_dir/etc/locale.conf']),
+            call([
+                'chroot', 'root_dir', 'systemd-firstboot',
+                '--locale=POSIX'
+            ])
+        ])
 
     @patch('kiwi.system.setup.Command.run')
     def test_setup_timezone(self, mock_command):


### PR DESCRIPTION
As of SLE15 and onwards /etc/sysconfig/language is considered to be
obsolete and just kept for compatibility purposes. Thus there is no
need to manage the file anymore.

Fixes #1471
