### PR TITLE
Add disk.sh script payload

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -463,9 +463,7 @@ class DiskBuilder:
             )
 
         # run post sync script hook
-        if self.system_setup.script_exists(
-            defaults.post_disk_sync_script_name
-        ):
+        if self.system_setup.file_or_directory_exists(defaults.post_disk_sync_script_name):
             disk_system = SystemSetup(
                 self.xml_state, self.system.get_mountpoint()
             )

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -468,6 +468,7 @@ class DiskBuilder:
                 self.xml_state, self.system.get_mountpoint()
             )
             disk_system.import_description()
+            disk_system.import_payload()
             disk_system.call_disk_script()
             disk_system.cleanup()
 

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -69,6 +69,7 @@ class DiskBuilder:
         * signing_keys: list of package signing keys
         * xz_options: string of XZ compression parameters
     """
+
     def __init__(self, xml_state, target_dir, root_dir, custom_args=None):
         self.arch = Defaults.get_platform_name()
         self.root_dir = root_dir

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -41,6 +41,10 @@ this.edit_boot_config_script_name = 'edit_boot_config.sh'
 this.edit_boot_install_script_name = 'edit_boot_install.sh'
 this.image_metadata_directory = 'image'
 
+# Anything in this directory is copied then to a /tmp/payload
+# on the final image and used by disk.sh afterwards, then purged.
+DISK_SYNC_DIR = 'payload'
+
 
 class Defaults:
     """
@@ -48,6 +52,7 @@ class Defaults:
 
     Provides static methods for default values and state information
     """
+
     def __init__(self):
         self.defaults = {
             # alignment in bytes

--- a/kiwi/path.py
+++ b/kiwi/path.py
@@ -121,6 +121,11 @@ class Path:
             shutil.rmtree(path)
         except FileNotFoundError:
             log.warning("Skipped wiping {} -- path does not exists".format(path))
+        except NotADirectoryError:
+            try:
+                os.unlink(path)
+            except Exception as ex:
+                raise KiwiFileAccessError(ex)
         except Exception as ex:
             raise KiwiFileAccessError(ex)
 

--- a/kiwi/path.py
+++ b/kiwi/path.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import shutil
 import logging
 import collections
 
@@ -114,10 +115,12 @@ class Path:
 
         :param string path: path name
         """
-        if os.path.exists(path):
-            Command.run(
-                ['rm', '-r', '-f', path]
-            )
+        try:
+            shutil.rmtree(path)
+        except FileNotFoundError:
+            log.warning("Skipped wiping {} -- path does not exists".format(path))
+        except Exception as ex:
+            raise KiwiFileAccessError(ex)
 
     @staticmethod
     def remove(path):

--- a/kiwi/path.py
+++ b/kiwi/path.py
@@ -98,16 +98,14 @@ class Path:
         return os.access(path, mode, **kwargs)
 
     @staticmethod
-    def create(path):
+    def create(path, mode=0o755):
         """
         Create path and all sub directories to target
 
         :param string path: path name
+        :param int mode: directory permissions, default 0o755
         """
-        if not os.path.exists(path):
-            Command.run(
-                ['mkdir', '-p', path]
-            )
+        os.makedirs(path, mode=mode, exist_ok=True)
 
     @staticmethod
     def wipe(path):

--- a/kiwi/path.py
+++ b/kiwi/path.py
@@ -106,6 +106,7 @@ class Path:
         :param string path: path name
         :param int mode: directory permissions, default 0o755
         """
+        log.debug('EXEC: Make directories: %s', path)
         os.makedirs(path, mode=mode, exist_ok=True)
 
     @staticmethod
@@ -115,6 +116,7 @@ class Path:
 
         :param string path: path name
         """
+        log.debug('EXEC: Attempt to wipe %s', path)
         try:
             shutil.rmtree(path)
         except FileNotFoundError:

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -136,7 +136,7 @@ class SystemSetup:
         os.chroot("/")
         payload_dst: str = os.path.join(self.root_dir, "tmp", defaults.DISK_SYNC_DIR)
         if os.path.exists(payload_dst):
-            shutil.rmtree(os.path.join(self.root_dir, "tmp", defaults.DISK_SYNC_DIR), ignore_errors=False)
+            shutil.rmtree(payload_dst, ignore_errors=False)
 
     def import_repositories_marked_as_imageinclude(self):
         """

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -106,9 +106,11 @@ class SystemSetup:
         self._import_custom_archives()
         self._import_cdroot_archive()
 
-    def script_exists(self, name):
         """
         Check if provided script base name exists in the image description
+    def file_or_directory_exists(self, name):
+        """
+        Check if provided target base name exists in the image description
         """
         return os.path.exists(os.path.join(self.description_dir, name))
 

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -17,6 +17,7 @@
 #
 import glob
 import os
+import shutil
 import logging
 import copy
 from collections import OrderedDict
@@ -106,9 +107,15 @@ class SystemSetup:
         self._import_custom_archives()
         self._import_cdroot_archive()
 
+    def import_payload(self):
         """
-        Check if provided script base name exists in the image description
-    def file_or_directory_exists(self, name):
+        Import payload content.
+        """
+        if self.file_or_directory_exists(defaults.DISK_SYNC_DIR):
+            log.info("Importing disk.sh working payload")
+            payload_dst: str = os.path.join(self.root_dir, "tmp", defaults.DISK_SYNC_DIR)
+            shutil.copytree(os.path.join(self.description_dir, defaults.DISK_SYNC_DIR), payload_dst)
+
     def file_or_directory_exists(self, target: str) -> bool:
         """
         Check if provided target base name exists in the image description
@@ -126,6 +133,10 @@ class SystemSetup:
                 'rm', '-rf', '.kconfig', defaults.image_metadata_directory
             ]
         )
+        os.chroot("/")
+        payload_dst: str = os.path.join(self.root_dir, "tmp", defaults.DISK_SYNC_DIR)
+        if os.path.exists(payload_dst):
+            shutil.rmtree(os.path.join(self.root_dir, "tmp", defaults.DISK_SYNC_DIR), ignore_errors=False)
 
     def import_repositories_marked_as_imageinclude(self):
         """

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -71,6 +71,7 @@ class SystemSetup:
         image archives, overlay files
     :param str root_dir: root directory path name
     """
+
     def __init__(self, xml_state, root_dir):
         self.arch = Defaults.get_platform_name()
         self.xml_state = xml_state

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -109,10 +109,11 @@ class SystemSetup:
         """
         Check if provided script base name exists in the image description
     def file_or_directory_exists(self, name):
+    def file_or_directory_exists(self, target: str) -> bool:
         """
         Check if provided target base name exists in the image description
         """
-        return os.path.exists(os.path.join(self.description_dir, name))
+        return os.path.exists(os.path.join(self.description_dir, target))
 
     def cleanup(self):
         """

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -1188,5 +1188,5 @@ class TestSystemSetup:
 
     @patch('os.path.exists')
     def test_script_exists(self, mock_path_exists):
-        assert self.setup.script_exists('some-script') == \
+        assert self.setup.file_or_directory_exists('some-script') == \
             mock_path_exists.return_value


### PR DESCRIPTION
Doing everything in `disk.sh` is not that perfect. For example, I would like to call, say, Ansible module locally. Or Ansible state. Or some Perl script. Or some binary in Go or Rust or C or whatever. I don't want to package it and install and then pinch. I want to just call it "as is".

This adds a value of keeping `disk.sh` merely a caller to more complex things, which can be setup without "scripting mess", say in declarative YAML etc.

This PR expects `payload` directory in the image description with whatever needs to be called on the target (in my case a set of rules and a binary modules for that) in order to maintain proper configuration management (for example). This content is then copied to `/tmp/payload` on the target image and then purged afterwards.