### PR TITLE
Fixes live ISOs

### DIFF
--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -241,6 +241,8 @@ class LiveImageBuilder:
         live_filesystem.sync_data(
             Defaults.get_exclude_list_for_root_data_sync()
         )
+        live_filesystem.umount()
+
         log.info('--> Creating squashfs container for root image')
         self.live_container_dir = mkdtemp(
             prefix='live-container.', dir=self.target_dir

--- a/kiwi/filesystem/base.py
+++ b/kiwi/filesystem/base.py
@@ -164,6 +164,15 @@ class FileSystemBase:
             exclude=exclude
         )
 
+    def umount(self):
+        """
+        Umounts the filesystem in case it is mounted, does nothing otherwise
+        """
+        if self.filesystem_mount:
+            log.info('umount %s instance', type(self).__name__)
+            self.filesystem_mount.umount()
+            self.filesystem_mount = None
+
     def _apply_attributes(self):
         """
         Apply filesystem attributes
@@ -187,6 +196,5 @@ class FileSystemBase:
                 )
 
     def __del__(self):
-        if self.filesystem_mount:
-            log.info('Cleaning up %s instance', type(self).__name__)
-            self.filesystem_mount.umount()
+        log.info('Cleaning up %s instance', type(self).__name__)
+        self.umount()

--- a/test/unit/filesystem/base_test.py
+++ b/test/unit/filesystem/base_test.py
@@ -71,7 +71,13 @@ class TestFileSystemBase:
         filesystem_mount.mount.assert_called_once_with([])
         assert self.fsbase.get_mountpoint() == 'tmpdir'
 
+    def test_umount(self):
+        mount = mock.Mock()
+        self.fsbase.filesystem_mount = mount
+        self.fsbase.umount()
+        mount.umount.assert_called_once_with()
+
     def test_destructor_valid_mountpoint(self):
         self.fsbase.filesystem_mount = mock.Mock()
         self.fsbase.__del__()
-        self.fsbase.filesystem_mount.umount.assert_called_once_with()
+        assert self.fsbase.filesystem_mount is None


### PR DESCRIPTION
This commit fixes iso images. Due to a change introduced in c7ed1cf
live ISOs were no longer booting as the rootfs.img filesystem was
copied to the squashfs container while being still mounted. Because of
that, at boot time, it refused to mount.

This commit adds umount method for the filesystem base class, so it
can be manually umounted before deleting the instance.

Fixes #1489
