### PR TITLE
Describe targets in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@
 #
 
 [tox]
+minversion = 3.5.0
 skip_missing_interpreters = True
 skipsdist = True
 envlist =
@@ -22,6 +23,9 @@ envlist =
 
 
 [testenv]
+description =
+    {unit_py3_6,unit_py3_7}: Unit Test run with basepython set to {basepython}
+    devel: Test KIWI
 whitelist_externals = *
 basepython =
     {check,devel,packagedoc,doc,doc_travis,doc_suse}: python3
@@ -76,8 +80,8 @@ commands =
         --cov-config .coveragerc {posargs}
 
 
-# Documentation build suitable for local review
 [testenv:doc]
+description = Documentation build suitable for local review
 skip_install = True
 usedevelop = True
 deps = {[testenv]deps}
@@ -87,8 +91,8 @@ commands =
     {[testenv:doc.man]commands}
 
 
-# Documentation build run suitable for doc deployment in package(rpm)
 [testenv:packagedoc]
+description = Documentation build run suitable for doc deployment in package(rpm)
 skip_install = True
 usedevelop = True
 deps = {[testenv]deps}
@@ -98,8 +102,8 @@ commands =
     {[testenv:doc.man]commands}
 
 
-# Documentation build suitable for doc deployment in travis env
 [testenv:doc_travis]
+description = Documentation build suitable for doc deployment in travis env
 skip_install = True
 usedevelop = True
 deps = {[testenv:doc]deps}
@@ -110,8 +114,8 @@ commands =
     bash -c 'touch ./build_travis/.nojekyll'
 
 
-# Documentation build suitable for SUSE documentation
 [testenv:doc_suse]
+description = Documentation build suitable for SUSE documentation
 skip_install = True
 usedevelop = True
 deps = {[testenv:doc]deps}
@@ -124,8 +128,8 @@ commands =
     bash -c 'cd build && daps -d DC-kiwi html'
 
 
-# Documentation build html result
 [testenv:doc.html]
+description = Documentation build html result
 skip_install = True
 deps = {[testenv:doc]deps}
 changedir=doc
@@ -133,8 +137,8 @@ commands =
     make html
 
 
-# Documentation build xml result
 [testenv:doc.xml]
+description = Documentation build xml result
 skip_install = True
 deps = {[testenv:doc]deps}
 changedir=doc
@@ -144,8 +148,8 @@ commands =
     mv build/xml build/restxml
 
 
-# Documentation build PDF result
 [testenv:doc.latexpdf]
+description = Documentation build PDF result
 skip_install = True
 deps = {[testenv:doc]deps}
 changedir=doc
@@ -153,8 +157,8 @@ commands =
     make latexpdf
 
 
-# Documentation build man pages
 [testenv:doc.man]
+description = Documentation build man pages
 skip_install = True
 deps = {[testenv:doc]deps}
 changedir=doc
@@ -162,8 +166,8 @@ commands =
     make man
 
 
-# Source code quality/integrity check
 [testenv:check]
+description = Source code quality/integrity check
 deps = {[testenv]deps}
 skip_install = True
 usedevelop = True


### PR DESCRIPTION
No related issue.

Changes proposed in this pull request:

* Make use of description to show them with "tox -av"
* Use comments as "description" lines
* Define minimal tox version

I think, the changes are minimal and non-destructive. :wink: With the above changes, you can run `tox` like this:

```
$ tox -av
using tox.ini: ... (pid 14991)
using tox-3.14.5 from /usr/lib/python3.6/site-packages/tox/__init__.py (pid 14991)
default environments:
check        -> Source code quality/integrity check
unit_py3_7   -> Unit Test run with basepython set to python3.7
unit_py3_6   -> Unit Test run with basepython set to python3.6
packagedoc   -> Documentation build run suitable for doc deployment in package(rpm)
devel        -> Test KIWI

additional environments:
doc          -> Documentation build suitable for local review
doc_travis   -> Documentation build suitable for doc deployment in travis env
doc_suse     -> Documentation build suitable for SUSE documentation
doc.html     -> Documentation build html result
doc.xml      -> Documentation build xml result
doc.latexpdf -> Documentation build PDF result
doc.man      -> Documentation build man pages
```

