### PR TITLE
Do not create a md5 checksum output file for archive images

### DIFF
--- a/kiwi/builder/archive.py
+++ b/kiwi/builder/archive.py
@@ -21,7 +21,6 @@ import logging
 from kiwi.defaults import Defaults
 from kiwi.archive.tar import ArchiveTar
 from kiwi.system.setup import SystemSetup
-from kiwi.utils.checksum import Checksum
 from kiwi.system.result import Result
 from kiwi.runtime_config import RuntimeConfig
 
@@ -52,7 +51,6 @@ class ArchiveBuilder:
             xml_state=xml_state, root_dir=self.root_dir
         )
         self.filename = self._target_file_for('tar.xz')
-        self.checksum = self._target_file_for('md5')
         self.xz_options = custom_args['xz_options'] if custom_args \
             and 'xz_options' in custom_args else None
 
@@ -87,9 +85,6 @@ class ArchiveBuilder:
                 self.root_dir, xz_options=self.xz_options,
                 exclude=Defaults.get_exclude_list_for_root_data_sync()
             )
-            checksum = Checksum(self.filename)
-            log.info('--> Creating archive checksum')
-            checksum.md5(self.checksum)
             self.result.verify_image_size(
                 self.runtime_config.get_max_size_constraint(),
                 self.filename
@@ -100,11 +95,6 @@ class ArchiveBuilder:
                 use_for_bundle=True,
                 compress=False,
                 shasum=True
-            )
-            self.result.add(
-                key='root_archive_md5',
-                filename=self.checksum,
-                use_for_bundle=False
             )
             self.result.add(
                 key='image_packages',

--- a/test/unit/builder/archive_test.py
+++ b/test/unit/builder/archive_test.py
@@ -50,12 +50,9 @@ class TestArchiveBuilder:
             archive.create()
 
     @patch('kiwi.builder.archive.ArchiveTar')
-    @patch('kiwi.builder.archive.Checksum')
     @patch('platform.machine')
-    def test_create(self, mock_machine, mock_checksum, mock_tar):
+    def test_create(self, mock_machine, mock_tar):
         mock_machine.return_value = 'x86_64'
-        checksum = mock.Mock()
-        mock_checksum.return_value = checksum
         archive = mock.Mock()
         mock_tar.return_value = archive
         self.archive.create()
@@ -66,12 +63,6 @@ class TestArchiveBuilder:
             'root_dir', exclude=[
                 'image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi'
             ], xz_options=None
-        )
-        mock_checksum.assert_called_once_with(
-            'target_dir/myimage.x86_64-1.2.3.tar.xz'
-        )
-        checksum.md5.assert_called_once_with(
-            'target_dir/myimage.x86_64-1.2.3.md5'
         )
         self.setup.export_package_verification.assert_called_once_with(
             'target_dir'


### PR DESCRIPTION
This commit removes the creation of the md5 file that includes a
checksum of the image binary for the `tbz` image type. Removing it
as this is the only image type that includes it as part of the result
and because the bundle procedure already creates a sha256 file out of
the results, so there is still the chance to produce validation
checksums.
