### PR TITLE
Include CentOS vendor in grub2 configuration

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -759,6 +759,8 @@ class Defaults:
         """
         efi_vendor_directories = [
             'EFI/fedora',
+            'EFI/redhat',
+            'EFI/centos',
             'EFI/opensuse'
         ]
         for efi_vendor_directory in efi_vendor_directories:


### PR DESCRIPTION
This commit ensures the vendor files for grubenv consider CentOS
vendor.

Related to https://github.com/OSInside/kiwi/pull/1508#issuecomment-656221457