### PR TITLE
Update Ubuntu and Debian image tests

### DIFF
--- a/build-tests/x86/debian/test-image-iso-oem-vmx/appliance.kiwi
+++ b/build-tests/x86/debian/test-image-iso-oem-vmx/appliance.kiwi
@@ -3,26 +3,26 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.2" name="LimeJeOS-Ubuntu-20.04">
+<image schemaversion="7.2" name="LimeJeOS-Debian-Buster">
     <description type="system">
-        <author>Marcus Schaefer</author>
-        <contact>ms@suse.com</contact>
-        <specification>vmx disk test build for Ubuntu</specification>
+        <author>Marcus Schäfer</author>
+        <contact>ms@suse.de</contact>
+        <specification>Debian Buster JeOS</specification>
     </description>
     <profiles>
-        <profile name="Live" description="Live image of Ubuntu 20.04"/>
-        <profile name="Virtual" description="Virtual image of Ubuntu 20.04"/>
-        <profile name="Disk" description="OEM image of Ubuntu 20.04"/>
+        <profile name="Live" description="Live image of Debian Buster"/>
+        <profile name="Virtual" description="Virtual image of Debian Buster"/>
+        <profile name="Disk" description="OEM image of Debian Buster"/>
     </profiles>
     <preferences>
-        <version>1.16.4</version>
+        <version>10.4</version>
         <packagemanager>apt-get</packagemanager>
-        <bootsplash-theme>sabily</bootsplash-theme>
-        <bootloader-theme>ubuntu-mate</bootloader-theme>
+        <bootsplash-theme>fade-in</bootsplash-theme>
+        <bootloader-theme>starfield</bootloader-theme>
+        <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
         <keytable>us</keytable>
-        <timezone>UTC</timezone>
-        <rpm-check-signatures>false</rpm-check-signatures>
+        <timezone>Europe/Berlin</timezone>
     </preferences>
     <preferences profiles="Live">
         <type image="iso" flags="overlay" hybridpersistent_filesystem="ext4" hybridpersistent="true" firmware="efi" kernelcmdline="console=ttyS0">
@@ -35,7 +35,7 @@
         </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" filesystem="ext4" initrd_system="dracut" installiso="true" firmware="efi" kernelcmdline="console=ttyS0">
+        <type image="oem" filesystem="ext4" initrd_system="dracut" firmware="efi" installiso="true" kernelcmdline="console=ttyS0">
             <bootloader name="grub2" console="serial gfxterm"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>
@@ -47,28 +47,30 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="apt-deb" alias="kiwi-next-generation" priority="1" repository_gpgcheck="false">
-        <source path="obs://Virtualization:Appliances:Staging/xUbuntu_20.04"/>
+    <repository type="apt-deb" distribution="buster" components="main contrib non-free" repository_gpgcheck="false">
+        <source path="obs://Debian:10/universe"/>
     </repository>
-    <repository type="apt-deb" alias="Ubuntu-Focal-Universe" distribution="focal" components="main multiverse restricted universe" repository_gpgcheck="false">
-        <source path="obs://Ubuntu:20.04/universe"/>
+    <repository type="apt-deb" distribution="buster" components="main contrib non-free" repository_gpgcheck="false">
+        <source path="obs://Debian:10/standard"/>
     </repository>
-    <repository type="apt-deb" alias="Ubuntu-Focal" distribution="focal" components="main multiverse restricted universe" repository_gpgcheck="false">
-        <source path="obs://Ubuntu:20.04/standard"/>
+    <repository type="apt-deb" repository_gpgcheck="false">
+        <source path="obs://Virtualization:Appliances:Builder/Debian_10"/>
     </repository>
     <packages type="image">
-        <package name="grub2-themes-ubuntu-mate"/>
-        <package name="plymouth-theme-sabily"/>
+        <package name="grub-theme-starfield"/>
+        <package name="plymouth-themes"/>
+        <package name="vim"/>
         <package name="plymouth"/>
         <package name="grub-pc-bin"/>
         <package name="grub2-common"/>
         <package name="grub-efi-amd64-bin"/>
-        <package name="linux-generic"/>
+        <package name="dracut"/>
+        <package name="xz-utils"/>
+        <package name="binutils"/>
+        <package name="linux-image-amd64"/>
         <package name="isolinux"/>
         <package name="syslinux"/>
         <package name="syslinux-common"/>
-        <package name="systemd"/>
-        <package name="dracut"/>
         <package name="init"/>
         <package name="gnupg"/>
         <package name="iproute2"/>
@@ -77,9 +79,7 @@
         <package name="ifupdown"/>
         <package name="isc-dhcp-client"/>
         <package name="netbase"/>
-        <package name="dbus"/>
-        <package name="btrfs-progs"/>
-        <package name="xz-utils"/>
+        <package name="bsdmainutils"/>
     </packages>
     <packages type="image" profiles="Live">
         <package name="dracut-kiwi-live"/>
@@ -89,7 +89,7 @@
         <package name="dracut-kiwi-oem-dump"/>
     </packages>
     <packages type="bootstrap">
-        <package name="mawk"/>
+        <!-- comptibility package for /usr/lib paths -->
         <package name="usrmerge"/>
     </packages>
 </image>

--- a/build-tests/x86/debian/test-image-iso-oem-vmx/config.sh
+++ b/build-tests/x86/debian/test-image-iso-oem-vmx/config.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#================
+# FILE          : config.sh
+#----------------
+# PROJECT       : OpenSuSE KIWI Image System
+# COPYRIGHT     : (c) 2006 SUSE LINUX Products GmbH. All rights reserved
+#               :
+# AUTHOR        : Marcus Schaefer <ms@suse.de>
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : configuration script for Debian based
+#               : operating systems
+#               :
+#               :
+# STATUS        : BETA
+#----------------
+#======================================
+# Functions...
+#--------------------------------------
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+#======================================
+# Greeting...
+#--------------------------------------
+echo "Configure image: [$kiwi_iname]..."
+
+#======================================
+# Activate services
+#--------------------------------------
+baseInsertService sshd
+
+#======================================
+# Setup default target, multi-user
+#--------------------------------------
+baseSetRunlevel 3

--- a/build-tests/x86/debian/test-image-iso-oem-vmx/root/etc/network/interfaces.d/lan0
+++ b/build-tests/x86/debian/test-image-iso-oem-vmx/root/etc/network/interfaces.d/lan0
@@ -1,0 +1,2 @@
+auto lan0
+iface lan0 inet dhcp

--- a/build-tests/x86/debian/test-image-iso-oem-vmx/root/etc/udev/rules.d/70-persistent-net.rules
+++ b/build-tests/x86/debian/test-image-iso-oem-vmx/root/etc/udev/rules.d/70-persistent-net.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="?*", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="?*", NAME="lan0"


### PR DESCRIPTION
This commit updates Ubuntu test to Focal distribution and adds an
additional Debian Buster image test.

Related to #1468
