### PR TITLE
Don't keep copy of grub2-install in the system

### DIFF
--- a/kiwi/bootloader/install/grub2.py
+++ b/kiwi/bootloader/install/grub2.py
@@ -297,7 +297,7 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
             )
             if os.path.exists(grub2_install_backup):
                 Command.run(
-                    ['cp', '-p', grub2_install_backup, grub2_install]
+                    ['mv', grub2_install_backup, grub2_install]
                 )
 
     def _get_grub2_install_tool_name(self, root_path):

--- a/test/unit/bootloader/install/grub2_test.py
+++ b/test/unit/bootloader/install/grub2_test.py
@@ -316,7 +316,7 @@ class TestBootLoaderInstallGrub2:
                 '/dev/some-device'
             ]),
             call([
-                'cp', '-p', 'tmp_root/usr/sbin/grub2-install.orig',
+                'mv', 'tmp_root/usr/sbin/grub2-install.orig',
                 'tmp_root/usr/sbin/grub2-install'
             ])
         ]


### PR DESCRIPTION
To prevent shim-install from calling grub2-install in uefi mode
kiwi temporary replaces the tool by a noop. This acts as a
workaround for an issue in shim-install. However the workaround
left a file copy of grub2-install in the system which should
not happen. This commit Fixes bsc#1173226 and Fixes #1490

