### PR TITLE
Use rsync in inplace transfer mode

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -223,6 +223,17 @@ class Defaults:
         )).lstrip(os.sep)
 
     @staticmethod
+    def get_sync_options():
+        """
+        Provides list of default data sync options
+
+        :return: list of rsync options
+
+        :rtype: list
+        """
+        return ['-a', '-H', '-X', '-A', '--one-file-system', '--inplace']
+
+    @staticmethod
     def get_exclude_list_for_root_data_sync():
         """
         Provides the list of files or folders that are created

--- a/kiwi/filesystem/base.py
+++ b/kiwi/filesystem/base.py
@@ -20,6 +20,7 @@ import logging
 import copy
 
 # project
+from kiwi.defaults import Defaults
 from kiwi.utils.sync import DataSync
 from kiwi.mount_manager import MountManager
 from kiwi.command import Command
@@ -160,8 +161,7 @@ class FileSystemBase:
             self.root_dir, self.filesystem_mount.mountpoint
         )
         data.sync_data(
-            options=['-a', '-H', '-X', '-A', '--one-file-system'],
-            exclude=exclude
+            exclude=exclude, options=Defaults.get_sync_options()
         )
 
     def umount(self):

--- a/kiwi/oci_tools/buildah.py
+++ b/kiwi/oci_tools/buildah.py
@@ -161,7 +161,7 @@ class OCIBuildah(OCIBase):
         self._sync_data(
             ''.join([root_dir, os.sep]), self.oci_root_dir,
             exclude_list=exclude_list,
-            options=['-a', '-H', '-X', '-A', '--delete']
+            options=Defaults.get_sync_options() + ['--delete']
         )
 
     def import_rootfs(self, root_dir, exclude_list=None):
@@ -173,7 +173,8 @@ class OCIBuildah(OCIBase):
         """
         self._sync_data(
             os.sep.join([self.oci_root_dir, '']), root_dir,
-            exclude_list=exclude_list, options=['-a', '-H', '-X', '-A']
+            exclude_list=exclude_list,
+            options=Defaults.get_sync_options()
         )
 
     def repack(self, oci_config):

--- a/kiwi/oci_tools/umoci.py
+++ b/kiwi/oci_tools/umoci.py
@@ -119,7 +119,7 @@ class OCIUmoci(OCIBase):
             ''.join([root_dir, os.sep]),
             os.sep.join([self.oci_root_dir, 'rootfs']),
             exclude_list=exclude_list,
-            options=['-a', '-H', '-X', '-A', '--delete']
+            options=Defaults.get_sync_options() + ['--delete']
         )
 
     def import_rootfs(self, root_dir, exclude_list=None):
@@ -132,7 +132,7 @@ class OCIUmoci(OCIBase):
         self._sync_data(
             os.sep.join([self.oci_root_dir, 'rootfs', '']),
             root_dir, exclude_list=exclude_list,
-            options=['-a', '-H', '-X', '-A']
+            options=Defaults.get_sync_options()
         )
 
     def repack(self, oci_config):

--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -20,6 +20,7 @@ import os
 import logging
 
 # project
+from kiwi.defaults import Defaults
 from kiwi.command import Command
 from kiwi.utils.sync import DataSync
 from kiwi.path import Path
@@ -156,7 +157,7 @@ class PackageManagerApt(PackageManagerBase):
                 bootstrap_dir + '/', self.root_dir
             )
             data.sync_data(
-                options=['-a', '-H', '-X', '-A'],
+                options=Defaults.get_sync_options(),
                 exclude=['proc', 'sys', 'dev']
             )
         except Exception as e:

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -337,8 +337,7 @@ class VolumeManagerBase(DeviceProvider):
                 self.mount_volumes()
             data = DataSync(self.root_dir, self.mountpoint)
             data.sync_data(
-                options=['-a', '-H', '-X', '-A', '--one-file-system'],
-                exclude=exclude
+                options=Defaults.get_sync_options(), exclude=exclude
             )
 
     def set_property_readonly_root(self):

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -320,8 +320,7 @@ class VolumeManagerBtrfs(VolumeManagerBase):
                 )
             data = DataSync(self.root_dir, sync_target)
             data.sync_data(
-                options=['-a', '-H', '-X', '-A', '--one-file-system'],
-                exclude=exclude
+                options=Defaults.get_sync_options(), exclude=exclude
             )
             if self.custom_args['quota_groups'] and \
                self.custom_args['root_is_snapshot']:

--- a/test/unit/filesystem/base_test.py
+++ b/test/unit/filesystem/base_test.py
@@ -60,7 +60,7 @@ class TestFileSystemBase:
         mock_sync.assert_called_once_with('root_dir', 'tmpdir')
         data_sync.sync_data.assert_called_once_with(
             exclude=['exclude_me'],
-            options=['-a', '-H', '-X', '-A', '--one-file-system']
+            options=['-a', '-H', '-X', '-A', '--one-file-system', '--inplace']
         )
         mock_mount.assert_called_once_with(
             device='/dev/loop0'

--- a/test/unit/oci_tools/buildah_test.py
+++ b/test/unit/oci_tools/buildah_test.py
@@ -66,7 +66,10 @@ class TestOCIBuildah:
         )
         sync.sync_data.assert_called_once_with(
             exclude=['/dev', '/proc'],
-            options=['-a', '-H', '-X', '-A', '--delete']
+            options=[
+                '-a', '-H', '-X', '-A', '--one-file-system',
+                '--inplace', '--delete'
+            ]
         )
 
     @patch('kiwi.oci_tools.base.DataSync')
@@ -80,7 +83,7 @@ class TestOCIBuildah:
         )
         sync.sync_data.assert_called_once_with(
             exclude=['/dev', '/proc'],
-            options=['-a', '-H', '-X', '-A']
+            options=['-a', '-H', '-X', '-A', '--one-file-system', '--inplace']
         )
 
     @patch('kiwi.oci_tools.umoci.Command.run')

--- a/test/unit/oci_tools/umoci_test.py
+++ b/test/unit/oci_tools/umoci_test.py
@@ -47,7 +47,10 @@ class TestOCIUmoci:
         )
         sync.sync_data.assert_called_once_with(
             exclude=['/dev', '/proc'],
-            options=['-a', '-H', '-X', '-A', '--delete']
+            options=[
+                '-a', '-H', '-X', '-A', '--one-file-system',
+                '--inplace', '--delete'
+            ]
         )
 
     @patch('kiwi.oci_tools.base.DataSync')
@@ -61,7 +64,7 @@ class TestOCIUmoci:
         )
         sync.sync_data.assert_called_once_with(
             exclude=['/dev', '/proc'],
-            options=['-a', '-H', '-X', '-A']
+            options=['-a', '-H', '-X', '-A', '--one-file-system', '--inplace']
         )
 
     @patch('kiwi.oci_tools.umoci.mkdtemp')

--- a/test/unit/package_manager/apt_test.py
+++ b/test/unit/package_manager/apt_test.py
@@ -99,8 +99,8 @@ class TestPackageManagerApt:
             'root-dir.debootstrap/', 'root-dir'
         )
         data.sync_data.assert_called_once_with(
-            exclude=['proc', 'sys', 'dev'],
-            options=['-a', '-H', '-X', '-A']
+            options=['-a', '-H', '-X', '-A', '--one-file-system', '--inplace'],
+            exclude=['proc', 'sys', 'dev']
         )
         assert mock_run.call_args_list == [
             call(
@@ -143,8 +143,8 @@ class TestPackageManagerApt:
             'root-dir.debootstrap/', 'root-dir'
         )
         data.sync_data.assert_called_once_with(
-            exclude=['proc', 'sys', 'dev'],
-            options=['-a', '-H', '-X', '-A']
+            options=['-a', '-H', '-X', '-A', '--one-file-system', '--inplace'],
+            exclude=['proc', 'sys', 'dev']
         )
         assert mock_run.call_args_list == [
             call(

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -224,7 +224,7 @@ class TestVolumeManagerBase:
         )
         data_sync.sync_data.assert_called_once_with(
             exclude=['exclude_me'],
-            options=['-a', '-H', '-X', '-A', '--one-file-system']
+            options=['-a', '-H', '-X', '-A', '--one-file-system', '--inplace']
         )
         assert self.volume_manager.get_mountpoint() == 'mountpoint'
 

--- a/test/unit/volume_manager/btrfs_test.py
+++ b/test/unit/volume_manager/btrfs_test.py
@@ -415,7 +415,7 @@ class TestVolumeManagerBtrfs:
         )
         sync.sync_data.assert_called_once_with(
             exclude=['exclude_me'],
-            options=['-a', '-H', '-X', '-A', '--one-file-system']
+            options=['-a', '-H', '-X', '-A', '--one-file-system', '--inplace']
         )
         assert m_open.call_args_list == [
             call('tmpdir/@/.snapshots/1/info.xml', 'w'),
@@ -474,7 +474,7 @@ class TestVolumeManagerBtrfs:
         )
         sync.sync_data.assert_called_once_with(
             exclude=['exclude_me'],
-            options=['-a', '-H', '-X', '-A', '--one-file-system']
+            options=['-a', '-H', '-X', '-A', '--one-file-system', '--inplace']
         )
         assert m_open.call_args_list == [
             call('tmpdir/@/.snapshots/1/info.xml', 'w'),
@@ -508,7 +508,7 @@ class TestVolumeManagerBtrfs:
         )
         sync.sync_data.assert_called_once_with(
             exclude=['exclude_me'],
-            options=['-a', '-H', '-X', '-A', '--one-file-system']
+            options=['-a', '-H', '-X', '-A', '--one-file-system', '--inplace']
         )
 
     @patch('kiwi.volume_manager.btrfs.Command.run')


### PR DESCRIPTION
Using the --inplace option in rsync helps to save space on
syncing the rootfs data and prevents e.g OBS workers from
running out of VM space when transfering root filesystem
data. Also using --inplace allows to keep hardlinks intact.
This is related to bsc#1096738


