### PR TITLE
Fixed grub setup in EFI/BOOT directory

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -803,8 +803,8 @@ class Defaults:
         :rtype: str
         """
         shim_vendor_patterns = [
-            '/boot/efi/EFI/*/shim.efi',
-            '/EFI/*/shim.efi'
+            '/boot/efi/EFI/*/shim*.efi',
+            '/EFI/*/shim*.efi'
         ]
         for shim_vendor_pattern in shim_vendor_patterns:
             for shim_file in glob.iglob(root_path + shim_vendor_pattern):


### PR DESCRIPTION
kiwi copied the same grub.cfg file as it exists in boot/grub2
to the efi path. This is wrong as the setup in the efi boot
directory is used to enable normal grub loading and not providing
the user grub configuration. In addition the changes here makes
sure that the early grub boot code is placed into the system
in any EFI case except for secure boot when shim-install is
present. If shim-install is present it also creates the early
grub boot setup such that kiwi doesn't have to do it.
This Fixes #1491 and Fixes bsc#1172908

