### PR TITLE
Fixed corrections in BootLoaderSpec grub config

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -293,6 +293,19 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 with open(config_file, 'w') as grub_config_file:
                     grub_config_file.write(grub_config)
 
+                loader_entries_pattern = os.sep.join(
+                    [self.root_mount.mountpoint, 'boot', 'entries', '*.conf']
+                )
+                for menu_entry_file in glob.iglob(loader_entries_pattern):
+                    with open(menu_entry_file) as grub_menu_entry_file:
+                        menu_entry = grub_menu_entry_file.read()
+                        menu_entry = menu_entry.replace(
+                            'root={0}'.format(boot_options.get('root_device')),
+                            self.root_reference
+                        )
+                    with open(menu_entry_file, 'w') as grub_menu_entry_file:
+                        grub_menu_entry_file.write(menu_entry)
+
                 if self.firmware.efi_mode():
                     vendor_grubenv_file = \
                         Defaults.get_vendor_grubenv(self.efi_mount.mountpoint)

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -422,11 +422,13 @@ class TestBootLoaderConfigGrub2:
     @patch('kiwi.bootloader.config.grub2.CommandCapabilities.check_version')
     @patch('kiwi.bootloader.config.grub2.Path.which')
     @patch('kiwi.defaults.Defaults.get_vendor_grubenv')
+    @patch('glob.iglob')
     def test_setup_disk_image_config(
-        self, mock_get_vendor_grubenv, mock_Path_which,
+        self, mock_iglob, mock_get_vendor_grubenv, mock_Path_which,
         mock_CommandCapabilities_check_version, mock_Command_run,
         mock_copy_grub_config_to_efi_path, mock_mount_system
     ):
+        mock_iglob.return_value = ['some_entry.conf']
         mock_CommandCapabilities_check_version.return_value = True
         mock_get_vendor_grubenv.return_value = 'grubenv'
         mock_Path_which.return_value = '/path/to/grub2-mkconfig'
@@ -461,6 +463,7 @@ class TestBootLoaderConfigGrub2:
                 'efi_mount_point', 'root_mount_point/boot/grub2/grub.cfg'
             )
             assert file_handle.write.call_args_list == [
+                call('root=overlay:UUID=ID'),
                 call('root=overlay:UUID=ID'),
                 call('root=overlay:UUID=ID')
             ]


### PR DESCRIPTION
Distributions like Fedora RawHide or CentOS8 applies to the
grub BootLoaderSpec as described here:

    https://www.freedesktop.org/wiki/Specifications/BootLoaderSpec

Part of the spec is that menu entries are handled in extra files
below /boot/loader/entries. Unfortunately the grub2-mkconfig code
has still no clue how to find the correct root device in special
environments like obs workers or in overlay systems. To fixup the
result of grub2-mkconfig there is code in kiwi which needs to be
adapted because the file that contains the wrong information is
now no longer grub.cfg but some /boot/loader/entries/*.conf file.
This commit solves the issue.

