### PR TITLE
Fixed scope of remove_hierarchy

### DIFF
--- a/kiwi/path.py
+++ b/kiwi/path.py
@@ -133,15 +133,20 @@ class Path:
         )
 
     @staticmethod
-    def remove_hierarchy(path):
+    def remove_hierarchy(root, path):
         """
         Recursively remove an empty path and its sub directories
-        ignore non empty or protected paths and leave them untouched
+        starting at a given root directory. Ignore non empty or
+        protected paths and leave them untouched
 
-        :param string path: path name
+        :param string root: start at directory
+        :param string path: path name below root
         """
         Command.run(
-            ['rmdir', '--ignore-fail-on-non-empty', path]
+            [
+                'rmdir', '--ignore-fail-on-non-empty',
+                os.path.normpath(os.sep.join([root, path]))
+            ]
         )
         path_elements = path.split(os.sep)
         protected_elements = [
@@ -153,12 +158,15 @@ class Path:
                 if path_elements[path_index - 1] in protected_elements:
                     log.warning(
                         'remove_hierarchy: path {0} is protected'.format(
-                            sub_path
+                            os.path.normpath(os.sep.join([root, sub_path]))
                         )
                     )
                     return
                 Command.run(
-                    ['rmdir', '--ignore-fail-on-non-empty', sub_path]
+                    [
+                        'rmdir', '--ignore-fail-on-non-empty',
+                        os.path.normpath(os.sep.join([root, sub_path]))
+                    ]
                 )
 
     @staticmethod

--- a/kiwi/system/root_bind.py
+++ b/kiwi/system/root_bind.py
@@ -284,7 +284,7 @@ class RootBind:
     def _cleanup_dir_stack(self):
         for location in reversed(self.dir_stack):
             try:
-                Path.remove_hierarchy(self.root_dir + location)
+                Path.remove_hierarchy(root=self.root_dir, path=location)
             except Exception as e:
                 log.warning(
                     'Failed to remove directory hierarchy {0}: {1}'.format(

--- a/test/unit/path_test.py
+++ b/test/unit/path_test.py
@@ -56,7 +56,7 @@ class TestPath:
 
     @patch('kiwi.command.Command.run')
     def test_remove_hierarchy(self, mock_command):
-        Path.remove_hierarchy('/my_root/tmp/foo/bar')
+        Path.remove_hierarchy('/my_root', '/tmp/foo/bar')
         with self._caplog.at_level(logging.WARNING):
             assert mock_command.call_args_list == [
                 call(
@@ -74,6 +74,11 @@ class TestPath:
             ]
             assert 'remove_hierarchy: path /my_root/tmp is protected' in \
                 self._caplog.text
+        mock_command.reset_mock()
+        Path.remove_hierarchy('/home/kiwi/my_root', 'foo')
+        mock_command.assert_called_once_with(
+            ['rmdir', '--ignore-fail-on-non-empty', '/home/kiwi/my_root/foo']
+        )
 
     def test_move_to_root(self):
         assert [

--- a/test/unit/system/root_bind_test.py
+++ b/test/unit/system/root_bind_test.py
@@ -161,7 +161,9 @@ class TestRootBind:
         with self._caplog.at_level(logging.WARNING):
             self.bind_root.cleanup()
             self.mount_manager.umount_lazy.assert_called_once_with()
-            mock_remove_hierarchy.assert_called_once_with('root-dir/mountpoint')
+            mock_remove_hierarchy.assert_called_once_with(
+                root='root-dir', path='/mountpoint'
+            )
             assert mock_command.call_args_list == [
                 call(['rm', '-f', 'root-dir/etc/sysconfig/proxy']),
                 call(


### PR DESCRIPTION
The remove_hierarchy method walked through the entire path
it was given. That included the root path which is beyond
its scope. This Fixes #1515

