### PR TITLE
Fixed code logic in resize_filesystem method

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-filesystem-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-filesystem-lib.sh
@@ -30,7 +30,7 @@ function resize_filesystem {
         return
     ;;
     esac
-    if _is_ramdisk_device "${device}"; then
+    if ! _is_ramdisk_device "${device}"; then
         check_filesystem "${device}"
     fi
     info "Resizing ${fstype} filesystem on ${device}..."
@@ -104,9 +104,5 @@ function probe_filesystem {
 # Methods considered private
 #--------------------------------------
 function _is_ramdisk_device {
-    local device=$1
-    if echo "${device}" | grep -qi "/dev/ram";then
-        return 1
-    fi
-    return 0
+    echo "$1" | grep -qi "/dev/ram"
 }


### PR DESCRIPTION
resize_filesystem runs fs-check on the filesytem prior to
resize. This check however should not be done if the filesystem
got deployed on a ramdisk. For that purpose the _is_ramdisk_device
method exists. The logic in the method as well as the call
were wrong. This in the end lead to a correct logic but is
completely confusing. This commit fixes and simplifies the
_is_ramdisk_device method and corrects the caller logic

