### PR TITLE
Skip filesystem check for XFS prior xfs_grow

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-filesystem-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-filesystem-lib.sh
@@ -67,11 +67,10 @@ function check_filesystem {
         check_fs_return_ok="test \$? -eq 0"
     ;;
     xfs)
-        # xfs_repair -n (no modify mode) will return a status of 1 if
-        # filesystem corruption was detected and 0 if no filesystem
-        # corruption was detected.
-        check_fs="xfs_repair -n ${device}"
-        check_fs_return_ok="test \$? -eq 0"
+        # xfs_repair can be used to check the filesystem. However
+        # for subsequent xfs_growfs no check is needed. Thus for
+        # xfs we skip the checking
+        return
     ;;
     *)
         # don't know how to check this filesystem


### PR DESCRIPTION
running xfs_repair check isn't strictly necessary before resizing,
and in some cases it may even prevent resizing by giving an error
that would be cleared through mounting the fs (e.g. when the fs
wasn't cleanly umounted, and thus letting xfs recover and replay
its journal). Given that xfs can only grow online (while being mounted),
this is sufficient to ensure that the fs is in a state where it
can be resized. This is related to bsc#1174009


