### PR TITLE
Fixed legacy custom kiwi initrd based image builds

### DIFF
--- a/build-tests/x86/suse/test-image-oem-legacy/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-oem-legacy/appliance.kiwi
@@ -63,6 +63,7 @@
         <package name="dracut-kiwi-oem-dump"/>
     </packages>
     <packages type="bootstrap">
+        <package name="gawk"/>
         <package name="udev"/>
         <package name="filesystem"/>
         <package name="glibc-locale"/>

--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -542,8 +542,6 @@ class BootLoaderConfigBase:
         self.proc_mount.bind_mount()
 
     def _get_root_cmdline_parameter(self, uuid):
-        firmware = self.xml_state.build_type.get_firmware()
-        initrd_system = self.xml_state.get_initrd_system()
         cmdline = self.xml_state.build_type.get_kernelcmdline()
         if cmdline and 'root=' in cmdline:
             log.info(
@@ -553,28 +551,14 @@ class BootLoaderConfigBase:
             if root_search:
                 return root_search.group(1)
 
-        want_root_cmdline_parameter = False
-        if firmware and 'ec2' in firmware:
-            # EC2 requires to specifiy the root device in the bootloader
-            # configuration. This is because the used pvgrub or hvmloader
-            # reads this information and passes it to the guest configuration
-            # which has an impact on the devices attached to the guest.
-            want_root_cmdline_parameter = True
-
-        if initrd_system == 'dracut':
-            # When using a dracut initrd we have to specify the location
-            # of the root device
-            want_root_cmdline_parameter = True
-
-        if want_root_cmdline_parameter:
-            if uuid and self.xml_state.build_type.get_overlayroot():
-                return 'root=overlay:UUID={0}'.format(uuid)
-            elif uuid:
-                return 'root=UUID={0} rw'.format(uuid)
-            else:
-                log.warning(
-                    'root=UUID=<uuid> setup requested, but uuid is not provided'
-                )
+        if uuid and self.xml_state.build_type.get_overlayroot():
+            return 'root=overlay:UUID={0}'.format(uuid)
+        elif uuid:
+            return 'root=UUID={0} rw'.format(uuid)
+        else:
+            log.warning(
+                'root=UUID=<uuid> setup requested, but uuid is not provided'
+            )
 
     def __del__(self):
         log.info('Cleaning up %s instance', type(self).__name__)

--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -644,16 +644,6 @@ function baseStripInitrd {
     for path in /sbin /usr/sbin /usr/bin /bin;do
         baseStripTools "${path}" "${tools}"
     done
-    #==========================================
-    # remove unused libs
-    #------------------------------------------
-    baseStripUnusedLibs "${kiwi_strip_libs}"
-    #==========================================
-    # remove package manager meta data
-    #------------------------------------------
-    for p in dpkg rpm yum;do
-        rm -rf "/var/lib/$p"
-    done
 }
 
 #======================================

--- a/kiwi/config/strip.xml
+++ b/kiwi/config/strip.xml
@@ -324,6 +324,7 @@
     no reference except for the ones listed here
     -->
     <strip type="libs">
+        <file name="libpam"/>
         <file name="libfontenc"/>
         <file name="libfreetype"/>
         <file name="libgcc_s"/>


### PR DESCRIPTION
This patch is two fold:
    
* Image builds that uses the kiwi initrd system did not apply
   the grub config file fixes because the root= parameter is
   an optional information when using a kiwi initrd. However
   this information is required to apply the grub config file
   fixes. Therefore this patch simplifies the kernel commandline
   processing such that it is the same for dracut and custom
   kiwi initrd based systems. This means root= is passed in
   any case.
    
* The other part of the patch disables the method that strips
   unused libraries from the custom kiwi initrd. It has turned
   out that is safes us almost nothing but could causes corrupted
   initrds missing important libraries e.g libpam which is linked
   against udev and other tools. Therefore libpam is also added
   to the protected strip list

