### PR TITLE
Make use of POSIX locale in Arch Linux integration tests

### DIFF
--- a/build-tests/x86/archlinux/test-image-iso-oem-vmx-kis/appliance.kiwi
+++ b/build-tests/x86/archlinux/test-image-iso-oem-vmx-kis/appliance.kiwi
@@ -25,7 +25,7 @@
     <preferences>
         <version>1.0.0</version>
         <packagemanager>pacman</packagemanager>
-        <locale>en_US</locale>
+        <locale>POSIX</locale>
         <keytable>us</keytable>
         <timezone>UTC</timezone>
         <rpm-check-signatures>false</rpm-check-signatures>

--- a/build-tests/x86/archlinux/test-image-iso-oem-vmx-kis/config.sh
+++ b/build-tests/x86/archlinux/test-image-iso-oem-vmx-kis/config.sh
@@ -31,6 +31,8 @@ baseInsertService systemd-resolved
 sed -ie '0,/#Server/s/#Server/Server/' /etc/pacman.d/mirrorlist
 
 #======================================
-# Set system locale
+# Generate system locale and configure it
 #--------------------------------------
-echo LANG=en_US.UTF-8 > /etc/locale.conf
+sed -ie '0,/#en_US.UTF-8/s/#en_US.UTF-8/en_US.UTF-8/' /etc/locale.gen
+locale-gen
+echo "LANG=en_US.UTF-8" > /etc/locale.conf


### PR DESCRIPTION
Current Arch Linux (August 2020) has no other locale than POSIX or
C enabled on the system by default. In fact, to enable further locales
in Arch it is required to uncomment the desired ones in `/etc/locale.gen`
and then execute the tool `locale-gen`, after that the selected locales
are eligible for the common system adminstration tools such as
`localectl`.

In KIWI the locale setting happens before running `config.sh` so there
aren't changes to generate any custom locale before applying the value
configured in the description XML file.
