### PR TITLE
Fix target setup on grub install

### DIFF
--- a/kiwi/bootloader/install/grub2.py
+++ b/kiwi/bootloader/install/grub2.py
@@ -129,12 +129,16 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
             self.install_arguments.append('--removable')
 
         if Defaults.is_x86_arch(self.arch):
-            self.target = 'i386-pc'
+            if self.firmware and self.firmware.efi_mode():
+                self.target = 'x86_64-efi'
+            else:
+                self.target = 'i386-pc'
             self.install_device = self.device
             self.modules = ' '.join(
                 Defaults.get_grub_bios_modules(multiboot=True)
             )
             self.install_arguments.append('--skip-fs-probe')
+
         elif self.arch.startswith('ppc64'):
             if not self.custom_args or 'prep_device' not in self.custom_args:
                 raise KiwiBootLoaderGrubInstallError(

--- a/test/unit/bootloader/install/grub2_test.py
+++ b/test/unit/bootloader/install/grub2_test.py
@@ -279,7 +279,7 @@ class TestBootLoaderInstallGrub2:
         mock_exists.return_value = True
         mock_glob.return_value = ['tmp_root/boot/grub2/grubenv']
         mock_grub_path.return_value = \
-            self.root_mount.mountpoint + '/usr/lib/grub2/i386-pc'
+            self.root_mount.mountpoint + '/usr/lib/grub2/x86_64-efi'
         self.firmware.efi_mode.return_value = 'uefi'
         self.boot_mount.device = self.root_mount.device
 
@@ -296,9 +296,9 @@ class TestBootLoaderInstallGrub2:
         assert mock_command.call_args_list == [
             call([
                 'chroot', 'tmp_root', 'grub2-install', '--skip-fs-probe',
-                '--directory', '/usr/lib/grub2/i386-pc',
+                '--directory', '/usr/lib/grub2/x86_64-efi',
                 '--boot-directory', '/boot',
-                '--target', 'i386-pc',
+                '--target', 'x86_64-efi',
                 '--modules', ' '.join(
                     Defaults.get_grub_bios_modules(multiboot=True)
                 ),
@@ -340,7 +340,7 @@ class TestBootLoaderInstallGrub2:
         mock_exists.return_value = True
         mock_glob.return_value = ['tmp_root/boot/grub2/grubenv']
         mock_grub_path.return_value = \
-            self.root_mount.mountpoint + '/usr/lib/grub2/i386-pc'
+            self.root_mount.mountpoint + '/usr/lib/grub2/x86_64-efi'
         self.firmware.efi_mode.return_value = 'uefi'
         self.boot_mount.device = self.root_mount.device
 
@@ -357,9 +357,9 @@ class TestBootLoaderInstallGrub2:
         assert mock_command.call_args_list == [
             call([
                 'chroot', 'tmp_root', 'grub2-install', '--skip-fs-probe',
-                '--directory', '/usr/lib/grub2/i386-pc',
+                '--directory', '/usr/lib/grub2/x86_64-efi',
                 '--boot-directory', '/boot',
-                '--target', 'i386-pc',
+                '--target', 'x86_64-efi',
                 '--modules', ' '.join(
                     Defaults.get_grub_bios_modules(multiboot=True)
                 ),


### PR DESCRIPTION
The parameter --target in a grub install call specifies the
target platform. For the EFI target the setting was wrong.
Strange enough this did not cause problems on some distros
and was therefore not seen until now. This Fixes #1547

