### PR TITLE
Make oem image use dracut by default

### DIFF
--- a/build-tests/arm/suse/test-image-rpi-oem/appliance.kiwi
+++ b/build-tests/arm/suse/test-image-rpi-oem/appliance.kiwi
@@ -15,7 +15,7 @@
         <keytable>us</keytable>
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
-        <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 swiotlb=512 cma=64M console=ttyS0,115200n8 console=tty" bootpartition="false" devicepersistency="by-label" btrfs_root_is_snapshot="true" efipartsize="16" editbootinstall="editbootinstall_rpi.sh">
+        <type image="oem" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 swiotlb=512 cma=64M console=ttyS0,115200n8 console=tty" bootpartition="false" devicepersistency="by-label" btrfs_root_is_snapshot="true" efipartsize="16" editbootinstall="editbootinstall_rpi.sh">
             <bootloader name="grub2"/>
             <systemdisk name="RaspberryPi">
                 <volume name="home"/>

--- a/build-tests/ppc/sle15/test-image-vmx-oem/appliance.kiwi
+++ b/build-tests/ppc/sle15/test-image-vmx-oem/appliance.kiwi
@@ -28,12 +28,12 @@
         </type>
     </preferences>
     <preferences profiles="PhysicalBSZ_4096">
-        <type image="oem" filesystem="ext4" initrd_system="dracut" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install" target_blocksize="4096">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install" target_blocksize="4096">
             <bootloader name="grub2" console="serial"/>
         </type>
     </preferences>
     <preferences profiles="PhysicalBSZ_512">
-        <type image="oem" filesystem="ext4" initrd_system="dracut" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install">
             <bootloader name="grub2" console="serial"/>
         </type>
     </preferences>

--- a/build-tests/ppc/suse/test-image-oem/appliance.kiwi
+++ b/build-tests/ppc/suse/test-image-oem/appliance.kiwi
@@ -24,12 +24,12 @@
         <bootloader-theme>openSUSE</bootloader-theme>
     </preferences>
     <preferences profiles="PhysicalBSZ_4096">
-        <type image="oem" filesystem="ext4" initrd_system="dracut" kernelcmdline="console=ttyS0 splash" firmware="ofw" installiso="true" installboot="install" target_blocksize="4096">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0 splash" firmware="ofw" installiso="true" installboot="install" target_blocksize="4096">
             <bootloader name="grub2" console="serial"/>
         </type>
     </preferences>
     <preferences profiles="PhysicalBSZ_512">
-        <type image="oem" filesystem="ext4" initrd_system="dracut" kernelcmdline="console=ttyS0 splash" firmware="ofw" installiso="true" installboot="install">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0 splash" firmware="ofw" installiso="true" installboot="install">
             <bootloader name="grub2" console="serial"/>
         </type>
     </preferences>

--- a/build-tests/s390/sle15/test-image-vmx-oem/appliance.kiwi
+++ b/build-tests/s390/sle15/test-image-vmx-oem/appliance.kiwi
@@ -27,7 +27,7 @@
         </type>
     </preferences>
     <preferences profiles="PhysicalBSZ_4096">
-        <type image="oem" filesystem="ext4" initrd_system="dracut" kernelcmdline="console=ttyS0  cio_ignore=all,!ipldev,!condev" target_blocksize="4096">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0  cio_ignore=all,!ipldev,!condev" target_blocksize="4096">
             <bootloader name="grub2_s390x_emu" console="serial" targettype="CDL"/>
             <systemdisk>
                 <volume name="home"/>

--- a/build-tests/s390/suse/test-image-oem/appliance.kiwi
+++ b/build-tests/s390/suse/test-image-oem/appliance.kiwi
@@ -14,7 +14,7 @@
         <locale>en_US</locale>
         <keytable>us</keytable>
         <timezone>Europe/Berlin</timezone>
-        <type image="oem" filesystem="xfs" initrd_system="dracut" kernelcmdline="cio_ignore=all,!ipldev,!condev">
+        <type image="oem" filesystem="xfs" kernelcmdline="cio_ignore=all,!ipldev,!condev">
             <bootloader name="grub2_s390x_emu" console="serial" targettype="FBA"/>
             <systemdisk>
                 <volume name="home"/>

--- a/build-tests/x86/archlinux/test-image-iso-oem-vmx-kis/appliance.kiwi
+++ b/build-tests/x86/archlinux/test-image-iso-oem-vmx-kis/appliance.kiwi
@@ -37,7 +37,7 @@
         <type image="vmx" primary="true" filesystem="ext4" bootloader="grub2" firmware="efi"/>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" initrd_system="dracut" filesystem="ext4" bootloader="grub2" installiso="true"/>
+        <type image="oem" filesystem="ext4" bootloader="grub2" installiso="true"/>
     </preferences>
     <preferences profiles="KIS">
         <type image="kis" filesystem="ext4"/>

--- a/build-tests/x86/centos/test-image-iso-oem-vmx-v7/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-iso-oem-vmx-v7/appliance.kiwi
@@ -34,7 +34,7 @@
         </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" initrd_system="dracut" filesystem="ext4" installiso="true" firmware="uefi" kernelcmdline="console=ttyS0">
+        <type image="oem" filesystem="ext4" installiso="true" firmware="uefi" kernelcmdline="console=ttyS0">
             <bootloader name="grub2" console="serial gfxterm"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>

--- a/build-tests/x86/centos/test-image-iso-oem-vmx-v8/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-iso-oem-vmx-v8/appliance.kiwi
@@ -34,7 +34,7 @@
         </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" initrd_system="dracut" filesystem="ext4" installiso="true" firmware="uefi" kernelcmdline="console=ttyS0">
+        <type image="oem" filesystem="ext4" installiso="true" firmware="uefi" kernelcmdline="console=ttyS0">
             <bootloader name="grub2" console="serial gfxterm"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>

--- a/build-tests/x86/debian/test-image-iso-oem-vmx/appliance.kiwi
+++ b/build-tests/x86/debian/test-image-iso-oem-vmx/appliance.kiwi
@@ -35,7 +35,7 @@
         </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" filesystem="ext4" initrd_system="dracut" firmware="efi" installiso="true" kernelcmdline="console=ttyS0">
+        <type image="oem" filesystem="ext4" firmware="efi" installiso="true" kernelcmdline="console=ttyS0">
             <bootloader name="grub2" console="serial gfxterm"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>

--- a/build-tests/x86/fedora/test-image-iso-oem-vmx/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-iso-oem-vmx/appliance.kiwi
@@ -35,7 +35,7 @@
         </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" initrd_system="dracut" filesystem="ext4" installiso="true" firmware="uefi" kernelcmdline="console=ttyS0">
+        <type image="oem" filesystem="ext4" installiso="true" firmware="uefi" kernelcmdline="console=ttyS0">
             <bootloader name="grub2" console="serial gfxterm"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>

--- a/build-tests/x86/suse/test-image-custom-partitions/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-custom-partitions/appliance.kiwi
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext4" initrd_system="dracut" firmware="uefi" spare_part="500M" editbootconfig="custom_partitions_create.sh" editbootinstall="custom_partitions_setup.sh" installiso="true" bootloader="grub2">
+        <type image="oem" filesystem="ext4" firmware="uefi" spare_part="500M" editbootconfig="custom_partitions_create.sh" editbootinstall="custom_partitions_setup.sh" installiso="true" bootloader="grub2">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>512</oem-swapsize>

--- a/build-tests/x86/suse/test-image-oem/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-oem/appliance.kiwi
@@ -16,7 +16,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" initrd_system="dracut" kernelcmdline="console=ttyS0 splash" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true" installboot="install">
+        <type image="oem" filesystem="btrfs" kernelcmdline="console=ttyS0 splash" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true" installboot="install">
             <bootloader name="grub2" console="serial"/>
             <oemconfig>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/suse/test-image-orthos-oem/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-orthos-oem/appliance.kiwi
@@ -13,7 +13,7 @@
         <keytable>us</keytable>
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
-        <type image="oem" initrd_system="dracut" filesystem="btrfs" kernelcmdline="console=ttyS0,115200" firmware="efi" installpxe="true">
+        <type image="oem" filesystem="btrfs" kernelcmdline="console=ttyS0,115200" firmware="efi" installpxe="true">
             <bootloader name="grub2" console="serial"/>
             <oemconfig>
                 <oem-skip-verify>true</oem-skip-verify>

--- a/build-tests/x86/ubuntu/test-image-iso-oem-vmx/appliance.kiwi
+++ b/build-tests/x86/ubuntu/test-image-iso-oem-vmx/appliance.kiwi
@@ -35,7 +35,7 @@
         </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" filesystem="ext4" initrd_system="dracut" installiso="true" firmware="efi" kernelcmdline="console=ttyS0">
+        <type image="oem" filesystem="ext4" installiso="true" firmware="efi" kernelcmdline="console=ttyS0">
             <bootloader name="grub2" console="serial gfxterm"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>

--- a/kiwi.yml
+++ b/kiwi.yml
@@ -84,6 +84,9 @@
 #      # verify for legacy kiwi boot images that they exist on the host
 #      - check_boot_description_exists
 
+#      # verify if kiwi initrd_system was set if a boot attribute exists
+#      - check_initrd_selection_required
+
 #      # verify for legacy kiwi boot images that the same kernel is used
 #      - check_consistent_kernel_in_boot_and_system_image
 

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -316,6 +316,37 @@ class RuntimeChecker:
                     )
                 )
 
+    def check_initrd_selection_required(self):
+        """
+        If the boot attribute is used without selecting kiwi
+        as the initrd_system, the setting of the boot attribute
+        will not have any effect. We assume that configurations
+        which explicitly specify the boot attribute wants to use
+        the custom kiwi initrd system and not dracut.
+        """
+        message_kiwi_initrd_system_not_selected = dedent('''\n
+            Missing initrd_system selection for boot attribute
+
+            The selected boot="'{0}'" boot description indicates
+            the custom kiwi initrd system should be used instead
+            of dracut. If this is correct please explicitly request
+            the kiwi initrd system as follows:
+
+            <type initrd_system="kiwi"/>
+
+            If this is not want you want and dracut should be used
+            as initrd system, please delete the boot attribute
+            as it is obsolete in this case.
+        ''')
+        initrd_system = self.xml_state.get_initrd_system()
+        boot_image_reference = self.xml_state.build_type.get_boot()
+        if initrd_system != 'kiwi' and boot_image_reference:
+            raise KiwiRuntimeError(
+                message_kiwi_initrd_system_not_selected.format(
+                    boot_image_reference
+                )
+            )
+
     def check_boot_description_exists(self):
         """
         If a kiwi initrd is used, a lookup to the specified boot

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -73,6 +73,7 @@ class CliTask:
         self.checks_before_command_args = {
             'check_minimal_required_preferences': [],
             'check_efi_mode_for_disk_overlay_correctly_setup': [],
+            'check_initrd_selection_required': [],
             'check_boot_description_exists': [],
             'check_consistent_kernel_in_boot_and_system_image': [],
             'check_container_tool_chain_installed': [],

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -140,9 +140,12 @@ class XMLState:
         if self.get_build_type_name() in ['vmx', 'iso', 'kis']:
             # vmx, iso and kis image types always use dracut as initrd system
             initrd_system = 'dracut'
-        elif self.get_build_type_name() in ['oem', 'pxe']:
-            # pxe and oem image types default to kiwi if unset
+        elif self.get_build_type_name() == 'pxe':
+            # pxe image type defaults to kiwi if unset
             initrd_system = self.build_type.get_initrd_system() or 'kiwi'
+        elif self.get_build_type_name() == 'oem':
+            # oem image type defaults to dracut if unset
+            initrd_system = self.build_type.get_initrd_system() or 'dracut'
         else:
             initrd_system = self.build_type.get_initrd_system()
         return initrd_system

--- a/test/data/example_arm_disk_size_config.xml
+++ b/test/data/example_arm_disk_size_config.xml
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" spare_part="42M"/>
+        <type image="oem" filesystem="btrfs" spare_part="42M"/>
     </preferences>
     <repository>
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_btrfs_config.xml
+++ b/test/data/example_btrfs_config.xml
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" kernelcmdline="splash" firmware="efi">
+        <type image="oem" filesystem="btrfs" installiso="true" kernelcmdline="splash" firmware="efi">
             <systemdisk/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>

--- a/test/data/example_disk_config.xml
+++ b/test/data/example_disk_config.xml
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" kernelcmdline="splash" firmware="efi" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true">
+        <type image="oem" filesystem="btrfs" initrd_system="kiwi" boot="oemboot/example-distribution" installiso="true" kernelcmdline="splash" firmware="efi" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true">
             <oemconfig>
                 <oem-multipath-scan>false</oem-multipath-scan>
                 <oem-swap>true</oem-swap>

--- a/test/data/example_disk_size_oem_volume_config.xml
+++ b/test/data/example_disk_size_oem_volume_config.xml
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext3" boot="oemboot/suse-13.2" kernelcmdline="splash" firmware="efi">
+        <type image="oem" filesystem="ext3" kernelcmdline="splash" firmware="efi">
             <systemdisk>
                 <volume name="usr/lib" size="1G"/>
                 <volume name="usr/bin" size="5"/>

--- a/test/data/example_dot_profile_config.xml
+++ b/test/data/example_dot_profile_config.xml
@@ -19,7 +19,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" primary="true" filesystem="ext3" boot="oemboot/suse-13.2" installiso="true" kernelcmdline="splash" firmware="efi" ramonly="true" xen_server="true">
+        <type image="oem" primary="true" filesystem="ext3" installiso="true" kernelcmdline="splash" firmware="efi" ramonly="true" xen_server="true">
             <systemdisk>
                 <volume name="usr/lib" size="1G"/>
                 <volume name="@root" freespace="500M"/>

--- a/test/data/example_lvm_default_config.xml
+++ b/test/data/example_lvm_default_config.xml
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext3" boot="oemboot/suse-13.2" installiso="true" kernelcmdline="splash" firmware="efi">
+        <type image="oem" filesystem="ext3" installiso="true" kernelcmdline="splash" firmware="efi">
             <systemdisk>
                 <volume name="usr/lib" size="1G" label="library"/>
                 <volume name="@root" freespace="500M"/>

--- a/test/data/example_lvm_no_root_config.xml
+++ b/test/data/example_lvm_no_root_config.xml
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext3" boot="oemboot/suse-13.2" installiso="true" kernelcmdline="splash" firmware="efi">
+        <type image="oem" filesystem="ext3" installiso="true" kernelcmdline="splash" firmware="efi">
             <systemdisk/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>

--- a/test/data/example_lvm_no_root_full_usr_config.xml
+++ b/test/data/example_lvm_no_root_full_usr_config.xml
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext3" boot="oemboot/suse-13.2" installiso="true" kernelcmdline="splash" firmware="efi">
+        <type image="oem" filesystem="ext3" installiso="true" kernelcmdline="splash" firmware="efi">
             <systemdisk>
                 <volume name="usr" size="all"/>
             </systemdisk>

--- a/test/data/example_lvm_preferred_config.xml
+++ b/test/data/example_lvm_preferred_config.xml
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" kernelcmdline="splash" firmware="efi">
+        <type image="oem" filesystem="btrfs" installiso="true" kernelcmdline="splash" firmware="efi">
             <systemdisk preferlvm="true"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>

--- a/test/data/example_no_image_packages_config.xml
+++ b/test/data/example_no_image_packages_config.xml
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" kernelcmdline="splash" firmware="efi" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true"/>
+        <type image="oem" filesystem="btrfs" installiso="true" kernelcmdline="splash" firmware="efi" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true"/>
     </preferences>
     <repository>
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_ppc_disk_size_config.xml
+++ b/test/data/example_ppc_disk_size_config.xml
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" firmware="ofw" rootfs_label="MYLABEL"/>
+        <type image="oem" filesystem="btrfs" firmware="ofw" rootfs_label="MYLABEL"/>
     </preferences>
     <repository>
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_pxe_config.xml
+++ b/test/data/example_pxe_config.xml
@@ -18,7 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="pxe" filesystem="squashfs" boot="netboot/suse-13.2"/>
+        <type image="pxe" filesystem="squashfs" boot="netboot/..."/>
     </preferences>
     <repository>
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_runtime_checker_boot_desc_not_found.xml
+++ b/test/data/example_runtime_checker_boot_desc_not_found.xml
@@ -16,7 +16,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" initrd_system="kiwi" filesystem="ext3" boot="oemboot/foo"/>
+        <type image="oem" initrd_system="kiwi" filesystem="ext3" boot="oemboot/..."/>
     </preferences>
     <repository>
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_runtime_checker_no_initrd_system_reference.xml
+++ b/test/data/example_runtime_checker_no_initrd_system_reference.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.2" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
-        <specification>
-            openSUSE 13.2 JeOS, is a small text based image
-        </specification>
+        <specification>JeOS</specification>
     </description>
     <preferences>
-        <version>1.13.2</version>
+        <version>1.1.0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_US</locale>
         <keytable>us.map.gz</keytable>
@@ -18,13 +16,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" installiso="true" kernelcmdline="splash" firmware="efi">
-            <oemconfig>
-                <oem-inplace-recovery>true</oem-inplace-recovery>
-                <oem-recovery-part-size>200</oem-recovery-part-size>
-                <oem-swap>true</oem-swap>
-            </oemconfig>
-        </type>
+        <type image="oem" boot="oemboot/example-distribution" filesystem="ext3"/>
     </preferences>
     <repository>
         <source path="obs://13.2/repo/oss"/>

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -181,6 +181,15 @@ class TestRuntimeChecker:
         with raises(KiwiRuntimeError):
             runtime_checker.check_consistent_kernel_in_boot_and_system_image()
 
+    def test_check_initrd_selection_required(self):
+        description = XMLDescription(
+            '../data/example_runtime_checker_no_initrd_system_reference.xml'
+        )
+        xml_state = XMLState(description.load())
+        runtime_checker = RuntimeChecker(xml_state)
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_initrd_selection_required()
+
     def test_check_boot_description_exists_no_boot_ref(self):
         description = XMLDescription(
             '../data/example_runtime_checker_no_boot_reference.xml'

--- a/test/unit/system/profile_test.py
+++ b/test/unit/system/profile_test.py
@@ -86,7 +86,7 @@ class TestProfile:
             'kiwi_oemvmcp_parmfile': None,
             'kiwi_profiles': '',
             'kiwi_ramonly': True,
-            'kiwi_initrd_system': 'kiwi',
+            'kiwi_initrd_system': 'dracut',
             'kiwi_install_volid': 'INSTALL',
             'kiwi_btrfs_root_is_snapshot': None,
             'kiwi_gpt_hybrid_mbr': None,

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -106,6 +106,8 @@ class TestSystemBuildTask:
         self.runtime_checker.\
             check_boot_description_exists.assert_called_once_with()
         self.runtime_checker.\
+            check_initrd_selection_required.assert_called_once_with()
+        self.runtime_checker.\
             check_consistent_kernel_in_boot_and_system_image.\
             assert_called_once_with()
         self.runtime_checker.\

--- a/test/unit/tasks/system_prepare_test.py
+++ b/test/unit/tasks/system_prepare_test.py
@@ -96,6 +96,8 @@ class TestSystemPrepareTask:
         self.runtime_checker.\
             check_boot_description_exists.assert_called_once_with()
         self.runtime_checker.\
+            check_initrd_selection_required.assert_called_once_with()
+        self.runtime_checker.\
             check_consistent_kernel_in_boot_and_system_image.\
             assert_called_once_with()
         self.runtime_checker.\

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -820,7 +820,7 @@ class TestXMLState:
         state = XMLState(xml_data, ['vmxFlavour'], 'docker')
         assert state.get_initrd_system() is None
         state = XMLState(xml_data, [], 'oem')
-        assert state.get_initrd_system() == 'kiwi'
+        assert state.get_initrd_system() == 'dracut'
 
     def test_get_rpm_locale_filtering(self):
         assert self.state.get_rpm_locale_filtering() is True


### PR DESCRIPTION
Before this commit an oem image still had the kiwi initrd_system set as default.

As we are decommission the custom kiwi initrd concept the default should be changed. It is still possible to use a custom kiwi initrd but it needs to be explicitly requested via the initrd_system="kiwi" attribute. In addition to the changed default a runtime check was introduced that checks the presence of the boot= attribute which only makes sense in combination with the kiwi initrd_system. If boot= is set but initrd_system="kiwi" is not, a message is raised that explains the situation and either requests setting initrd_system properly or deleting the boot attribute. The change only affects people who still use oem with a boot="oemboot/..." setting and no explicit selection of kiwi as the initrd_system.

As these image type configurations should not be in use anyway because this is all legacy and announced to go away, we
need to make the next step and enforce a new default in code.

This is related to Issue #1299

