### PR TITLE
Include loadenv as a default module for grub images

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -455,7 +455,8 @@ class Defaults:
             'crypto',
             'cryptodisk',
             'test',
-            'true'
+            'true',
+            'loadenv'
         ]
         if multiboot:
             modules.append('multiboot')

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -717,8 +717,8 @@ class TestBootLoaderConfigGrub2:
                     'gettext', 'font', 'minicmd', 'gfxterm', 'gfxmenu',
                     'all_video', 'xfs', 'btrfs', 'lvm', 'luks',
                     'gcry_rijndael', 'gcry_sha256', 'gcry_sha512', 'crypto',
-                    'cryptodisk', 'test', 'true', 'multiboot', 'part_gpt',
-                    'part_msdos', 'efi_gop', 'efi_uga', 'linuxefi'
+                    'cryptodisk', 'test', 'true', 'loadenv', 'multiboot',
+                    'part_gpt', 'part_msdos', 'efi_gop', 'efi_uga', 'linuxefi'
                 ]
             )
         ]
@@ -789,8 +789,8 @@ class TestBootLoaderConfigGrub2:
                     'gettext', 'font', 'minicmd', 'gfxterm', 'gfxmenu',
                     'all_video', 'xfs', 'btrfs', 'lvm', 'luks',
                     'gcry_rijndael', 'gcry_sha256', 'gcry_sha512', 'crypto',
-                    'cryptodisk', 'test', 'true', 'part_gpt', 'part_msdos',
-                    'efi_gop', 'efi_uga', 'linuxefi'
+                    'cryptodisk', 'test', 'true', 'loadenv', 'part_gpt',
+                    'part_msdos', 'efi_gop', 'efi_uga', 'linuxefi'
                 ]
             )
         ]
@@ -1201,8 +1201,8 @@ class TestBootLoaderConfigGrub2:
                     'gettext', 'font', 'minicmd', 'gfxterm', 'gfxmenu',
                     'all_video', 'xfs', 'btrfs', 'lvm', 'luks',
                     'gcry_rijndael', 'gcry_sha256', 'gcry_sha512',
-                    'crypto', 'cryptodisk', 'test', 'true', 'part_gpt',
-                    'part_msdos', 'biosdisk', 'vga', 'vbe',
+                    'crypto', 'cryptodisk', 'test', 'true', 'loadenv',
+                    'part_gpt', 'part_msdos', 'biosdisk', 'vga', 'vbe',
                     'chain', 'boot'
                 ]
             ),
@@ -1226,8 +1226,8 @@ class TestBootLoaderConfigGrub2:
                     'gettext', 'font', 'minicmd', 'gfxterm', 'gfxmenu',
                     'all_video', 'xfs', 'btrfs', 'lvm', 'luks',
                     'gcry_rijndael', 'gcry_sha256', 'gcry_sha512',
-                    'crypto', 'cryptodisk', 'test', 'true', 'part_gpt',
-                    'part_msdos', 'efi_gop', 'efi_uga', 'linuxefi'
+                    'crypto', 'cryptodisk', 'test', 'true', 'loadenv',
+                    'part_gpt', 'part_msdos', 'efi_gop', 'efi_uga', 'linuxefi'
                 ]
             )
         ]


### PR DESCRIPTION
This commit includes the 'loadenv' module to the list of basic grub
modules. This makes sure the module is included in any grub-mkimage
that KIWI does.

Fixes #1547
