### PR TITLE
Make oem be a superset of vmx

### DIFF
--- a/build-tests/arm/fedora/test-image-iso/appliance.kiwi
+++ b/build-tests/arm/fedora/test-image-iso/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="ISO-Fedora">
+<image schemaversion="7.3" name="ISO-Fedora">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/arm/suse/test-image-iso/appliance.kiwi
+++ b/build-tests/arm/suse/test-image-iso/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="ISO-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="ISO-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/arm/suse/test-image-rpi-oem/appliance.kiwi
+++ b/build-tests/arm/suse/test-image-rpi-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="OEM-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="OEM-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/ppc/fedora/test-image-vmx/appliance.kiwi
+++ b/build-tests/ppc/fedora/test-image-vmx/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="VMX-Fedora-30.0">
+<image schemaversion="7.3" name="VMX-Fedora-30.0">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -15,7 +15,10 @@
         <keytable>us</keytable>
         <timezone>UTC</timezone>
         <rpm-check-signatures>false</rpm-check-signatures>
-        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0 splash" firmware="ofw" format="qcow2">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0 splash" firmware="ofw" format="qcow2">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2" console="serial"/>
         </type>
     </preferences>

--- a/build-tests/ppc/sle15/test-image-vmx-oem/appliance.kiwi
+++ b/build-tests/ppc/sle15/test-image-vmx-oem/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.2" name="SLE15">
+<image schemaversion="7.3" name="SLE15">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -23,7 +23,10 @@
         <rpm-check-signatures>false</rpm-check-signatures>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0 splash" firmware="ofw" format="qcow2">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0 splash" firmware="ofw" format="qcow2">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2" console="serial"/>
         </type>
     </preferences>

--- a/build-tests/ppc/suse/test-image-oem/appliance.kiwi
+++ b/build-tests/ppc/suse/test-image-oem/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.2" name="OEM-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="OEM-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/ppc/suse/test-image-vmx/appliance.kiwi
+++ b/build-tests/ppc/suse/test-image-vmx/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="VMX-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="VMX-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -16,7 +16,10 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0 splash" firmware="ofw" format="qcow2">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0 splash" firmware="ofw" format="qcow2">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2" console="serial"/>
         </type>
     </preferences>

--- a/build-tests/s390/sle15/test-image-vmx-oem/appliance.kiwi
+++ b/build-tests/s390/sle15/test-image-vmx-oem/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.2" name="SLE15">
+<image schemaversion="7.3" name="SLE15">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -22,7 +22,10 @@
         <rpm-check-signatures>false</rpm-check-signatures>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="vmx" filesystem="xfs" kernelcmdline="console=ttyS0 cio_ignore=all,!ipldev,!condev" format="qcow2">
+        <type image="oem" filesystem="xfs" kernelcmdline="console=ttyS0 cio_ignore=all,!ipldev,!condev" format="qcow2">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2_s390x_emu" console="serial" targettype="FBA"/>
         </type>
     </preferences>

--- a/build-tests/s390/suse/test-image-oem/appliance.kiwi
+++ b/build-tests/s390/suse/test-image-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="OEM-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="OEM-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/s390/suse/test-image-vmx/appliance.kiwi
+++ b/build-tests/s390/suse/test-image-vmx/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="VMX-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="VMX-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -14,7 +14,10 @@
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
-        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0" format="qcow2">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" format="qcow2">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2_s390x_emu" console="serial" targettype="SCSI"/>
         </type>
     </preferences>

--- a/build-tests/x86/archlinux/test-image-iso-oem-vmx-kis/appliance.kiwi
+++ b/build-tests/x86/archlinux/test-image-iso-oem-vmx-kis/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="6.8" name="LimeJeOS-Arch">
+<image schemaversion="7.3" name="LimeJeOS-Arch">
     <description type="system">
         <author>David Cassany</author>
         <contact>dcassany@suse.com</contact>
@@ -31,13 +31,20 @@
         <rpm-check-signatures>false</rpm-check-signatures>
     </preferences>
     <preferences profiles="Live">
-        <type image="iso" flags="overlay" hybrid="true" hybridpersistent_filesystem="ext4" hybridpersistent="true" firmware="efi"/>
+        <type image="iso" flags="overlay" hybridpersistent_filesystem="ext4" hybridpersistent="true" firmware="efi"/>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="vmx" primary="true" filesystem="ext4" bootloader="grub2" firmware="efi"/>
+        <type image="oem" primary="true" filesystem="ext4" firmware="efi">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+            <bootloader name="grub2"/>
+        </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" filesystem="ext4" bootloader="grub2" installiso="true"/>
+        <type image="oem" filesystem="ext4" installiso="true">
+            <bootloader name="grub2"/>
+        </type>
     </preferences>
     <preferences profiles="KIS">
         <type image="kis" filesystem="ext4"/>

--- a/build-tests/x86/centos/test-image-iso-oem-vmx-v7/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-iso-oem-vmx-v7/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.2" name="LimeJeOS-CentOS-07.0">
+<image schemaversion="7.3" name="LimeJeOS-CentOS-07.0">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>
@@ -29,7 +29,10 @@
         </type>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="vmx" primary="true" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="uefi" format="qcow2">
+        <type image="oem" primary="true" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="uefi" format="qcow2">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2" console="serial gfxterm"/>
         </type>
     </preferences>

--- a/build-tests/x86/centos/test-image-iso-oem-vmx-v8/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-iso-oem-vmx-v8/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.2" name="LimeJeOS-CentOS-08.0">
+<image schemaversion="7.3" name="LimeJeOS-CentOS-08.0">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>
@@ -29,7 +29,10 @@
         </type>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="vmx" primary="true" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="uefi" format="qcow2">
+        <type image="oem" primary="true" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="uefi" format="qcow2">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2" console="serial gfxterm"/>
         </type>
     </preferences>

--- a/build-tests/x86/debian/test-image-iso-oem-vmx/appliance.kiwi
+++ b/build-tests/x86/debian/test-image-iso-oem-vmx/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.2" name="LimeJeOS-Debian-Buster">
+<image schemaversion="7.3" name="LimeJeOS-Debian-Buster">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>
@@ -30,7 +30,10 @@
         </type>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="efi" format="qcow2">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="efi" format="qcow2">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2" console="serial gfxterm"/>
         </type>
     </preferences>
@@ -89,7 +92,6 @@
         <package name="dracut-kiwi-oem-dump"/>
     </packages>
     <packages type="bootstrap">
-        <!-- comptibility package for /usr/lib paths -->
         <package name="usrmerge"/>
     </packages>
 </image>

--- a/build-tests/x86/fedora/test-image-iso-oem-vmx/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-iso-oem-vmx/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.2" name="LimeJeOS-Fedora-Rawhide">
+<image schemaversion="7.3" name="LimeJeOS-Fedora-Rawhide">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>
@@ -30,7 +30,10 @@
         </type>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="uefi" format="qcow2">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="uefi" format="qcow2">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2" console="serial gfxterm"/>
         </type>
     </preferences>

--- a/build-tests/x86/suse/test-image-MicroOS/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-MicroOS/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="MicroOS-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="MicroOS-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -16,7 +16,10 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="btrfs" format="qcow2" firmware="uefi" kernelcmdline="plymouth.enable=0 console=ttyS0,115200 console=tty0 net.ifnames=0 swapaccount=1" bootpartition="false" bootkernel="custom" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true" btrfs_quota_groups="false" spare_part="5G" spare_part_mountpoint="/var" spare_part_fs="ext4" spare_part_is_last="true">
+        <type image="oem" filesystem="btrfs" format="qcow2" firmware="uefi" kernelcmdline="plymouth.enable=0 console=ttyS0,115200 console=tty0 net.ifnames=0 swapaccount=1" bootpartition="false" bootkernel="custom" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true" btrfs_quota_groups="false" spare_part="5G" spare_part_mountpoint="/var" spare_part_fs="ext4" spare_part_is_last="true">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2" console="gfxterm"/>
             <systemdisk>
                 <volume name="home"/>

--- a/build-tests/x86/suse/test-image-azure/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-azure/appliance.kiwi
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="Azure-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="Azure-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>
         <specification>azure test build</specification>
     </description>
     <preferences>
-        <type image="vmx" filesystem="xfs" kernelcmdline="USE_BY_UUID_DEVICE_NAMES=1 earlyprintk=ttyS0 console=ttyS0 rootdelay=300 net.ifnames=0 dis_ucode_ldr" devicepersistency="by-uuid" formatoptions="force_size" format="vhd-fixed" vhdfixedtag="22222222-3333-4444-5555-666666666666" bootpartition="true" bootpartsize="1024">
+        <type image="oem" filesystem="xfs" kernelcmdline="USE_BY_UUID_DEVICE_NAMES=1 earlyprintk=ttyS0 console=ttyS0 rootdelay=300 net.ifnames=0 dis_ucode_ldr" devicepersistency="by-uuid" formatoptions="force_size" format="vhd-fixed" vhdfixedtag="22222222-3333-4444-5555-666666666666" bootpartition="true" bootpartsize="1024">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2" console="serial"/>
             <size unit="M">30720</size>
         </type>

--- a/build-tests/x86/suse/test-image-custom-partitions/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-custom-partitions/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-TW">
+<image schemaversion="7.3" name="LimeJeOS-TW">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>
@@ -18,12 +18,13 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext4" firmware="uefi" spare_part="500M" editbootconfig="custom_partitions_create.sh" editbootinstall="custom_partitions_setup.sh" installiso="true" bootloader="grub2">
+        <type image="oem" filesystem="ext4" firmware="uefi" spare_part="500M" editbootconfig="custom_partitions_create.sh" editbootinstall="custom_partitions_setup.sh" installiso="true">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>512</oem-swapsize>
                 <oem-device-filter>/dev/ram</oem-device-filter>
             </oemconfig>
+            <bootloader name="grub2"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/suse/test-image-docker-derived/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-docker-derived/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="docker-builder-image">
+<image schemaversion="7.3" name="docker-builder-image">
     <description type="system">
         <author>David Cassany</author>
         <contact>dcassany@suse.de</contact>

--- a/build-tests/x86/suse/test-image-docker/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-docker/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="Docker-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="Docker-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-ec2/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-ec2/appliance.kiwi
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="EC2-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="EC2-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>
         <specification>ec2 test build</specification>
     </description>
     <preferences>
-        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0 multipath=off net.ifnames=0" devicepersistency="by-label" firmware="ec2">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0 multipath=off net.ifnames=0" devicepersistency="by-label" firmware="ec2">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2" timeout="1"/>
             <size unit="M">10240</size>
             <machine xen_loader="pvgrub"/>

--- a/build-tests/x86/suse/test-image-gce/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-gce/appliance.kiwi
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="GCE-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="GCE-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>
         <specification>GCE test build</specification>
     </description>
     <preferences>
-        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0,38400n8 net.ifnames=0 NON_PERSISTENT_DEVICE_NAMES=1 dis_ucode_ldr" format="gce" gcelicense="1111111111111111111" firmware="efi">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0,38400n8 net.ifnames=0 NON_PERSISTENT_DEVICE_NAMES=1 dis_ucode_ldr" format="gce" gcelicense="1111111111111111111" firmware="efi">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2" timeout="1"/>
             <size unit="M">10240</size>
         </type>

--- a/build-tests/x86/suse/test-image-iso/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-iso/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="ISO-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="ISO-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-luks/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-luks/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="VMX-LUKS-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="VMX-LUKS-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -16,7 +16,10 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0 splash" firmware="uefi" luks="linux" bootpartition="false">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0 splash" firmware="uefi" luks="linux" bootpartition="false">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2"/>
         </type>
     </preferences>

--- a/build-tests/x86/suse/test-image-oem-legacy/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-oem-legacy/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="OEM-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="OEM-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-oem/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="OEM-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="OEM-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-orthos-oem/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-orthos-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="factory-kiwi">
+<image schemaversion="7.3" name="factory-kiwi">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/suse/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-overlayroot/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="VMX-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="VMX-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -16,7 +16,10 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext3" kernelcmdline="console=ttyS0 splash" firmware="efi" format="vmdk" overlayroot="true">
+        <type image="oem" filesystem="ext3" kernelcmdline="console=ttyS0 splash" firmware="efi" format="vmdk" overlayroot="true">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2"/>
             <size unit="G">4</size>
         </type>

--- a/build-tests/x86/suse/test-image-pxe/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-pxe/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.2" name="PXE-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="PXE-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-qcow-openstack/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-qcow-openstack/appliance.kiwi
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="TW-OpenStack">
+<image schemaversion="7.3" name="TW-OpenStack">
     <description type="system">
         <author>KIWI Team</author>
         <contact>kiwi-images@googlegroups.com</contact>
         <specification>SUSE Tumbleweed guest image for OpenStack</specification>
     </description>
     <preferences>
-        <type image="vmx" filesystem="ext4" format="qcow2" kernelcmdline="console=tty1 console=ttyS0 net.ifnames=0">
+        <type image="oem" filesystem="ext4" format="qcow2" kernelcmdline="console=tty1 console=ttyS0 net.ifnames=0">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2" timeout="1"/>
             <size unit="M">10240</size>
         </type>

--- a/build-tests/x86/suse/test-image-suse-on-dnf/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-suse-on-dnf/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="VMX-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="VMX-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -16,7 +16,10 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext3" kernelcmdline="console=ttyS0 splash" firmware="uefi" format="vmdk">
+        <type image="oem" filesystem="ext3" kernelcmdline="console=ttyS0 splash" firmware="uefi" format="vmdk">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2"/>
         </type>
     </preferences>

--- a/build-tests/x86/suse/test-image-tbz/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-tbz/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="TBZ-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="TBZ-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-vagrant/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-vagrant/appliance.kiwi
@@ -4,7 +4,7 @@
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 <!-- OBS-ExclusiveArch: x86_64 -->
 
-<image schemaversion="7.2" name="Tumbleweed">
+<image schemaversion="7.3" name="Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -28,14 +28,20 @@
         <bootloader-theme>openSUSE</bootloader-theme>
     </preferences>
     <preferences profiles="libvirt">
-        <type image="vmx" filesystem="ext4" format="vagrant" firmware="efi" kernelcmdline="net.ifnames=0">
+        <type image="oem" filesystem="ext4" format="vagrant" firmware="efi" kernelcmdline="net.ifnames=0">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2" timeout="0"/>
             <vagrantconfig provider="libvirt" virtualsize="42"/>
             <size unit="G">42</size>
         </type>
     </preferences>
     <preferences profiles="virtualbox">
-        <type image="vmx" filesystem="ext4" format="vagrant" kernelcmdline="net.ifnames=0">
+        <type image="oem" filesystem="ext4" format="vagrant" kernelcmdline="net.ifnames=0">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2" timeout="0"/>
             <vagrantconfig provider="virtualbox" virtualbox_guest_additions_present="true" virtualsize="42"/>
             <size unit="G">42</size>

--- a/build-tests/x86/suse/test-image-vmx-lvm/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-vmx-lvm/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="VMX-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="VMX-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -16,7 +16,10 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext3" kernelcmdline="console=ttyS0 splash" firmware="uefi" format="vmdk">
+        <type image="oem" filesystem="ext3" kernelcmdline="console=ttyS0 splash" firmware="uefi" format="vmdk">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2"/>
             <systemdisk>
                 <volume name="home"/>

--- a/build-tests/x86/suse/test-image-vmx/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-vmx/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="VMX-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="VMX-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -16,7 +16,10 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext3" kernelcmdline="console=ttyS0 splash" firmware="uefi" format="vmdk">
+        <type image="oem" filesystem="ext3" kernelcmdline="console=ttyS0 splash" firmware="uefi" format="vmdk">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2"/>
         </type>
     </preferences>

--- a/build-tests/x86/suse/test-image-wsl/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-wsl/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="WSL-openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="WSL-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/ubuntu/test-image-iso-oem-vmx/appliance.kiwi
+++ b/build-tests/x86/ubuntu/test-image-iso-oem-vmx/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.2" name="LimeJeOS-Ubuntu-20.04">
+<image schemaversion="7.3" name="LimeJeOS-Ubuntu-20.04">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>
@@ -30,7 +30,10 @@
         </type>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="vmx" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="efi" format="qcow2">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="efi" format="qcow2">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <bootloader name="grub2" console="serial gfxterm"/>
         </type>
     </preferences>

--- a/doc/source/building_images.rst
+++ b/doc/source/building_images.rst
@@ -12,8 +12,8 @@ Building Images for Supported Types
    :maxdepth: 1
 
    building_images/build_live_iso
-   building_images/build_vmx_disk
-   building_images/build_oem_disk
+   building_images/build_simple_disk
+   building_images/build_expandable_disk
    building_images/build_docker_container
    building_images/build_wsl_container
    building_images/build_kis

--- a/doc/source/building_images/build_expandable_disk.rst
+++ b/doc/source/building_images/build_expandable_disk.rst
@@ -1,23 +1,24 @@
-.. _oem:
+.. _expandable_disk:
 
-Build an OEM Expandable Disk Image
-==================================
+Build an Expandable Disk Image
+==============================
 
 .. sidebar:: Abstract
 
-   This page explains how to build an OEM disk image. It contains:
+   This page explains how to build an expandable disk image.
+   It contains how to:
 
-   * how to build an OEM image
-   * how to deploy an OEM image
-   * how to run the deployed system
+   * build an expandable disk image
+   * deploy an expandable disk image
+   * run the deployed system
 
-An OEM disk represents the system disk with the capability to auto
+An expandable disk represents the system disk with the capability to auto
 expand the disk and its filesystem to a custom disk geometry. This
-allows deploying the same OEM image on target systems of a different
+allows deploying the same disk image on target systems with different
 hardware setup.
 
-The following example shows how to build and deploy an OEM disk image
-based on openSUSE Leap using a QEMU virtual machine as OEM target
+The following example shows how to build and deploy such a disk image
+based on openSUSE Leap using a QEMU virtual machine as the target
 system:
 
 1. Make sure you have checked out the example image descriptions,
@@ -33,11 +34,11 @@ system:
 
    Find the following result images below :file:`/tmp/myimage`.
 
-   * The OEM disk image with the suffix :file:`.raw` is an expandable
+   * The disk image with the suffix :file:`.raw` is an expandable
      virtual disk. It can expand itself to a custom disk geometry.
 
-   * The OEM installation image with the suffix :file:`install.iso` is a
-     hybrid installation system which contains the OEM disk image and is
+   * The installation image with the suffix :file:`install.iso` is a
+     hybrid installation system which contains the disk image and is
      capable to install this image on any target disk.
 
 .. _deployment_methods:
@@ -45,25 +46,25 @@ system:
 Deployment Methods
 ------------------
 
-The basic idea behind an OEM image is to provide the virtual disk data for
-OEM vendors to support easy deployment of the system to physical storage
-media.
+The basic idea behind an expandable disk image is to provide the virtual
+disk data for OEM vendors to support easy deployment of the system to
+physical storage media.
 
 There are the following basic deployment strategies:
 
 1. :ref:`deploy_manually`
 
-   Manually deploy the OEM disk image onto the target disk
+   Manually deploy the disk image onto the target disk.
 
 2. :ref:`deploy_from_iso`
 
-   Boot the OEM installation image and let {kiwi}'s OEM installer
-   deploy the OEM disk image from CD/DVD or USB stick onto the target disk
+   Boot the installation image and let {kiwi}'s installer
+   deploy the disk image from CD/DVD or USB stick onto the target disk.
 
 3. :ref:`deploy_from_network`
 
-   PXE boot the target system and let {kiwi}'s OEM installer
-   deploy the OEM disk image from the network onto the target disk
+   PXE boot the target system and let {kiwi}'s installer
+   deploy the disk image from the network onto the target disk.
 
 .. _deploy_manually:
 
@@ -83,11 +84,11 @@ The following steps shows how to do it:
    .. note:: Retaining the Disk Geometry
 
        If the target disk geometry is less or equal to the geometry of
-       the OEM disk image itself, the disk expansion performed for a physical
-       disk install during the OEM boot workflow will be skipped and the
+       the disk image itself, the disk expansion performed for a physical
+       disk install during the boot workflow will be skipped and the
        original disk geometry stays untouched.
 
-2. Dump OEM image on target disk
+2. Dump disk image on target disk.
 
    .. code:: bash
 
@@ -117,8 +118,8 @@ The following steps shows how to do it:
 
    Follow the steps above to create a virtual target disk
 
-2. Boot the OEM installation image as CD/DVD with the
-   target disk attached
+2. Boot the installation image as CD/DVD with the
+   target disk attached.
 
    .. code:: bash
 
@@ -126,7 +127,7 @@ The following steps shows how to do it:
 
    .. note:: USB Stick Deployment
 
-       Like any other iso image built with {kiwi}, also the OEM installation
+       Like any other ISO image built with {kiwi}, also the installation
        image is a hybrid image. Thus it can also be used on USB stick and
        serve as installation stick image like it is explained in
        :ref:`hybrid_iso`
@@ -136,7 +137,7 @@ The following steps shows how to do it:
 Network Deployment
 ------------------
 
-The deployment from the network downloads the OEM disk image from a
+The deployment from the network downloads the disk image from a
 PXE boot server. This requires a PXE network boot server to be setup
 as explained in :ref:`network-boot-server`
 
@@ -145,7 +146,7 @@ deployment process over the network using a QEMU virtual machine as
 target system:
 
 1. Make sure to create an installation PXE TAR archive along with your
-   OEM image by replacing the following setup in
+   disk image by replacing the following setup in
    kiwi-descriptions/suse/x86_64/{exc_description}/config.xml
 
    Instead of
@@ -180,7 +181,7 @@ target system:
           scp pxeboot.{exc_image_base_name}.x86_64-{exc_image_version}.initrd.xz PXE_SERVER_IP:/srv/tftpboot/boot/initrd
           scp pxeboot.{exc_image_base_name}.x86_64-{exc_image_version}.kernel PXE_SERVER_IP:/srv/tftpboot/boot/linux
 
-3. Copy the OEM disk image, MD5 file, system kernel, initrd and bootoptions to
+3. Copy the disk image, MD5 file, system kernel, initrd and bootoptions to
    the PXE boot server:
 
    Activation of the deployed system is done via `kexec` of the kernel
@@ -292,29 +293,37 @@ element like the following example shows:
    </oemconfig>
 
 
-The following list of optional oem element settings exists:
+The following list of optional `oem` element settings exists:
+
+oemconfig.oem-resize Element
+  Specify if the disk has the capability to expand itself to
+  a new disk geometry or not. By default, this feature is activated.
+  The implementation of the resize capability is done in a dracut
+  module packaged as `dracut-kiwi-oem-repart`. If `oem-resize` is
+  set to false, the installation of the corresponding dracut package
+  can be skipped as well.
 
 oemconfig.oem-boot-title Element
   By default, the string OEM will be used as the boot manager menu
   entry when KIWI creates the GRUB configuration during deployment.
-  The oem-boot-title element allows you to set a custom name for the
+  The `oem-boot-title` element allows you to set a custom name for the
   grub menu entry. This value is represented by the
   ``kiwi_oemtitle`` variable in the initrd
 
 oemconfig.oem-bootwait Element
   Specify if the system should wait for user interaction prior to
-  continuing the boot process after the oem image has been dumped to
+  continuing the boot process after the disk image has been dumped to
   the designated storage device (default value is false). This value
   is represented by the ``kiwi_oembootwait`` variable in the initrd
 
 oemconfig.oem-reboot Element
-  Specify if the system is to be rebooted after the oem image has
+  Specify if the system is to be rebooted after the disk image has
   been deployed to the designated storage device (default value is
   false). This value is represented by the ``kiwi_oemreboot``
   variable in the initrd
 
 oemconfig.oem-reboot-interactive Element
-  Specify if the system is to be rebooted after the oem image has
+  Specify if the system is to be rebooted after the disk image has
   been deployed to the designated storage device (default value is
   false). Prior to reboot a message is posted and must be
   acknowledged by the user in order for the system to reboot. This
@@ -322,19 +331,19 @@ oemconfig.oem-reboot-interactive Element
   in the initrd
 
 oemconfig.oem-silent-boot Element
-  Specify if the system should boot in silent mode after the oem
+  Specify if the system should boot in silent mode after the disk
   image has been deployed to the designated storage device (default
   value is false). This value is represented by the
   ``kiwi_oemsilentboot`` variable in the initrd
 
 oemconfig.oem-shutdown Element
-  Specify if the system is to be powered down after the oem image
+  Specify if the system is to be powered down after the disk image
   has been deployed to the designated storage device (default value
   is false). This value is represented by the ``kiwi_oemshutdown``
   variable in the initrd
 
 oemconfig.oem-shutdown-interactive Element
-  Specify if the system is to be powered down after the oem image
+  Specify if the system is to be powered down after the disk image
   has been deployed to the designated storage device (default value
   is false). Prior to shutdown a message is posted and must be
   acknowledged by the user in order for the system to power off.
@@ -363,9 +372,9 @@ oemconfig.oem-systemsize Element
   specifies the size of the LVM partition which contains all
   specified volumes. Thus, the sum of all specified volume sizes
   plus the sum of the specified freespace for each volume must be
-  smaller or equal to the size specified with the oem-systemsize.
-  This value is represented by the variable ``kiwi_oemrootMB`` in
-  the initrd
+  smaller or equal to the size specified with the `oem-systemsize`
+  element. This value is represented by the variable ``kiwi_oemrootMB``
+  in the initrd
 
 oemconfig.oem-unattended Element
   The installation of the image to the target system occurs

--- a/doc/source/building_images/build_simple_disk.rst
+++ b/doc/source/building_images/build_simple_disk.rst
@@ -1,33 +1,40 @@
-.. _vmx:
+.. _simple_disk:
 
 Build a Virtual Disk Image
 ==========================
 
 .. sidebar:: Abstract
 
-   This chapter explains how to build a simple disk image, including:
+   This page explains how to build a simple disk image.
+   It contains how to:
 
-   - how to define a vmx image in the image description
-   - how to build a vmx image
-   - how to run it with QEMU
+   - define a simple disk image in the image description
+   - build a simple disk image
+   - run it with QEMU
 
-A Virtual Disk Image is a compressed system disk with additional metadata
-useful for cloud frameworks like Amazon EC2, Google Compute Engine, or
-Microsoft Azure.
+A simple Virtual Disk Image is a compressed system disk with additional
+metadata useful for cloud frameworks like Amazon EC2, Google Compute Engine,
+or Microsoft Azure. It is used as the native disk of a system and does
+not require an extra installation workflow or a complex first boot setup
+procedure which is why we call it a *simple* disk image.
 
-To instruct {kiwi} to build a VMX image add a `type` element with
-`image="vmx"` in :file:`config.xml`. An example configuration for a 42 GB
-large VMDK image with 512 MB RAM, an IDE controller and a bridged network
-interface is shown below:
+To instruct {kiwi} to build a simple disk image add a `type` element with
+`image="oem"` in :file:`config.xml` that has the `oem-resize` feature
+disabled. An example configuration for a 42 GB large VMDK image with
+512 MB RAM, an IDE controller and a bridged network interface is shown
+below:
 
 .. code:: xml
 
    <image schemaversion="7.2" name="JeOS-Tumbleweed">
      <!-- snip -->
      <preferences>
-       <type image="vmx" filesystem="ext4" format="vmdk">
+       <type image="oem" filesystem="ext4" format="vmdk">
          <bootloader name="grub2" timeout="0"/>
          <size unit="G">42</size>
+         <oemconfig>
+             <oem-resize>false</oem-resize>
+         </oemconfig>
          <machine memory="512" guestOS="suse" HWversion="4">
            <vmdisk id="0" controller="ide"/>
            <vmnic driver="e1000" interface="0" mode="bridged"/>
@@ -39,7 +46,7 @@ interface is shown below:
    </image>
 
 The following attributes of the `type` element are of special interest
-when building VMX images:
+when building simple disk images:
 
 - `format`: Specifies the format of the virtual disk, possible values are:
   `gce`, `ova`, `qcow2`, `vagrant`, `vmdk`, `vdi`, `vhd`, `vhdx` and
@@ -53,8 +60,8 @@ when building VMX images:
 
 The `bootloader`, `size` and `machine` child-elements of `type` can be
 used to customize the virtual machine image further. We describe them in
-the following sections: :ref:`vmx-bootloader`, :ref:`vmx-the-size-element`
-and :ref:`vmx-the-machine-element`
+the following sections: :ref:`disk-bootloader`, :ref:`disk-the-size-element`
+and :ref:`disk-the-machine-element`
 
 Once your image description is finished (or you are content with a image
 from the :ref:`example descriptions <example-descriptions>` and use one of
@@ -62,7 +69,7 @@ them) build the image with {kiwi}:
 
 .. code:: bash
 
-   $ sudo kiwi-ng --type vmx system build \
+   $ sudo kiwi-ng --type oem system build \
        --description kiwi-descriptions/suse/x86_64/{exc_description} \
        --target-dir /tmp/myimage
 
@@ -86,7 +93,7 @@ framework see:
 
 For information how to setup a Vagrant box, see: :ref:`setup_vagrant`.
 
-.. _vmx-bootloader:
+.. _disk-bootloader:
 
 Setting up the Bootloader of the Image
 --------------------------------------
@@ -137,7 +144,7 @@ targettype="CDL|LDL|FBA|SCSI":
   emulated DASD devices use `FBA`. The attribute is available for the
   zipl loader only
 
-.. _vmx-the-size-element:
+.. _disk-the-size-element:
 
 Modifying the Size of the Image
 -------------------------------
@@ -149,8 +156,11 @@ added to the virtual machine image of which 5 GB are left unpartitioned:
 .. code:: xml
 
    <preferences>
-     <type image="vmx" format="vmdk">
+     <type image="oem" format="vmdk">
        <size unit="G" additive="true" unpartitioned="5">20</size>
+       <oemconfig>
+           <oem-resize>false</oem-resize>
+       </oemconfig>
      </type>
    </preferences>
 
@@ -170,7 +180,7 @@ further:
   `unit` or the default.
 
 
-.. _vmx-the-machine-element:
+.. _disk-the-machine-element:
 
 Customizing the Virtual Machine
 -------------------------------
@@ -240,7 +250,7 @@ The following example adds the two entries `numvcpus = "4"` and
 .. code:: xml
 
    <preferences>
-     <type image="vmx" filesystem="ext4" format="vmdk">
+     <type image="oem" filesystem="ext4" format="vmdk">
        <machine memory="512" guestOS="suse" HWversion="4">
          <vmconfig-entry>numvcpus = "4"</vmconfig-entry>
          <vmconfig-entry>cpuid.coresPerSocket = "2"</vmconfig-entry>
@@ -263,7 +273,7 @@ In the following example we add a bridged network interface using the
 .. code:: xml
 
    <preferences>
-     <type image="vmx" filesystem="ext4" format="vmdk">
+     <type image="oem" filesystem="ext4" format="vmdk">
        <machine memory="4096" guestOS="suse" HWversion="4">
          <vmnic driver="e1000" interface="0" mode="bridged"/>
        </machine>
@@ -299,7 +309,7 @@ The following example adds a disk with the ID 0 using an IDE controller:
 .. code:: xml
 
    <preferences>
-     <type image="vmx" filesystem="ext4" format="vmdk">
+     <type image="oem" filesystem="ext4" format="vmdk">
        <machine memory="512" guestOS="suse" HWversion="4">
          <vmdisk id="0" controller="ide"/>
        </machine>
@@ -336,7 +346,7 @@ IDE controller:
 .. code:: xml
 
    <preferences>
-     <type image="vmx" filesystem="ext4">
+     <type image="oem" filesystem="ext4">
        <machine memory="512" xen_loader="hvmloader">
          <vmdvd id="0" controller="scsi"/>
          <vmdvd id="1" controller="ide"/>

--- a/doc/source/commands/kiwi.rst
+++ b/doc/source/commands/kiwi.rst
@@ -124,7 +124,7 @@ EXAMPLE
 
    $ git clone https://github.com/OSInside/kiwi-descriptions
 
-   $ kiwi --type vmx system build \
+   $ kiwi --type oem system build \
        --description kiwi-descriptions/suse/x86_64/{exc_description} \
        --target-dir /tmp/myimage
 
@@ -142,4 +142,4 @@ to use a legacy {kiwi} commandline as follows:
 
    $ kiwi compat \
        --build kiwi-descriptions/suse/x86_64/{exc_description} \
-       --type vmx -d /tmp/myimage
+       --type oem -d /tmp/myimage

--- a/doc/source/concept_and_workflow/packages.rst
+++ b/doc/source/concept_and_workflow/packages.rst
@@ -28,7 +28,7 @@ removal. Each `packages` element acts as a group, whose behavior can be
 configured via the following attributes:
 
 - `type`: either `bootstrap`, `image`, `delete`, `uninstall` or one of the
-  following build types: `docker`, `iso`, `oem`, `kis`, `vmx`, `oci`.
+  following build types: `docker`, `iso`, `oem`, `kis`, `oci`.
 
   Packages for `type="bootstrap"` are pre-installed to populate the images'
   root file system before chrooting into it.

--- a/doc/source/concept_and_workflow/profiles.rst
+++ b/doc/source/concept_and_workflow/profiles.rst
@@ -10,7 +10,7 @@ configurations.
 
 The use of profiles is advisable to distinguish image builds of the same
 type but with different settings. In the following example, two virtual
-machine images of the vmx type are configured: one for QEMU (using the
+machine images of the `oem` type are configured: one for QEMU (using the
 `qcow2` format) and one for VMWare (using the `vmdk` format).
 
 .. code:: xml
@@ -25,10 +25,10 @@ machine images of the vmx type are configured: one for QEMU (using the
            <packagemanager>zypper</packagemanager>
        </preferences>
        <preferences profiles="QEMU">
-           <type image="vmx" format="qcow2" filesystem="ext4">
+           <type image="oem" format="qcow2" filesystem="ext4">
        </preferences>
        <preferences profiles="VMWare">
-           <type image="vmx" format="vmdk" filesystem="ext4">
+           <type image="oem" format="vmdk" filesystem="ext4">
        </preferences>
    </image>
 

--- a/doc/source/concept_and_workflow/shell_scripts.rst
+++ b/doc/source/concept_and_workflow/shell_scripts.rst
@@ -30,16 +30,15 @@ images.sh
   a live iso but not when building a virtual disk image.
 
 disk.sh
-  is executed for the disk image types `vmx` and `oem`
-  only and runs after the synchronisation of the root tree into the
-  disk image loop file. At call time of the script the device name
-  of the currently mapped root device is passed as a parameter.
-  The chroot environment for this script call is the virtual disk
-  itself and not the root tree as with :file:`config.sh` and
-  :file:`images.sh`. :file:`disk.sh` is usually used to apply
-  changes at parts of the system that are not an element of the
-  file based root tree such as the partition table, the bootloader
-  or filesystem attributes.
+  is executed for the disk image type `oem` only and runs after the
+  synchronisation of the root tree into the disk image loop file.
+  At call time of the script the device name of the currently mapped
+  root device is passed as a parameter. The chroot environment for
+  this script call is the virtual disk itself and not the root tree
+  as with :file:`config.sh` and :file:`images.sh`. The script :file:`disk.sh`
+  is usually used to apply changes at parts of the system that are not an
+  element of the file based root tree such as the partition table, the
+  bootloader or filesystem attributes.
 
 {kiwi} executes scripts via the operating system if their executable
 bit is set (in that case a shebang is mandatory) otherwise they will be

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -265,16 +265,14 @@ image="iso"
   system storage components. A useful pocket system for testing
   and demo and debugging purposes.
 
-image="vmx"
-  An image representing the system disk, useful for cloud frameworks
-  like Amazon EC2, Google Compute Engine or Microsoft Azure.
-
 image="oem"
   An image representing an expandable system disk. This means after
   deployment the system can resize itself to the new disk geometry.
   The resize operation is configurable as part of the image description
   and an installation image for CD/DVD, USB stick and Network deployment
-  can be created in addition.
+  can be created in addition. For use in cloud frameworks like
+  Amazon EC2, Google Compute Engine or Microsoft Azure this disk
+  type also supports the common virtual disk formats.
 
 image="docker"
   An archive image suitable for the docker container engine.
@@ -434,29 +432,35 @@ spare_part="number":
   of the requested size. The attribute takes a size value
   and allows a unit in MB or GB, e.g 200M. If no unit is given
   the value is considered to be mbytes. A spare partition
-  can only be configured for the disk image types oem and vmx
+  can only be configured for the disk image type oem
 
 spare_part_mountpoint="dir_path":
   Specify mount point for spare partition in the system.
-  Can only be configured for the disk image types oem and vmx
+  Can only be configured for the disk image type oem
 
 spare_part_fs="btrfs|ext2|ext3|ext4|xfs":
   Specify filesystem for spare partition in the system.
-  Can only be configured for the disk image types oem and vmx
+  Can only be configured for the disk image type oem
 
 spare_part_fs_attributes="attribute_list":
   Specify filesystem attributes for the spare partition.
   Attributes can be specified as comma separated list.
   Currently the attributes `no-copy-on-write` and `synchronous-updates`
   are available. Can only be configured for the disk image
-  types oem and vmx
+  type oem
 
 spare_part_is_last="true|false":
   Specify if the spare partition should be the last one in
-  the partition table. Can only be configured for the vmx
-  disk image type. By default the root partition is the last
-  one and the spare partition lives before it. With this
-  attribute that setup can be toggled.
+  the partition table. Can only be configured for the `oem`
+  type with oem-resize switched off. By default the root
+  partition is the last one and the spare partition lives
+  before it. With this attribute that setup can be toggled.
+  However, if the root partition is no longer the last one
+  the oem repart/resize code can no longer work because
+  the spare part would block it. Because of that moving
+  the spare part at the end of the disk is only applied
+  if oem-resize is switched off. There is a runtime
+  check in the {kiwi} code to check this condition
 
 devicepersistency="by-uuid|by-label|by-path":
   Specifies which method to use for persistent device names.
@@ -473,7 +477,7 @@ overlayroot="true|false"
   out of a squashfs compressed read-only root system
   overlayed using the overlayfs filesystem into an
   extra read-write partition. Available for the disk
-  image types, vmx and oem
+  image type oem only
 
 bootfilesystem="ext2|ext3|ext4|fat32|fat16":
   If an extra boot partition is required this attribute
@@ -491,7 +495,7 @@ flags="overlay|dmsquash"
   module.
 
 format="gce|ova|qcow2|vagrant|vmdk|vdi|vhd|vhdx|vhd-fixed":
-  For disk image types vmx and oem, specifies the format of
+  For disk image type oem, specifies the format of
   the virtual disk such that it can run on the desired target
   virtualization platform.
 
@@ -610,8 +614,8 @@ element including references to their usage in a detailed type setup:
 
 <preferences><type><bootloader>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Used to describe the bootloader setup in vmx or oem disk image types.
-For details see: :ref:`vmx-bootloader`
+Used to describe the bootloader setup in the oem disk image type.
+For details see: :ref:`disk-bootloader`
 
 <preferences><type><containerconfig>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -621,12 +625,12 @@ image types. For details see: :ref:`building_docker_build` and:
 
 <preferences><type><vagrantconfig>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Used to describe vagrant configuration metadata in vmx disk image
+Used to describe vagrant configuration metadata in a disk image
 that is being used as a vagrant box. For details see: :ref:`setup_vagrant`
 
 <preferences><type><systemdisk>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Used to describe the geometry, partitions and volumes, in a vmx or oem
+Used to describe the geometry, partitions and volumes, in a
 disk image. For details see: :ref:`custom_volumes`
 
 <preferences><type><oemconfig>
@@ -636,14 +640,14 @@ For details see: :ref:`oem_customize`
 
 <preferences><type><size>
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-Used to customize the size of the resulting disk image in a vmx or
-oem image. For details see: :ref:`vmx-the-size-element`
+Used to customize the size of the resulting disk image in an
+oem image. For details see: :ref:`disk-the-size-element`
 
 <preferences><type><machine>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Used to customize the virtual machine configuration which describes
 the components of an emulated hardware.
-For details see: :ref:`vmx-the-machine-element`
+For details see: :ref:`disk-the-machine-element`
 
 .. _sec.repository:
 
@@ -1058,15 +1062,15 @@ For example:
      <packagemanager name="zypper"/>
    </preferences>
 
-   <preferences profiles="vmx_qcow_format">
-     <type image="vmx" filesystem="ext4" format="qcow2"/>
+   <preferences profiles="oem_qcow_format">
+     <type image="oem" filesystem="ext4" format="qcow2"/>
    </preferences>
 
-   <preferences profiles="vmx_vmdk_format">
-     <type image="vmx" filesystem="ext4" format="vmdk"/>
+   <preferences profiles="oem_vmdk_format">
+     <type image="oem" filesystem="ext4" format="vmdk"/>
    </preferences>
 
-The above example configures two version of the same vmx type.
+The above example configures two version of the same oem type.
 One builds a disk in qcow2 format the other builds a disk in
 vmdk format. The global preferences section without a profile
 assigned will be used in any case and defines those preferences

--- a/doc/source/image_types_and_results.rst
+++ b/doc/source/image_types_and_results.rst
@@ -20,14 +20,14 @@ ISO Hybrid Live Image
 Virtual Disk Image
   An image representing the system disk, useful for cloud frameworks
   like Amazon EC2, Google Compute Engine or Microsoft Azure.
-  For further details refer to :ref:`vmx`
+  For further details refer to :ref:`simple_disk`
 
 OEM Expandable Disk Image
   An image representing an expandable system disk. This means after
   deployment the system can resize itself to the new disk geometry.
   The resize operation is configurable as part of the image description
   and an installation image for CD/DVD, USB stick and Network deployment
-  can be created in addition. For further details refer to: :ref:`oem`
+  can be created in addition. For further details refer to: :ref:`expandable_disk`
 
 Docker Container Image
   An archive image suitable for the docker container engine.
@@ -128,23 +128,13 @@ image="iso"
   - **live image**:
     :file:`{exc_image_base_name}.x86_64-{exc_image_version}.iso`
 
-image="vmx"
-  An image representing the system disk. The disk format can be
-  defined in :ref:`\<preferences\>\<type\><sec.preferences>` element as
-  documented in :ref:`vmx`. For a `format="qcow2"` the result is:
-
-  - **disk image**:
-    :file:`{exc_image_base_name}.x86_64-{exc_image_version}.qcow2`
-
 image="oem"
-  An image representing an expandable system disk. As for `vmx` type this
-  results in a disk image. In addition to the `vmx` type `oem` has a couple
-  of optional additional installation images. {kiwi} can produce an
-  installation ISO (by setting `installiso="true"` in
-  :ref:`\<preferences\>\<type\><sec.preferences>`) or a tarball including
-  the artifacts for a network deployment (by setting `installiso="true"` in
-  :ref:`\<preferences\>\<type\><sec.preferences>`), see
-  :ref:`OEM example<oem>` for further details. The results for `oem` can be:
+  An image representing an expandable disk image. {kiwi} can also produce an
+  installation ISO for this disk image by setting `installiso="true"` in
+  the :ref:`\<preferences\>\<type\><sec.preferences>`) section or a tarball
+  including the artifacts for a network deployment by setting `installiso="true"`.
+  For further details see :ref:`expandable_disk`. The results for `oem`
+  can be:
 
   - **disk image**:
     :file:`{exc_image_base_name}.x86_64-{exc_image_version}.raw`
@@ -152,6 +142,17 @@ image="oem"
     :file:`{exc_image_base_name}.x86_64-{exc_image_version}.install.iso`
   - **installation pxe archive (optional)**:
     :file:`{exc_image_base_name}.x86_64-{exc_image_version}.install.tar`
+
+  The disk image can also be provided in one of the various virtual disk
+  formats which can be specified in `format` attribute of the
+  :ref:`\<preferences\>\<type\><sec.preferences>` section. For further
+  details see :ref:`simple_disk`. The result for e.g  `format="qcow2"`
+  would be:
+
+  - **disk image**:
+    :file:`{exc_image_base_name}.x86_64-{exc_image_version}.qcow2`
+
+  instead of the `.raw` default disk format.
 
 image="docker"
   An archive image suitable for the docker container engine. The result is

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -44,7 +44,7 @@ command in order to build it:
 
 .. code:: bash
 
-    $ sudo kiwi-ng --type vmx system build \
+    $ sudo kiwi-ng --type oem system build \
         --description kiwi-descriptions/suse/x86_64/{exc_description} \
         --target-dir /tmp/myimage
 

--- a/doc/source/working_with_images.rst
+++ b/doc/source/working_with_images.rst
@@ -12,18 +12,18 @@ Working with Images
 
    working_with_images/iso_to_usb_stick_deployment
    working_with_images/iso_to_usb_stick_file_based_deployment
-   working_with_images/vmx_setup_for_ec2
-   working_with_images/vmx_setup_for_azure
-   working_with_images/vmx_setup_for_google
+   working_with_images/disk_setup_for_ec2
+   working_with_images/disk_setup_for_azure
+   working_with_images/disk_setup_for_google
    working_with_images/setup_network_bootserver
    working_with_images/setup_yast_on_first_boot
-   working_with_images/vmx_vagrant_setup
+   working_with_images/disk_setup_for_vagrant
    working_with_images/network_live_iso_boot
-   working_with_images/oem_ramdisk_deployment
+   working_with_images/disk_ramdisk_deployment
    working_with_images/custom_partitions
    working_with_images/custom_volumes
    working_with_images/custom_fstab_extension
-   working_with_images/vmx_setup_for_luks
+   working_with_images/disk_setup_for_luks
    working_with_images/build_with_profiles
    working_with_images/build_in_buildservice
    working_with_images/legacy_netboot_root_filesystem

--- a/doc/source/working_with_images/disk_ramdisk_deployment.rst
+++ b/doc/source/working_with_images/disk_ramdisk_deployment.rst
@@ -9,7 +9,7 @@ Deploy and Run System in a RamDisk
    oem images built with {kiwi} and references the following
    articles:
 
-   * :ref:`oem`
+   * :ref:`expandable_disk`
 
 If a machine should run the OS completely in memory without
 the need for any persistent storage, the approach to deploy

--- a/doc/source/working_with_images/disk_setup_for_azure.rst
+++ b/doc/source/working_with_images/disk_setup_for_azure.rst
@@ -6,10 +6,10 @@ Image Description for Microsoft Azure
 .. sidebar:: Abstract
 
    This page provides further information for handling
-   vmx images built with {kiwi} and references the following
-   articles:
+   Azure disk images built with {kiwi} and references the
+   following articles:
 
-   * :ref:`vmx`
+   * :ref:`simple_disk`
 
 A virtual disk image which is able to boot in the Microsoft Azure
 cloud framework has to comply the following constraints:
@@ -39,11 +39,11 @@ description as follows:
 
 2. Image Type definition
 
-   Update the vmx image type setup as follows
+   Update the oem image type setup as follows
 
    .. code:: xml
 
-      <type image="vmx"
+      <type image="oem"
             filesystem="ext4"
             kernelcmdline="console=ttyS0 rootdelay=300 net.ifnames=0"
             devicepersistency="by-uuid"
@@ -53,6 +53,9 @@ description as follows:
             bootpartsize="1024">
         <bootloader name="grub2" timeout="1"/>
         <size unit="M">30720</size>
+        <oemconfig>
+            <oem-resize>false</oem-resize>
+        </oemconfig>
       </type>
 
 An image built with the above setup can be uploaded into the

--- a/doc/source/working_with_images/disk_setup_for_ec2.rst
+++ b/doc/source/working_with_images/disk_setup_for_ec2.rst
@@ -6,10 +6,10 @@ Image Description for Amazon EC2
 .. sidebar:: Abstract
 
    This page provides further information for handling
-   vmx images built with {kiwi} and references the following
+   Amazon EC2 images built with {kiwi} and references the following
    articles:
 
-   * :ref:`vmx`
+   * :ref:`simple_disk`
 
 A virtual disk image which is able to boot in the Amazon EC2
 cloud framework has to comply the following constraints:
@@ -45,11 +45,11 @@ description as follows:
 
 2. Image Type definition
 
-   Update the vmx image type setup as follows
+   Update the oem image type setup as follows
 
    .. code:: xml
 
-      <type image="vmx"
+      <type image="oem"
             filesystem="ext4"
             kernelcmdline="console=xvc0 multipath=off net.ifnames=0"
             devicepersistency="by-label"
@@ -57,6 +57,9 @@ description as follows:
         <bootloader name="grub2" timeout="1"/>
         <size unit="M">10240</size>
         <machine xen_loader="hvmloader"/>
+        <oemconfig>
+            <oem-resize>false</oem-resize>
+        </oemconfig>
       </type>
 
 3. Cloud Init setup

--- a/doc/source/working_with_images/disk_setup_for_google.rst
+++ b/doc/source/working_with_images/disk_setup_for_google.rst
@@ -6,10 +6,10 @@ Image Description for Google Compute Engine
 .. sidebar:: Abstract
 
    This page provides further information for handling
-   vmx images built with {kiwi} and references the following
+   GCE images built with {kiwi} and references the following
    articles:
 
-   * :ref:`vmx`
+   * :ref:`simple_disk`
 
 A virtual disk image which is able to boot in the Google Compute Engine
 cloud framework has to comply the following constraints:
@@ -47,8 +47,8 @@ description as follows:
    boot code which can resize the disk from within the initrd before
    the system gets activated through systemd.
 
-   Update the vmx image type setup to be changed into an expandable
-   (oem) type as follows:
+   Update the oem image type setup to be changed into an expandable
+   type as follows:
 
    .. code:: xml
 
@@ -60,6 +60,7 @@ description as follows:
         <bootloader name="grub2" timeout="1"/>
         <size unit="M">10240</size>
         <oemconfig>
+            <oem-resize>true</oem-resize>
             <oem-swap>false</oem-swap>
         </oemconfig>
       </type>

--- a/doc/source/working_with_images/disk_setup_for_luks.rst
+++ b/doc/source/working_with_images/disk_setup_for_luks.rst
@@ -6,11 +6,11 @@ Image Description Encrypted Disk
 .. sidebar:: Abstract
 
    This page provides further information for handling
-   vmx images with an encrypted root filesystem setup.
+   disk images with an encrypted root filesystem setup.
    The information here is based on top of the following
    article:
 
-   * :ref:`vmx`
+   * :ref:`simple_disk`
 
 A virtual disk image can be partially or fully encrypted
 using the LUKS extension supported by {kiwi}. A fully encrypted
@@ -41,26 +41,24 @@ Update the {kiwi} image description as follows:
 
 2. Image Type definition
 
-   Update the vmx image type setup as follows
+   Update the oem image type setup as follows
 
    Full disk encryption including :file:`/boot`:
      .. code:: xml
 
-        <type image="vmx"
-            image="vmx"
-            filesystem="ext4"
-            luks="linux"
-            bootpartition="false">
+        <type image="oem" filesystem="ext4" luks="linux" bootpartition="false">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
         </type>
 
    Encrypted root partition with an unencrypted extra :file:`/boot` partition:
      .. code:: xml
 
-        <type image="vmx"
-            image="vmx"
-            filesystem="ext4"
-            luks="linux"
-            bootpartition="true">
+        <type image="oem" filesystem="ext4" luks="linux" bootpartition="true">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
         </type>
 
    .. note::

--- a/doc/source/working_with_images/disk_setup_for_vagrant.rst
+++ b/doc/source/working_with_images/disk_setup_for_vagrant.rst
@@ -6,10 +6,10 @@ Image Description for Vagrant
 .. sidebar:: Abstract
 
    This page provides further information for handling
-   VMX images built with {kiwi} and references the following
-   article:
+   Vagrant controlled disk images built with {kiwi} and references
+   the following article:
 
-   * :ref:`vmx`
+   * :ref:`simple_disk`
 
 `Vagrant <https://www.vagrantup.com>`_ is a framework to
 implement consistent processing/testing work environments based on
@@ -35,17 +35,20 @@ building and maintaining boxes.
 Vagrant expects boxes to be setup in a specific way (for details refer to
 the `Vagrant box documentation
 <https://www.vagrantup.com/docs/boxes/base.html>`_.), applied to the
-referenced {kiwi} image description from :ref:`vmx`, the following steps are
-required:
+referenced {kiwi} image description from :ref:`simple_disk`, the following
+steps are required:
 
 1. Update the image type setup
 
    .. code:: xml
 
-      <type image="vmx" filesystem="ext4" format="vagrant">
+      <type image="oem" filesystem="ext4" format="vagrant">
           <bootloader name="grub2" timeout="0"/>
           <vagrantconfig provider="libvirt" virtualsize="42"/>
           <size unit="G">42</size>
+          <oemconfig>
+              <oem-resize>false</oem-resize>
+          </oemconfig>
       </type>
 
    This modifies the type to build a Vagrant box for the libvirt
@@ -58,7 +61,7 @@ required:
 
    .. code:: xml
 
-      <type image="vmx" filesystem="ext4" format="vagrant">
+      <type image="oem" filesystem="ext4" format="vagrant">
           <bootloader name="grub2" timeout="0"/>
           <vagrantconfig
             provider="virtualbox"
@@ -66,6 +69,9 @@ required:
             virtualsize="42"
           />
           <size unit="G">42</size>
+          <oemconfig>
+              <oem-resize>false</oem-resize>
+          </oemconfig>
       </type>
 
    The resulting Vagrant box then uses the ``vboxfs`` module for the
@@ -227,7 +233,7 @@ description directory next to :file:`config.sh`):
 
 .. code:: xml
 
-   <type image="vmx" filesystem="ext4" format="vagrant">
+   <type image="oem" filesystem="ext4" format="vagrant">
        <bootloader name="grub2" timeout="0"/>
        <vagrantconfig
          provider="libvirt"
@@ -235,6 +241,9 @@ description directory next to :file:`config.sh`):
          embedded_vagrantfile="MyVagrantfile"
        />
        <size unit="G">42</size>
+       <oemconfig>
+           <oem-resize>false</oem-resize>
+       </oemconfig>
    </type>
 
 
@@ -259,7 +268,7 @@ customized one (the libvirt profile in the following example):
 
      <preferences profiles="libvirt">
        <type
-         image="vmx"
+         image="oem"
          filesystem="ext4"
          format="vagrant">
            <bootloader name="grub2" timeout="0"/>
@@ -269,11 +278,14 @@ customized one (the libvirt profile in the following example):
              embedded_vagrantfile="LibvirtVagrantfile"
            />
            <size unit="G">42</size>
+           <oemconfig>
+               <oem-resize>false</oem-resize>
+           </oemconfig>
       </type>
       </preferences>
       <preferences profiles="virtualbox">
         <type
-          image="vmx"
+          image="oem"
           filesystem="ext4"
           format="vagrant">
             <bootloader name="grub2" timeout="0"/>
@@ -283,6 +295,9 @@ customized one (the libvirt profile in the following example):
               virtualsize="42"
             />
             <size unit="G">42</size>
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
         </type>
       </preferences>
 

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -107,6 +107,8 @@ class DiskBuilder:
         self.target_removable = xml_state.build_type.get_target_removable()
         self.root_filesystem_is_multipath = \
             xml_state.get_oemconfig_oem_multipath_scan()
+        self.disk_resize_requested = \
+            xml_state.get_oemconfig_oem_resize()
         self.swap_mbytes = xml_state.get_oemconfig_swap_mbytes()
         self.disk_setup = DiskSetup(
             xml_state, root_dir
@@ -216,8 +218,9 @@ class DiskBuilder:
         """
         if self.install_media and self.build_type_name != 'oem':
             raise KiwiInstallMediaError(
-                'Install media requires oem type setup, got %s' %
-                self.build_type_name
+                'Install media requires oem type setup, got {0}'.format(
+                    self.build_type_name
+                )
             )
 
         if self.root_filesystem_is_overlay and self.volume_manager_name:
@@ -320,8 +323,8 @@ class DiskBuilder:
                     self.xml_state.build_type.get_btrfs_root_is_readonly_snapshot(),
                 'quota_groups':
                     self.xml_state.build_type.get_btrfs_quota_groups(),
-                'image_type':
-                    self.xml_state.get_build_type_name()
+                'resize_on_boot':
+                    self.disk_resize_requested
             }
             self.volume_manager = VolumeManager(
                 self.volume_manager_name, device_map,
@@ -403,7 +406,7 @@ class DiskBuilder:
                 self.boot_image.write_system_config_file(
                     config={'modules': ['kiwi-overlay']}
                 )
-            if self.build_type_name == 'oem':
+            if self.disk_resize_requested:
                 self.boot_image.include_module('kiwi-repart')
 
         # create initrd cpio archive

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1274,7 +1274,7 @@ class Defaults:
 
         :rtype: list
         """
-        return ['oem', 'vmx']
+        return ['oem']
 
     @staticmethod
     def get_live_image_types():

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -605,8 +605,10 @@ class RuntimeChecker:
         ''')
         required_dracut_package = 'dracut-kiwi-oem-repart'
         initrd_system = self.xml_state.get_initrd_system()
+        disk_resize_requested = self.xml_state.get_oemconfig_oem_resize()
         build_type = self.xml_state.get_build_type_name()
-        if build_type == 'oem' and initrd_system == 'dracut':
+        if build_type == 'oem' and initrd_system == 'dracut' and \
+           disk_resize_requested:
             package_names = \
                 self.xml_state.get_bootstrap_packages() + \
                 self.xml_state.get_system_packages()

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -62,7 +62,7 @@ div {
         attribute xsi:schemaLocation { xsd:anyURI }
     k.image.schemaversion.attribute =
         ## The allowed Schema version (fixed value)
-        attribute schemaversion { "7.2" }
+        attribute schemaversion { "7.3" }
     k.image.id =
         ## An identification number which is represented in a file
         ## named /etc/ImageID
@@ -381,6 +381,25 @@ div {
         element oem-bootwait {
             k.oem-bootwait.attlist,
             k.oem-bootwait.content
+        }
+}
+
+#==========================================
+# common element <oem-resize>
+#
+div {
+    k.oem-resize.content = xsd:boolean
+    k.oem-resize.attlist = empty
+    k.oem-resize =
+        ## activate/deactivate disk resize on first boot: true/false
+        ## By default the repart/resize is activated when creating
+        ## an oem image. If the disk image should be more simple
+        ## and should not react on storage geometry changes at all
+        ## this option allows to switch off the use and inclusion
+        ## of the kiwi oem dracut module that implements the resize
+        element oem-resize {
+            k.oem-resize.attlist,
+            k.oem-resize.content
         }
 }
 
@@ -1157,6 +1176,19 @@ div {
             ]
         ]
     ]
+    sch:pattern [
+        abstract = "true"
+        id = "image_expandable"
+        sch:rule [
+            context = "type[@$attr='true']"
+            sch:assert [
+                test = "oemconfig/oem-resize[contains(text(), 'false')]"
+                "$attr attribute also needs the setting: "
+                "<oem-resize>false</oem-resize> in the "
+                "<oemconfig> section of the selected <type>"
+            ]
+        ]
+    ]
     k.type.boot.attribute =
         ## Specifies the path of the boot image (initrd) description
         ## provided with KIWI
@@ -1178,7 +1210,7 @@ div {
         attribute xen_server { xsd:boolean }
         >> sch:pattern [ id = "xen_server" is-a = "image_type"
             sch:param [ name = "attr" value = "xen_server" ]
-            sch:param [ name = "types" value = "oem vmx" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.btrfs_quota_groups.attribute =
         ## activate the quota system if the filesystem is btrfs based.
@@ -1186,7 +1218,7 @@ div {
         attribute btrfs_quota_groups { xsd:boolean }
         >> sch:pattern [ id = "btrfs_quota_groups" is-a = "image_type"
             sch:param [ name = "attr" value = "btrfs_quota_groups" ]
-            sch:param [ name = "types" value = "oem vmx" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.btrfs_root_is_snapshot.attribute =
         ## Tell kiwi to install the system into a btrfs snapshot
@@ -1195,7 +1227,7 @@ div {
         attribute btrfs_root_is_snapshot { xsd:boolean }
         >> sch:pattern [ id = "btrfs_root_is_snapshot" is-a = "image_type"
             sch:param [ name = "attr" value = "btrfs_root_is_snapshot" ]
-            sch:param [ name = "types" value = "oem vmx" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.btrfs_root_is_readonly_snapshot.attribute =
         ## Tell kiwi to set the btrfs root filesystem snapshot read-only
@@ -1207,7 +1239,7 @@ div {
         attribute btrfs_root_is_readonly_snapshot { xsd:boolean }
         >> sch:pattern [ id = "btrfs_root_is_readonly_snapshot" is-a = "image_type"
             sch:param [ name = "attr" value = "btrfs_root_is_readonly_snapshot" ]
-            sch:param [ name = "types" value = "oem vmx" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.target_blocksize.attribute =
         ## Specifies the image blocksize in bytes which has to match
@@ -1218,7 +1250,7 @@ div {
         attribute target_blocksize { xsd:nonNegativeInteger }
         >> sch:pattern [ id = "target_blocksize" is-a = "image_type"
             sch:param [ name = "attr" value = "target_blocksize" ]
-            sch:param [ name = "types" value = "oem vmx" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.target_removable.attribute =
         ## Indicate if the target disk for oem images is deployed
@@ -1230,56 +1262,65 @@ div {
         attribute target_removable { xsd:boolean }
         >> sch:pattern [ id = "target_removable" is-a = "image_type"
             sch:param [ name = "attr" value = "target_removable" ]
-            sch:param [ name = "types" value = "oem vmx" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.spare_part.attribute =
         ## Request a spare partition right before the root partition
         ## of the requested size. The attribute takes a size value
         ## and allows a unit in MB or GB, e.g 200M. If no unit is given
         ## the value is considered to be mbytes. A spare partition
-        ## can only be configured for the disk image types oem and vmx
+        ## can only be configured for the disk image type oem
         attribute spare_part { partition-size-type }
         >> sch:pattern [ id = "spare_part" is-a = "image_type"
             sch:param [ name = "attr" value = "spare_part" ]
-            sch:param [ name = "types" value = "oem vmx" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.spare_part_mountpoint.attribute =
         ## Specify mount point for spare partition in the system.
-        ## Can only be configured for the disk image types oem and vmx
+        ## Can only be configured for the disk image type oem
         attribute spare_part_mountpoint { text }
         >> sch:pattern [ id = "spare_part_mountpoint" is-a = "image_type"
             sch:param [ name = "attr" value = "spare_part_mountpoint" ]
-            sch:param [ name = "types" value = "oem vmx" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.spare_part_fs.attribute =
         ## Specify filesystem for spare partition in the system.
-        ## Can only be configured for the disk image types oem and vmx
+        ## Can only be configured for the disk image type oem
         attribute spare_part_fs {
             "btrfs" | "ext2" | "ext3" | "ext4" | "xfs"
         }
         >> sch:pattern [ id = "spare_part_fs" is-a = "image_type"
             sch:param [ name = "attr" value = "spare_part_fs" ]
-            sch:param [ name = "types" value = "oem vmx" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.spare_part_fs_attributes.attribute =
         ## Specify filesystem attributes for the spare partition.
         ## Attributes can be specified as comma separated list.
-        ## Can only be configured for the disk image types oem and vmx
+        ## Can only be configured for the disk image type oem
         attribute spare_part_fs_attributes { fs_attributes }
         >> sch:pattern [ id = "spare_part_fs_attributes" is-a = "image_type"
             sch:param [ name = "attr" value = "spare_part_fs_attributes" ]
-            sch:param [ name = "types" value = "oem vmx" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.spare_part_is_last.attribute =
         ## Specify if the spare partition should be the last one in
-        ## the partition table. Can only be configured for the vmx
-        ## disk image type. By default the root partition is the last
-        ## one and the spare partition lives behind it. With this
-        ## attribute that setup can be toggled.
+        ## the partition table. Can only be configured for the oem
+        ## type with oem-resize switched off. By default the root
+        ## partition is the last one and the spare partition lives
+        ## before it. With this attribute that setup can be toggled.
+        ## However if the root partition is no longer the last one
+        ## the oem repart/resize code can no longer work because
+        ## the spare part would block it. Because of that moving
+        ## the spare part at the end of the disk is only applied
+        ## if oem-resize is switched off. There is a runtime
+        ## check in the kiwi code to check this condition
         attribute spare_part_is_last { xsd:boolean }
         >> sch:pattern [ id = "spare_part_is_last" is-a = "image_type"
             sch:param [ name = "attr" value = "spare_part_is_last" ]
-            sch:param [ name = "types" value = "vmx" ]
+            sch:param [ name = "types" value = "oem" ]
+        ]
+        >> sch:pattern [ id = "spare_part_is_last_valid" is-a = "image_expandable"
+            sch:param [ name = "attr" value = "spare_part_is_last" ]
         ]
     k.type.bootpartsize.attribute =
         ## For images with a separate boot partition this attribute
@@ -1288,7 +1329,7 @@ div {
         attribute bootpartsize { xsd:nonNegativeInteger }
         >> sch:pattern [ id = "bootpartsize" is-a = "image_type"
             sch:param [ name = "attr" value = "bootpartsize" ]
-            sch:param [ name = "types" value = "oem vmx" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.efipartsize.attribute =
         ## For images with an EFI fat partition this attribute
@@ -1297,7 +1338,7 @@ div {
         attribute efipartsize { xsd:nonNegativeInteger }
         >> sch:pattern [ id = "efipartsize" is-a = "image_type"
             sch:param [ name = "attr" value = "efipartsize" ]
-            sch:param [ name = "types" value = "oem vmx" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.efiparttable.attribute =
         ## For images with an EFI firmware specifies the partition
@@ -1306,7 +1347,7 @@ div {
         attribute efiparttable { "msdos" | "gpt" }
         >> sch:pattern [ id = "efiparttable" is-a = "image_type"
             sch:param [ name = "attr" value = "efiparttable" ]
-            sch:param [ name = "types" value = "oem vmx" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.bootprofile.attribute =
         ## Specifies the boot profile defined in the boot image
@@ -1315,7 +1356,7 @@ div {
         attribute bootprofile { text }
         >> sch:pattern [ id = "bootprofile" is-a = "image_type"
             sch:param [ name = "attr" value = "bootprofile" ]
-            sch:param [ name = "types" value = "oem vmx iso pxe cpio" ]
+            sch:param [ name = "types" value = "oem iso pxe cpio" ]
         ]
     k.type.compressed.attribute =
         ## Specifies whether the image output file should be
@@ -1338,7 +1379,7 @@ div {
         attribute editbootconfig { text }
         >> sch:pattern [ id = "editbootconfig" is-a = "image_type"
             sch:param [ name = "attr" value = "editbootconfig" ]
-            sch:param [ name = "types" value = "vmx oem iso" ]
+            sch:param [ name = "types" value = "oem iso" ]
         ]
     k.type.editbootinstall.attribute =
         ## Specifies the path to a script which is called right
@@ -1348,7 +1389,7 @@ div {
         attribute editbootinstall { text }
         >> sch:pattern [ id = "editbootinstall" is-a = "image_type"
             sch:param [ name = "attr" value = "editbootinstall" ]
-            sch:param [ name = "types" value = "vmx oem" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.filesystem.attribute = 
         ## Specifies the root filesystem type
@@ -1357,12 +1398,12 @@ div {
         }
         >> sch:pattern [ id = "filesystem" is-a = "image_type"
             sch:param [ name = "attr" value = "filesystem" ]
-            sch:param [ name = "types" value = "vmx oem pxe kis" ]
+            sch:param [ name = "types" value = "oem pxe kis" ]
         ]
         >> sch:pattern [
             id = "filesystem_mandatory" is-a = "image_type_requirement"
             sch:param [ name = "attr" value = "filesystem" ]
-            sch:param [ name = "types" value = "vmx oem" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
 	k.type.squashfscompression.attribute = 
         ## Specifies the compression type for mksquashfs
@@ -1371,18 +1412,18 @@ div {
         }
         >> sch:pattern [ id = "squashfscompression" is-a = "image_type"
             sch:param [ name = "attr" value = "squashfscompression" ]
-            sch:param [ name = "types" value = "vmx oem pxe kis iso" ]
+            sch:param [ name = "types" value = "oem pxe kis iso" ]
         ]
     k.type.overlayroot.attribute =
         ## Specifies to use an overlay root system consisting
         ## out of a squashfs compressed read-only root system
         ## overlayed using the overlayfs filesystem into an
         ## extra read-write partition. Available for the disk
-        ## image types, vmx and oem
+        ## image type oem
         attribute overlayroot { xsd:boolean }
         >> sch:pattern [ id = "overlayroot" is-a = "image_type"
             sch:param [ name = "attr" value = "overlayroot" ]
-            sch:param [ name = "types" value = "vmx oem" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.firmware.attribute =
         ## Specifies the boot firmware of the system. Most systems
@@ -1397,7 +1438,7 @@ div {
         }
         >> sch:pattern [ id = "firmware" is-a = "image_type"
             sch:param [ name = "attr" value = "firmware" ]
-            sch:param [ name = "types" value = "vmx oem pxe iso" ]
+            sch:param [ name = "types" value = "oem pxe iso" ]
         ]
     k.type.bootpartition.attribute =
         ## specify if an extra boot partition should be used or not.
@@ -1405,7 +1446,7 @@ div {
         attribute bootpartition { xsd:boolean }
         >> sch:pattern [ id = "bootpartition" is-a = "image_type"
             sch:param [ name = "attr" value = "bootpartition" ]
-            sch:param [ name = "types" value = "vmx oem" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.bootfilesystem.attribute =
         ## if an extra boot partition is required this attribute
@@ -1417,7 +1458,7 @@ div {
         }
         >> sch:pattern [ id = "bootfilesystem" is-a = "image_type"
             sch:param [ name = "attr" value = "bootfilesystem" ]
-            sch:param [ name = "types" value = "vmx oem" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.flags.attribute =
         ## Specifies live iso technology and dracut module to use.
@@ -1442,7 +1483,7 @@ div {
         }
         >> sch:pattern [ id = "format" is-a = "image_type"
             sch:param [ name = "attr" value = "format" ]
-            sch:param [ name = "types" value = "vmx oem" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.formatoptions.attribute =
         ## Specifies additional format options passed on to qemu-img
@@ -1453,7 +1494,7 @@ div {
         attribute formatoptions { text }
         >> sch:pattern [ id = "formatoptions" is-a = "image_type"
             sch:param [ name = "attr" value = "formatoptions" ]
-            sch:param [ name = "types" value = "vmx oem" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.force_mbr.attribute =
         ## Force use of MBR (msdos table) partition table even if the
@@ -1466,7 +1507,7 @@ div {
         attribute force_mbr { xsd:boolean }
         >> sch:pattern [ id = "force_mbr" is-a = "image_type"
             sch:param [ name = "attr" value = "force_mbr" ]
-            sch:param [ name = "types" value = "vmx oem" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.fsmountoptions.attribute =
         ## Specifies the filesystem mount options which also ends up in fstab
@@ -1500,7 +1541,7 @@ div {
         attribute gpt_hybrid_mbr { xsd:boolean }
         >> sch:pattern [ id = "gpt_hybrid_mbr" is-a = "image_type"
             sch:param [ name = "attr" value = "gpt_hybrid_mbr" ]
-            sch:param [ name = "types" value = "vmx oem" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.initrd_system.attribute =
         ## specify which initrd builder to use, default is kiwi's
@@ -1518,7 +1559,7 @@ div {
         attribute image {
             "btrfs" | "clicfs" | "cpio" | "docker" | "ext2" | "ext3" |
             "ext4" | "iso" | "oem" | "pxe" | "kis" | "squashfs" | "tbz" |
-            "vmx" | "xfs" | "oci" | "appx"
+            "xfs" | "oci" | "appx"
         }
         >> sch:pattern [
             id = "metadata_path_mandatory" is-a = "image_type_requirement"
@@ -1600,7 +1641,7 @@ div {
         attribute kernelcmdline { text }
         >> sch:pattern [ id = "kernelcmdline" is-a = "image_type"
             sch:param [ name = "attr" value = "kernelcmdline" ]
-            sch:param [ name = "types" value = "oem vmx iso pxe kis" ]
+            sch:param [ name = "types" value = "oem iso pxe kis" ]
         ]
     k.type.luks.attribute =
         ## Setup cryptographic volume along with the given filesystem
@@ -1610,7 +1651,7 @@ div {
         attribute luks { text }
         >> sch:pattern [ id = "luks" is-a = "image_type"
             sch:param [ name = "attr" value = "luks" ]
-            sch:param [ name = "types" value = "oem vmx iso pxe kis" ]
+            sch:param [ name = "types" value = "oem iso pxe kis" ]
         ]
     k.type.luksOS.attribute =
         ## With the luksOS value a predefined set of ciper, keysize
@@ -1622,7 +1663,7 @@ div {
         }
         >> sch:pattern [ id = "luksOS" is-a = "image_type"
             sch:param [ name = "attr" value = "luksOS" ]
-            sch:param [ name = "types" value = "oem vmx iso pxe kis" ]
+            sch:param [ name = "types" value = "oem iso pxe kis" ]
         ]
     k.type.mdraid.attribute =
         ## Setup software raid in degraded mode with one disk
@@ -1632,7 +1673,7 @@ div {
         }
         >> sch:pattern [ id = "mdraid" is-a = "image_type"
             sch:param [ name = "attr" value = "mdraid" ]
-            sch:param [ name = "types" value = "oem vmx" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.primary.attribute =
         ## Specifies the primary type (choose KIWI option type)
@@ -1643,14 +1684,14 @@ div {
         attribute ramonly { xsd:boolean }
         >> sch:pattern [ id = "ramonly" is-a = "image_type"
             sch:param [ name = "attr" value = "ramonly" ]
-            sch:param [ name = "types" value = "oem vmx" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.rootfs_label.attribute =
         ## label to set for the root filesystem. By default ROOT is used
         attribute rootfs_label { text }
         >> sch:pattern [ id = "rootfs_label" is-a = "image_type"
             sch:param [ name = "attr" value = "rootfs_label" ]
-            sch:param [ name = "types" value = "oem vmx pxe kis docker" ]
+            sch:param [ name = "types" value = "oem pxe kis docker" ]
         ] 
     k.type.vga.attribute =
         ## Specifies the kernel framebuffer mode. More information
@@ -1659,21 +1700,21 @@ div {
         attribute vga { text }
         >> sch:pattern [ id = "vga" is-a = "image_type"
             sch:param [ name = "attr" value = "vga" ]
-            sch:param [ name = "types" value = "oem vmx pxe kis iso" ]
+            sch:param [ name = "types" value = "oem pxe kis iso" ]
         ]
     k.type.gcelicense.attribute =
         ## Specifies the license tag in a GCE format
         attribute gcelicense { text }
         >> sch:pattern [ id = "gcelicense" is-a = "image_type"
             sch:param [ name = "attr" value = "gcelicense" ]
-            sch:param [ name = "types" value = "oem vmx" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.vhdfixedtag.attribute =
         ## Specifies the GUID in a fixed format VHD
         attribute vhdfixedtag { vhd-tag-type }
         >> sch:pattern [ id = "vhdfixedtag" is-a = "image_type"
             sch:param [ name = "attr" value = "vhdfixedtag" ]
-            sch:param [ name = "types" value = "oem vmx" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.volid.attribute =
         ## for the iso type only:
@@ -1716,7 +1757,7 @@ div {
         attribute disk_start_sector { xsd:integer { minInclusive = "2048" } }
         >> sch:pattern [ id = "disk_start_sector" is-a = "image_type"
             sch:param [ name = "attr" value = "disk_start_sector" ]
-            sch:param [ name = "types" value = "vmx oem" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.attlist =
         ## Specifies the image type
@@ -2111,7 +2152,7 @@ div {
         }
         >> sch:pattern [ id = "loader_name" is-a = "bootloader_image_type"
             sch:param [ name = "attr" value = "name" ]
-            sch:param [ name = "types" value = "oem vmx iso" ]
+            sch:param [ name = "types" value = "oem iso" ]
         ]
     k.bootloader.console.attribute =
         ## Specifies the bootloader console.
@@ -2518,6 +2559,7 @@ div {
             k.oemconfig.attlist &
             k.oem-boot-title? &
             k.oem-bootwait? &
+            k.oem-resize? &
             k.oem-resize-once? &
             k.oem-device-filter? &
             k.oem-nic-filter? &
@@ -2686,7 +2728,7 @@ div {
         ## packages are only installed if this build type is requested.
         attribute type {
             "bootstrap" | "delete" | "docker" | "image" |
-            "iso" | "oem" | "pxe" | "kis" | "vmx" | "oci" |
+            "iso" | "oem" | "pxe" | "kis" | "oci" |
             "uninstall"
         }
     k.packages.profiles.attribute = k.profiles.attribute

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -130,7 +130,7 @@ second the location of the XSD Schema
     <define name="k.image.schemaversion.attribute">
       <attribute name="schemaversion">
         <a:documentation>The allowed Schema version (fixed value)</a:documentation>
-        <value>7.2</value>
+        <value>7.3</value>
       </attribute>
     </define>
     <define name="k.image.id">
@@ -645,6 +645,31 @@ of the OEM image</a:documentation>
         <a:documentation>For oemboot driven images: halt system after image dump true/false</a:documentation>
         <ref name="k.oem-bootwait.attlist"/>
         <ref name="k.oem-bootwait.content"/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <oem-resize>
+    
+  -->
+  <div>
+    <define name="k.oem-resize.content">
+      <data type="boolean"/>
+    </define>
+    <define name="k.oem-resize.attlist">
+      <empty/>
+    </define>
+    <define name="k.oem-resize">
+      <element name="oem-resize">
+        <a:documentation>activate/deactivate disk resize on first boot: true/false
+By default the repart/resize is activated when creating
+an oem image. If the disk image should be more simple
+and should not react on storage geometry changes at all
+this option allows to switch off the use and inclusion
+of the kiwi oem dracut module that implements the resize</a:documentation>
+        <ref name="k.oem-resize.attlist"/>
+        <ref name="k.oem-resize.content"/>
       </element>
     </define>
   </div>
@@ -1765,6 +1790,11 @@ volume management system</a:documentation>
         <sch:assert test="@$attr">$attr attribute must be set for the following image types: $types</sch:assert>
       </sch:rule>
     </sch:pattern>
+    <sch:pattern abstract="true" id="image_expandable">
+      <sch:rule context="type[@$attr='true']">
+        <sch:assert test="oemconfig/oem-resize[contains(text(), 'false')]">$attr attribute also needs the setting: &lt;oem-resize&gt;false&lt;/oem-resize&gt; in the &lt;oemconfig&gt; section of the selected &lt;type&gt;</sch:assert>
+      </sch:rule>
+    </sch:pattern>
     <define name="k.type.boot.attribute">
       <attribute name="boot">
         <a:documentation>Specifies the path of the boot image (initrd) description
@@ -1792,7 +1822,7 @@ the Xen Hypervisor</a:documentation>
       </attribute>
       <sch:pattern id="xen_server" is-a="image_type">
         <sch:param name="attr" value="xen_server"/>
-        <sch:param name="types" value="oem vmx"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.btrfs_quota_groups.attribute">
@@ -1803,7 +1833,7 @@ By default the quota system is inactive</a:documentation>
       </attribute>
       <sch:pattern id="btrfs_quota_groups" is-a="image_type">
         <sch:param name="attr" value="btrfs_quota_groups"/>
-        <sch:param name="types" value="oem vmx"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.btrfs_root_is_snapshot.attribute">
@@ -1815,7 +1845,7 @@ toolkit. By default no snapshots are used</a:documentation>
       </attribute>
       <sch:pattern id="btrfs_root_is_snapshot" is-a="image_type">
         <sch:param name="attr" value="btrfs_root_is_snapshot"/>
-        <sch:param name="types" value="oem vmx"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.btrfs_root_is_readonly_snapshot.attribute">
@@ -1830,7 +1860,7 @@ is writable</a:documentation>
       </attribute>
       <sch:pattern id="btrfs_root_is_readonly_snapshot" is-a="image_type">
         <sch:param name="attr" value="btrfs_root_is_readonly_snapshot"/>
-        <sch:param name="types" value="oem vmx"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.target_blocksize.attribute">
@@ -1844,7 +1874,7 @@ desired target by calling: blockdev --report device</a:documentation>
       </attribute>
       <sch:pattern id="target_blocksize" is-a="image_type">
         <sch:param name="attr" value="target_blocksize"/>
-        <sch:param name="types" value="oem vmx"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.target_removable.attribute">
@@ -1859,7 +1889,7 @@ expected to be non-removable</a:documentation>
       </attribute>
       <sch:pattern id="target_removable" is-a="image_type">
         <sch:param name="attr" value="target_removable"/>
-        <sch:param name="types" value="oem vmx"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.spare_part.attribute">
@@ -1868,28 +1898,28 @@ expected to be non-removable</a:documentation>
 of the requested size. The attribute takes a size value
 and allows a unit in MB or GB, e.g 200M. If no unit is given
 the value is considered to be mbytes. A spare partition
-can only be configured for the disk image types oem and vmx</a:documentation>
+can only be configured for the disk image type oem</a:documentation>
         <ref name="partition-size-type"/>
       </attribute>
       <sch:pattern id="spare_part" is-a="image_type">
         <sch:param name="attr" value="spare_part"/>
-        <sch:param name="types" value="oem vmx"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.spare_part_mountpoint.attribute">
       <attribute name="spare_part_mountpoint">
         <a:documentation>Specify mount point for spare partition in the system.
-Can only be configured for the disk image types oem and vmx</a:documentation>
+Can only be configured for the disk image type oem</a:documentation>
       </attribute>
       <sch:pattern id="spare_part_mountpoint" is-a="image_type">
         <sch:param name="attr" value="spare_part_mountpoint"/>
-        <sch:param name="types" value="oem vmx"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.spare_part_fs.attribute">
       <attribute name="spare_part_fs">
         <a:documentation>Specify filesystem for spare partition in the system.
-Can only be configured for the disk image types oem and vmx</a:documentation>
+Can only be configured for the disk image type oem</a:documentation>
         <choice>
           <value>btrfs</value>
           <value>ext2</value>
@@ -1900,33 +1930,42 @@ Can only be configured for the disk image types oem and vmx</a:documentation>
       </attribute>
       <sch:pattern id="spare_part_fs" is-a="image_type">
         <sch:param name="attr" value="spare_part_fs"/>
-        <sch:param name="types" value="oem vmx"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.spare_part_fs_attributes.attribute">
       <attribute name="spare_part_fs_attributes">
         <a:documentation>Specify filesystem attributes for the spare partition.
 Attributes can be specified as comma separated list.
-Can only be configured for the disk image types oem and vmx</a:documentation>
+Can only be configured for the disk image type oem</a:documentation>
         <ref name="fs_attributes"/>
       </attribute>
       <sch:pattern id="spare_part_fs_attributes" is-a="image_type">
         <sch:param name="attr" value="spare_part_fs_attributes"/>
-        <sch:param name="types" value="oem vmx"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.spare_part_is_last.attribute">
       <attribute name="spare_part_is_last">
         <a:documentation>Specify if the spare partition should be the last one in
-the partition table. Can only be configured for the vmx
-disk image type. By default the root partition is the last
-one and the spare partition lives behind it. With this
-attribute that setup can be toggled.</a:documentation>
+the partition table. Can only be configured for the oem
+type with oem-resize switched off. By default the root
+partition is the last one and the spare partition lives
+before it. With this attribute that setup can be toggled.
+However if the root partition is no longer the last one
+the oem repart/resize code can no longer work because
+the spare part would block it. Because of that moving
+the spare part at the end of the disk is only applied
+if oem-resize is switched off. There is a runtime
+check in the kiwi code to check this condition</a:documentation>
         <data type="boolean"/>
       </attribute>
       <sch:pattern id="spare_part_is_last" is-a="image_type">
         <sch:param name="attr" value="spare_part_is_last"/>
-        <sch:param name="types" value="vmx"/>
+        <sch:param name="types" value="oem"/>
+      </sch:pattern>
+      <sch:pattern id="spare_part_is_last_valid" is-a="image_expandable">
+        <sch:param name="attr" value="spare_part_is_last"/>
       </sch:pattern>
     </define>
     <define name="k.type.bootpartsize.attribute">
@@ -1938,7 +1977,7 @@ size is set to 200 MB</a:documentation>
       </attribute>
       <sch:pattern id="bootpartsize" is-a="image_type">
         <sch:param name="attr" value="bootpartsize"/>
-        <sch:param name="types" value="oem vmx"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.efipartsize.attribute">
@@ -1950,7 +1989,7 @@ size is set to 20 MB</a:documentation>
       </attribute>
       <sch:pattern id="efipartsize" is-a="image_type">
         <sch:param name="attr" value="efipartsize"/>
-        <sch:param name="types" value="oem vmx"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.efiparttable.attribute">
@@ -1965,7 +2004,7 @@ table type.</a:documentation>
       </attribute>
       <sch:pattern id="efiparttable" is-a="image_type">
         <sch:param name="attr" value="efiparttable"/>
-        <sch:param name="types" value="oem vmx"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.bootprofile.attribute">
@@ -1976,7 +2015,7 @@ information is passed as add-profile option</a:documentation>
       </attribute>
       <sch:pattern id="bootprofile" is-a="image_type">
         <sch:param name="attr" value="bootprofile"/>
-        <sch:param name="types" value="oem vmx iso pxe cpio"/>
+        <sch:param name="types" value="oem iso pxe cpio"/>
       </sch:pattern>
     </define>
     <define name="k.type.compressed.attribute">
@@ -2011,7 +2050,7 @@ structure</a:documentation>
       </attribute>
       <sch:pattern id="editbootconfig" is-a="image_type">
         <sch:param name="attr" value="editbootconfig"/>
-        <sch:param name="types" value="vmx oem iso"/>
+        <sch:param name="types" value="oem iso"/>
       </sch:pattern>
     </define>
     <define name="k.type.editbootinstall.attribute">
@@ -2023,7 +2062,7 @@ structure</a:documentation>
       </attribute>
       <sch:pattern id="editbootinstall" is-a="image_type">
         <sch:param name="attr" value="editbootinstall"/>
-        <sch:param name="types" value="vmx oem"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.filesystem.attribute">
@@ -2040,11 +2079,11 @@ structure</a:documentation>
       </attribute>
       <sch:pattern id="filesystem" is-a="image_type">
         <sch:param name="attr" value="filesystem"/>
-        <sch:param name="types" value="vmx oem pxe kis"/>
+        <sch:param name="types" value="oem pxe kis"/>
       </sch:pattern>
       <sch:pattern id="filesystem_mandatory" is-a="image_type_requirement">
         <sch:param name="attr" value="filesystem"/>
-        <sch:param name="types" value="vmx oem"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.squashfscompression.attribute">
@@ -2061,7 +2100,7 @@ structure</a:documentation>
       </attribute>
       <sch:pattern id="squashfscompression" is-a="image_type">
         <sch:param name="attr" value="squashfscompression"/>
-        <sch:param name="types" value="vmx oem pxe kis iso"/>
+        <sch:param name="types" value="oem pxe kis iso"/>
       </sch:pattern>
     </define>
     <define name="k.type.overlayroot.attribute">
@@ -2070,12 +2109,12 @@ structure</a:documentation>
 out of a squashfs compressed read-only root system
 overlayed using the overlayfs filesystem into an
 extra read-write partition. Available for the disk
-image types, vmx and oem</a:documentation>
+image type oem</a:documentation>
         <data type="boolean"/>
       </attribute>
       <sch:pattern id="overlayroot" is-a="image_type">
         <sch:param name="attr" value="overlayroot"/>
-        <sch:param name="types" value="vmx oem"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.firmware.attribute">
@@ -2098,7 +2137,7 @@ the standard x86 bios firmware setup is used</a:documentation>
       </attribute>
       <sch:pattern id="firmware" is-a="image_type">
         <sch:param name="attr" value="firmware"/>
-        <sch:param name="types" value="vmx oem pxe iso"/>
+        <sch:param name="types" value="oem pxe iso"/>
       </sch:pattern>
     </define>
     <define name="k.type.bootpartition.attribute">
@@ -2109,7 +2148,7 @@ This will overwrite kiwi's default layout</a:documentation>
       </attribute>
       <sch:pattern id="bootpartition" is-a="image_type">
         <sch:param name="attr" value="bootpartition"/>
-        <sch:param name="types" value="vmx oem"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.bootfilesystem.attribute">
@@ -2128,7 +2167,7 @@ e.g for the syslinux loader fat is required</a:documentation>
       </attribute>
       <sch:pattern id="bootfilesystem" is-a="image_type">
         <sch:param name="attr" value="bootfilesystem"/>
-        <sch:param name="types" value="vmx oem"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.flags.attribute">
@@ -2167,7 +2206,7 @@ a different set of live features.</a:documentation>
       </attribute>
       <sch:pattern id="format" is-a="image_type">
         <sch:param name="attr" value="format"/>
-        <sch:param name="types" value="vmx oem"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.formatoptions.attribute">
@@ -2180,7 +2219,7 @@ the -o option in the qemu-img call</a:documentation>
       </attribute>
       <sch:pattern id="formatoptions" is-a="image_type">
         <sch:param name="attr" value="formatoptions"/>
-        <sch:param name="types" value="vmx oem"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.force_mbr.attribute">
@@ -2196,7 +2235,7 @@ partitions</a:documentation>
       </attribute>
       <sch:pattern id="force_mbr" is-a="image_type">
         <sch:param name="attr" value="force_mbr"/>
-        <sch:param name="types" value="vmx oem"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.fsmountoptions.attribute">
@@ -2244,7 +2283,7 @@ create a hybrid GPT/MBR partition table</a:documentation>
       </attribute>
       <sch:pattern id="gpt_hybrid_mbr" is-a="image_type">
         <sch:param name="attr" value="gpt_hybrid_mbr"/>
-        <sch:param name="types" value="vmx oem"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.initrd_system.attribute">
@@ -2279,7 +2318,6 @@ system does not support all features of the kiwi initrd</a:documentation>
           <value>kis</value>
           <value>squashfs</value>
           <value>tbz</value>
-          <value>vmx</value>
           <value>xfs</value>
           <value>oci</value>
           <value>appx</value>
@@ -2391,7 +2429,7 @@ kernel command line options</a:documentation>
       </attribute>
       <sch:pattern id="kernelcmdline" is-a="image_type">
         <sch:param name="attr" value="kernelcmdline"/>
-        <sch:param name="types" value="oem vmx iso pxe kis"/>
+        <sch:param name="types" value="oem iso pxe kis"/>
       </sch:pattern>
     </define>
     <define name="k.type.luks.attribute">
@@ -2403,7 +2441,7 @@ mount that filesystem while booting</a:documentation>
       </attribute>
       <sch:pattern id="luks" is-a="image_type">
         <sch:param name="attr" value="luks"/>
-        <sch:param name="types" value="oem vmx iso pxe kis"/>
+        <sch:param name="types" value="oem iso pxe kis"/>
       </sch:pattern>
     </define>
     <define name="k.type.luksOS.attribute">
@@ -2416,7 +2454,7 @@ distribution</a:documentation>
       </attribute>
       <sch:pattern id="luksOS" is-a="image_type">
         <sch:param name="attr" value="luksOS"/>
-        <sch:param name="types" value="oem vmx iso pxe kis"/>
+        <sch:param name="types" value="oem iso pxe kis"/>
       </sch:pattern>
     </define>
     <define name="k.type.mdraid.attribute">
@@ -2430,7 +2468,7 @@ Thus only mirroring and striping is possible</a:documentation>
       </attribute>
       <sch:pattern id="mdraid" is-a="image_type">
         <sch:param name="attr" value="mdraid"/>
-        <sch:param name="types" value="oem vmx"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.primary.attribute">
@@ -2447,7 +2485,7 @@ will force any COW action to happen in RAM</a:documentation>
       </attribute>
       <sch:pattern id="ramonly" is-a="image_type">
         <sch:param name="attr" value="ramonly"/>
-        <sch:param name="types" value="oem vmx"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.rootfs_label.attribute">
@@ -2456,7 +2494,7 @@ will force any COW action to happen in RAM</a:documentation>
       </attribute>
       <sch:pattern id="rootfs_label" is-a="image_type">
         <sch:param name="attr" value="rootfs_label"/>
-        <sch:param name="types" value="oem vmx pxe kis docker"/>
+        <sch:param name="types" value="oem pxe kis docker"/>
       </sch:pattern>
     </define>
     <define name="k.type.vga.attribute">
@@ -2467,7 +2505,7 @@ hwinfo --framebuffer or in /usr/src/linux/Documentation/fb/vesafb.txt</a:documen
       </attribute>
       <sch:pattern id="vga" is-a="image_type">
         <sch:param name="attr" value="vga"/>
-        <sch:param name="types" value="oem vmx pxe kis iso"/>
+        <sch:param name="types" value="oem pxe kis iso"/>
       </sch:pattern>
     </define>
     <define name="k.type.gcelicense.attribute">
@@ -2476,7 +2514,7 @@ hwinfo --framebuffer or in /usr/src/linux/Documentation/fb/vesafb.txt</a:documen
       </attribute>
       <sch:pattern id="gcelicense" is-a="image_type">
         <sch:param name="attr" value="gcelicense"/>
-        <sch:param name="types" value="oem vmx"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.vhdfixedtag.attribute">
@@ -2486,7 +2524,7 @@ hwinfo --framebuffer or in /usr/src/linux/Documentation/fb/vesafb.txt</a:documen
       </attribute>
       <sch:pattern id="vhdfixedtag" is-a="image_type">
         <sch:param name="attr" value="vhdfixedtag"/>
-        <sch:param name="types" value="oem vmx"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.volid.attribute">
@@ -2544,7 +2582,7 @@ default.</a:documentation>
       </attribute>
       <sch:pattern id="disk_start_sector" is-a="image_type">
         <sch:param name="attr" value="disk_start_sector"/>
-        <sch:param name="types" value="vmx oem"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.attlist">
@@ -3271,7 +3309,7 @@ the editbootinstall and editbootconfig custom scripts</a:documentation>
       </attribute>
       <sch:pattern id="loader_name" is-a="bootloader_image_type">
         <sch:param name="attr" value="name"/>
-        <sch:param name="types" value="oem vmx iso"/>
+        <sch:param name="types" value="oem iso"/>
       </sch:pattern>
     </define>
     <define name="k.bootloader.console.attribute">
@@ -3855,6 +3893,9 @@ and setup the system disk.</a:documentation>
             <ref name="k.oem-bootwait"/>
           </optional>
           <optional>
+            <ref name="k.oem-resize"/>
+          </optional>
+          <optional>
             <ref name="k.oem-resize-once"/>
           </optional>
           <optional>
@@ -4182,7 +4223,6 @@ packages are only installed if this build type is requested.</a:documentation>
           <value>oem</value>
           <value>pxe</value>
           <value>kis</value>
-          <value>vmx</value>
           <value>oci</value>
           <value>uninstall</value>
         </choice>

--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -41,7 +41,7 @@ class DiskSetup:
         self.root_filesystem_is_overlay = xml_state.build_type.get_overlayroot()
         self.swap_mbytes = xml_state.get_oemconfig_swap_mbytes()
         self.configured_size = xml_state.get_build_type_size()
-        self.build_type_name = xml_state.get_build_type_name()
+        self.disk_resize_requested = xml_state.get_oemconfig_oem_resize()
         self.filesystem = xml_state.build_type.get_filesystem()
         self.bootpart_requested = xml_state.build_type.get_bootpartition()
         self.bootpart_mbytes = xml_state.build_type.get_bootpartsize()
@@ -278,10 +278,10 @@ class DiskSetup:
         data_volume_mbytes = self._calculate_volume_mbytes()
         root_volume = self._get_root_volume_configuration()
 
-        # For oem types we only add the default min volume size
-        # because their target size request is handled on first boot
-        # of the disk image in oemboot/repart
-        if self.build_type_name == 'oem':
+        # If disk resize is requested we only add the default min
+        # volume size because their target size request is handled
+        # on first boot of the disk image in oemboot/repart
+        if self.disk_resize_requested:
             for volume in self.volumes:
                 disk_volume_mbytes += Defaults.get_min_volume_mbytes()
             return disk_volume_mbytes

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -256,7 +256,7 @@ class VolumeManagerBase(DeviceProvider):
         )
 
     def get_volume_mbsize(
-        self, volume, all_volumes, filesystem_name, image_type=None
+        self, volume, all_volumes, filesystem_name, resize_on_boot=False
     ):
         """
         Implements size lookup for the given path and desired
@@ -265,7 +265,13 @@ class VolumeManagerBase(DeviceProvider):
         :param tuple volume: volume to check size for
         :param list all_volumes: list of all volume tuples
         :param str filesystem_name: filesystem name
-        :param image_type: build type name
+        :param resize_on_boot:
+            specify the time of the resize. If the resize happens at
+            boot time the volume size is only the minimum size to
+            just store the data. If the volume size is fixed and
+            does not change at boot time the returned size is the
+            requested size which can be greater than the minimum
+            needed size.
 
         :return: mbsize
 
@@ -278,12 +284,11 @@ class VolumeManagerBase(DeviceProvider):
         )
         mbsize = int(mbsize)
 
-        if image_type and image_type == 'oem':
-            # only for vmx types we need to create the volumes in the
-            # configured size. oem disks are self expandable and will
-            # resize to the configured sizes on first boot of the disk
-            # image. Therefore the requested size is set to null
-            # and we add the required minimum size to hold the data
+        if resize_on_boot:
+            # If resize_on_boot is true, the disk is self expandable and
+            # will resize to the configured sizes on first boot
+            # Therefore the requested size is set to null and we add
+            # the required minimum size for just storing the data
             size_type = 'freespace'
             mbsize = Defaults.get_min_volume_mbytes()
 

--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -50,8 +50,8 @@ class VolumeManagerLVM(VolumeManagerBase):
             self.custom_args = {}
         if 'root_label' not in self.custom_args:
             self.custom_args['root_label'] = 'ROOT'
-        if 'image_type' not in self.custom_args:
-            self.custom_args['image_type'] = None
+        if 'resize_on_boot' not in self.custom_args:
+            self.custom_args['resize_on_boot'] = False
 
         if self.custom_filesystem_args['mount_options']:
             self.mount_options = self.custom_filesystem_args['mount_options'][0]
@@ -161,7 +161,7 @@ class VolumeManagerLVM(VolumeManagerBase):
         for volume in canonical_volume_list.volumes:
             volume_mbsize = self.get_volume_mbsize(
                 volume, self.volumes, filesystem_name,
-                self.custom_args['image_type']
+                self.custom_args['resize_on_boot']
             )
             log.info(
                 '--> volume %s with %s MB', volume.name, volume_mbsize

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -5842,7 +5842,7 @@ class oemconfig(GeneratedsSuper):
     which are used to repartition and setup the system disk."""
     subclass = None
     superclass = None
-    def __init__(self, oem_boot_title=None, oem_bootwait=None, oem_resize_once=None, oem_device_filter=None, oem_nic_filter=None, oem_inplace_recovery=None, oem_kiwi_initrd=None, oem_multipath_scan=None, oem_vmcp_parmfile=None, oem_partition_install=None, oem_reboot=None, oem_reboot_interactive=None, oem_recovery=None, oem_recoveryID=None, oem_recovery_part_size=None, oem_shutdown=None, oem_shutdown_interactive=None, oem_silent_boot=None, oem_silent_install=None, oem_silent_verify=None, oem_skip_verify=None, oem_swap=None, oem_swapsize=None, oem_systemsize=None, oem_unattended=None, oem_unattended_id=None):
+    def __init__(self, oem_boot_title=None, oem_bootwait=None, oem_resize=None, oem_resize_once=None, oem_device_filter=None, oem_nic_filter=None, oem_inplace_recovery=None, oem_kiwi_initrd=None, oem_multipath_scan=None, oem_vmcp_parmfile=None, oem_partition_install=None, oem_reboot=None, oem_reboot_interactive=None, oem_recovery=None, oem_recoveryID=None, oem_recovery_part_size=None, oem_shutdown=None, oem_shutdown_interactive=None, oem_silent_boot=None, oem_silent_install=None, oem_silent_verify=None, oem_skip_verify=None, oem_swap=None, oem_swapsize=None, oem_systemsize=None, oem_unattended=None, oem_unattended_id=None):
         self.original_tagname_ = None
         if oem_boot_title is None:
             self.oem_boot_title = []
@@ -5852,6 +5852,10 @@ class oemconfig(GeneratedsSuper):
             self.oem_bootwait = []
         else:
             self.oem_bootwait = oem_bootwait
+        if oem_resize is None:
+            self.oem_resize = []
+        else:
+            self.oem_resize = oem_resize
         if oem_resize_once is None:
             self.oem_resize_once = []
         else:
@@ -5969,6 +5973,11 @@ class oemconfig(GeneratedsSuper):
     def add_oem_bootwait(self, value): self.oem_bootwait.append(value)
     def insert_oem_bootwait_at(self, index, value): self.oem_bootwait.insert(index, value)
     def replace_oem_bootwait_at(self, index, value): self.oem_bootwait[index] = value
+    def get_oem_resize(self): return self.oem_resize
+    def set_oem_resize(self, oem_resize): self.oem_resize = oem_resize
+    def add_oem_resize(self, value): self.oem_resize.append(value)
+    def insert_oem_resize_at(self, index, value): self.oem_resize.insert(index, value)
+    def replace_oem_resize_at(self, index, value): self.oem_resize[index] = value
     def get_oem_resize_once(self): return self.oem_resize_once
     def set_oem_resize_once(self, oem_resize_once): self.oem_resize_once = oem_resize_once
     def add_oem_resize_once(self, value): self.oem_resize_once.append(value)
@@ -6093,6 +6102,7 @@ class oemconfig(GeneratedsSuper):
         if (
             self.oem_boot_title or
             self.oem_bootwait or
+            self.oem_resize or
             self.oem_resize_once or
             self.oem_device_filter or
             self.oem_nic_filter or
@@ -6155,6 +6165,9 @@ class oemconfig(GeneratedsSuper):
         for oem_bootwait_ in self.oem_bootwait:
             showIndent(outfile, level, pretty_print)
             outfile.write('<oem-bootwait>%s</oem-bootwait>%s' % (self.gds_format_boolean(oem_bootwait_, input_name='oem-bootwait'), eol_))
+        for oem_resize_ in self.oem_resize:
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<oem-resize>%s</oem-resize>%s' % (self.gds_format_boolean(oem_resize_, input_name='oem-resize'), eol_))
         for oem_resize_once_ in self.oem_resize_once:
             showIndent(outfile, level, pretty_print)
             outfile.write('<oem-resize-once>%s</oem-resize-once>%s' % (self.gds_format_boolean(oem_resize_once_, input_name='oem-resize-once'), eol_))
@@ -6251,6 +6264,16 @@ class oemconfig(GeneratedsSuper):
                 raise_parse_error(child_, 'requires boolean')
             ival_ = self.gds_validate_boolean(ival_, node, 'oem_bootwait')
             self.oem_bootwait.append(ival_)
+        elif nodeName_ == 'oem-resize':
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_resize')
+            self.oem_resize.append(ival_)
         elif nodeName_ == 'oem-resize-once':
             sval_ = child_.text
             if sval_ in ('true', '1'):

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -861,6 +861,21 @@ class XMLState:
         if oemconfig_sections:
             return oemconfig_sections[0]
 
+    def get_oemconfig_oem_resize(self):
+        """
+        State value to activate/deactivate disk resize. Returns a
+        boolean value if specified or True to set resize on by default
+
+        :return: Content of <oem-resize> section value
+
+        :rtype: bool
+        """
+        oemconfig = self.get_build_type_oemconfig_section()
+        if oemconfig and oemconfig.get_oem_resize():
+            return oemconfig.get_oem_resize()[0]
+        else:
+            return True
+
     def get_oemconfig_oem_multipath_scan(self):
         """
         State value to activate multipath maps. Returns a boolean

--- a/kiwi/xsl/convert72to73.xsl
+++ b/kiwi/xsl/convert72to73.xsl
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv72to73">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv72to73"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>7.2</literal> to <literal>7.3</literal>.
+</para>
+<xsl:template match="image" mode="conv72to73">
+    <xsl:choose>
+        <!-- nothing to do if already at 7.3 -->
+        <xsl:when test="@schemaversion > 7.2">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="7.3">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv72to73"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- change vmx type to oem type with oem-resize set to false-->
+<xsl:template match="type[@image='vmx']" mode="conv72to73">
+    <type image="oem">
+        <xsl:copy-of select="@*[local-name() != 'image']"/>
+        <oemconfig>
+            <xsl:apply-templates select="oemconfig/*[not(self::oem-resize)]" mode="conv72to73"/>
+            <oem-resize>false</oem-resize>
+        </oemconfig>
+        <xsl:apply-templates select="*[not(self::oemconfig)]" mode="conv72to73"/>
+    </type>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/kiwi/xsl/master.xsl
+++ b/kiwi/xsl/master.xsl
@@ -43,6 +43,7 @@
 <xsl:import href="convert69to70.xsl"/>
 <xsl:import href="convert70to71.xsl"/>
 <xsl:import href="convert71to72.xsl"/>
+<xsl:import href="convert72to73.xsl"/>
 <xsl:import href="pretty.xsl"/>
 
 
@@ -201,8 +202,12 @@
         <xsl:apply-templates select="exslt:node-set($v71)" mode="conv71to72"/>
     </xsl:variable>
 
+    <xsl:variable name="v73">
+        <xsl:apply-templates select="exslt:node-set($v72)" mode="conv72to73"/>
+    </xsl:variable>
+
     <xsl:apply-templates
-        select="exslt:node-set($v72)" mode="pretty"
+        select="exslt:node-set($v73)" mode="pretty"
     />
 </xsl:template>
 

--- a/test/data/example_arm_disk_size_config.xml
+++ b/test/data/example_arm_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_btrfs_config.xml
+++ b/test/data/example_btrfs_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.3" name="LimeJeOS" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>
@@ -22,17 +22,20 @@
         <author>Marcus</author>
         <contact>ms@suse.com</contact>
         <specification>
-            openSUSE 13.2 JeOS, is a small text based image
+            Testing various configuration states
         </specification>
     </description>
     <profiles>
-        <profile name="xenFlavour" description="VMX with Xen kernel"/>
-        <profile name="ec2Flavour" description="VMX with EC2/Xen kernel"/>
-        <profile name="vmxFlavour" description="VMX with default kernel" import="true"/>
-        <profile name="derivedContainer" description="Container built on top of a base issue"/>
+        <profile name="xenDom0Flavour" description="Disk Dom0"/>
+        <profile name="xenDomUFlavour" description="Disk DomU"/>
+        <profile name="ec2Flavour" description="Disk EC2"/>
+        <profile name="vmxFlavour" description="Disk" import="true"/>
+        <profile name="vmxSimpleFlavour" description="Disk no resize"/>
+        <profile name="containerFlavour" description="Container image"/>
+        <profile name="derivedContainer" description="Container from a base"/>
         <profile name="composedProfile" description="Composed profile">
-            <requires profile="vmxFlavour"/>
-            <requires profile="xenFlavour"/>
+            <requires profile="vmxSimpleFlavour"/>
+            <requires profile="xenDomUFlavour"/>
         </profile>
     </profiles>
     <preferences>
@@ -40,6 +43,17 @@
         <rpm-locale-filtering>true</rpm-locale-filtering>
     </preferences>
     <preferences>
+        <version>1.13.2</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>true</rpm-check-signatures>
+        <bootsplash-theme>openSUSE</bootsplash-theme>
+        <bootloader-theme>openSUSE</bootloader-theme>
+    </preferences>
+    <preferences profiles="vmxFlavour">
         <type image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" fscreateoptions="-O ^has_journal" btrfs_root_is_snapshot="true" spare_part="200M" spare_part_fs_attributes="no-copy-on-write" xen_server="true" formatoptions="force_size,super=man" filesystem="ext4">
             <size unit="G" additive="true">1</size>
             <systemdisk name="mydisk"/>
@@ -56,27 +70,27 @@
             </oemconfig>
             <vagrantconfig provider="libvirt" virtualsize="42"/>
         </type>
-        <version>1.13.2</version>
-        <packagemanager>zypper</packagemanager>
-        <locale>en_US</locale>
-        <keytable>us.map.gz</keytable>
-        <timezone>Europe/Berlin</timezone>
-        <rpm-excludedocs>true</rpm-excludedocs>
-        <rpm-check-signatures>true</rpm-check-signatures>
-        <bootsplash-theme>openSUSE</bootsplash-theme>
-        <bootloader-theme>openSUSE</bootloader-theme>
     </preferences>
     <preferences profiles="ec2Flavour">
-        <type image="vmx" filesystem="ext3" bootprofile="ec2" bootkernel="ec2k" kernelcmdline="xencons=xvc0 console=xvc0 multipath=off splash" firmware="ec2"/>
+        <type image="oem" filesystem="ext3" bootprofile="ec2" bootkernel="ec2k" kernelcmdline="xencons=xvc0 console=xvc0 multipath=off splash" firmware="ec2">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+        </type>
     </preferences>
-    <preferences profiles="xenFlavour">
-        <type image="vmx" filesystem="ext3" bootprofile="xen" bootkernel="xenk" kernelcmdline="splash">
+    <preferences profiles="xenDomUFlavour">
+        <type image="oem" filesystem="ext3" bootprofile="xen" bootkernel="xenk" kernelcmdline="splash">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <machine memory="512" xen_loader="hvmloader">
                 <vmdisk id="0" device="/dev/xvda" controller="ide"/>
                 <vmnic interface=""/>
             </machine>
             <size>10</size>
         </type>
+    </preferences>
+    <preferences profiles="xenDom0Flavour">
         <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" bootprofile="xen" bootkernel="xenk" installiso="true" kernelcmdline="splash">
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
@@ -85,8 +99,11 @@
         </type>
         <type image="docker"/>
     </preferences>
-    <preferences profiles="vmxFlavour">
-        <type image="vmx" filesystem="ext3" format="vmdk" kernelcmdline="splash" bootpartition="false">
+    <preferences profiles="vmxSimpleFlavour">
+        <type image="oem" filesystem="ext3" format="vmdk" kernelcmdline="splash" bootpartition="false">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <size unit="G" unpartitioned="1">4</size>
             <systemdisk name="systemVG"/>
             <machine memory="512" guestOS="suse" HWversion="4">
@@ -96,16 +113,9 @@
                 <vmconfig-entry>cpuid.coresPerSocket = "2"</vmconfig-entry>
             </machine>
         </type>
-        <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" installiso="true" kernelcmdline="splash">
-            <oemconfig>
-                <oem-systemsize>2048</oem-systemsize>
-                <oem-swap>true</oem-swap>
-            </oemconfig>
-            <machine memory="512" guestOS="suse" HWversion="4">
-                <vmdisk id="0" controller="ide"/>
-                <vmnic driver="e1000" interface="0" mode="bridged"/>
-            </machine>
-        </type>
+        <type image="iso" mediacheck="true"/>
+    </preferences>
+    <preferences profiles="containerFlavour">
         <type image="docker">
             <containerconfig name="container_name" maintainer="tux" user="root" workingdir="/root" tag="container_tag" additionaltags="current,foobar">
                 <entrypoint execute="/bin/bash">
@@ -133,7 +143,6 @@
                 <history author="history author" created_by="created by text" application_id="123" launcher="app" package_version="2003.12.0.0">This is a comment</history>
             </containerconfig>
         </type>
-        <type image="iso" mediacheck="true"/>
     </preferences>
     <preferences profiles="derivedContainer">
         <type image="docker" derived_from="obs://project/repo/image#mytag">
@@ -180,7 +189,7 @@
         <package name="xen-tools" arch="x86_64"/>
         <package name="xen" arch="x86_64"/>
     </packages>
-    <packages type="image" profiles="xenFlavour">
+    <packages type="image" profiles="xenDom0Flavour,xenDomUFlavour">
         <package name="kernel-xen"/>
         <package name="xen-tools" arch="x86_64"/>
         <package name="xen" arch="x86_64"/>

--- a/test/data/example_disk_config.xml
+++ b/test/data/example_disk_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_config.xml
+++ b/test/data/example_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_empty_vol_config.xml
+++ b/test/data/example_disk_size_empty_vol_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,10 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext3" kernelcmdline="splash" firmware="efi">
+        <type image="oem" filesystem="ext3" kernelcmdline="splash" firmware="efi">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <systemdisk/>
         </type>
     </preferences>

--- a/test/data/example_disk_size_oem_volume_config.xml
+++ b/test/data/example_disk_size_oem_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_vol_root_config.xml
+++ b/test/data/example_disk_size_vol_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,10 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext3" kernelcmdline="splash" firmware="efi">
+        <type image="oem" filesystem="ext3" kernelcmdline="splash" firmware="efi">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <systemdisk>
                 <volume name="@root" size="5M"/>
             </systemdisk>

--- a/test/data/example_disk_size_volume_config.xml
+++ b/test/data/example_disk_size_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,10 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext3" kernelcmdline="splash" firmware="efi">
+        <type image="oem" filesystem="ext3" kernelcmdline="splash" firmware="efi">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <systemdisk>
                 <volume name="usr/lib" size="1G"/>
                 <volume name="usr/bin" size="5"/>

--- a/test/data/example_dot_profile_config.xml
+++ b/test/data/example_dot_profile_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_default_config.xml
+++ b/test/data/example_lvm_default_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_config.xml
+++ b/test/data/example_lvm_no_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_full_usr_config.xml
+++ b/test/data/example_lvm_no_root_full_usr_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_preferred_config.xml
+++ b/test/data/example_lvm_preferred_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_multiple_users_config.xml
+++ b/test/data/example_multiple_users_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -23,7 +23,11 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="btrfs" kernelcmdline="splash" firmware="efi"/>
+        <type image="oem" filesystem="btrfs" kernelcmdline="splash" firmware="efi">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+        </type>
     </preferences>
     <users>
         <user pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>

--- a/test/data/example_no_default_type.xml
+++ b/test/data/example_no_default_type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -26,7 +26,11 @@
         <bootloader-theme>openSUSE</bootloader-theme>
     </preferences>
     <preferences profiles="vmxFlavor">
-        <type image="vmx" filesystem="btrfs" kernelcmdline="splash" firmware="efi"/>
+        <type image="oem" filesystem="btrfs" kernelcmdline="splash" firmware="efi">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+        </type>
     </preferences>
     <users>
         <user pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>

--- a/test/data/example_no_image_packages_config.xml
+++ b/test/data/example_no_image_packages_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_imageinclude_config.xml
+++ b/test/data/example_no_imageinclude_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_ppc_disk_size_config.xml
+++ b/test/data/example_ppc_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_pxe_config.xml
+++ b/test/data/example_pxe_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_boot_desc_not_found.xml
+++ b/test/data/example_runtime_checker_boot_desc_not_found.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="JeOS">
+<image schemaversion="7.3" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>
@@ -28,14 +28,16 @@
     <profiles>
         <profile name="metadata" description="Inlude some preferences metadata"/>
         <profile name="noVersion" description="Does not include version element"/>
-        <profile name="xenFlavour" description="VMX with Xen kernel"/>
-        <profile name="ec2Flavour" description="VMX with EC2/Xen kernel"/>
+        <profile name="xenDom0Flavour" description="Disk Xen dom0"/>
+        <profile name="xenDomUFlavour" description="Disk Xen domU"/>
+        <profile name="ec2Flavour" description="Disk with EC2/Xen kernel"/>
         <profile name="docker" description="docker image">
             <requires profile="noVersion"/>
         </profile>
-        <profile name="vmxFlavour" description="VMX with default kernel" import="true">
+        <profile name="vmxFlavour" description="Disk with default kernel" import="true">
             <requires profile="metadata"/>
         </profile>
+        <profile name="vmxSimpleFlavour" description="Disk no resize"/>
         <profile name="wsl_launcher" description="Appx invalid launcher name"/>
         <profile name="wsl_id" description="Appx invalid id"/>
     </profiles>
@@ -56,24 +58,14 @@
     <preferences profiles="wsl_launcher">
         <type image="appx" metadata_path="/usr/share/wsl-appx">
             <containerconfig name="Tumbleweed">
-                <history
-                    author="KIWI-Team"
-                    application_id="tumbleweed"
-                    package_version="2003.12.0.0"
-                    launcher="Invalid-Launcher"
-                >Tumbleweed JeOS text based</history>
+                <history author="KIWI-Team" application_id="tumbleweed" package_version="2003.12.0.0" launcher="Invalid-Launcher">Tumbleweed JeOS text based</history>
             </containerconfig>
         </type>
     </preferences>
     <preferences profiles="wsl_id">
         <type image="appx" metadata_path="/usr/share/wsl-appx">
             <containerconfig name="Tumbleweed">
-                <history
-                    author="KIWI-Team"
-                    application_id="invalid-id"
-                    package_version="2003.12.0.0"
-                    launcher="openSUSE-Tumbleweed.exe"
-                >Tumbleweed JeOS text based</history>
+                <history author="KIWI-Team" application_id="invalid-id" package_version="2003.12.0.0" launcher="openSUSE-Tumbleweed.exe">Tumbleweed JeOS text based</history>
             </containerconfig>
         </type>
     </preferences>
@@ -83,15 +75,24 @@
         </type>
     </preferences>
     <preferences profiles="ec2Flavour">
-        <type image="vmx" filesystem="ext3" bootprofile="ec2" bootkernel="ec2k" kernelcmdline="xencons=xvc0 console=xvc0 multipath=off splash" firmware="ec2"/>
+        <type image="oem" filesystem="ext3" bootprofile="ec2" bootkernel="ec2k" kernelcmdline="xencons=xvc0 console=xvc0 multipath=off splash" firmware="ec2">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+        </type>
     </preferences>
-    <preferences profiles="xenFlavour">
-        <type image="vmx" filesystem="ext3" bootprofile="xen" bootkernel="xenk" kernelcmdline="splash">
+    <preferences profiles="xenDomUFlavour">
+        <type image="oem" filesystem="ext3" bootprofile="xen" bootkernel="xenk" kernelcmdline="splash">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <machine memory="512" xen_loader="pvgrub">
                 <vmdisk id="0" device="/dev/xvda" controller="ide"/>
                 <vmnic interface=""/>
             </machine>
         </type>
+    </preferences>
+    <preferences profiles="xenDom0Flavour">
         <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" bootprofile="xen" bootkernel="xenk" installiso="true" kernelcmdline="splash" xen_server="true" firmware="bios">
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
@@ -99,8 +100,11 @@
             </oemconfig>
         </type>
     </preferences>
-    <preferences profiles="vmxFlavour">
-        <type image="vmx" filesystem="ext3" format="vmdk" kernelcmdline="splash" bootpartition="false">
+    <preferences profiles="vmxSimpleFlavour">
+        <type image="oem" filesystem="ext3" format="vmdk" kernelcmdline="splash" bootpartition="false">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
             <systemdisk name="systemVG">
                 <volume name="foo" label="SWAP"/>
             </systemdisk>
@@ -109,6 +113,8 @@
                 <vmnic driver="e1000" interface="0" mode="bridged"/>
             </machine>
         </type>
+    </preferences>
+    <preferences profiles="vmxFlavour">
         <type image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="my_edit_boot_install" filesystem="btrfs" initrd_system="dracut" installiso="true">
             <size unit="G" additive="true">1</size>
             <systemdisk name="mydisk">
@@ -160,7 +166,7 @@
         <package name="xen-tools" arch="x86_64"/>
         <package name="xen" arch="x86_64"/>
     </packages>
-    <packages type="image" profiles="xenFlavour">
+    <packages type="image" profiles="xenDom0Flavour">
         <package name="kernel-xen"/>
         <package name="xen-tools" arch="x86_64"/>
         <package name="xen" arch="x86_64"/>

--- a/test/data/example_runtime_checker_no_boot_reference.xml
+++ b/test/data/example_runtime_checker_no_boot_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="JeOS">
+<image schemaversion="7.3" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/isoboot/example-distribution-no-delete-section/config.xml
+++ b/test/data/isoboot/example-distribution-no-delete-section/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="initrd-isoboot-suse-13.2">
+<image schemaversion="7.3" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/isoboot/example-distribution/config.xml
+++ b/test/data/isoboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="initrd-isoboot-suse-13.2">
+<image schemaversion="7.3" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/oemboot/example-distribution/config.xml
+++ b/test/data/oemboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="initrd-oemboot-suse-13.2">
+<image schemaversion="7.3" name="initrd-oemboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/unit/boot/image/builtin_kiwi_test.py
+++ b/test/unit/boot/image/builtin_kiwi_test.py
@@ -128,7 +128,7 @@ class TestBootImageKiwi:
             ''.join(
                 [
                     self.boot_image.target_dir,
-                    '/LimeJeOS-openSUSE-13.2.x86_64-1.13.2.initrd'
+                    '/LimeJeOS.x86_64-1.13.2.initrd'
                 ]
             )
         )
@@ -136,7 +136,7 @@ class TestBootImageKiwi:
             ''.join(
                 [
                     self.boot_image.target_dir,
-                    '/LimeJeOS-openSUSE-13.2.x86_64-1.13.2.initrd'
+                    '/LimeJeOS.x86_64-1.13.2.initrd'
                 ]
             )
         )

--- a/test/unit/boot/image/dracut_test.py
+++ b/test/unit/boot/image/dracut_test.py
@@ -140,12 +140,12 @@ class TestBootImageKiwi:
                 '--add', ' foo ', '--omit', ' bar ',
                 '--install', 'system-directory/etc/foo',
                 '--install', '/system-directory/var/lib/bar',
-                'LimeJeOS-openSUSE-13.2.x86_64-1.13.2.initrd.xz', '1.2.3'
+                'LimeJeOS.x86_64-1.13.2.initrd.xz', '1.2.3'
             ], stderr_to_stdout=True),
             call([
                 'mv',
                 'system-directory/'
-                'LimeJeOS-openSUSE-13.2.x86_64-1.13.2.initrd.xz',
+                'LimeJeOS.x86_64-1.13.2.initrd.xz',
                 'some-target-dir'
             ])
         ]

--- a/test/unit/bootloader/config/base_test.py
+++ b/test/unit/bootloader/config/base_test.py
@@ -239,13 +239,13 @@ class TestBootLoaderConfigBase:
     def test_get_menu_entry_title(self, mock_displayname):
         mock_displayname.return_value = None
         assert self.bootloader.get_menu_entry_title() == \
-            'LimeJeOS-openSUSE-13.2 [ OEM ]'
+            'LimeJeOS [ OEM ]'
 
     @patch('kiwi.xml_parse.image.get_displayname')
     def test_get_menu_entry_title_plain(self, mock_displayname):
         mock_displayname.return_value = None
         assert self.bootloader.get_menu_entry_title(plain=True) == \
-            'LimeJeOS-openSUSE-13.2'
+            'LimeJeOS'
 
     @patch('kiwi.xml_parse.image.get_displayname')
     def test_get_menu_entry_title_by_displayname(self, mock_displayname):
@@ -257,7 +257,7 @@ class TestBootLoaderConfigBase:
     def test_get_menu_entry_install_title(self, mock_displayname):
         mock_displayname.return_value = None
         assert self.bootloader.get_menu_entry_install_title() == \
-            'LimeJeOS-openSUSE-13.2'
+            'LimeJeOS'
 
     @patch('kiwi.xml_parse.type_.get_vga')
     def test_get_gfxmode_default(self, mock_get_vga):

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -219,7 +219,7 @@ class TestDiskBuilder:
     def test_create_invalid_type_for_install_media(
         self, mock_cmd, mock_fs
     ):
-        self.disk_builder.build_type_name = 'vmx'
+        self.disk_builder.build_type_name = 'kis'
         with patch('builtins.open'):
             with raises(KiwiInstallMediaError):
                 self.disk_builder.create_disk()
@@ -872,6 +872,7 @@ class TestDiskBuilder:
         self.disk.create_root_partition.reset_mock()
         self.disk.create_spare_partition.reset_mock()
         self.disk_builder.spare_part_is_last = True
+        self.disk_builder.disk_resize_requested = False
 
         with patch('builtins.open'):
             self.disk_builder.create_disk()

--- a/test/unit/builder/init_test.py
+++ b/test/unit/builder/init_test.py
@@ -23,7 +23,7 @@ class TestImageBuilder:
     def test_disk_builder(self, mock_builder):
         xml_state = Mock()
         xml_state.get_build_type_name = Mock(
-            return_value='vmx'
+            return_value='oem'
         )
         ImageBuilder(xml_state, 'target_dir', 'root_dir')
         mock_builder.assert_called_once_with(

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -78,7 +78,7 @@ class TestCli:
             sys.argv[0],
             '--compat', '--',
             '--build', 'description',
-            '--type', 'vmx',
+            '--type', 'oem',
             '-d', 'destination'
         ]
         cli = Cli()
@@ -89,7 +89,7 @@ class TestCli:
             sys.argv[0],
             'compat',
             '--build', 'description',
-            '--type', 'vmx',
+            '--type', 'oem',
             '-d', 'destination'
         ]
         cli = Cli()
@@ -132,13 +132,13 @@ class TestCli:
             sys.argv[0],
             '--compat', '--',
             '--build', 'description',
-            '--type', 'vmx',
+            '--type', 'oem',
             '-d', 'destination'
         ]
         cli = Cli()
         cli.load_command()
         mock_compat.assert_called_once_with(
-            ['--build', 'description', '--type', 'vmx', '-d', 'destination']
+            ['--build', 'description', '--type', 'oem', '-d', 'destination']
         )
 
     @patch('kiwi.cli.Path.which')

--- a/test/unit/kiwi_compat_test.py
+++ b/test/unit/kiwi_compat_test.py
@@ -27,7 +27,7 @@ class TestKiwiCompat:
         sys.argv = [
             'kiwicompat',
             '--create', 'root_dir',
-            '--type', 'vmx',
+            '--type', 'oem',
             '-d', 'destination'
         ]
         mock_exec.side_effect = OSError('exec failed')
@@ -43,7 +43,7 @@ class TestKiwiCompat:
         sys.argv = [
             'kiwicompat',
             '--create', 'root_dir',
-            '--type', 'vmx',
+            '--type', 'oem',
             '-d', 'destination'
         ]
         kiwi.kiwi_compat.main()
@@ -70,7 +70,7 @@ class TestKiwiCompat:
         sys.argv = [
             'kiwicompat',
             '--build', 'description',
-            '--type', 'vmx',
+            '--type', 'oem',
             '--ignore-repos',
             '--set-repo', 'repo_a',
             '--set-repoalias', 'a', '--set-repopriority', '1',
@@ -92,7 +92,7 @@ class TestKiwiCompat:
                 'kiwi',
                 '--logfile', 'logfile',
                 '--debug',
-                '--type', 'vmx',
+                '--type', 'oem',
                 '--profile', 'profile',
                 'system', 'build',
                 '--description', 'description',
@@ -111,14 +111,14 @@ class TestKiwiCompat:
         sys.argv = [
             'kiwicompat',
             '--create', 'root_dir',
-            '--type', 'vmx',
+            '--type', 'oem',
             '-d', 'destination'
         ]
         kiwi.kiwi_compat.main()
         mock_exec.assert_called_once_with(
             'kiwi-ng', [
                 'kiwi',
-                '--type', 'vmx',
+                '--type', 'oem',
                 'system', 'create',
                 '--root', 'root_dir',
                 '--target-dir', 'destination'

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -68,7 +68,7 @@ class TestRuntimeChecker:
 
     def test_check_volume_setup_defines_reserved_labels(self):
         xml_state = XMLState(
-            self.description.load(), ['vmxFlavour'], 'vmx'
+            self.description.load(), ['vmxSimpleFlavour'], 'oem'
         )
         runtime_checker = RuntimeChecker(xml_state)
         with raises(KiwiRuntimeError):
@@ -306,7 +306,7 @@ class TestRuntimeChecker:
 
     def test_check_preferences_data_no_packagemanager(self):
         xml_state = XMLState(
-            self.description.load(), ['xenFlavour'], 'vmx'
+            self.description.load(), ['xenDom0Flavour'], 'oem'
         )
         runtime_checker = RuntimeChecker(xml_state)
         with raises(KiwiRuntimeError):
@@ -324,7 +324,7 @@ class TestRuntimeChecker:
         with raises(KiwiRuntimeError):
             runtime_checker.check_architecture_supports_iso_firmware_setup()
         xml_state = XMLState(
-            self.description.load(), ['xenFlavour'], 'oem'
+            self.description.load(), ['xenDom0Flavour'], 'oem'
         )
         runtime_checker = RuntimeChecker(xml_state)
         with raises(KiwiRuntimeError):
@@ -344,7 +344,7 @@ class TestRuntimeChecker:
         with raises(KiwiRuntimeError):
             runtime_checker.check_syslinux_installed_if_isolinux_is_used()
         xml_state = XMLState(
-            self.description.load(), ['xenFlavour'], 'oem'
+            self.description.load(), ['xenDom0Flavour'], 'oem'
         )
         runtime_checker = RuntimeChecker(xml_state)
         with raises(KiwiRuntimeError):

--- a/test/unit/storage/setup_test.py
+++ b/test/unit/storage/setup_test.py
@@ -146,7 +146,6 @@ class TestDiskSetup:
 
     def test_get_disksize_mbytes_configured_additive(self):
         self.setup.configured_size = mock.Mock()
-        self.setup.build_type_name = 'vmx'
         self.setup.configured_size.additive = True
         self.setup.configured_size.mbytes = 42
         root_size = self.size.accumulate_mbyte_file_sizes.return_value
@@ -159,7 +158,6 @@ class TestDiskSetup:
 
     def test_get_disksize_mbytes_configured(self):
         self.setup.configured_size = mock.Mock()
-        self.setup.build_type_name = 'vmx'
         self.setup.configured_size.additive = False
         self.setup.configured_size.mbytes = 42
         with self._caplog.at_level(logging.WARNING):

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -91,7 +91,7 @@ class TestSystemPrepare:
         root_bind.root_dir = 'root_dir'
         mock_root_bind.return_value = root_bind
         state = XMLState(
-            xml, profiles=['vmxFlavour'], build_type='docker'
+            xml, profiles=['containerFlavour'], build_type='docker'
         )
         uri = mock.Mock()
         get_derived_from_image_uri = mock.Mock(

--- a/test/unit/tasks/image_info_test.py
+++ b/test/unit/tasks/image_info_test.py
@@ -26,7 +26,7 @@ class TestImageInfoTask:
             ]
         )
         self.result_info = {
-            'image': 'LimeJeOS-openSUSE-13.2',
+            'image': 'LimeJeOS',
             'resolved-packages': {
                 'packagename': {
                     'version': '0.8.15', 'arch': 'x86_64',
@@ -96,7 +96,7 @@ class TestImageInfoTask:
         self.task.process()
         self.runtime_checker.check_repositories_configured.assert_called_once_with()
         mock_out.assert_called_once_with(
-            {'image': 'LimeJeOS-openSUSE-13.2'}
+            {'image': 'LimeJeOS'}
         )
 
     @patch('kiwi.tasks.image_info.DataOutput')
@@ -106,7 +106,7 @@ class TestImageInfoTask:
         self.task.global_args['--color-output'] = True
         self.task.process()
         mock_out.assert_called_once_with(
-            {'image': 'LimeJeOS-openSUSE-13.2'}, style='color'
+            {'image': 'LimeJeOS'}, style='color'
         )
 
     @patch('kiwi.tasks.image_info.DataOutput')

--- a/test/unit/tasks/image_resize_test.py
+++ b/test/unit/tasks/image_resize_test.py
@@ -25,8 +25,8 @@ class TestImageResizeTask:
 
     def setup(self):
         sys.argv = [
-            sys.argv[0], '--type', 'vmx', 'image', 'resize',
-            '--target-dir', 'target_dir', '--size', '20g',
+            sys.argv[0], '--profile', 'vmxSimpleFlavour', '--type', 'oem',
+            'image', 'resize', '--target-dir', 'target_dir', '--size', '20g',
             '--root', '../data/root-dir'
         ]
         self.abs_root_dir = os.path.abspath('../data/root-dir')
@@ -144,8 +144,8 @@ class TestImageResizeTask:
             assert '--> loaded {0}'.format(
                 os.sep.join([self.abs_root_dir, 'image', 'config.xml'])
             ) in self._caplog.text
-            assert '--> Selected build type: vmx' in self._caplog.text
-            assert '--> Selected profiles: vmxFlavour' in self._caplog.text
+            assert '--> Selected build type: oem' in self._caplog.text
+            assert '--> Selected profiles: vmxSimpleFlavour' in self._caplog.text
             assert 'Resizing raw disk to 42 bytes' in self._caplog.text
             assert 'Raw disk is already at 42 bytes' in self._caplog.text
 

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -129,7 +129,7 @@ class TestVolumeManagerBase:
         mock_size.return_value = size
         assert self.volume_manager.get_volume_mbsize(
             self.volume_manager.volumes[0], self.volume_manager.volumes,
-            'ext3', 'oem'
+            'ext3', True
         ) == 72
 
     @patch('kiwi.volume_manager.base.SystemSize')
@@ -188,7 +188,7 @@ class TestVolumeManagerBase:
         ]
         assert self.volume_manager.get_volume_mbsize(
             self.volume_manager.volumes[2], self.volume_manager.volumes,
-            'ext3', 'oem'
+            'ext3', True
         ) == 72
         size.accumulate_mbyte_file_sizes.assert_called_once_with(
             ['root_dir/usr', 'root_dir/usr/lib']

--- a/test/unit/volume_manager/lvm_test.py
+++ b/test/unit/volume_manager/lvm_test.py
@@ -76,7 +76,7 @@ class TestVolumeManagerLVM:
     def test_post_init_no_additional_custom_args(self):
         self.volume_manager.post_init(None)
         assert self.volume_manager.custom_args == {
-            'root_label': 'ROOT', 'image_type': None
+            'root_label': 'ROOT', 'resize_on_boot': False
         }
 
     def test_post_init_no_mount_options(self):


### PR DESCRIPTION
A vmx image is the same disk as an oem just without the dracut
repart/resize feature. This difference is better handled with
an oemconfig parameter <oem-resize> which allows to switch resize
on or off. The extra image type vmx will be dropped and an XSLT
stylesheet automatically transforms a vmx description to be a
oem image with the resize feature switched off.
This Fixes #1425

