### PR TITLE
Fix the early boot grub.cfg file

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -888,8 +888,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 )
             )
             early_boot.write(
-                'configfile ($root)/boot/{0}/grub.cfg{1}'.format(
-                    self.boot_directory_name, os.linesep
+                'configfile ($root){0}/{1}/grub.cfg{2}'.format(
+                    self.get_boot_path(), self.boot_directory_name, os.linesep
                 )
             )
 

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -767,7 +767,7 @@ class TestBootLoaderConfigGrub2:
                 call('set root="cryptouuid/0815"\n'),
                 call('search --fs-uuid --set=root 0815\n'),
                 call('set prefix=($root)//grub2\n'),
-                call('configfile ($root)/boot/grub2/grub.cfg\n')
+                call('configfile ($root)//grub2/grub.cfg\n')
             ]
         assert mock_command.call_args_list == [
             call(
@@ -825,7 +825,7 @@ class TestBootLoaderConfigGrub2:
                 call('set root="cryptouuid/0815"\n'),
                 call('search --fs-uuid --set=root 0815\n'),
                 call('set prefix=($root)//grub2\n'),
-                call('configfile ($root)/boot/grub2/grub.cfg\n')
+                call('configfile ($root)//grub2/grub.cfg\n')
             ]
             mock_open.assert_called_once_with(
                 'root_dir/boot/efi/EFI/BOOT/grub.cfg', 'w'


### PR DESCRIPTION
This commit makes sure that the early boot configuration files
for grub make use of the proper boot path and omitting the `/boot`
prefix if there is a dedicated boot partition.

Fixes #1553
