### PR TITLE
Change Appliance names to drop the name LimeJeOS

### DIFF
--- a/build-tests/x86/archlinux/test-image-iso-oem-vmx-kis/appliance.kiwi
+++ b/build-tests/x86/archlinux/test-image-iso-oem-vmx-kis/appliance.kiwi
@@ -3,11 +3,11 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="LimeJeOS-Arch">
+<image schemaversion="7.3" name="Arch_appliance">
     <description type="system">
         <author>David Cassany</author>
         <contact>dcassany@suse.com</contact>
-        <specification>Arch JeOS</specification>
+        <specification>Arch Appliance</specification>
     </description>
     <profiles>
         <profile name="Live" description="Live image of Arch Linux">

--- a/build-tests/x86/centos/test-image-iso-oem-vmx-v7/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-iso-oem-vmx-v7/appliance.kiwi
@@ -3,11 +3,11 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="LimeJeOS-CentOS-07.0">
+<image schemaversion="7.3" name="CentOS-07.0_appliance">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>
-        <specification>CentOS Enterprise 7 JeOS</specification>
+        <specification>CentOS Enterprise 7 Appliance</specification>
     </description>
     <profiles>
         <profile name="Live" description="Live image of CentOS 7"/>

--- a/build-tests/x86/centos/test-image-iso-oem-vmx-v8/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-iso-oem-vmx-v8/appliance.kiwi
@@ -3,11 +3,11 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="LimeJeOS-CentOS-08.0">
+<image schemaversion="7.3" name="CentOS-08.0_appliance">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>
-        <specification>CentOS Enterprise 8 JeOS</specification>
+        <specification>CentOS Enterprise 8 Appliance</specification>
     </description>
     <profiles>
         <profile name="Live" description="Live image of CentOS 8"/>

--- a/build-tests/x86/debian/test-image-iso-oem-vmx/appliance.kiwi
+++ b/build-tests/x86/debian/test-image-iso-oem-vmx/appliance.kiwi
@@ -3,11 +3,11 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="LimeJeOS-Debian-Buster">
+<image schemaversion="7.3" name="Debian-Buster_appliance">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>
-        <specification>Debian Buster JeOS</specification>
+        <specification>Debian Buster Appliance</specification>
     </description>
     <profiles>
         <profile name="Live" description="Live image of Debian Buster"/>

--- a/build-tests/x86/fedora/test-image-iso-oem-vmx/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-iso-oem-vmx/appliance.kiwi
@@ -3,11 +3,11 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="LimeJeOS-Fedora-Rawhide">
+<image schemaversion="7.3" name="Fedora-Rawhide_appliance">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>
-        <specification>Fedora Rawhide JeOS</specification>
+        <specification>Fedora Rawhide Appliance</specification>
     </description>
     <profiles>
         <profile name="Live" description="Live image of Fedora Rawhide"/>

--- a/build-tests/x86/suse/test-image-custom-partitions/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-custom-partitions/appliance.kiwi
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-TW">
+<image schemaversion="7.3" name="Tumbleweed_appliance">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>
         <specification>
-            TW JeOS, is a small text based image
+            Tumbleweed Appliance, is a small text based image
         </specification>
     </description>
     <preferences>

--- a/build-tests/x86/suse/test-image-wsl/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-wsl/appliance.kiwi
@@ -15,7 +15,7 @@
         <keytable>us</keytable>
         <type image="appx" metadata_path="/usr/share/wsl-appx">
             <containerconfig name="Tumbleweed">
-                <history author="KIWI-Team" application_id="tumbleweed" package_version="2003.12.0.0" launcher="openSUSE-Tumbleweed.exe">Tumbleweed JeOS text based</history>
+                <history author="KIWI-Team" application_id="tumbleweed" package_version="2003.12.0.0" launcher="openSUSE-Tumbleweed.exe">Tumbleweed appliance text based</history>
             </containerconfig>
         </type>
     </preferences>

--- a/build-tests/x86/ubuntu/test-image-iso-oem-vmx/appliance.kiwi
+++ b/build-tests/x86/ubuntu/test-image-iso-oem-vmx/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="LimeJeOS-Ubuntu-20.04">
+<image schemaversion="7.3" name="Ubuntu-20.04_appliance">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/doc/source/building_images/build_live_iso.rst
+++ b/doc/source/building_images/build_live_iso.rst
@@ -20,7 +20,7 @@ To add a live ISO build to your appliance, create a `type` element with
 
 .. code:: xml
 
-   <image schemaversion="6.9" name="JeOS-Tumbleweed">
+   <image schemaversion="{schema_version}" name="Tumbleweed_appliance">
      <!-- snip -->
      <preferences>
        <type image="iso" primary="true" flags="overlay" hybridpersistent_filesystem="ext4" hybridpersistent="true"/>

--- a/doc/source/building_images/build_simple_disk.rst
+++ b/doc/source/building_images/build_simple_disk.rst
@@ -26,7 +26,7 @@ below:
 
 .. code:: xml
 
-   <image schemaversion="7.2" name="JeOS-Tumbleweed">
+   <image schemaversion="{schema_version}" name="Tumbleweed_appliance">
      <!-- snip -->
      <preferences>
        <type image="oem" filesystem="ext4" format="vmdk">

--- a/doc/source/building_images/build_wsl_container.rst
+++ b/doc/source/building_images/build_wsl_container.rst
@@ -128,7 +128,7 @@ openSUSE TW:
 #. Setup the image type:
 
    Edit the XML description file:
-   :file:`kiwi-descriptions/suse/x86_64/suse-tumbleweed-JeOS/config.xml`
+   :file:`kiwi-descriptions/suse/x86_64/suse-tumbleweed/config.xml`
    and add the following type and containerconfig:
 
    .. code:: xml
@@ -141,7 +141,7 @@ openSUSE TW:
                   application_id="tumbleweed"
                   package_version="2003.12.0.0"
                   launcher="openSUSE-Tumbleweed.exe"
-              >TW JeOS text based</history>
+              >Tumbleweed Appliance text based</history>
           </containerconfig>
       </type>
 
@@ -158,7 +158,7 @@ openSUSE TW:
    .. code:: bash
 
       $ sudo kiwi-ng --type appx system build \
-          --description kiwi-descriptions/suse/x86_64/suse-tumbleweed-JeOS \
+          --description kiwi-descriptions/suse/x86_64/suse-tumbleweed \
           --target-dir /tmp/myimage
 
 Testing the WSL image

--- a/doc/source/commands/kiwi.rst
+++ b/doc/source/commands/kiwi.rst
@@ -43,10 +43,9 @@ scripts or configuration data.
 
 A collection of example image descriptions can be found on the github
 repository here: https://github.com/OSInside/kiwi-descriptions. Most of the
-descriptions provide a so called JeOS image. JeOS means Just enough
-Operating System. A JeOS is a small, text only based image including a
-predefined remote source setup to allow installation of missing
-software components at a later point in time.
+descriptions provide a so called appliance image. Appliance means that it's a small, text only based
+image including a predefined remote source setup to allow installation of missing software
+components at a later point in time.
 
 {kiwi} operates in two steps. The system build command combines
 both steps into one to make it easier to start with {kiwi}. The first

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -65,8 +65,8 @@ def setup(app):
 
 
 prolog_replacements = {
-    '{exc_image_base_name}': 'LimeJeOS-Leap-15.1',
-    '{exc_description}': 'suse-leap-15.1-JeOS',
+    '{exc_image_base_name}': 'Leap-15.1_appliance',
+    '{exc_description}': 'suse-leap-15.1',
     '{exc_netboot}': 'netboot/suse-leap15.1',
     '{exc_os_version}': '15.1',
     '{exc_image_version}': '1.15.1',

--- a/doc/source/working_with_images/build_in_buildservice.rst
+++ b/doc/source/working_with_images/build_in_buildservice.rst
@@ -100,7 +100,7 @@ The notable differences to running {kiwi} locally include:
 
         <!-- OBS-Profiles: foo_profile bar_profile -->
 
-        <image schemaversion="7.2" name="openSUSE-Leap-15.1">
+        <image schemaversion="{schema_version}" name="openSUSE-Leap-15.1">
           <!-- image description with the profiles foo_profile and bar_profile
         </image>
 
@@ -118,7 +118,7 @@ The notable differences to running {kiwi} locally include:
 
      <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-     <image schemaversion="7.2" name="openSUSE-Leap-15.1">
+     <image schemaversion="{schema_version}" name="openSUSE-Leap-15.1">
        <!-- image description with the profiles foo_profile and bar_profile
      </image>
 
@@ -210,7 +210,7 @@ your dependent packages. These repositories can be provided in two ways:
    .. code:: xml
 
       <project name="Virtualization:Appliances:Images:openSUSE-Tumbleweed">
-        <title>JeOS for Tumbleweed </title>
+        <title>Tumbleweed JeOS images</title>
         <description>Host JeOS images for Tumbleweed</description>
         <repository name="images">
           <path project="Virtualization:Appliances:Builder" repository="Factory"/>
@@ -225,7 +225,7 @@ your dependent packages. These repositories can be provided in two ways:
    .. code:: xml
 
       <project name="Virtualization:Appliances:Images:openSUSE-Tumbleweed">
-        <title>JeOS for Tumbleweed </title>
+        <title>Tumbleweed JeOS images</title>
         <description>Host JeOS images for Tumbleweed</description>
         <repository name="images">
           <path project="Virtualization:Appliances:Builder" repository="Factory"/>

--- a/doc/source/working_with_images/build_with_profiles.rst
+++ b/doc/source/working_with_images/build_with_profiles.rst
@@ -31,8 +31,8 @@ Building with the Open Build Service
 The Open Build Service (OBS) support profiles via the `multibuild
 <https://openbuildservice.org/help/manuals/obs-reference-guide/cha.obs.multibuild.html>`_
 feature. An example project using this feature is the
-`openSUSE-Tumbleweed-JeOS
-<https://build.opensuse.org/package/show/openSUSE:Factory/openSUSE-Tumbleweed-JeOS>`_
+`openSUSE-Tumbleweed
+<https://build.opensuse.org/package/show/openSUSE:Factory/openSUSE-Tumbleweed>`_
 image.
 
 To enable and use the profiles, follow these steps:

--- a/doc/source/working_with_images/custom_volumes.rst
+++ b/doc/source/working_with_images/custom_volumes.rst
@@ -19,7 +19,7 @@ elements of the `systemdisk` element:
 
 .. code:: xml
 
-   <image schemaversion="7.2" name="openSUSE-Leap-15.1">
+   <image schemaversion="{schema_version}" name="openSUSE-Leap-15.1">
      <type image="oem" filesystem="btrfs" preferlvm="true">
        <systemdisk name="vgroup">
          <volume name="usr/lib" size="1G" label="library"/>


### PR DESCRIPTION
The name LimeJeOS was an invention of the SUSE Studio project.
Since the project does no longer exist, users have no idea
what the name means. Therefore the integration tests as well
as the documentation now changes the image names to provide
more clarity. This Fixes #1544


