### PR TITLE
Get default maintainer and author from image description

### DIFF
--- a/kiwi/container/setup/base.py
+++ b/kiwi/container/setup/base.py
@@ -50,7 +50,7 @@ class ContainerSetupBase:
         self.root_dir = root_dir
         self.custom_args = custom_args or {}
         if 'container_name' not in self.custom_args:
-            self.custom_args['container_name'] = 'systemContainer'
+            self.custom_args['container_name'] = 'system-container'
         self.post_init(custom_args)
 
     def post_init(self, custom_args):

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1119,6 +1119,16 @@ class XMLState:
         container_config.update(
             self._match_docker_history()
         )
+
+        desc = self.get_description_section()
+        author_contact = "{0} <{1}>".format(desc.author, desc.contact)
+        if 'history' not in container_config:
+            container_config['history'] = {}
+        if 'author' not in container_config['history']:
+            container_config['history']['author'] = author_contact
+        if 'maintainer' not in container_config:
+            container_config['maintainer'] = author_contact
+
         return container_config
 
     def set_container_config_tag(self, tag):

--- a/test/unit/container/setup/base_test.py
+++ b/test/unit/container/setup/base_test.py
@@ -30,7 +30,7 @@ class TestContainerSetupBase:
         self.container.custom_args == {}
 
     def test_get_container_name(self):
-        assert self.container.get_container_name() == 'systemContainer'
+        assert self.container.get_container_name() == 'system-container'
 
     @patch('os.path.exists')
     def test_deactivate_bootloader_setup(self, mock_exists):

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -718,7 +718,10 @@ class TestXMLState:
         state.add_container_config_label('somelabel', 'newlabelvalue')
         with self._caplog.at_level(logging.WARNING):
             config = state.get_container_config()
-            assert not config
+            assert config == {
+                'history': {'author': 'Marcus <ms@suse.com>'},
+                'maintainer': 'Marcus <ms@suse.com>'
+            }
 
     def test_set_container_tag_not_applied(self):
         with self._caplog.at_level(logging.WARNING):
@@ -766,6 +769,7 @@ class TestXMLState:
             'workingdir': '/root',
             'user': 'root',
             'entry_command': [],
+            'history': {'author': 'Marcus <ms@suse.com>'}
         }
         xml_data = self.description.load()
         state = XMLState(xml_data, ['derivedContainer'], 'docker')


### PR DESCRIPTION
This commit sets the maintainer and author metadata from the description
section of the image in they are not explicitly specified in
container-config section.

In addition it sets the default container name to `system-container`
instead of `systemContainer` as uppercase letters are not valid for
docker container references.

Fixes #1419
