### PR TITLE
Added consistency runtime check for the type setup

### DIFF
--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -89,7 +89,8 @@ class CliTask:
             'check_dracut_module_for_oem_install_in_package_list': [],
             'check_architecture_supports_iso_firmware_setup': [],
             'check_appx_naming_conventions_valid': [],
-            'check_syslinux_installed_if_isolinux_is_used': []
+            'check_syslinux_installed_if_isolinux_is_used': [],
+            'check_image_type_unique': []
         }
         self.checks_after_command_args = {
             'check_repositories_configured': [],

--- a/test/data/example_runtime_checker_conflicting_types.xml
+++ b/test/data/example_runtime_checker_conflicting_types.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="7.3" name="TypeConflict">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>ms@suse.de</contact>
+        <specification>Test conflicting type setup</specification>
+    </description>
+    <preferences>
+        <version>1.1.0</version>
+        <packagemanager>zypper</packagemanager>
+        <type image="oem" filesystem="ext3"/>
+        <type image="oem" filesystem="xfs"/>
+    </preferences>
+    <repository>
+        <source path="obs://13.2/repo/oss"/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-openSUSE-base"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+    </packages>
+</image>

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -350,5 +350,14 @@ class TestRuntimeChecker:
         with raises(KiwiRuntimeError):
             runtime_checker.check_syslinux_installed_if_isolinux_is_used()
 
+    def test_check_image_type_unique(self):
+        description = XMLDescription(
+            '../data/example_runtime_checker_conflicting_types.xml'
+        )
+        xml_state = XMLState(description.load())
+        runtime_checker = RuntimeChecker(xml_state)
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_image_type_unique()
+
     def teardown(self):
         sys.argv = argv_kiwi_tests


### PR DESCRIPTION
multiple type sections within one preferences section is allowed
in a kiwi image description. However, if multiple type sections
for the same image attribute are configured only the last type
configuration will be ever reachable. The proposed runtime check
in this commit detects this situation and raises an exception
showing the conflicting types including a solution suggestion
which needs to be based on profiles to distinguish between
types of the same image type name.

