### PR TITLE
Refactor ImageBuilder Factory

### DIFF
--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -39,23 +39,13 @@ class FileSystemBuilder:
     """
     **Filesystem image builder**
 
-    :param str label: filesystem label
-    :param str root_uuid: UUID of the created filesystem (on block device only)
-    :param str root_dir: root directory path name
+    :param obsject xml_state: Instance of :class:`XMLState`
     :param str target_dir: target directory path name
-    :param str requested_image_type: configured image type
-    :param str requested_filesystem: requested filesystem name
-    :param obejct system_setup: instance of :class:`SystemSetup`
-    :param str filename: file name of the filesystem image
-    :param int blocksize: configured disk blocksize
-    :param object filesystem_setup: instance of :class:`FileSystemSetup`
-    :param object filesystems_no_device_node: List of filesystems which are
-        created from a data tree and do not require a block device e.g loop
-    :param dict filesystem_custom_parameters: Configured custom filesystem
-        mount and creation arguments
-    :param object result: instance of :class:`Result`
+    :param str root_dir: root directory path name
+    :param dict custom_args: Custom processing arguments defined as hash keys:
+        * None
     """
-    def __init__(self, xml_state, target_dir, root_dir):
+    def __init__(self, xml_state, target_dir, root_dir, custom_args=None):
         self.label = None
         self.root_uuid = None
         self.root_dir = root_dir

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -263,7 +263,7 @@ class SystemBuildTask(CliTask):
         del setup
 
         log.info('Creating system image')
-        image_builder = ImageBuilder(
+        image_builder = ImageBuilder.new(
             self.xml_state,
             abs_target_dir_path,
             image_root,

--- a/kiwi/tasks/system_create.py
+++ b/kiwi/tasks/system_create.py
@@ -96,7 +96,7 @@ class SystemCreateTask(CliTask):
         )
         setup.call_image_script()
 
-        image_builder = ImageBuilder(
+        image_builder = ImageBuilder.new(
             self.xml_state,
             abs_target_dir_path,
             abs_root_path,

--- a/test/unit/.coveragerc
+++ b/test/unit/.coveragerc
@@ -7,6 +7,7 @@ omit =
 [report]
 omit =
     */filesystem/__init__.py
+    */builder/__init__.py
     */app.py
     */kiwi.py
     */xml_parse.py

--- a/test/unit/builder/init_test.py
+++ b/test/unit/builder/init_test.py
@@ -4,50 +4,55 @@ from mock import (
 from pytest import raises
 
 from kiwi.builder import ImageBuilder
+
 from kiwi.exceptions import KiwiRequestedTypeError
 
 
 class TestImageBuilder:
-    @patch('kiwi.builder.FileSystemBuilder')
+    def test_factory_init(self):
+        with raises(TypeError):
+            ImageBuilder()
+
+    @patch('kiwi.builder.filesystem.FileSystemBuilder')
     def test_filesystem_builder(self, mock_builder):
         xml_state = Mock()
         xml_state.get_build_type_name = Mock(
             return_value='ext4'
         )
-        ImageBuilder(xml_state, 'target_dir', 'root_dir')
+        ImageBuilder.new(xml_state, 'target_dir', 'root_dir')
         mock_builder.assert_called_once_with(
-            xml_state, 'target_dir', 'root_dir'
+            xml_state, 'target_dir', 'root_dir', None
         )
 
-    @patch('kiwi.builder.DiskBuilder')
+    @patch('kiwi.builder.disk.DiskBuilder')
     def test_disk_builder(self, mock_builder):
         xml_state = Mock()
         xml_state.get_build_type_name = Mock(
             return_value='oem'
         )
-        ImageBuilder(xml_state, 'target_dir', 'root_dir')
+        ImageBuilder.new(xml_state, 'target_dir', 'root_dir')
         mock_builder.assert_called_once_with(
             xml_state, 'target_dir', 'root_dir', None
         )
 
-    @patch('kiwi.builder.LiveImageBuilder')
+    @patch('kiwi.builder.live.LiveImageBuilder')
     def test_live_builder(self, mock_builder):
         xml_state = Mock()
         xml_state.get_build_type_name = Mock(
             return_value='iso'
         )
-        ImageBuilder(xml_state, 'target_dir', 'root_dir')
+        ImageBuilder.new(xml_state, 'target_dir', 'root_dir')
         mock_builder.assert_called_once_with(
             xml_state, 'target_dir', 'root_dir', None
         )
 
-    @patch('kiwi.builder.KisBuilder')
+    @patch('kiwi.builder.kis.KisBuilder')
     def test_kis_builder(self, mock_builder):
         xml_state = Mock()
         xml_state.get_build_type_name = Mock(
             return_value='kis'
         )
-        ImageBuilder(xml_state, 'target_dir', 'root_dir')
+        ImageBuilder.new(xml_state, 'target_dir', 'root_dir')
         mock_builder.assert_called_once_with(
             xml_state, 'target_dir', 'root_dir', None
         )
@@ -55,29 +60,29 @@ class TestImageBuilder:
         xml_state.get_build_type_name = Mock(
             return_value='pxe'
         )
-        ImageBuilder(xml_state, 'target_dir', 'root_dir')
+        ImageBuilder.new(xml_state, 'target_dir', 'root_dir')
         mock_builder.assert_called_once_with(
             xml_state, 'target_dir', 'root_dir', None
         )
 
-    @patch('kiwi.builder.ArchiveBuilder')
+    @patch('kiwi.builder.archive.ArchiveBuilder')
     def test_archive_builder(self, mock_builder):
         xml_state = Mock()
         xml_state.get_build_type_name = Mock(
             return_value='tbz'
         )
-        ImageBuilder(xml_state, 'target_dir', 'root_dir')
+        ImageBuilder.new(xml_state, 'target_dir', 'root_dir')
         mock_builder.assert_called_once_with(
             xml_state, 'target_dir', 'root_dir', None
         )
 
-    @patch('kiwi.builder.ContainerBuilder')
+    @patch('kiwi.builder.container.ContainerBuilder')
     def test_container_builder(self, mock_builder):
         xml_state = Mock()
         xml_state.get_build_type_name = Mock(
             return_value='docker'
         )
-        ImageBuilder(xml_state, 'target_dir', 'root_dir')
+        ImageBuilder.new(xml_state, 'target_dir', 'root_dir')
         mock_builder.assert_called_once_with(
             xml_state, 'target_dir', 'root_dir', None
         )
@@ -88,4 +93,4 @@ class TestImageBuilder:
             return_value='bogus'
         )
         with raises(KiwiRequestedTypeError):
-            ImageBuilder(xml_state, 'target_dir', 'root_dir')
+            ImageBuilder.new(xml_state, 'target_dir', 'root_dir')

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -69,7 +69,7 @@ class TestSystemBuildTask:
         self.builder.create = mock.Mock(
             return_value=self.result
         )
-        kiwi.tasks.system_build.ImageBuilder = mock.Mock(
+        kiwi.tasks.system_build.ImageBuilder.new = mock.Mock(
             return_value=self.builder
         )
 

--- a/test/unit/tasks/system_create_test.py
+++ b/test/unit/tasks/system_create_test.py
@@ -48,7 +48,7 @@ class TestSystemCreateTask:
         self.builder.create = mock.Mock(
             return_value=self.result
         )
-        kiwi.tasks.system_create.ImageBuilder = mock.Mock(
+        kiwi.tasks.system_create.ImageBuilder.new = mock.Mock(
             return_value=self.builder
         )
 


### PR DESCRIPTION
This commit refactors the ImageBuilder factory to be a real
factory and to add type hints such that its use from an api
perspective is clear and enforced. Related to Issue #1498


