### PR TITLE
Fix s390 offset setup for non dasd table

### DIFF
--- a/build-tests/s390/sle15/test-image-disk/appliance.kiwi
+++ b/build-tests/s390/sle15/test-image-disk/appliance.kiwi
@@ -22,7 +22,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" format="qcow2">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" format="qcow2" target_blocksize="512">
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>

--- a/build-tests/s390/suse/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/s390/suse/test-image-disk-simple/appliance.kiwi
@@ -14,7 +14,7 @@
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
-        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" format="qcow2">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" format="qcow2" target_blocksize="512">
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>

--- a/kiwi/bootloader/config/zipl.py
+++ b/kiwi/bootloader/config/zipl.py
@@ -188,7 +188,6 @@ class BootLoaderConfigZipl(BootLoaderConfigBase):
                 )
             return start_track * blocks
         else:
-            blocks = self._read_msdos_disk_geometry('blocks per track')
             parted_call = Command.run(
                 ['parted', '-m', self.target_device, 'unit', 's', 'print']
             )
@@ -199,7 +198,7 @@ class BootLoaderConfigZipl(BootLoaderConfigBase):
                     'unknown partition format: %s' % parted_output
                 )
             start_track = int(first_partition_format.group(1))
-            return start_track * blocks
+            return start_track
 
     def _read_msdos_disk_geometry(self, value):
         sfdisk_call = Command.run(

--- a/test/unit/bootloader/config/zipl_test.py
+++ b/test/unit/bootloader/config/zipl_test.py
@@ -166,7 +166,12 @@ class TestBootLoaderConfigZipl:
     def test_setup_disk_image_config_msdos_invalid_geometry(self, mock_command):
         self.bootloader.target_table_type = 'msdos'
         command_results = [
-            self.command_type(output='bogus data\n')
+            self.command_type(output='bogus data\n'),
+            self.command_type(
+                output='BYT; /dev/sda:312500000s:scsi:512:512:msdos:ATA '
+                'WDC WD1600HLFS-7; 1:2048s:251660287s:251658240s:ext4::type=83;'
+                ' 2:251660288s:312499999s:60839712s:linux-swap(v1)::type=82;'
+            )
         ]
 
         def side_effect(arg):
@@ -235,10 +240,6 @@ class TestBootLoaderConfigZipl:
                 output='BYT; /dev/sda:312500000s:scsi:512:512:msdos:ATA '
                 'WDC WD1600HLFS-7; 1:2048s:251660287s:251658240s:ext4::type=83;'
                 ' 2:251660288s:312499999s:60839712s:linux-swap(v1)::type=82;'
-            ),
-            self.command_type(
-                output='/dev/sda: 242251 cylinders, 256 heads, '
-                '63 sectors/track\n'
             )
         ]
 
@@ -256,7 +257,7 @@ class TestBootLoaderConfigZipl:
             {
                 'blocksize': '4096',
                 'initrd_file': 'initrd',
-                'offset': 129024,
+                'offset': 2048,
                 'device': '/dev/loop0',
                 'kernel_file': 'image',
                 'title': 'image-name_(_OEM_)',


### PR DESCRIPTION
This change is two fold

**Fixed zipl targetoffset setup for non dasd devices**
    
It seems zipl expects a sector based information for the
targetoffset setting but kiwi provided blocks. This
Fixes bsc#1170863

**Fixed s390 Virtual disk integration tests**
    
Explicitly set 512byte block size for images that should run
in KVM. The default blocksize set by kiwi is 4k on s390

