### PR TITLE
Refactor BootImage Factory

### DIFF
--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -49,6 +49,11 @@ class BootImageKiwi(BootImageBase):
         root filesystem which is a separate image to create
         the initrd from
         """
+        # builtin kiwi initrd builds its own root tree to create
+        # an initrd from. Thus there is no pre defined boot root
+        # directory
+        self.boot_root_directory = None
+
         self.temp_directories = []
 
     def prepare(self):

--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -39,6 +39,13 @@ class BootImageDracut(BootImageBase):
 
         Initialize empty list of dracut caller options
         """
+        # signing keys are only taken into account on install of
+        # packages. As dracut runs from a pre defined root directory,
+        # no signing keys will be used in the process of creating
+        # an initrd with dracut
+        self.signing_keys = None
+
+        # Initialize empty list of dracut caller options
         self.dracut_options = []
         self.included_files = []
         self.included_files_install = []

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -121,7 +121,7 @@ class DiskBuilder:
         if custom_args and 'signing_keys' in custom_args:
             self.signing_keys = custom_args['signing_keys']
 
-        self.boot_image = BootImage(
+        self.boot_image = BootImage.new(
             xml_state, target_dir, root_dir, signing_keys=self.signing_keys
         )
         self.firmware = FirmWare(

--- a/kiwi/builder/kis.py
+++ b/kiwi/builder/kis.py
@@ -69,7 +69,7 @@ class KisBuilder:
         self.xz_options = custom_args['xz_options'] if custom_args \
             and 'xz_options' in custom_args else None
 
-        self.boot_image_task = BootImage(
+        self.boot_image_task = BootImage.new(
             xml_state, target_dir, root_dir,
             signing_keys=self.boot_signing_keys
         )

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -27,7 +27,7 @@ from kiwi.filesystem import FileSystem
 from kiwi.filesystem.isofs import FileSystemIsoFs
 from kiwi.filesystem.setup import FileSystemSetup
 from kiwi.storage.loop_device import LoopDevice
-from kiwi.boot.image import BootImageDracut
+from kiwi.boot.image.dracut import BootImageDracut
 from kiwi.system.size import SystemSize
 from kiwi.system.setup import SystemSetup
 from kiwi.firmware import FirmWare

--- a/test/unit/.coveragerc
+++ b/test/unit/.coveragerc
@@ -6,6 +6,7 @@ omit =
 
 [report]
 omit =
+    */boot/image/__init__.py
     */filesystem/__init__.py
     */app.py
     */kiwi.py

--- a/test/unit/boot/image/init_test.py
+++ b/test/unit/boot/image/init_test.py
@@ -14,23 +14,27 @@ class TestBootImage:
             return_value='kiwi'
         )
 
+    def test_factory_init(self):
+        with raises(TypeError):
+            BootImage()
+
     def test_boot_image_not_implemented(self):
         self.xml_state.get_initrd_system.return_value = 'foo'
         with raises(KiwiBootImageSetupError):
-            BootImage(self.xml_state, 'target_dir')
+            BootImage.new(self.xml_state, 'target_dir')
 
-    @patch('kiwi.boot.image.BootImageKiwi')
+    @patch('kiwi.boot.image.builtin_kiwi.BootImageKiwi')
     def test_boot_image_task_kiwi(self, mock_kiwi):
         self.xml_state.get_initrd_system.return_value = 'kiwi'
-        BootImage(self.xml_state, 'target_dir')
+        BootImage.new(self.xml_state, 'target_dir')
         mock_kiwi.assert_called_once_with(
             self.xml_state, 'target_dir', None, None
         )
 
-    @patch('kiwi.boot.image.BootImageDracut')
+    @patch('kiwi.boot.image.dracut.BootImageDracut')
     def test_boot_image_task_dracut(self, mock_dracut):
         self.xml_state.get_initrd_system.return_value = 'dracut'
-        BootImage(self.xml_state, 'target_dir', 'root_dir')
+        BootImage.new(self.xml_state, 'target_dir', 'root_dir')
         mock_dracut.assert_called_once_with(
             self.xml_state, 'target_dir', 'root_dir', None
         )

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -156,7 +156,7 @@ class TestDiskBuilder:
             kernel_name='linux.vmx',
             initrd_name='initrd.vmx'
         )
-        kiwi.builder.disk.BootImage = mock.Mock(
+        kiwi.builder.disk.BootImage.new = mock.Mock(
             return_value=self.boot_image_task
         )
         self.firmware = mock.Mock()

--- a/test/unit/builder/kis_test.py
+++ b/test/unit/builder/kis_test.py
@@ -26,7 +26,7 @@ class TestKisBuilder:
         self.boot_image_task = MagicMock()
         self.boot_image_task.boot_root_directory = 'initrd_dir'
         self.boot_image_task.initrd_filename = 'initrd_file_name'
-        mock_boot.return_value = self.boot_image_task
+        mock_boot.new.return_value = self.boot_image_task
         self.filesystem = MagicMock()
         self.filesystem.filename = 'myimage.fs'
         self.filesystem.root_uuid = 'some_uuid'


### PR DESCRIPTION
This commit refactors the BootImage factory to be a real
factory and to add type hints such that its use from an api
perspective is clear and enforced. Related to Issue #1498

