### PR TITLE
Add support for package changelog info

### DIFF
--- a/kiwi.yml
+++ b/kiwi.yml
@@ -25,6 +25,10 @@
 #  # Specify if the bundle tarball should contain compressed results.
 #  # Note: already compressed result information will not be touched
 #  - compress: false
+#  # Specify if the image build result and bundle should contain
+#  # a .changes file. The .changes file contains the package changelog
+#  # information from all packages installed into the image.
+#  - has_package_changes: false
 
 
 # Setup behaviour of XZ compressor

--- a/kiwi/builder/archive.py
+++ b/kiwi/builder/archive.py
@@ -106,6 +106,15 @@ class ArchiveBuilder:
                 shasum=False
             )
             self.result.add(
+                key='image_changes',
+                filename=self.system_setup.export_package_changes(
+                    self.target_dir
+                ),
+                use_for_bundle=True,
+                compress=True,
+                shasum=False
+            )
+            self.result.add(
                 key='image_verified',
                 filename=self.system_setup.export_package_verification(
                     self.target_dir

--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -157,6 +157,15 @@ class ContainerBuilder:
             shasum=False
         )
         self.result.add(
+            key='image_changes',
+            filename=self.system_setup.export_package_changes(
+                self.target_dir
+            ),
+            use_for_bundle=True,
+            compress=True,
+            shasum=False
+        )
+        self.result.add(
             key='image_verified',
             filename=self.system_setup.export_package_verification(
                 self.target_dir

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -515,6 +515,15 @@ class DiskBuilder:
             shasum=False
         )
         self.result.add(
+            key='image_changes',
+            filename=self.system_setup.export_package_changes(
+                self.target_dir
+            ),
+            use_for_bundle=True,
+            compress=True,
+            shasum=False
+        )
+        self.result.add(
             key='image_verified',
             filename=self.system_setup.export_package_verification(
                 self.target_dir

--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -139,6 +139,15 @@ class FileSystemBuilder:
             shasum=False
         )
         self.result.add(
+            key='image_changes',
+            filename=self.system_setup.export_package_changes(
+                self.target_dir
+            ),
+            use_for_bundle=True,
+            compress=True,
+            shasum=False
+        )
+        self.result.add(
             key='image_verified',
             filename=self.system_setup.export_package_verification(
                 self.target_dir

--- a/kiwi/builder/kis.py
+++ b/kiwi/builder/kis.py
@@ -244,6 +244,15 @@ class KisBuilder:
             shasum=False
         )
         self.result.add(
+            key='image_changes',
+            filename=self.system_setup.export_package_changes(
+                self.target_dir
+            ),
+            use_for_bundle=True,
+            compress=True,
+            shasum=False
+        )
+        self.result.add(
             key='image_verified',
             filename=self.system_setup.export_package_verification(
                 self.target_dir

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -302,6 +302,15 @@ class LiveImageBuilder:
             shasum=False
         )
         self.result.add(
+            key='image_changes',
+            filename=self.system_setup.export_package_changes(
+                self.target_dir
+            ),
+            use_for_bundle=True,
+            compress=True,
+            shasum=False
+        )
+        self.result.add(
             key='image_verified',
             filename=self.system_setup.export_package_verification(
                 self.target_dir

--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -94,6 +94,37 @@ class RuntimeConfig:
             obs_public = True
         return bool(obs_public)
 
+    def get_package_changes(self, default=True):
+        """
+        Return boolean value to express if the image build and bundle
+        should contain a .changes file. The .changes file contains
+        the package changelog information from all packages installed
+        into the image.
+
+        bundle:
+          - has_package_changes: true|false
+
+        By default the creation is switched on.
+        When building in the Open Build Service the default is
+        switched off because obs provides a .report file containing
+        the same information.
+
+        :param bool default: Default value
+
+        :return: True or False
+
+        :rtype: bool
+        """
+        bundle_package_changes = self._get_attribute(
+            element='bundle', attribute='has_package_changes'
+        )
+        if bundle_package_changes is None:
+            if Defaults.is_buildservice_worker():
+                bundle_package_changes = False
+            else:
+                bundle_package_changes = default
+        return bool(bundle_package_changes)
+
     def get_bundle_compression(self, default=True):
         """
         Return boolean value to express if the image bundle should

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -520,6 +520,32 @@ class SystemSetup:
             self._export_pacman_package_list(filename)
             return filename
 
+    def export_package_changes(self, target_dir):
+        """
+        Export image package changelog for comparision of
+        actual changes of the installed packages
+
+        :param str target_dir: path name
+        """
+        filename = ''.join(
+            [
+                target_dir, '/',
+                self.xml_state.xml_data.get_name(),
+                '.' + self.arch,
+                '-' + self.xml_state.get_image_version(),
+                '.changes'
+            ]
+        )
+        packager = Defaults.get_default_packager_tool(
+            self.xml_state.get_package_manager()
+        )
+        if packager == 'rpm':
+            self._export_rpm_package_changes(filename)
+            return filename
+        elif packager == 'dpkg':
+            self._export_deb_package_changes(filename)
+            return filename
+
     def export_package_verification(self, target_dir):
         """
         Export package verification result as metadata reference
@@ -1079,7 +1105,12 @@ class SystemSetup:
 
     def _export_pacman_package_list(self, filename):
         log.info('Export pacman packages metadata')
-        query_call = Command.run(['pacman', '-Qe'])
+        query_call = Command.run(
+            [
+                'pacman', '--query', '--dbpath',
+                os.sep.join([self.root_dir, 'var/lib/pacman'])
+            ]
+        )
         with open(filename, 'w') as packages:
             for line in query_call.output.splitlines():
                 package, _, version_release = line.partition(' ')
@@ -1089,6 +1120,41 @@ class SystemSetup:
                         package, version, release, os.linesep
                     )
                 ])
+
+    def _export_rpm_package_changes(self, filename):
+        log.info('Export rpm packages changelog metadata')
+        dbpath_option = [
+            '--dbpath', self._get_rpm_database_location()
+        ]
+        query_call = Command.run(
+            [
+                'rpm', '--root', self.root_dir,
+                '-qa', '--qf', '%{NAME}|\\n', '--changelog'
+            ] + dbpath_option
+        )
+        with open(filename, 'w', encoding='utf-8') as changelog:
+            changelog.write(query_call.output)
+
+    def _export_deb_package_changes(self, filename):
+        log.info('Export deb packages changelog metadata')
+        package_doc_dir = os.sep.join(
+            [self.root_dir, '/usr/share/doc']
+        )
+        with open(filename, 'w', encoding='utf-8') as changelog:
+            for package in sorted(os.listdir(package_doc_dir)):
+                changelog_file = os.sep.join(
+                    [package_doc_dir, package, 'changelog.Debian.gz']
+                )
+                if os.path.exists(changelog_file):
+                    changelog.write(
+                        '{0}{1}{2}'.format(package, '|', os.linesep)
+                    )
+                    changelog.write(
+                        '{0}{1}'.format(
+                            Command.run(['zcat', changelog_file]).output,
+                            os.linesep
+                        )
+                    )
 
     def _export_rpm_package_verification(self, filename):
         log.info('Export rpm verification metadata')

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -26,6 +26,7 @@ from tempfile import NamedTemporaryFile
 # project
 import kiwi.defaults as defaults
 
+from kiwi.runtime_config import RuntimeConfig
 from kiwi.mount_manager import MountManager
 from kiwi.system.uri import Uri
 from kiwi.repository import Repository
@@ -73,6 +74,7 @@ class SystemSetup:
     """
 
     def __init__(self, xml_state, root_dir):
+        self.runtime_config = RuntimeConfig()
         self.arch = Defaults.get_platform_name()
         self.xml_state = xml_state
         self.description_dir = \
@@ -527,24 +529,25 @@ class SystemSetup:
 
         :param str target_dir: path name
         """
-        filename = ''.join(
-            [
-                target_dir, '/',
-                self.xml_state.xml_data.get_name(),
-                '.' + self.arch,
-                '-' + self.xml_state.get_image_version(),
-                '.changes'
-            ]
-        )
-        packager = Defaults.get_default_packager_tool(
-            self.xml_state.get_package_manager()
-        )
-        if packager == 'rpm':
-            self._export_rpm_package_changes(filename)
-            return filename
-        elif packager == 'dpkg':
-            self._export_deb_package_changes(filename)
-            return filename
+        if self.runtime_config.get_package_changes():
+            filename = ''.join(
+                [
+                    target_dir, '/',
+                    self.xml_state.xml_data.get_name(),
+                    '.' + self.arch,
+                    '-' + self.xml_state.get_image_version(),
+                    '.changes'
+                ]
+            )
+            packager = Defaults.get_default_packager_tool(
+                self.xml_state.get_package_manager()
+            )
+            if packager == 'rpm':
+                self._export_rpm_package_changes(filename)
+                return filename
+            elif packager == 'dpkg':
+                self._export_deb_package_changes(filename)
+                return filename
 
     def export_package_verification(self, target_dir):
         """

--- a/test/unit/builder/container_test.py
+++ b/test/unit/builder/container_test.py
@@ -119,6 +119,7 @@ class TestContainerBuilder:
         )
         mock_image.return_value = container_image
         self.setup.export_package_verification.return_value = '.verified'
+        self.setup.export_package_changes.return_value = '.changes'
         self.setup.export_package_list.return_value = '.packages'
         self.container.base_image = None
         self.container.create()
@@ -145,6 +146,13 @@ class TestContainerBuilder:
                 filename='.packages',
                 use_for_bundle=True,
                 compress=False,
+                shasum=False
+            ),
+            call(
+                key='image_changes',
+                filename='.changes',
+                use_for_bundle=True,
+                compress=True,
                 shasum=False
             ),
             call(
@@ -193,6 +201,7 @@ class TestContainerBuilder:
         )
         mock_checksum.return_value = checksum
 
+        self.setup.export_package_changes.return_value = '.changes'
         self.setup.export_package_verification.return_value = '.verified'
         self.setup.export_package_list.return_value = '.packages'
 
@@ -223,6 +232,13 @@ class TestContainerBuilder:
                 filename='.packages',
                 use_for_bundle=True,
                 compress=False,
+                shasum=False
+            ),
+            call(
+                key='image_changes',
+                filename='.changes',
+                use_for_bundle=True,
+                compress=True,
                 shasum=False
             ),
             call(

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -170,6 +170,7 @@ class TestLiveImageBuilder:
         )
         mock_size.return_value = rootsize
 
+        self.setup.export_package_changes.return_value = '.changes'
         self.setup.export_package_verification.return_value = '.verified'
         self.setup.export_package_list.return_value = '.packages'
 
@@ -285,6 +286,13 @@ class TestLiveImageBuilder:
                 filename='.packages',
                 use_for_bundle=True,
                 compress=False,
+                shasum=False
+            ),
+            call(
+                key='image_changes',
+                filename='.changes',
+                use_for_bundle=True,
+                compress=True,
                 shasum=False
             ),
             call(

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -115,3 +115,20 @@ class TestRuntimeConfig:
             'check_dracut_module_for_oem_install_in_package_list',
             'check_container_tool_chain_installed'
         ]
+
+    def test_get_package_changes_default(self):
+        assert self.runtime_config.get_package_changes() is True
+
+    @patch('kiwi.runtime_checker.Defaults.is_buildservice_worker')
+    def test_get_packages_changes_default_for_obs(
+        self, mock_is_buildservice_worker
+    ):
+        mock_is_buildservice_worker.return_value = True
+        assert self.runtime_config.get_package_changes() is False
+
+    @patch.object(RuntimeConfig, '_get_attribute')
+    def test_get_packages_changes_explicit_setup(self, mock_get_attribute):
+        mock_get_attribute.return_value = False
+        assert self.runtime_config.get_package_changes() is False
+        mock_get_attribute.return_value = True
+        assert self.runtime_config.get_package_changes() is True

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -29,7 +29,13 @@ class TestSystemSetup:
         self._caplog = caplog
 
     @patch('platform.machine')
-    def setup(self, mock_machine):
+    @patch('kiwi.system.setup.RuntimeConfig')
+    def setup(self, mock_RuntimeConfig, mock_machine):
+        self.runtime_config = Mock()
+        self.runtime_config.get_package_changes = Mock(
+            return_value=True
+        )
+        mock_RuntimeConfig.return_value = self.runtime_config
         mock_machine.return_value = 'x86_64'
         self.xml_state = MagicMock()
         self.xml_state.get_package_manager = Mock(
@@ -1095,6 +1101,7 @@ class TestSystemSetup:
                 '%{NAME}|\\n', '--changelog', '--dbpath', 'image_dbpath'
             ]
         )
+        self.runtime_config.get_package_changes.assert_called_once_with()
 
     @patch('kiwi.system.setup.Command.run')
     @patch('os.path.exists')
@@ -1126,6 +1133,7 @@ class TestSystemSetup:
                 call('package_b|\n'),
                 call('changes\n')
             ]
+        self.runtime_config.get_package_changes.assert_called_once_with()
 
     @patch('kiwi.system.setup.Command.run')
     @patch('kiwi.system.setup.RpmDataBase')

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import logging
+import io
 from mock import (
     patch, call, Mock, MagicMock, mock_open
 )
@@ -1060,7 +1061,71 @@ class TestSystemSetup:
             )
 
         assert result == 'target_dir/some-image.x86_64-1.2.3.packages'
-        mock_command.assert_called_once_with(['pacman', '-Qe'])
+        mock_command.assert_called_once_with(
+            ['pacman', '--query', '--dbpath', 'root_dir/var/lib/pacman']
+        )
+
+    @patch('kiwi.system.setup.Command.run')
+    @patch('kiwi.system.setup.RpmDataBase')
+    @patch('kiwi.system.setup.MountManager')
+    def test_export_package_changes_rpm(
+        self, mock_MountManager, mock_RpmDataBase, mock_command
+    ):
+        rpmdb = Mock()
+        rpmdb.rpmdb_image.expand_query.return_value = 'image_dbpath'
+        rpmdb.rpmdb_host.expand_query.return_value = 'host_dbpath'
+        rpmdb.has_rpm.return_value = True
+        mock_RpmDataBase.return_value = rpmdb
+        command = Mock()
+        command.output = 'package|\nchanges'
+        mock_command.return_value = command
+
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            result = self.setup.export_package_changes('target_dir')
+            mock_open.assert_called_once_with(
+                'target_dir/some-image.x86_64-1.2.3.changes', 'w',
+                encoding='utf-8'
+            )
+
+        assert result == 'target_dir/some-image.x86_64-1.2.3.changes'
+        mock_command.assert_called_once_with(
+            [
+                'rpm', '--root', 'root_dir', '-qa', '--qf',
+                '%{NAME}|\\n', '--changelog', '--dbpath', 'image_dbpath'
+            ]
+        )
+
+    @patch('kiwi.system.setup.Command.run')
+    @patch('os.path.exists')
+    @patch('os.listdir')
+    def test_export_package_changes_dpkg(
+        self, mock_os_listdir, mock_os_path_exists, mock_command
+    ):
+        command = Mock()
+        command.output = 'changes'
+        mock_command.return_value = command
+        self.xml_state.get_package_manager = Mock(
+            return_value='apt-get'
+        )
+        mock_os_listdir.return_value = ['package_b', 'package_a']
+        mock_os_path_exists.return_value = True
+
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            result = self.setup.export_package_changes('target_dir')
+            file_handle = mock_open.return_value.__enter__.return_value
+            mock_open.assert_called_once_with(
+                'target_dir/some-image.x86_64-1.2.3.changes', 'w',
+                encoding='utf-8'
+            )
+            assert result == 'target_dir/some-image.x86_64-1.2.3.changes'
+            assert file_handle.write.call_args_list == [
+                call('package_a|\n'),
+                call('changes\n'),
+                call('package_b|\n'),
+                call('changes\n')
+            ]
 
     @patch('kiwi.system.setup.Command.run')
     @patch('kiwi.system.setup.RpmDataBase')


### PR DESCRIPTION
In addition to the .packages file which shows details about
the installed packages in terms of version, license, etc...
we now also create a .changes file which contains the changelog
information of the installed packages. The file can be used
to compare the package changelogs between image builds.


