### PR TITLE
Refactor BootLoaderConfig

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -251,7 +251,7 @@ class DiskBuilder:
         )
 
         # create the bootloader instance
-        self.bootloader_config = BootLoaderConfig(
+        self.bootloader_config = BootLoaderConfig.new(
             self.bootloader, self.xml_state, root_dir=self.root_dir,
             boot_dir=self.root_dir, custom_args={
                 'targetbase':

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -195,7 +195,7 @@ class InstallImageBuilder:
             # This also embedds an MBR and the respective BIOS modules
             # for compat boot. The complete bootloader setup will be
             # based on grub
-            bootloader_config = BootLoaderConfig(
+            bootloader_config = BootLoaderConfig.new(
                 'grub2', self.xml_state, root_dir=self.root_dir,
                 boot_dir=self.media_dir, custom_args={
                     'grub_directory_name':
@@ -210,7 +210,7 @@ class InstallImageBuilder:
             # setup bootloader config to boot the ISO via isolinux.
             # This allows for booting on x86 platforms in BIOS mode
             # only.
-            bootloader_config = BootLoaderConfig(
+            bootloader_config = BootLoaderConfig.new(
                 'isolinux', self.xml_state, root_dir=self.root_dir,
                 boot_dir=self.media_dir
             )

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -143,7 +143,7 @@ class LiveImageBuilder:
             # This also embedds an MBR and the respective BIOS modules
             # for compat boot. The complete bootloader setup will be
             # based on grub
-            bootloader_config = BootLoaderConfig(
+            bootloader_config = BootLoaderConfig.new(
                 'grub2', self.xml_state, root_dir=self.root_dir,
                 boot_dir=self.media_dir, custom_args={
                     'grub_directory_name':
@@ -157,7 +157,7 @@ class LiveImageBuilder:
             # setup bootloader config to boot the ISO via isolinux.
             # This allows for booting on x86 platforms in BIOS mode
             # only.
-            bootloader_config = BootLoaderConfig(
+            bootloader_config = BootLoaderConfig.new(
                 'isolinux', self.xml_state, root_dir=self.root_dir,
                 boot_dir=self.media_dir
             )

--- a/test/unit/bootloader/config/init_test.py
+++ b/test/unit/bootloader/config/init_test.py
@@ -10,24 +10,24 @@ from kiwi.bootloader.config import BootLoaderConfig
 class TestBootLoaderConfig:
     def test_bootloader_config_not_implemented(self):
         with raises(KiwiBootLoaderConfigSetupError):
-            BootLoaderConfig('foo', Mock(), 'root_dir')
+            BootLoaderConfig.new('foo', Mock(), 'root_dir')
 
-    @patch('kiwi.bootloader.config.BootLoaderConfigGrub2')
+    @patch('kiwi.bootloader.config.grub2.BootLoaderConfigGrub2')
     def test_bootloader_config_grub2(self, mock_grub2):
         xml_state = Mock()
-        BootLoaderConfig('grub2', xml_state, 'root_dir')
+        BootLoaderConfig.new('grub2', xml_state, 'root_dir')
         mock_grub2.assert_called_once_with(xml_state, 'root_dir', None, None)
 
-    @patch('kiwi.bootloader.config.BootLoaderConfigIsoLinux')
+    @patch('kiwi.bootloader.config.isolinux.BootLoaderConfigIsoLinux')
     def test_bootloader_config_isolinux(self, mock_isolinux):
         xml_state = Mock()
-        BootLoaderConfig('isolinux', xml_state, 'root_dir', 'boot_dir')
+        BootLoaderConfig.new('isolinux', xml_state, 'root_dir', 'boot_dir')
         mock_isolinux.assert_called_once_with(
             xml_state, 'root_dir', 'boot_dir', None
         )
 
-    @patch('kiwi.bootloader.config.BootLoaderConfigZipl')
+    @patch('kiwi.bootloader.config.zipl.BootLoaderConfigZipl')
     def test_bootloader_config_zipl(self, mock_zipl):
         xml_state = Mock()
-        BootLoaderConfig('grub2_s390x_emu', xml_state, 'root_dir')
+        BootLoaderConfig.new('grub2_s390x_emu', xml_state, 'root_dir')
         mock_zipl.assert_called_once_with(xml_state, 'root_dir', None, None)

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -141,7 +141,7 @@ class TestDiskBuilder:
         self.bootloader_config.get_boot_cmdline = mock.Mock(
             return_value='boot_cmdline'
         )
-        kiwi.builder.disk.BootLoaderConfig = mock.MagicMock(
+        kiwi.builder.disk.BootLoaderConfig.new = mock.MagicMock(
             return_value=self.bootloader_config
         )
         kiwi.builder.disk.DiskSetup = mock.MagicMock(

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -46,7 +46,7 @@ class TestInstallImageBuilder:
             return_value=self.mbrid
         )
         kiwi.builder.install.Path = mock.Mock()
-        kiwi.builder.install.BootLoaderConfig = mock.Mock()
+        kiwi.builder.install.BootLoaderConfig.new = mock.Mock()
         self.checksum = mock.Mock()
         kiwi.builder.install.Checksum = mock.Mock(
             return_value=self.checksum
@@ -110,7 +110,7 @@ class TestInstallImageBuilder:
         )
         assert install_image.arch == 'ix86'
 
-    @patch('kiwi.builder.install.BootLoaderConfig')
+    @patch('kiwi.builder.install.BootLoaderConfig.new')
     @patch('kiwi.builder.install.IsoToolsBase.setup_media_loader_directory')
     @patch('kiwi.builder.install.shutil.copy')
     @patch('kiwi.builder.install.mkdtemp')

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -41,7 +41,7 @@ class TestLiveImageBuilder:
         )
 
         self.bootloader = mock.Mock()
-        kiwi.builder.live.BootLoaderConfig = mock.Mock(
+        kiwi.builder.live.BootLoaderConfig.new = mock.Mock(
             return_value=self.bootloader
         )
 
@@ -221,7 +221,7 @@ class TestLiveImageBuilder:
             config_file='root_dir/etc/dracut.conf.d/02-livecd.conf'
         )
 
-        kiwi.builder.live.BootLoaderConfig.assert_called_once_with(
+        kiwi.builder.live.BootLoaderConfig.new.assert_called_once_with(
             'grub2', self.xml_state, root_dir='root_dir',
             boot_dir='temp_media_dir', custom_args={
                 'grub_directory_name': 'grub2'
@@ -304,9 +304,9 @@ class TestLiveImageBuilder:
 
         self.firmware.efi_mode.return_value = None
         tmpdir_name = ['temp-squashfs', 'temp_media_dir']
-        kiwi.builder.live.BootLoaderConfig.reset_mock()
+        kiwi.builder.live.BootLoaderConfig.new.reset_mock()
         self.live_image.create()
-        kiwi.builder.live.BootLoaderConfig.assert_called_once_with(
+        kiwi.builder.live.BootLoaderConfig.new.assert_called_once_with(
             'isolinux', self.xml_state, root_dir='root_dir',
             boot_dir='temp_media_dir'
         )


### PR DESCRIPTION
This commit refactors BootLoaderConfig to turn it into a proper factory
class and to also include type hints to facilitate it's use from an API
POV.

Related to #1498
