### PR TITLE
Refactor BootLoaderInstall

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1096,7 +1096,7 @@ class DiskBuilder:
                 "custom arguments for bootloader installation %s",
                 custom_install_arguments
             )
-            bootloader = BootLoaderInstall(
+            bootloader = BootLoaderInstall.new(
                 self.bootloader, self.root_dir, self.disk.storage_provider,
                 custom_install_arguments
             )

--- a/test/unit/bootloader/install/init_test.py
+++ b/test/unit/bootloader/install/init_test.py
@@ -10,16 +10,16 @@ from kiwi.bootloader.install import BootLoaderInstall
 class TestBootLoaderInstall:
     def test_bootloader_install_not_implemented(self):
         with raises(KiwiBootLoaderInstallSetupError):
-            BootLoaderInstall('foo', 'root_dir', Mock())
+            BootLoaderInstall.new('foo', 'root_dir', Mock())
 
-    @patch('kiwi.bootloader.install.BootLoaderInstallGrub2')
+    @patch('kiwi.bootloader.install.grub2.BootLoaderInstallGrub2')
     def test_bootloader_install_grub2(self, mock_grub2):
         device_provider = Mock()
-        BootLoaderInstall('grub2', 'root_dir', device_provider)
+        BootLoaderInstall.new('grub2', 'root_dir', device_provider)
         mock_grub2.assert_called_once_with('root_dir', device_provider, None)
 
-    @patch('kiwi.bootloader.install.BootLoaderInstallZipl')
+    @patch('kiwi.bootloader.install.zipl.BootLoaderInstallZipl')
     def test_bootloader_install_zipl(self, mock_zipl):
         device_provider = Mock()
-        BootLoaderInstall('grub2_s390x_emu', 'root_dir', device_provider)
+        BootLoaderInstall.new('grub2_s390x_emu', 'root_dir', device_provider)
         mock_zipl.assert_called_once_with('root_dir', device_provider, None)

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -134,7 +134,7 @@ class TestDiskBuilder:
             return_value=True
         )
         self.bootloader_install = mock.Mock()
-        kiwi.builder.disk.BootLoaderInstall = mock.MagicMock(
+        kiwi.builder.disk.BootLoaderInstall.new = mock.MagicMock(
             return_value=self.bootloader_install
         )
         self.bootloader_config = mock.Mock()


### PR DESCRIPTION
This commit refactors BootLoaderInstall class to make it a proper
factory class. In addition type hints are added for the constructor
method.

Related to #1498
