### PR TITLE
When Kiwi fails to download something, I want to see which URL it failed to get

### DIFF
--- a/kiwi/solver/repository/base.py
+++ b/kiwi/solver/repository/base.py
@@ -132,7 +132,7 @@ class SolverRepositoryBase:
             location = urlopen(request)
         except Exception as e:
             raise KiwiUriOpenError(
-                '{0}: {1}'.format(type(e).__name__, format(e))
+                '{0}: {1} {2}'.format(type(e).__name__, format(e), os.sep.join([self._get_mime_typed_uri(), repo_source]))
             )
         with open(target, 'wb') as target_file:
             target_file.write(location.read())

--- a/kiwi/solver/repository/base.py
+++ b/kiwi/solver/repository/base.py
@@ -118,6 +118,7 @@ class SolverRepositoryBase:
 
         :raises KiwiUriOpenError: if the download fails
         """
+        download_link = None
         try:
             download_link = os.sep.join(
                 [

--- a/kiwi/solver/repository/base.py
+++ b/kiwi/solver/repository/base.py
@@ -119,9 +119,13 @@ class SolverRepositoryBase:
         :raises KiwiUriOpenError: if the download fails
         """
         try:
-            request = Request(
-                os.sep.join([self._get_mime_typed_uri(), repo_source])
+            download_link = os.sep.join(
+                [
+                    self._get_mime_typed_uri(),
+                    repo_source
+                ]
             )
+            request = Request(download_link)
             if self.user and self.secret:
                 credentials = b64encode(
                     format(':'.join([self.user, self.secret])).encode()
@@ -132,7 +136,7 @@ class SolverRepositoryBase:
             location = urlopen(request)
         except Exception as e:
             raise KiwiUriOpenError(
-                '{0}: {1} {2}'.format(type(e).__name__, format(e), os.sep.join([self._get_mime_typed_uri(), repo_source]))
+                '{0}: {1} {2}'.format(type(e).__name__, format(e), download_link)
             )
         with open(target, 'wb') as target_file:
             target_file.write(location.read())

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -252,6 +252,7 @@ class Uri:
         name_parts = name.split(os.sep)
         repository = name_parts.pop()
         project = os.sep.join(name_parts)
+        download_link = None
         try:
             download_link = os.sep.join(
                 [

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -271,7 +271,7 @@ class Uri:
                 return download_link
         except Exception as e:
             raise KiwiUriOpenError(
-                '{0}: {1}'.format(type(e).__name__, format(e))
+                '{0}: {1} {2}'.format(type(e).__name__, format(e), download_link)
             )
 
     def _buildservice_path(self, name, urischeme, fragment=None):


### PR DESCRIPTION
Fixes #1571.

Changes proposed in this pull request:
* Detail `raise`s of `KiwiUriOpenError` with the URI which it failed to fetch 
* solver/repository/base.py : refactor download_link (avoid building it twice, for use and for error message)
