### PR TITLE
Fix compat link for rpmdb location

### DIFF
--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -201,7 +201,8 @@ class RepositoryZypper(RepositoryBase):
             )
             Command.run(
                 [
-                    'ln', '-s', ''.join(['../..', host_rpm_dbpath]),
+                    'ln', '-s', '--no-target-directory',
+                    ''.join(['../..', host_rpm_dbpath]),
                     self.root_dir + image_rpm_compat_link
                 ], raise_on_error=False
             )

--- a/test/unit/repository/zypper_test.py
+++ b/test/unit/repository/zypper_test.py
@@ -244,7 +244,8 @@ class TestRepositoryZypper:
         mock_Path_create.assert_called_once_with('../data/var/lib')
         mock_Command_run.assert_called_once_with(
             [
-                'ln', '-s', '../../usr/lib/sysimage/rpm', '../data/var/lib/rpm'
+                'ln', '-s', '--no-target-directory',
+                '../../usr/lib/sysimage/rpm', '../data/var/lib/rpm'
             ], raise_on_error=False
         )
         mock_Command_run.reset_mock()
@@ -276,7 +277,8 @@ class TestRepositoryZypper:
         mock_Path_create.assert_called_once_with('../data/var/lib')
         mock_Command_run.assert_called_once_with(
             [
-                'ln', '-s', '../../usr/lib/sysimage/rpm', '../data/var/lib/rpm'
+                'ln', '-s', '--no-target-directory',
+                '../../usr/lib/sysimage/rpm', '../data/var/lib/rpm'
             ], raise_on_error=False
         )
 


### PR DESCRIPTION
This commit fixes the symlink creation for `/var/lib/rpm`. More specific
for derived container images in which the base root tree already
included the `/var/lib/rpm` the link, the `ln` command was creating a
symlink inside the `/var/lib/rpm` folder givent that it was following
the already existing symlink. Adding the `--no-target-directory` force
`ln` command to treat `/var/lib/rpm` path as the fully qualified symlink name.

Fixes bsc#1176977
