### PR TITLE
Align dracut-kiwi-lib version with packages requiring it

### DIFF
--- a/package/python-kiwi-pkgbuild-template
+++ b/package/python-kiwi-pkgbuild-template
@@ -42,14 +42,14 @@ package_dracut-kiwi-lib(){
 }
 
 package_dracut-kiwi-oem-repart(){
-  depends=(dracut-kiwi-lib)
+  depends=(dracut-kiwi-lib=${pkgver})
   cd kiwi-${pkgver}
   install -d -m 755 ${pkgdir}/usr/lib/dracut/modules.d/90kiwi-repart
   cp -a dracut/modules.d/90kiwi-repart ${pkgdir}/usr/lib/dracut/modules.d/
 }
 
 package_dracut-kiwi-oem-dump(){
-  depends=(dracut-kiwi-lib multipath-tools)
+  depends=(dracut-kiwi-lib=${pkgver} multipath-tools)
   cd kiwi-${pkgver}
   install -d -m 755 ${pkgdir}/usr/lib/dracut/modules.d/90kiwi-dump
   cp -a dracut/modules.d/90kiwi-dump ${pkgdir}/usr/lib/dracut/modules.d/

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -272,7 +272,7 @@ Summary:        KIWI - Dracut module for oem(repart) image type
 # to set up the build environment...
 BuildRequires:  dracut
 %endif
-Requires:       dracut-kiwi-lib
+Requires:       dracut-kiwi-lib = %{version}
 License:        GPL-3.0-or-later
 Group:          %{sysgroup}
 
@@ -289,7 +289,7 @@ Summary:        KIWI - Dracut module for oem(install) image type
 # to set up the build environment...
 BuildRequires:  dracut
 %endif
-Requires:       dracut-kiwi-lib
+Requires:       dracut-kiwi-lib = %{version}
 Requires:       kexec-tools
 Requires:       gawk
 Requires:       kpartx


### PR DESCRIPTION
This commit enforces dracut-kiwi-oem-repart and
dracut-kiwi-oem-dump to require dracut-kiwi-lib of the same exact
version. This prevents dracut-kiwi-lib and the packages
dependent on it being installed on a image with inconsistent versions.

Fixes #1529