### PR TITLE
Delete length limitation of image id attribute

### DIFF
--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -66,7 +66,7 @@ div {
     k.image.id =
         ## An identification number which is represented in a file
         ## named /etc/ImageID
-        attribute id { xsd:string {length="10"} }
+        attribute id { text }
     k.image.attlist = k.image.name.attribute 
         & k.image.displayname.attribute?
         & k.image.id?

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -137,9 +137,6 @@ second the location of the XSD Schema
       <attribute name="id">
         <a:documentation>An identification number which is represented in a file
 named /etc/ImageID</a:documentation>
-        <data type="string">
-          <param name="length">10</param>
-        </data>
       </attribute>
     </define>
     <define name="k.image.attlist">


### PR DESCRIPTION
For legacy reasons the <image id="..."/> attributes was
limited to 10digits. The contents of /etc/ImageID are now
free format and no longer strictly evaluated. Thus the
limitations on the id attribute can be deleted

