### PR TITLE
Make dependencies to dracut-kiwi-lib release specific

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -272,7 +272,7 @@ Summary:        KIWI - Dracut module for oem(repart) image type
 # to set up the build environment...
 BuildRequires:  dracut
 %endif
-Requires:       dracut-kiwi-lib = %{version}
+Requires:       dracut-kiwi-lib = %{version}-%{release}
 License:        GPL-3.0-or-later
 Group:          %{sysgroup}
 
@@ -289,7 +289,7 @@ Summary:        KIWI - Dracut module for oem(install) image type
 # to set up the build environment...
 BuildRequires:  dracut
 %endif
-Requires:       dracut-kiwi-lib = %{version}
+Requires:       dracut-kiwi-lib = %{version}-%{release}
 Requires:       kexec-tools
 Requires:       gawk
 Requires:       kpartx


### PR DESCRIPTION
This commit adds a dracut-kiwi-lib dependency to dracut-kiwi-oem-dump and
darcut-kiwi-oem-repart to match up to the release level. This way the
dependency ensures the pulled binaries they are all part of the same build.