### PR TITLE
Enhance scope of _fix_grub_root_device_reference

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -1142,10 +1142,19 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 # the correct value.
                 with open(config_file) as grub_config_file:
                     grub_config = grub_config_file.read()
-                    grub_config = grub_config.replace(
-                        'root={0}'.format(boot_options.get('root_device')),
-                        self.root_reference
+                    # The following expression matches any of the following
+                    # grub mkconfig root= settings and replaces it with a
+                    # correct value
+                    # 1. root=LOCAL-KIWI-MAPPED-DEVICE
+                    # 2. root=.*(lazy)=ANY-LINUX-BY-ID-VALUE
+                    grub_config = re.sub(
+                        r'(root=.*?=[a-zA-Z0-9:\.-]+)|(root={0})'.format(
+                            boot_options.get('root_device')
+                        ),
+                        '{0}'.format(self.root_reference),
+                        grub_config
                     )
+
                 with open(config_file, 'w') as grub_config_file:
                     grub_config_file.write(grub_config)
 

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -542,7 +542,7 @@ class TestBootLoaderConfigGrub2:
             file_handle_grubenv = \
                 mock_open_grubenv.return_value.__enter__.return_value
 
-            file_handle_grub.read.return_value = 'root=rootdev'
+            file_handle_grub.read.return_value = 'root=PARTUUID=xx'
             file_handle_grubenv.read.return_value = 'root=rootdev'
             file_handle_menu.read.return_value = 'options foo bar'
 
@@ -576,7 +576,7 @@ class TestBootLoaderConfigGrub2:
                     '    fi\n'
                     'fi\n'
                 ),
-                call('root=rootdev'),
+                call('root=PARTUUID=xx'),
                 # second write of grub.cfg, setting overlay root
                 call('root=overlay:UUID=ID')
             ]


### PR DESCRIPTION
In addition to the wrong root=/dev/mapper/loop... reference
fixing, written by grub2-mkconfig when used in obs there is
also the case that grub2-mkconfig writes root=PARTUUID which
is also unwanted and needs fixing.

