### PR TITLE
Fix profile docs

### DIFF
--- a/doc/source/working_with_images/build_with_profiles.rst
+++ b/doc/source/working_with_images/build_with_profiles.rst
@@ -16,8 +16,7 @@ command line flag `--profile=$PROFILE_NAME`:
 
 .. code:: shell-session
 
-   $ sudo kiwi-ng --type iso system build \
-         --profile=workstation \
+   $ sudo kiwi-ng --type iso --profile=workstation system build \
          --description kiwi-descriptions/suse/x86_64/{exc_description} \
          --target-dir /tmp/myimage
 


### PR DESCRIPTION
This commit fixes the profiles documentation. The example KIWI-NG
command was using wrong flags order. This commit fixes the `--profile`
flag order in documentation.
