### PR TITLE
Fixed device_array structure in get_selected_disk

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -137,7 +137,7 @@ function get_selected_disk {
         local count=0
         local device_index=0
         for entry in ${disk_list};do
-            if [ $((count % 3)) -eq 0 ];then
+            if [ $((count % 2)) -eq 0 ];then
                 device_array[${device_index}]=${entry}
                 device_index=$((device_index + 1))
             fi


### PR DESCRIPTION
In reference to Issue #880 a bug was introduced that broke
the contents of the device_array which causes issues on
installations with two or more attached disks. The change
in the mentioned PR reduced the tuple for each disk
from 3 elements to 2 elements. Therefore the loop that
iterates over the disk tuples via modulo 3 was broken.
This commit fixes the modulo operation to correctly
parse the disk_list. Fixes #1588


