### PR TITLE
Limit the use of linuxefi command

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -299,7 +299,10 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
         else:
             log.info('--> Using standard boot install template')
-            hybrid_boot = True
+            hybrid_boot = False
+            module_path = self._get_efi_modules_path(self.root_dir)
+            if os.path.exists(module_path + '/linuxefi.mod'):
+                hybrid_boot = True
             template = self.grub2.get_install_template(
                 self.failsafe_boot, hybrid_boot, self.terminal,
                 self.continue_on_timeout
@@ -358,7 +361,10 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
         else:
             log.info('--> Using standard boot template')
-            hybrid_boot = True
+            hybrid_boot = False
+            module_path = self._get_efi_modules_path(self.root_dir)
+            if os.path.exists(module_path + '/linuxefi.mod'):
+                hybrid_boot = True
             template = self.grub2.get_iso_template(
                 self.failsafe_boot, hybrid_boot,
                 self.terminal, self.mediacheck_boot
@@ -1113,21 +1119,23 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             # Any subsequent call of the grub config tool will overwrite
             # the setup and disables dynamic EFI environment checking
             # at boot time
-            with open(config_file) as grub_config_file:
-                grub_config = grub_config_file.read()
-                grub_config = re.sub(
-                    r'([ \t]+)linux(efi|16)*([ \t]+)', r'\1$linux\3',
-                    grub_config
-                )
-                grub_config = re.sub(
-                    r'([ \t]+)initrd(efi|16)*([ \t]+)', r'\1$initrd\3',
-                    grub_config
-                )
-            with open(config_file, 'w') as grub_config_file:
-                grub_config_file.write(
-                    Template(self.grub2.header_hybrid).substitute()
-                )
-                grub_config_file.write(grub_config)
+            module_path = self._get_efi_modules_path(self.root_dir)
+            if os.path.exists(module_path + '/linuxefi.mod'):
+                with open(config_file) as grub_config_file:
+                    grub_config = grub_config_file.read()
+                    grub_config = re.sub(
+                        r'([ \t]+)linux(efi|16)*([ \t]+)', r'\1$linux\3',
+                        grub_config
+                    )
+                    grub_config = re.sub(
+                        r'([ \t]+)initrd(efi|16)*([ \t]+)', r'\1$initrd\3',
+                        grub_config
+                    )
+                with open(config_file, 'w') as grub_config_file:
+                    grub_config_file.write(
+                        Template(self.grub2.header_hybrid).substitute()
+                    )
+                    grub_config_file.write(grub_config)
 
     def _fix_grub_root_device_reference(self, config_file, boot_options):
         if self.root_reference:

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -472,13 +472,18 @@ class TestBootLoaderConfigGrub2:
             True, 'gfxterm', None
         )
 
+    @patch('kiwi.bootloader.config.grub2.os.path.exists')
+    @patch('kiwi.bootloader.config.grub2.Defaults.get_grub_path')
     @patch.object(BootLoaderConfigGrub2, '_copy_grub_config_to_efi_path')
     def test_setup_live_image_config_standard(
-        self, mock_copy_grub_config_to_efi_path
+        self, mock_copy_grub_config_to_efi_path,
+        mock_grub_path, mock_path_exists
     ):
         self.firmware.efi_mode = Mock(
             return_value='uefi'
         )
+        mock_path_exists.return_value = True
+        mock_grub_path.return_value = '/root_dir/usr/share/grub2'
         self.bootloader.early_boot_script_efi = 'earlyboot.cfg'
         self.bootloader.multiboot = False
         self.bootloader.setup_live_image_config(self.mbrid)
@@ -496,6 +501,8 @@ class TestBootLoaderConfigGrub2:
             True, 'gfxterm', True
         )
 
+    @patch('kiwi.bootloader.config.grub2.os.path.exists')
+    @patch('kiwi.bootloader.config.grub2.Defaults.get_grub_path')
     @patch.object(BootLoaderConfigGrub2, '_mount_system')
     @patch.object(BootLoaderConfigGrub2, '_copy_grub_config_to_efi_path')
     @patch('kiwi.bootloader.config.grub2.Command.run')
@@ -505,8 +512,10 @@ class TestBootLoaderConfigGrub2:
     def test_setup_disk_image_config(
         self, mock_iglob, mock_get_vendor_grubenv, mock_Path_which,
         mock_Command_run, mock_copy_grub_config_to_efi_path,
-        mock_mount_system
+        mock_mount_system, mock_grub_path, mock_path_exists
     ):
+        mock_path_exists.return_value = True
+        mock_grub_path.return_value = '/root_dir/usr/share/grub2'
         mock_iglob.return_value = ['some_entry.conf']
         mock_get_vendor_grubenv.return_value = 'grubenv'
         mock_Path_which.return_value = '/path/to/grub2-mkconfig'
@@ -587,14 +596,19 @@ class TestBootLoaderConfigGrub2:
                 'options some-cmdline root=UUID=foo'
             )
 
+    @patch('kiwi.bootloader.config.grub2.os.path.exists')
+    @patch('kiwi.bootloader.config.grub2.Defaults.get_grub_path')
     @patch.object(BootLoaderConfigGrub2, '_mount_system')
     @patch.object(BootLoaderConfigGrub2, '_copy_grub_config_to_efi_path')
     @patch('kiwi.bootloader.config.grub2.Command.run')
     @patch('kiwi.bootloader.config.grub2.Path.which')
     def test_setup_disk_image_config_validate_linuxefi(
         self, mock_Path_which, mock_Command_run,
-        mock_copy_grub_config_to_efi_path, mock_mount_system
+        mock_copy_grub_config_to_efi_path, mock_mount_system,
+        mock_grub_path, mock_path_exists
     ):
+        mock_path_exists.return_value = True
+        mock_grub_path.return_value = '/root_dir/usr/share/grub2'
         mock_Path_which.return_value = '/path/to/grub2-mkconfig'
         self.firmware.efi_mode = Mock(
             return_value='uefi'
@@ -643,10 +657,15 @@ class TestBootLoaderConfigGrub2:
                 )
             ]
 
+    @patch('kiwi.bootloader.config.grub2.os.path.exists')
+    @patch('kiwi.bootloader.config.grub2.Defaults.get_grub_path')
     @patch.object(BootLoaderConfigGrub2, '_copy_grub_config_to_efi_path')
     def test_setup_install_image_config_standard(
-        self, mock_copy_grub_config_to_efi_path
+        self, mock_copy_grub_config_to_efi_path,
+        mock_grub_path, mock_path_exists
     ):
+        mock_path_exists.return_value = True
+        mock_grub_path.return_value = '/root_dir/usr/share/grub2'
         self.firmware.efi_mode = Mock(
             return_value='uefi'
         )


### PR DESCRIPTION
This commit makes sure that the linuxefi grub2 command is only being
used by the KIWI grub2 config patches if the linuxefi.mod file is
found. Otherwise the config patch to alternate linux and linuxefi
commands at runtime is not applied.

Fixes #1559
