### PR TITLE
Update outdated OBS User Guide Links

### DIFF
--- a/doc/source/working_with_images/build_in_buildservice.rst
+++ b/doc/source/working_with_images/build_in_buildservice.rst
@@ -104,7 +104,7 @@ The notable differences to running {kiwi} locally include:
           <!-- image description with the profiles foo_profile and bar_profile
         </image>
 
-  2. Use the `multibuild <https://openbuildservice.org/help/manuals/obs-reference-guide/cha.obs.multibuild.html>`_ feature.
+  2. Use the `multibuild <https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.multibuild.html>`_ feature.
 
   The first option is simpler to use, but has the disadvantage that your
   appliances are built sequentially. The `multibuild` feature allows to

--- a/doc/source/working_with_images/build_with_profiles.rst
+++ b/doc/source/working_with_images/build_with_profiles.rst
@@ -29,7 +29,7 @@ Building with the Open Build Service
 ------------------------------------
 
 The Open Build Service (OBS) support profiles via the `multibuild
-<https://openbuildservice.org/help/manuals/obs-reference-guide/cha.obs.multibuild.html>`_
+<https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.multibuild.html>`_
 feature. An example project using this feature is the
 `openSUSE-Tumbleweed
 <https://build.opensuse.org/package/show/openSUSE:Factory/openSUSE-Tumbleweed>`_


### PR DESCRIPTION
Hi,

The 2 links to the multibuild chapter of the OBS User Guide are outdated and points to 404.

Old link:
https://openbuildservice.org/help/manuals/obs-reference-guide/cha.obs.multibuild.html

New link:
https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.multibuild.html