### PR TITLE
Rename image build tests

### DIFF
--- a/build-tests/arm/fedora/test-image-live/appliance.kiwi
+++ b/build-tests/arm/fedora/test-image-live/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="Fedora">
+<image schemaversion="7.3" name="kiwi-test-image-live">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/arm/suse/test-image-live/appliance.kiwi
+++ b/build-tests/arm/suse/test-image-live/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-live">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/arm/suse/test-image-rpi/appliance.kiwi
+++ b/build-tests/arm/suse/test-image-rpi/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-rpi">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/ppc/fedora/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/ppc/fedora/test-image-disk-simple/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="Fedora">
+<image schemaversion="7.3" name="kiwi-test-image-disk-simple">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/ppc/sle15/test-image-disk/appliance.kiwi
+++ b/build-tests/ppc/sle15/test-image-disk/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="SLE15">
+<image schemaversion="7.3" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/ppc/suse/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/ppc/suse/test-image-disk-simple/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-disk-simple">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/ppc/suse/test-image-disk/appliance.kiwi
+++ b/build-tests/ppc/suse/test-image-disk/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/s390/sle15/test-image-disk/appliance.kiwi
+++ b/build-tests/s390/sle15/test-image-disk/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="SLE15">
+<image schemaversion="7.3" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/s390/suse/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/s390/suse/test-image-disk-simple/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-disk-simple">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/s390/suse/test-image-disk/appliance.kiwi
+++ b/build-tests/s390/suse/test-image-disk/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
+++ b/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="Arch">
+<image schemaversion="7.3" name="kiwi-test-image-live-disk-kis">
     <description type="system">
         <author>David Cassany</author>
         <contact>dcassany@suse.com</contact>

--- a/build-tests/x86/centos/test-image-live-disk-v7/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-live-disk-v7/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="CentOS">
+<image schemaversion="7.3" name="kiwi-test-image-live-disk-v7">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/centos/test-image-live-disk-v8/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-live-disk-v8/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="CentOS">
+<image schemaversion="7.3" name="kiwi-test-image-live-disk-v8">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/debian/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/debian/test-image-live-disk/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="Debian">
+<image schemaversion="7.3" name="kiwi-test-image-live-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="Fedora">
+<image schemaversion="7.3" name="kiwi-test-image-live-disk">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-MicroOS/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-MicroOS/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-MicroOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-azure/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-azure/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-azure">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/suse/test-image-custom-partitions/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-custom-partitions/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-custom-partitions">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/suse/test-image-disk-legacy/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-disk-legacy/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-disk-legacy">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-disk-simple/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-disk-simple">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-disk/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-disk/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-docker-derived/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-docker-derived/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-docker-derived">
     <description type="system">
         <author>David Cassany</author>
         <contact>dcassany@suse.de</contact>

--- a/build-tests/x86/suse/test-image-docker/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-docker/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-docker">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-ec2/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-ec2/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-ec2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/suse/test-image-gce/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-gce/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-gce">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/suse/test-image-live/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-live/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-live">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-luks/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-luks/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-luks">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-lvm/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-lvm/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-lvm">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-orthos/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-orthos/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-orthos">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/suse/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-overlayroot/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-overlayroot">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-pxe/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-pxe/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-pxe">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-qcow-openstack/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-qcow-openstack/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-qcow-openstack">
     <description type="system">
         <author>KIWI Team</author>
         <contact>kiwi-images@googlegroups.com</contact>

--- a/build-tests/x86/suse/test-image-suse-on-dnf/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-suse-on-dnf/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-suse-on-dnf">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-tbz/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-tbz/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-tbz">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-vagrant/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-vagrant/appliance.kiwi
@@ -4,7 +4,7 @@
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 <!-- OBS-ExclusiveArch: x86_64 -->
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-vagrant">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/suse/test-image-wsl/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-wsl/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="openSUSE-Tumbleweed">
+<image schemaversion="7.3" name="kiwi-test-image-wsl">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/ubuntu/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/ubuntu/test-image-live-disk/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="Ubuntu">
+<image schemaversion="7.3" name="kiwi-test-image-live-disk">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>


### PR DESCRIPTION
To use the image builds in openQA they have to have a unique
name such that it cannot happen that a cached version of an
image in openQA is used. The current names matched openQA
cached images e.g openSUSE-Tumbleweed and in addition different
image build tests used the same name. This commit uses the
name of the image as it is organized in its directory structure
prepending "kiwi-" to be unique in openQA when it fetches
the image. This is realted to Issue #1555

