### PR TITLE
Allow custom root volume name setup

### DIFF
--- a/doc/source/working_with_images/custom_volumes.rst
+++ b/doc/source/working_with_images/custom_volumes.rst
@@ -54,6 +54,16 @@ attributes:
 
         <volume name="@root" size="4G"/>
 
+     In addition to the custom size of the root volume it's also possible
+     to setup the name of the root volume as follows:
+
+     .. code:: xml
+
+        <volume name="@root=rootlv" size="4G"/>
+
+     If no name for the root volume is specified the
+     default name: **LVRoot** applies.
+
 - `freespace`: Optional attribute defining the additional free space added
   to the volume. If no suffix (`M` or `G`) is used, the value is considered
   to be in megabytes.

--- a/dracut/modules.d/99kiwi-lib/kiwi-lvm-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lvm-lib.sh
@@ -152,7 +152,6 @@ function read_volume_setup_all_free {
     local volume
     local name
     local mpoint
-    local have_root_volume_setup=false
     while read -r volspec;do
         if ! [[ "${volspec}" =~ "kiwi_Volume_" ]];then
             continue
@@ -160,18 +159,12 @@ function read_volume_setup_all_free {
         volume=$(echo "${volspec}" | cut -f2 -d= | tr -d \' | tr -d \")
         size=$(echo "${volume}" | cut -f2 -d\| | cut -f2 -d:)
         name=$(echo "${volume}" | cut -f1 -d\|)
-        if [ "${name}" = "LVRoot" ];then
-            have_root_volume_setup=true
-        fi
         if [ "${size}" = "all" ];then
             mpoint=$(echo "${volume}" | cut -f3 -d\|)
             echo "${name},${mpoint}"
             return
         fi
     done < "${profile}"
-    if [ "${have_root_volume_setup}" = "false" ];then
-        echo LVRoot,
-    fi
 }
 
 function get_all_free_volume {

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -37,6 +37,7 @@ PRE_CREATE_SCRIPT = 'images.sh'
 EDIT_BOOT_CONFIG_SCRIPT = 'edit_boot_config.sh'
 EDIT_BOOT_INSTALL_SCRIPT = 'edit_boot_install.sh'
 IMAGE_METADATA_DIR = 'image'
+ROOT_VOLUME_NAME = 'LVRoot'
 
 
 class Defaults:

--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -105,14 +105,13 @@ class Disk(DeviceProvider):
         """
         Create root partition for use with LVM
 
-        Populates kiwi_RootPart(id) and kiwi_RootPartVol(LVRoot)
+        Populates kiwi_RootPart(id)
 
         :param int mbsize: partition size
         """
         self.partitioner.create('p.lxlvm', mbsize, 't.lvm')
         self._add_to_map('root')
         self._add_to_public_id_map('kiwi_RootPart')
-        self._add_to_public_id_map('kiwi_RootPartVol', 'LVRoot')
 
     def create_root_raid_partition(self, mbsize):
         """

--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -322,7 +322,7 @@ class DiskSetup:
 
     def _get_root_volume_configuration(self):
         """
-        Provide LVRoot volume configuration if present and in
+        Provide root volume configuration if present and in
         use according to the selected volume management. So far
         this only affects the LVM volume manager
         """
@@ -330,7 +330,7 @@ class DiskSetup:
             'root_volume_type', ['size_type', 'req_size']
         )
         for volume in self.volumes:
-            if volume.name == 'LVRoot':
+            if volume.is_root_volume:
                 if volume.size:
                     [size_type, req_size] = volume.size.split(':')
                     return root_volume_type(

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -232,7 +232,11 @@ class Profile:
 
             volume_count = 1
             for volume in self.xml_state.get_volumes():
-                volume_id_name = 'kiwi_Volume_{id}'.format(id=volume_count)
+                if volume.is_root_volume:
+                    volume_id_name = 'kiwi_Volume_Root'
+                else:
+                    volume_id_name = 'kiwi_Volume_{id}'.format(id=volume_count)
+                    volume_count += 1
                 self.dot_profile[volume_id_name] = '|'.join(
                     [
                         volume.name,
@@ -240,7 +244,6 @@ class Profile:
                         volume.mountpoint or ''
                     ]
                 )
-                volume_count += 1
 
     def _preferences_to_profile(self):
         # kiwi_iversion

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -299,7 +299,7 @@ class VolumeManagerBase(DeviceProvider):
                 if lookup_path == volume_path:
                     continue
                 if lookup_path == os.sep:
-                    # exclude any sub volume path if lookup_path is / [LVRoot]
+                    # exclude any sub volume path if lookup_path is /
                     exclude_paths.append(
                         os.path.normpath(self.root_dir + os.sep + volume_path)
                     )

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -157,7 +157,7 @@ class VolumeManagerBtrfs(VolumeManagerBase):
             )
 
         for volume in canonical_volume_list.volumes:
-            if volume.name == 'LVRoot':
+            if volume.is_root_volume:
                 # the btrfs root volume named '@' has been created as
                 # part of the setup procedure
                 pass

--- a/test/data/example_lvm_custom_rootvol_config.xml
+++ b/test/data/example_lvm_custom_rootvol_config.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="7.3" name="custom-root-volume-setup">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>ms@suse.com</contact>
+        <specification>
+            openSUSE 13.2 JeOS, is a small text based image
+        </specification>
+    </description>
+    <preferences>
+        <version>1.13.2</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>false</rpm-check-signatures>
+        <bootsplash-theme>openSUSE</bootsplash-theme>
+        <bootloader-theme>openSUSE</bootloader-theme>
+        <type image="oem" filesystem="ext3" installiso="true" kernelcmdline="splash" firmware="efi">
+            <systemdisk>
+                <volume name="@root=myroot" freespace="500M"/>
+            </systemdisk>
+        </type>
+    </preferences>
+    <users>
+        <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+    </users>
+    <repository>
+        <source path="obs://13.2/repo/oss"/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-openSUSE-base"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+    </packages>
+</image>

--- a/test/unit/storage/disk_test.py
+++ b/test/unit/storage/disk_test.py
@@ -73,7 +73,6 @@ class TestDisk:
             'p.lxlvm', 100, 't.lvm'
         )
         assert self.disk.public_partition_id_map['kiwi_RootPart'] == 1
-        assert self.disk.public_partition_id_map['kiwi_RootPartVol'] == 'LVRoot'
 
     def test_create_root_raid_partition(self):
         self.disk.create_root_raid_partition(100)

--- a/test/unit/system/profile_test.py
+++ b/test/unit/system/profile_test.py
@@ -29,11 +29,11 @@ class TestProfile:
         os.remove(self.profile_file)
         assert self.profile.dot_profile == {
             'kiwi_Volume_1': 'usr_lib|size:1024|usr/lib',
-            'kiwi_Volume_2': 'LVRoot|freespace:500|',
-            'kiwi_Volume_3': 'etc_volume|freespace:30|etc',
-            'kiwi_Volume_4': 'bin_volume|size:all|/usr/bin',
-            'kiwi_Volume_5': 'usr_bin|freespace:30|usr/bin',
-            'kiwi_Volume_6': 'LVSwap|size:128|',
+            'kiwi_Volume_2': 'etc_volume|freespace:30|etc',
+            'kiwi_Volume_3': 'bin_volume|size:all|/usr/bin',
+            'kiwi_Volume_4': 'usr_bin|freespace:30|usr/bin',
+            'kiwi_Volume_5': 'LVSwap|size:128|',
+            'kiwi_Volume_Root': 'LVRoot|freespace:500|',
             'kiwi_bootkernel': None,
             'kiwi_bootloader': 'grub2',
             'kiwi_bootprofile': None,

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -19,7 +19,8 @@ class TestVolumeManagerBase:
                 'realpath',
                 'mountpoint',
                 'fullsize',
-                'attributes'
+                'attributes',
+                'is_root_volume'
             ]
         )
         mock_path.return_value = True
@@ -38,11 +39,13 @@ class TestVolumeManagerBase:
         self.volume_manager.volumes = [
             self.volume_type(
                 name='LVetc', size='freespace:200', realpath='/etc',
-                mountpoint='/etc', fullsize=False, attributes=[]
+                mountpoint='/etc', fullsize=False, attributes=[],
+                is_root_volume=False
             ),
             self.volume_type(
                 name='LVRoot', size='size:500', realpath='/',
-                mountpoint='/', fullsize=True, attributes=[]
+                mountpoint='/', fullsize=True, attributes=[],
+                is_root_volume=True
             )
         ]
 
@@ -146,11 +149,13 @@ class TestVolumeManagerBase:
         self.volume_manager.volumes = [
             self.volume_type(
                 name='LVusr', size='freespace:200', realpath='/usr',
-                mountpoint='/usr', fullsize=False, attributes=[]
+                mountpoint='/usr', fullsize=False, attributes=[],
+                is_root_volume=False
             ),
             self.volume_type(
                 name='LVusr_lib', size='freespace:100', realpath='/usr/lib',
-                mountpoint='/usr/lib', fullsize=False, attributes=[]
+                mountpoint='/usr/lib', fullsize=False, attributes=[],
+                is_root_volume=False
             )
         ]
         assert self.volume_manager.get_volume_mbsize(
@@ -175,15 +180,18 @@ class TestVolumeManagerBase:
         self.volume_manager.volumes = [
             self.volume_type(
                 name='LVusr', size='freespace:200', realpath='/usr',
-                mountpoint='/usr', fullsize=False, attributes=[]
+                mountpoint='/usr', fullsize=False, attributes=[],
+                is_root_volume=False
             ),
             self.volume_type(
                 name='LVusr_lib', size='freespace:100', realpath='/usr/lib',
-                mountpoint='/usr/lib', fullsize=False, attributes=[]
+                mountpoint='/usr/lib', fullsize=False, attributes=[],
+                is_root_volume=False
             ),
             self.volume_type(
                 name='LVRoot', size='size:500', realpath='/',
-                mountpoint='/', fullsize=True, attributes=[]
+                mountpoint='/', fullsize=True, attributes=[],
+                is_root_volume=True
             )
         ]
         assert self.volume_manager.get_volume_mbsize(
@@ -244,7 +252,8 @@ class TestVolumeManagerBase:
             'toplevel', self.volume_type(
                 name='LVetc', size='freespace:200', realpath='/etc',
                 mountpoint='/etc', fullsize=False,
-                attributes=['no-copy-on-write']
+                attributes=['no-copy-on-write'],
+                is_root_volume=False
             )
         )
         mock_command.assert_called_once_with(

--- a/test/unit/volume_manager/btrfs_test.py
+++ b/test/unit/volume_manager/btrfs_test.py
@@ -32,29 +32,30 @@ class TestVolumeManagerBtrfs:
                 'realpath',
                 'mountpoint',
                 'fullsize',
-                'attributes'
+                'attributes',
+                'is_root_volume'
             ]
         )
         self.volumes = [
             self.volume_type(
                 name='LVRoot', size='freespace:100', realpath='/',
                 mountpoint=None, fullsize=False,
-                attributes=[]
+                attributes=[], is_root_volume=True
             ),
             self.volume_type(
                 name='LVetc', size='freespace:200', realpath='/etc',
                 mountpoint='/etc', fullsize=False,
-                attributes=[]
+                attributes=[], is_root_volume=False
             ),
             self.volume_type(
                 name='myvol', size='size:500', realpath='/data',
                 mountpoint='LVdata', fullsize=False,
-                attributes=[]
+                attributes=[], is_root_volume=False
             ),
             self.volume_type(
                 name='LVhome', size=None, realpath='/home',
                 mountpoint='/home', fullsize=True,
-                attributes=[]
+                attributes=[], is_root_volume=False
             )
         ]
         mock_path.return_value = True
@@ -186,15 +187,23 @@ class TestVolumeManagerBtrfs:
             call(
                 'tmpdir/@/', self.volume_type(
                     name='myvol', size='size:500', realpath='/data',
-                    mountpoint='LVdata', fullsize=False, attributes=[])
+                    mountpoint='LVdata', fullsize=False, attributes=[],
+                    is_root_volume=False
+                )
             ),
-            call('tmpdir/@/', self.volume_type(
-                name='LVetc', size='freespace:200', realpath='/etc',
-                mountpoint='/etc', fullsize=False, attributes=[])
+            call(
+                'tmpdir/@/', self.volume_type(
+                    name='LVetc', size='freespace:200', realpath='/etc',
+                    mountpoint='/etc', fullsize=False, attributes=[],
+                    is_root_volume=False
+                )
             ),
-            call('tmpdir/@/', self.volume_type(
-                name='LVhome', size=None, realpath='/home',
-                mountpoint='/home', fullsize=True, attributes=[])
+            call(
+                'tmpdir/@/', self.volume_type(
+                    name='LVhome', size=None, realpath='/home',
+                    mountpoint='/home', fullsize=True, attributes=[],
+                    is_root_volume=False
+                )
             )
         ]
         assert mock_path.call_args_list == [

--- a/test/unit/volume_manager/lvm_test.py
+++ b/test/unit/volume_manager/lvm_test.py
@@ -28,29 +28,35 @@ class TestVolumeManagerLVM:
                 'mountpoint',
                 'fullsize',
                 'label',
-                'attributes'
+                'attributes',
+                'is_root_volume'
             ]
         )
         self.volumes = [
             self.volume_type(
                 name='LVRoot', size='freespace:100', realpath='/',
-                mountpoint=None, fullsize=False, label=None, attributes=[]
+                mountpoint=None, fullsize=False, label=None, attributes=[],
+                is_root_volume=True
             ),
             self.volume_type(
                 name='LVSwap', size='size:100', realpath='swap',
-                mountpoint=None, fullsize=False, label='SWAP', attributes=[]
+                mountpoint=None, fullsize=False, label='SWAP', attributes=[],
+                is_root_volume=False
             ),
             self.volume_type(
                 name='LVetc', size='freespace:200', realpath='/etc',
-                mountpoint='/etc', fullsize=False, label='etc', attributes=[]
+                mountpoint='/etc', fullsize=False, label='etc', attributes=[],
+                is_root_volume=False
             ),
             self.volume_type(
                 name='myvol', size='size:500', realpath='/data',
-                mountpoint='LVdata', fullsize=False, label=None, attributes=[]
+                mountpoint='LVdata', fullsize=False, label=None, attributes=[],
+                is_root_volume=False
             ),
             self.volume_type(
                 name='LVhome', size=None, realpath='/home',
-                mountpoint='/home', fullsize=True, label=None, attributes=[]
+                mountpoint='/home', fullsize=True, label=None, attributes=[],
+                is_root_volume=False
             ),
         ]
         mock_path.return_value = True
@@ -178,28 +184,28 @@ class TestVolumeManagerLVM:
                 'root_dir', self.volume_type(
                     name='LVSwap', size='size:100', realpath='swap',
                     mountpoint=None, fullsize=False, label='SWAP',
-                    attributes=[]
+                    attributes=[], is_root_volume=False
                 )
             ),
             call(
                 'root_dir', self.volume_type(
                     name='LVRoot', size='freespace:100', realpath='/',
                     mountpoint=None, fullsize=False, label=None,
-                    attributes=[]
+                    attributes=[], is_root_volume=True
                 )
             ),
             call(
                 'root_dir', self.volume_type(
                     name='myvol', size='size:500', realpath='/data',
                     mountpoint='LVdata', fullsize=False, label=None,
-                    attributes=[]
+                    attributes=[], is_root_volume=False
                 )
             ),
             call(
                 'root_dir', self.volume_type(
                     name='LVetc', size='freespace:200', realpath='/etc',
                     mountpoint='/etc', fullsize=False, label='etc',
-                    attributes=[]
+                    attributes=[], is_root_volume=False
                 )
             )
         ]

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -292,6 +292,35 @@ class TestXMLState:
             'composedProfile', 'vmxSimpleFlavour', 'xenDomUFlavour'
         ]
 
+    def test_get_volumes_custom_root_volume_name(self):
+        description = XMLDescription(
+            '../data/example_lvm_custom_rootvol_config.xml'
+        )
+        xml_data = description.load()
+        state = XMLState(xml_data)
+        volume_type = namedtuple(
+            'volume_type', [
+                'name',
+                'size',
+                'realpath',
+                'mountpoint',
+                'fullsize',
+                'label',
+                'attributes',
+                'is_root_volume'
+            ]
+        )
+        assert state.get_volumes() == [
+            volume_type(
+                name='myroot', size='freespace:500',
+                realpath='/',
+                mountpoint=None, fullsize=False,
+                label=None,
+                attributes=[],
+                is_root_volume=True
+            )
+        ]
+
     def test_get_volumes(self):
         description = XMLDescription('../data/example_lvm_default_config.xml')
         xml_data = description.load()
@@ -304,44 +333,51 @@ class TestXMLState:
                 'mountpoint',
                 'fullsize',
                 'label',
-                'attributes'
+                'attributes',
+                'is_root_volume'
             ]
         )
         assert state.get_volumes() == [
             volume_type(
                 name='usr_lib', size='size:1024',
                 realpath='usr/lib',
-                mountpoint='usr/lib', fullsize=False,
+                mountpoint='usr/lib',
+                fullsize=False,
                 label='library',
-                attributes=[]
+                attributes=[],
+                is_root_volume=False
             ),
             volume_type(
                 name='LVRoot', size='freespace:500',
                 realpath='/',
                 mountpoint=None, fullsize=False,
                 label=None,
-                attributes=[]
+                attributes=[],
+                is_root_volume=True
             ),
             volume_type(
                 name='etc_volume', size='freespace:30',
                 realpath='etc',
                 mountpoint='etc', fullsize=False,
                 label=None,
-                attributes=['no-copy-on-write']
+                attributes=['no-copy-on-write'],
+                is_root_volume=False
             ),
             volume_type(
                 name='bin_volume', size=None,
                 realpath='/usr/bin',
                 mountpoint='/usr/bin', fullsize=True,
                 label=None,
-                attributes=[]
+                attributes=[],
+                is_root_volume=False
             ),
             volume_type(
                 name='LVSwap', size='size:128',
                 realpath='swap',
                 mountpoint=None, fullsize=False,
                 label='SWAP',
-                attributes=[]
+                attributes=[],
+                is_root_volume=False
             )
         ]
 
@@ -357,7 +393,8 @@ class TestXMLState:
                 'mountpoint',
                 'fullsize',
                 'label',
-                'attributes'
+                'attributes',
+                'is_root_volume'
             ]
         )
         assert state.get_volumes() == [
@@ -365,14 +402,16 @@ class TestXMLState:
                 name='LVRoot', size=None, realpath='/',
                 mountpoint=None, fullsize=True,
                 label=None,
-                attributes=[]
+                attributes=[],
+                is_root_volume=True
             ),
             volume_type(
                 name='LVSwap', size='size:128',
                 realpath='swap',
                 mountpoint=None, fullsize=False,
                 label='SWAP',
-                attributes=[]
+                attributes=[],
+                is_root_volume=False
             )
         ]
 
@@ -390,7 +429,8 @@ class TestXMLState:
                 'mountpoint',
                 'fullsize',
                 'label',
-                'attributes'
+                'attributes',
+                'is_root_volume'
             ]
         )
         assert state.get_volumes() == [
@@ -398,20 +438,23 @@ class TestXMLState:
                 name='usr', size=None, realpath='usr',
                 mountpoint='usr', fullsize=True,
                 label=None,
-                attributes=[]
+                attributes=[],
+                is_root_volume=False
             ),
             volume_type(
                 name='LVRoot', size='freespace:30', realpath='/',
                 mountpoint=None, fullsize=False,
                 label=None,
-                attributes=[]
+                attributes=[],
+                is_root_volume=True
             ),
             volume_type(
                 name='LVSwap', size='size:128',
                 realpath='swap',
                 mountpoint=None, fullsize=False,
                 label='SWAP',
-                attributes=[]
+                attributes=[],
+                is_root_volume=False
             )
         ]
 


### PR DESCRIPTION
In addition to the custom size of the root volume it's now
also possible to setup the name of the root volume as follows:

```xml
<volume name="@root=rootlv"/>
```

If no name for the root volume is specified the default
name: LVRoot applies as before. This Fixes #1530

