### PR TITLE
Improve debootstap execution

### DIFF
--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -143,16 +143,22 @@ class PackageManagerApt(PackageManagerBase):
                 cmd.append('--no-check-gpg')
             if self.deboostrap_minbase:
                 cmd.append('--variant=minbase')
+            if self.package_requests:
+                cmd.append(
+                    '--include={}'.format(','.join(self.package_requests))
+                )
             if self.repository.components:
                 cmd.append(
                     '--components={0}'.format(
                         ','.join(self.repository.components)
                     )
                 )
+            self.cleanup_requests()
             cmd.extend([
                 self.distribution, bootstrap_dir, self.distribution_path
             ])
-            Command.run(cmd, self.command_env)
+            result = Command.call(cmd, self.command_env)
+            output, error = result.process.communicate()
             data = DataSync(
                 bootstrap_dir + '/', self.root_dir
             )
@@ -167,7 +173,7 @@ class PackageManagerApt(PackageManagerBase):
         finally:
             Path.wipe(bootstrap_dir)
 
-        return self.process_install_requests()
+        return result
 
     def process_install_requests(self):
         """

--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -20,9 +20,7 @@ import os
 import logging
 
 # project
-from kiwi.defaults import Defaults
 from kiwi.command import Command
-from kiwi.utils.sync import DataSync
 from kiwi.path import Path
 from kiwi.package_manager.base import PackageManagerBase
 from kiwi.exceptions import (
@@ -106,12 +104,15 @@ class PackageManagerApt(PackageManagerBase):
             'Package exclusion for (%s) not supported for apt-get', name
         )
 
-    def process_install_requests_bootstrap(self):
+    def process_install_requests_bootstrap(self, root_bind=None):
         """
         Process package install requests for bootstrap phase (no chroot)
         The debootstrap program is used to bootstrap a new system with
         a collection of predefined packages. The kiwi bootstrap section
         information is not used in this case
+
+        :param object root_bind: instance of RootBind to manage kernel
+            file systems before debootstrap call
 
         :raises KiwiDebootstrapError: if no main distribution repository
             is configured, if the debootstrap script is not found or if the
@@ -130,7 +131,17 @@ class PackageManagerApt(PackageManagerBase):
                 'debootstrap script for %s distribution not found' %
                 self.distribution
             )
-        bootstrap_dir = self.root_dir + '.debootstrap'
+
+        # APT package manager does not support bootstrapping. To circumvent
+        # this limitation there is the debootstrap tool for APT based distros.
+        # Because of that there is a little overlap between KIWI and
+        # debootstrap. Debootstrap manages itself the kernel file systems for
+        # chroot environment, thus we need to umount the kernel file systems
+        # before calling debootstrap and remount them afterwards.
+        root_bind.umount_kernel_file_systems()
+        # debootsrap will create its own dev/fd device
+        os.unlink(os.path.normpath(os.sep.join([self.root_dir, 'dev/fd'])))
+
         if 'apt-get' in self.package_requests:
             # debootstrap takes care to install apt-get
             self.package_requests.remove('apt-get')
@@ -155,25 +166,24 @@ class PackageManagerApt(PackageManagerBase):
                 )
             self.cleanup_requests()
             cmd.extend([
-                self.distribution, bootstrap_dir, self.distribution_path
+                self.distribution, self.root_dir, self.distribution_path
             ])
-            result = Command.call(cmd, self.command_env)
-            output, error = result.process.communicate()
-            data = DataSync(
-                bootstrap_dir + '/', self.root_dir
-            )
-            data.sync_data(
-                options=Defaults.get_sync_options(),
-                exclude=['proc', 'sys', 'dev']
-            )
+
+            return Command.call(cmd, self.command_env)
         except Exception as e:
             raise KiwiDebootstrapError(
                 '%s: %s' % (type(e).__name__, format(e))
             )
-        finally:
-            Path.wipe(bootstrap_dir)
 
-        return result
+    def post_process_install_requests_bootstrap(self, root_bind=None):
+        """
+        Mounts the kernel file systems to the chroot environment is
+        ready after the bootstrap procedure
+
+        :param object root_bind: instance of RootBind to manage kernel
+            file systems
+        """
+        root_bind.mount_kernel_file_systems()
 
     def process_install_requests(self):
         """

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -98,7 +98,7 @@ class PackageManagerBase:
         """
         raise NotImplementedError
 
-    def process_install_requests_bootstrap(self):
+    def process_install_requests_bootstrap(self, root_bind=None):
         """
         Process package install requests for bootstrap phase (no chroot)
 
@@ -182,7 +182,7 @@ class PackageManagerBase:
         """
         pass
 
-    def post_process_install_requests_bootstrap(self):
+    def post_process_install_requests_bootstrap(self, root_bind=None):
         """
         Process extra code required after bootstrapping
 

--- a/kiwi/package_manager/dnf.py
+++ b/kiwi/package_manager/dnf.py
@@ -84,9 +84,11 @@ class PackageManagerDnf(PackageManagerBase):
         """
         self.exclude_requests.append(name)
 
-    def process_install_requests_bootstrap(self):
+    def process_install_requests_bootstrap(self, root_bind=None):
         """
         Process package install requests for bootstrap phase (no chroot)
+
+        :param object root_bind: unused
 
         :return: process results in command type
 
@@ -258,10 +260,12 @@ class PackageManagerDnf(PackageManagerBase):
             '.*Removing: ' + re.escape(package_name) + '.*', dnf_output
         )
 
-    def post_process_install_requests_bootstrap(self):
+    def post_process_install_requests_bootstrap(self, root_bind=None):
         """
         Move the rpm database to the place as it is expected by the
         rpm package installed during bootstrap phase
+
+        :param object root_bind: unused
         """
         rpmdb = RpmDataBase(self.root_dir)
         if rpmdb.has_rpm():

--- a/kiwi/package_manager/pacman.py
+++ b/kiwi/package_manager/pacman.py
@@ -94,9 +94,11 @@ class PackageManagerPacman(PackageManagerBase):
         """
         self.exclude_requests.append(name)
 
-    def process_install_requests_bootstrap(self):
+    def process_install_requests_bootstrap(self, root_bind=None):
         """
         Process package install requests for bootstrap phase (no chroot)
+
+        :param object root_binf: unused
 
         :return: process results in command type
 

--- a/kiwi/package_manager/zypper.py
+++ b/kiwi/package_manager/zypper.py
@@ -97,9 +97,11 @@ class PackageManagerZypper(PackageManagerBase):
         """
         self.exclude_requests.append(name)
 
-    def process_install_requests_bootstrap(self):
+    def process_install_requests_bootstrap(self, root_bind=None):
         """
         Process package install requests for bootstrap phase (no chroot)
+
+        :param object root_bind: unused
 
         :return: process results in command type
 

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -219,7 +219,7 @@ class SystemPrepare:
             bootstrap_products
         )
         process = CommandProcess(
-            command=manager.process_install_requests_bootstrap(),
+            command=manager.process_install_requests_bootstrap(self.root_bind),
             log_topic='bootstrap'
         )
         try:
@@ -237,7 +237,7 @@ class SystemPrepare:
                         reason=issue
                     )
                 )
-        manager.post_process_install_requests_bootstrap()
+        manager.post_process_install_requests_bootstrap(self.root_bind)
         # process archive installations
         if bootstrap_archives:
             try:

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -291,12 +291,15 @@ class TestSystemPrepare:
             'kiwi'
         )
         self.manager.process_install_requests_bootstrap.assert_called_once_with(
+            self.system.root_bind
         )
         mock_tar.assert_called_once_with(
             '{0}/bootstrap.tgz'.format(self.description_dir)
         )
         tar.extract.assert_called_once_with('root_dir')
-        self.manager.post_process_install_requests_bootstrap.assert_called_once_with()
+        self.manager.post_process_install_requests_bootstrap.assert_called_once_with(
+            self.system.root_bind
+        )
 
     @patch('kiwi.xml_state.XMLState.get_bootstrap_packages_sections')
     def test_install_bootstrap_skipped(self, mock_bootstrap_section):

--- a/test/unit/system/root_bind_test.py
+++ b/test/unit/system/root_bind_test.py
@@ -95,6 +95,23 @@ class TestRootBind:
         shared_mount.bind_mount.assert_called_once_with()
 
     @patch('kiwi.system.root_bind.MountManager')
+    def test_umount_kernel_file_systems(self, mock_mount):
+        self.mount_manager.device = '/proc'
+        self.mount_manager.is_mounted = Mock(return_value=True)
+        self.bind_root.umount_kernel_file_systems()
+        self.mount_manager.umount_lazy.assert_called_once_with()
+        assert self.bind_root.mount_stack == []
+
+    @patch('kiwi.system.root_bind.MountManager')
+    def test_umount_kernel_file_systems_raises_error(self, mock_mount):
+        self.mount_manager.device = '/proc'
+        self.mount_manager.is_mounted = Mock(return_value=True)
+        self.mount_manager.umount_lazy = Mock(side_effect=Exception)
+        self.bind_root.umount_kernel_file_systems()
+        self.mount_manager.umount_lazy.assert_called_once_with()
+        assert self.bind_root.mount_stack == [self.mount_manager]
+
+    @patch('kiwi.system.root_bind.MountManager')
     @patch('kiwi.system.root_bind.Path.create')
     def test_mount_shared_directory(self, mock_path, mock_mount):
         shared_mount = Mock()


### PR DESCRIPTION
This PR refactors the bootstrap procedure of APT based images. Since APT is not capable to bootstrap the `debootstrap` tool is used. However `debootstrap` overlaps with KIWI on certain functionalities (for instance the mounts of kernel file systems for a proper chroot environment). In order to make debootstrap call as transparent as possible compared with non APT package managers small refactor is suggested.

Fixes #1587