### PR TITLE
Do not exclude filesystem folders in OCI images

### DIFF
--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -114,10 +114,9 @@ class ContainerImageOCI:
         :param string base_image: archive used as a base image
         """
         exclude_list = Defaults.get_exclude_list_for_root_data_sync()
-        exclude_list.append('boot')
-        exclude_list.append('dev')
-        exclude_list.append('sys')
-        exclude_list.append('proc')
+        exclude_list.append('dev/*')
+        exclude_list.append('sys/*')
+        exclude_list.append('proc/*')
 
         oci = OCI()
         if base_image:

--- a/test/unit/container/oci_test.py
+++ b/test/unit/container/oci_test.py
@@ -134,7 +134,7 @@ class TestContainerImageOCI:
         mock_oci.sync_rootfs.assert_called_once_with(
             'root_dir', [
                 'image', '.profile', '.kconfig', '.buildenv',
-                'var/cache/kiwi', 'boot', 'dev', 'sys', 'proc'
+                'var/cache/kiwi', 'dev/*', 'sys/*', 'proc/*'
             ]
         )
         mock_oci.repack.assert_called_once_with({
@@ -175,7 +175,7 @@ class TestContainerImageOCI:
         mock_oci.sync_rootfs.assert_called_once_with(
             'root_dir', [
                 'image', '.profile', '.kconfig', '.buildenv',
-                'var/cache/kiwi', 'boot', 'dev', 'sys', 'proc'
+                'var/cache/kiwi', 'dev/*', 'sys/*', 'proc/*'
             ]
         )
         mock_oci.repack.assert_called_once_with({


### PR DESCRIPTION
This commit does not exclude the /dev folder during the rsync call
in OCI images. It has been noted that including an empty /dev folder
does not hurt and it can eventually help to work around some limitations
of container related tools such as buildah.

Fixes bsc#1176129
