### PR TITLE
Refactor root image and volume manager factory

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -326,7 +326,7 @@ class DiskBuilder:
                 'resize_on_boot':
                     self.disk_resize_requested
             }
-            self.volume_manager = VolumeManager(
+            self.volume_manager = VolumeManager.new(
                 self.volume_manager_name, device_map,
                 self.root_dir + '/',
                 self.volumes,

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -75,7 +75,7 @@ class SystemPrepare:
         root.create()
         image_uri = xml_state.get_derived_from_image_uri()
         if image_uri:
-            root_import = RootImport(
+            root_import = RootImport.new(
                 root_dir, image_uri, xml_state.build_type.get_image()
             )
             root_import.sync_data()

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -716,7 +716,7 @@ class TestDiskBuilder:
         )
 
     @patch('kiwi.builder.disk.FileSystem.new')
-    @patch('kiwi.builder.disk.VolumeManager')
+    @patch('kiwi.builder.disk.VolumeManager.new')
     @patch('kiwi.builder.disk.Command.run')
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     @patch('os.path.exists')

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -68,7 +68,7 @@ class TestSystemPrepare:
         root_bind.setup_intermediate_config.assert_called_once_with()
         root_bind.mount_kernel_file_systems.assert_called_once_with()
 
-    @patch('kiwi.system.prepare.RootImport')
+    @patch('kiwi.system.prepare.RootImport.new')
     @patch('kiwi.system.prepare.RootInit')
     @patch('kiwi.system.prepare.RootBind')
     @patch('kiwi.logger.Logger.get_logfile')

--- a/test/unit/system/root_import/init_test.py
+++ b/test/unit/system/root_import/init_test.py
@@ -7,22 +7,22 @@ from kiwi.exceptions import KiwiRootImportError
 
 
 class TestRootImport:
-    @patch('kiwi.system.root_import.RootImportOCI')
+    @patch('kiwi.system.root_import.oci.RootImportOCI')
     def test_docker_import(self, mock_docker_import):
-        RootImport('root_dir', 'file:///image.tar.xz', 'docker')
+        RootImport.new('root_dir', 'file:///image.tar.xz', 'docker')
         mock_docker_import.assert_called_once_with(
             'root_dir', 'file:///image.tar.xz',
-            custom_args={'archive_transport': 'docker-archive'}
+            {'archive_transport': 'docker-archive'}
         )
 
-    @patch('kiwi.system.root_import.RootImportOCI')
+    @patch('kiwi.system.root_import.oci.RootImportOCI')
     def test_oci_import(self, mock_oci_import):
-        RootImport('root_dir', 'file:///image.tar.xz', 'oci')
+        RootImport.new('root_dir', 'file:///image.tar.xz', 'oci')
         mock_oci_import.assert_called_once_with(
             'root_dir', 'file:///image.tar.xz',
-            custom_args={'archive_transport': 'oci-archive'}
+            {'archive_transport': 'oci-archive'}
         )
 
     def test_not_implemented_import(self):
         with raises(KiwiRootImportError):
-            RootImport('root_dir', 'file:///image.tar.xz', 'foo')
+            RootImport.new('root_dir', 'file:///image.tar.xz', 'foo')

--- a/test/unit/volume_manager/init_test.py
+++ b/test/unit/volume_manager/init_test.py
@@ -11,26 +11,22 @@ from kiwi.exceptions import KiwiVolumeManagerSetupError
 class TestVolumeManager:
     def test_volume_manager_not_implemented(self):
         with raises(KiwiVolumeManagerSetupError):
-            VolumeManager('foo', Mock(), 'root_dir', Mock())
+            VolumeManager.new('foo', Mock(), 'root_dir', [Mock()])
 
-    @patch('kiwi.volume_manager.VolumeManagerLVM')
-    @patch('os.path.exists')
-    def test_volume_manager_lvm(self, mock_path, mock_lvm):
-        mock_path.return_value = True
+    @patch('kiwi.volume_manager.lvm.VolumeManagerLVM')
+    def test_volume_manager_lvm(self, mock_lvm):
         device_map = Mock()
-        volumes = Mock()
-        VolumeManager('lvm', device_map, 'root_dir', volumes)
+        volumes = [Mock()]
+        VolumeManager.new('lvm', device_map, 'root_dir', volumes)
         mock_lvm.assert_called_once_with(
             device_map, 'root_dir', volumes, None
         )
 
-    @patch('kiwi.volume_manager.VolumeManagerBtrfs')
-    @patch('os.path.exists')
-    def test_volume_manager_btrfs(self, mock_path, mock_btrfs):
-        mock_path.return_value = True
+    @patch('kiwi.volume_manager.btrfs.VolumeManagerBtrfs')
+    def test_volume_manager_btrfs(self, mock_btrfs):
         device_map = Mock()
-        volumes = Mock()
-        VolumeManager('btrfs', device_map, 'root_dir', volumes)
+        volumes = [Mock()]
+        VolumeManager.new('btrfs', device_map, 'root_dir', volumes)
         mock_btrfs.assert_called_once_with(
             device_map, 'root_dir', volumes, None
         )


### PR DESCRIPTION
Refactor VolumeManager / RootImport
    
This commit refactors VolumeManager and RootImport to turn them into proper
factory class and to also include type hints to facilitate it's
use from an API POV. Related to #1498


