### PR TITLE
Fixed install of bash completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # completion
-completion/kiwi-ng.sh
+completion/kiwi-ng
 
 # Schema formats
 kiwi/schema/kiwi.xsd

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ install:
 	# completion
 	install -d -m 755 ${buildroot}usr/share/bash-completion/completions
 	$(python) helper/completion_generator.py \
-		> ${buildroot}usr/share/bash-completion/completions/kiwi-ng.sh
+		> ${buildroot}usr/share/bash-completion/completions/kiwi-ng
 	# kiwi default configuration
 	install -d -m 755 ${buildroot}etc
 	install -m 644 kiwi.yml ${buildroot}etc/kiwi.yml

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -434,7 +434,7 @@ fi
 %{_bindir}/kiwi-ng-3*
 %{_bindir}/kiwicompat-3*
 %{python3_sitelib}/kiwi*
-%{_usr}/share/bash-completion/completions/kiwi-ng.sh
+%{_usr}/share/bash-completion/completions/kiwi-ng
 %{_defaultdocdir}/python-kiwi/LICENSE
 %{_defaultdocdir}/python-kiwi/README
 


### PR DESCRIPTION
The kiwi completion was installed as kiwi-ng.sh below
/usr/share/bash-completion/completions. This is wrong
because the completion does not pick up files with
a suffix like .sh. This commit changes the completion
file to be installed as kiwi-ng without the suffix
and Fixes #1603

