### PR TITLE
Fix quick start guide build command

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -44,7 +44,7 @@ command in order to build it:
 
 .. code:: bash
 
-    $ sudo kiwi-ng --type oem system build \
+    $ sudo kiwi-ng --profile=Disk --type oem system build \
         --description kiwi-descriptions/suse/x86_64/{exc_description} \
         --target-dir /tmp/myimage
 


### PR DESCRIPTION
The kiwi-descriptions were reorganized in profiles (See OSInside/kiwi-descriptions@788b919ea2500b9d495622c8140e618938634306).
However the build command in the quick start guide was not updated appropriately and therefore the build fails.

This commit will update the build command.


