### PR TITLE
Fixed regexp for grub rootdev substitution

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -1159,9 +1159,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                     # grub mkconfig root= settings and replaces it with a
                     # correct value
                     # 1. root=LOCAL-KIWI-MAPPED-DEVICE
-                    # 2. root=.*(lazy)=ANY-LINUX-BY-ID-VALUE
+                    # 2. root=[a-zA-Z]=ANY-LINUX-BY-ID-VALUE
                     grub_config = re.sub(
-                        r'(root=.*?=[a-zA-Z0-9:\.-]+)|(root={0})'.format(
+                        r'(root=[a-zA-Z]+=[a-zA-Z0-9:\.-]+)|(root={0})'.format(
                             boot_options.get('root_device')
                         ),
                         '{0}'.format(self.root_reference),

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -664,7 +664,9 @@ class TestBootLoaderConfigGrub2:
             file_handle_grubenv = \
                 mock_open_grubenv.return_value.__enter__.return_value
 
-            file_handle_grub.read.return_value = 'root=PARTUUID=xx'
+            file_handle_grub.read.return_value = \
+                'root=rootdev nomodeset console=ttyS0 console=tty0\n' \
+                'root=PARTUUID=xx'
             file_handle_grubenv.read.return_value = 'root=rootdev'
             file_handle_menu.read.return_value = 'options foo bar'
 
@@ -698,9 +700,17 @@ class TestBootLoaderConfigGrub2:
                     '    fi\n'
                     'fi\n'
                 ),
-                call('root=PARTUUID=xx'),
+                call(
+                    'root=rootdev nomodeset console=ttyS0 console=tty0'
+                    '\n'
+                    'root=PARTUUID=xx'
+                ),
                 # second write of grub.cfg, setting overlay root
-                call('root=overlay:UUID=ID')
+                call(
+                    'root=overlay:UUID=ID nomodeset console=ttyS0 console=tty0'
+                    '\n'
+                    'root=overlay:UUID=ID'
+                )
             ]
             file_handle_grubenv.write.assert_called_once_with(
                 'root=overlay:UUID=ID'


### PR DESCRIPTION
The regular expression to match the grub root device
used a lazy glob match ".*?". This however matches a
too long part depending on the rest of the content.
This commit fixes the expression to be strict on
the allowed characters and makes sure the anchor
characters are not part of the matching character
class. This Fixes #1607

