### PR TITLE
Move usrmerge package out of the bootstrap section

### DIFF
--- a/build-tests/x86/debian/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/debian/test-image-live-disk/appliance.kiwi
@@ -83,6 +83,7 @@
         <package name="isc-dhcp-client"/>
         <package name="netbase"/>
         <package name="bsdmainutils"/>
+        <package name="usrmerge"/>
     </packages>
     <packages type="image" profiles="Live">
         <package name="dracut-kiwi-live"/>
@@ -91,7 +92,5 @@
         <package name="dracut-kiwi-oem-repart"/>
         <package name="dracut-kiwi-oem-dump"/>
     </packages>
-    <packages type="bootstrap">
-        <package name="usrmerge"/>
-    </packages>
+    <packages type="bootstrap"/>
 </image>

--- a/build-tests/x86/ubuntu/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/ubuntu/test-image-live-disk/appliance.kiwi
@@ -83,6 +83,12 @@
         <package name="dbus"/>
         <package name="btrfs-progs"/>
         <package name="xz-utils"/>
+        <package name="usrmerge"/>
+        <!--
+            mawk is included so OBS adds it as a build dependency,
+            however this is installed by debootstrap
+        -->
+        <package name="mawk"/>
     </packages>
     <packages type="image" profiles="Live">
         <package name="dracut-kiwi-live"/>
@@ -91,8 +97,5 @@
         <package name="dracut-kiwi-oem-repart"/>
         <package name="dracut-kiwi-oem-dump"/>
     </packages>
-    <packages type="bootstrap">
-        <package name="mawk"/>
-        <package name="usrmerge"/>
-    </packages>
+    <packages type="bootstrap"/>
 </image>


### PR DESCRIPTION
Currently bootstrap phase on APT package manager makes use of the
debootstrap tool. However debootstrap is limited to execute  the
bootstrap using a single repository. This is causes several limitations
in OBS builds, such as the impossibility of using update repositories or
the inclusion of any package that is not part of the standard OBS
repository.

Usrmerge package is part of the universe repository in OBS which is not
te one used by debootstrap, so it can't be installed on bootstrap phase.
