### PR TITLE
Add editbootinstall script for Arch Linux tests

### DIFF
--- a/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
+++ b/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
@@ -31,12 +31,12 @@
         <rpm-check-signatures>false</rpm-check-signatures>
     </preferences>
     <preferences profiles="Live">
-        <type image="iso" flags="overlay" hybridpersistent_filesystem="ext4" hybridpersistent="true" firmware="efi" kernelcmdline="console=ttyS0">
+        <type image="iso" flags="overlay" hybridpersistent_filesystem="ext4" hybridpersistent="true" kernelcmdline="console=ttyS0">
             <bootloader name="grub2" console="serial"/>
         </type>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="oem" primary="true" filesystem="ext4" firmware="efi" kernelcmdline="console=ttyS0">
+        <type image="oem" primary="true" filesystem="ext4" firmware="efi" kernelcmdline="console=ttyS0" editbootinstall="editbootinstall_arch.sh">
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
@@ -44,7 +44,13 @@
         </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" filesystem="ext4" installiso="true" kernelcmdline="console=ttyS0">
+        <!--
+             KIWI does not natively provide EFI support for Arch Linux,
+             because of that the editbootinstall script is used to hot pacth
+             grub.cfg file. This hotpatch only applies for disk images
+             therefore the installation ISO does not support EFI
+        -->
+        <type image="oem" filesystem="ext4" installiso="true" kernelcmdline="console=ttyS0" editbootinstall="editbootinstall_arch.sh" firmware="efi">
             <bootloader name="grub2" console="serial"/>
         </type>
     </preferences>

--- a/build-tests/x86/archlinux/test-image-live-disk-kis/editbootinstall_arch.sh
+++ b/build-tests/x86/archlinux/test-image-live-disk-kis/editbootinstall_arch.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -x
+
+# Arch Linux does not support linuxefi grub module or command,
+# however KIWI relies on it to create a grub.cfg that can be
+# used for EFI and non EFI environments.
+# In Arch linux command is already capable to EFI boot
+set -e
+
+disk_img=$1
+mapped_dev=$2
+tmp_mount=$(mktemp -d disk_XXXXX)
+
+mount "${mapped_dev}" "${tmp_mount}"
+
+grub_config="${tmp_mount}/boot/grub/grub.cfg"
+
+if [ -f  "${grub_config}" ]; then
+    echo "Patching grub configuration file: ${grub_config}"
+    sed -i "s|linuxefi|linux|g" "${grub_config}"
+    sed -i "s|initrdefi|initrd|g" "${grub_config}"
+fi
+umount "${tmp_mount}" && rm -r ${tmp_mount}


### PR DESCRIPTION
This commit adds the editbootinstall script to Arch Linux OEM
integration tests. The provided script removes the use of linuxefi and
initrdefi commands on grub configuration since Arch does not support
linuxefi module.

Fixes #1559