### PR TITLE
Update packaging spec

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -352,7 +352,7 @@ Group:          %{sysgroup}
 %description -n kiwi-man-pages
 Provides manual pages to describe the kiwi commands
 
-%package -n kiwi-host-setup-for-building-containers
+%package -n kiwi-systemdeps-containers
 Summary:        KIWI - host requirements for container images
 Group:          System/Management
 Obsoletes:      kiwi-image-docker-requires
@@ -368,11 +368,11 @@ Requires:       buildah
 Requires:       skopeo
 
 %if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version}
-%description -n kiwi-host-setup-for-building-containers
+%description -n kiwi-systemdeps-containers
 Host setup helper to pull in all packages required/useful on
 the build host to build container images e.g docker, wsl
 
-%package -n kiwi-host-setup-for-building-iso-media
+%package -n kiwi-systemdeps-iso-media
 Summary:        KIWI - host requirements for live and install iso images
 Group:          System/Management
 Obsoletes:      kiwi-image-iso-requires
@@ -387,11 +387,11 @@ Requires:       gfxboot
 %endif
 %endif
 
-%description -n kiwi-host-setup-for-building-iso-media
+%description -n kiwi-systemdeps-iso-media
 Host setup helper to pull in all packages required/useful on
 the build host to build live and install iso images.
 
-%package -n kiwi-host-setup-for-building-filesystem-images
+%package -n kiwi-systemdeps-filesystem-images
 Summary:        KIWI - host requirements for filesystems
 Group:          System/Management
 Obsoletes:      kiwi-image-pxe-requires
@@ -416,24 +416,24 @@ Requires:       squashfs-tools
 Requires:       squashfs
 %endif
 
-%description -n kiwi-host-setup-for-building-filesystem-images
+%description -n kiwi-systemdeps-filesystem-images
 Host setup helper to pull in all packages required/useful on
 the build host to build filesystem images
 
-%package -n kiwi-host-setup-for-building-disk-images
+%package -n kiwi-systemdeps-disk-images
 Summary:        KIWI - host requirements for disk images
 Obsoletes:      kiwi-image-oem-requires
 Obsoletes:      kiwi-image-vmx-requires
 Group:          System/Management
 Provides:       kiwi-image:oem
 Provides:       kiwi-image:vmx
-Requires:       kiwi-host-setup-for-building-filesystem-images
+Requires:       kiwi-systemdeps-filesystem-images
 
-%description -n kiwi-host-setup-for-building-disk-images
+%description -n kiwi-systemdeps-disk-images
 Host setup helper to pull in all packages required/useful on
 the build host to build disk images
 
-%package -n kiwi-host-setup-for-image-validation
+%package -n kiwi-systemdeps-image-validation
 Summary:        KIWI - host requirements for handling image descriptions better
 Group:          System/Management
 %if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?suse_version} || 0%{?debian} || 0%{?ubuntu}
@@ -444,7 +444,7 @@ Requires:       python%{python3_pkgversion}-solv
 %endif
 Requires:       python%{python3_pkgversion}-anymarkup
 
-%description -n kiwi-host-setup-for-image-validation
+%description -n kiwi-systemdeps-image-validation
 Host setup helper to pull in all packages required/useful on
 the build host to handling image descriptions better. This also
 includes reading of image descriptions for different markup
@@ -566,19 +566,19 @@ fi
 %endif
 
 %if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version}
-%files -n kiwi-host-setup-for-building-containers
+%files -n kiwi-systemdeps-containers
 %defattr(-, root, root)
 
-%files -n kiwi-host-setup-for-building-iso-media
+%files -n kiwi-systemdeps-iso-media
 %defattr(-, root, root)
 
-%files -n kiwi-host-setup-for-building-filesystem-images
+%files -n kiwi-systemdeps-filesystem-images
 %defattr(-, root, root)
 
-%files -n kiwi-host-setup-for-building-disk-images
+%files -n kiwi-systemdeps-disk-images
 %defattr(-, root, root)
 
-%files -n kiwi-host-setup-for-image-validation
+%files -n kiwi-systemdeps-image-validation
 %defattr(-, root, root)
 %endif
 

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -44,7 +44,7 @@
 
 Name:           python-kiwi
 Version:        %%VERSION
-Provides:       kiwi-schema = 7.2
+Provides:       kiwi-schema = 7.3
 Release:        0
 Url:            https://github.com/OSInside/kiwi
 Summary:        KIWI - Appliance Builder Next Generation
@@ -85,9 +85,6 @@ Group:          Development/Languages/Python
 Obsoletes:      python2-kiwi
 Conflicts:      python2-kiwi
 Conflicts:      kiwi-man-pages < %{version}
-%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?suse_version} || 0%{?debian} || 0%{?ubuntu}
-Recommends:     jing
-%endif
 %if 0%{?ubuntu} || 0%{?debian}
 Requires:       python%{python3_pkgversion}-yaml
 %else
@@ -107,9 +104,6 @@ Requires:       python%{python3_pkgversion}-pyxattr
 %ifarch x86_64
 Requires:       grub2-x86_64-efi
 %endif
-%ifarch %{ix86} x86_64
-Recommends:     gfxboot
-%endif
 Requires:       qemu-tools
 Requires:       squashfs
 Requires:       gptfdisk
@@ -124,15 +118,8 @@ Requires(postun): chkconfig
 Requires:       qemu-img
 Requires:       squashfs-tools
 Requires:       gdisk
-%if 0%{?fedora} || 0%{?rhel} >= 8
-Recommends:     gnupg2
 %endif
-%endif
-%if 0%{?suse_version}
-# If it's available, let's pull it in
-Recommends:     dnf
-Recommends:     gpg2
-%endif
+Provides:       kiwi-image:tbz
 %if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?suse_version} >= 1550
 Provides:       kiwi-packagemanager:microdnf
 Requires:       microdnf
@@ -151,7 +138,6 @@ Requires:       debootstrap
 Requires:       qemu-utils
 Requires:       squashfs-tools
 Requires:       gdisk
-Recommends:     gnupg
 %endif
 Requires:       dosfstools
 Requires:       e2fsprogs
@@ -174,9 +160,6 @@ Requires:       u-boot-tools
 %endif
 %ifarch s390 s390x
 Requires:       s390-tools
-%endif
-%if ! (0%{?rhel} && 0%{?rhel} < 8)
-Recommends:     kiwi-man-pages
 %endif
 
 %description -n python%{python3_pkgversion}-kiwi
@@ -230,14 +213,11 @@ Requires:       cryptsetup
 %if 0%{?fedora} || 0%{?rhel} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 %if 0%{?rhel} && 0%{?rhel} < 8
 Requires:       btrfs-progs
-%else
-Recommends:     btrfs-progs
 %endif
 Requires:       gdisk
 Requires:       dracut-network
 %else
 %if 0%{?debian} || 0%{?ubuntu}
-Recommends:     btrfs-tools
 Requires:       gdisk
 %else
 Requires:       btrfsprogs
@@ -372,6 +352,103 @@ Group:          %{sysgroup}
 %description -n kiwi-man-pages
 Provides manual pages to describe the kiwi commands
 
+%package -n kiwi-host-setup-for-building-containers
+Summary:        KIWI - host requirements for container images
+Group:          System/Management
+Obsoletes:      kiwi-image-docker-requires
+Obsoletes:      kiwi-image-wsl-requires
+Provides:       kiwi-image:docker
+Provides:       kiwi-image:wsl
+%if 0%{?suse_version}
+Requires:       umoci
+Requires:       fb-util-for-appx
+%else
+Requires:       buildah
+%endif
+Requires:       skopeo
+
+%description -n kiwi-host-setup-for-building-containers
+Host setup helper to pull in all packages required/useful on
+the build host to build container images e.g docker, wsl
+
+%package -n kiwi-host-setup-for-building-iso-media
+Summary:        KIWI - host requirements for live and install iso images
+Group:          System/Management
+Obsoletes:      kiwi-image-iso-requires
+Provides:       kiwi-image:iso
+Requires:       checkmedia
+Requires:       dosfstools
+Requires:       xorriso
+%ifarch %{ix86} x86_64
+Requires:       syslinux
+%if 0%{?suse_version}
+Requires:       gfxboot
+%endif
+%endif
+
+%description -n kiwi-host-setup-for-building-iso-media
+Host setup helper to pull in all packages required/useful on
+the build host to build live and install iso images.
+
+%package -n kiwi-host-setup-for-building-filesystem-images
+Summary:        KIWI - host requirements for filesystems
+Group:          System/Management
+Obsoletes:      kiwi-image-pxe-requires
+Obsoletes:      kiwi-filesystem-requires
+Provides:       kiwi-image:pxe
+Provides:       kiwi-image:kis
+Provides:       kiwi-filesystem:btrfs
+Provides:       kiwi-filesystem:ext3
+Provides:       kiwi-filesystem:ext4
+Provides:       kiwi-filesystem:squashfs
+Provides:       kiwi-filesystem:xfs
+Requires:       e2fsprogs
+Requires:       xfsprogs
+%if 0%{?fedora} || 0%{?rhel} < 8 || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
+Requires:       btrfs-progs
+%else
+Requires:       btrfsprogs
+%endif
+%if 0%{?fedora} || 0%{?rhel} || 0%{?ubuntu} || 0%{?debian}
+Requires:       squashfs-tools
+%else
+Requires:       squashfs
+%endif
+
+%description -n kiwi-host-setup-for-building-filesystem-images
+Host setup helper to pull in all packages required/useful on
+the build host to build filesystem images
+
+%package -n kiwi-host-setup-for-building-disk-images
+Summary:        KIWI - host requirements for disk images
+Obsoletes:      kiwi-image-oem-requires
+Obsoletes:      kiwi-image-vmx-requires
+Group:          System/Management
+Provides:       kiwi-image:oem
+Provides:       kiwi-image:vmx
+Requires:       kiwi-host-setup-for-building-filesystem-images
+
+%description -n kiwi-host-setup-for-building-disk-images
+Host setup helper to pull in all packages required/useful on
+the build host to build disk images
+
+%package -n kiwi-host-setup-for-image-validation
+Summary:        KIWI - host requirements for handling image descriptions better
+Group:          System/Management
+%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?suse_version} || 0%{?debian} || 0%{?ubuntu}
+Requires:       jing
+%endif
+%if 0%{?suse_version}
+Requires:       python%{python3_pkgversion}-solv
+%endif
+Requires:       python%{python3_pkgversion}-anymarkup
+
+%description -n kiwi-host-setup-for-image-validation
+Host setup helper to pull in all packages required/useful on
+the build host to handling image descriptions better. This also
+includes reading of image descriptions for different markup
+languages
+
 %prep
 %setup -q -n kiwi-%{version}
 
@@ -485,5 +562,20 @@ fi
 %dir /srv/tftpboot/boot
 %endif
 %endif
+
+%files -n kiwi-host-setup-for-building-containers
+%defattr(-, root, root)
+
+%files -n kiwi-host-setup-for-building-iso-media
+%defattr(-, root, root)
+
+%files -n kiwi-host-setup-for-building-filesystem-images
+%defattr(-, root, root)
+
+%files -n kiwi-host-setup-for-building-disk-images
+%defattr(-, root, root)
+
+%files -n kiwi-host-setup-for-image-validation
+%defattr(-, root, root)
 
 %changelog

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -367,6 +367,7 @@ Requires:       buildah
 %endif
 Requires:       skopeo
 
+%if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version}
 %description -n kiwi-host-setup-for-building-containers
 Host setup helper to pull in all packages required/useful on
 the build host to build container images e.g docker, wsl
@@ -448,6 +449,7 @@ Host setup helper to pull in all packages required/useful on
 the build host to handling image descriptions better. This also
 includes reading of image descriptions for different markup
 languages
+%endif
 
 %prep
 %setup -q -n kiwi-%{version}
@@ -563,6 +565,7 @@ fi
 %endif
 %endif
 
+%if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version}
 %files -n kiwi-host-setup-for-building-containers
 %defattr(-, root, root)
 
@@ -577,5 +580,6 @@ fi
 
 %files -n kiwi-host-setup-for-image-validation
 %defattr(-, root, root)
+%endif
 
 %changelog

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -107,6 +107,10 @@ Requires:       grub2-x86_64-efi
 Requires:       qemu-tools
 Requires:       squashfs
 Requires:       gptfdisk
+Requires:       gpg2
+%endif
+%if 0%{?fedora} || 0%{?rhel} >= 8
+Requires:       gnupg2
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %ifarch x86_64
@@ -138,6 +142,7 @@ Requires:       debootstrap
 Requires:       qemu-utils
 Requires:       squashfs-tools
 Requires:       gdisk
+Requires:       gnupg
 %endif
 Requires:       dosfstools
 Requires:       e2fsprogs


### PR DESCRIPTION
Get rid of spec file Recommends because this is not implemented
consistently across all distro rpm versions. In addition the
recommended software components only makes sense if used in
an image build context. To create context a collection of
kiwi-host-setup-for-CONTEXT sub packages are added which
pulls in the context required software components. This
Fixes #1503

