### PR TITLE
Add support for the Micro DNF package manager

### DIFF
--- a/kiwi/package_manager/__init__.py
+++ b/kiwi/package_manager/__init__.py
@@ -21,6 +21,7 @@ import logging
 from kiwi.package_manager.zypper import PackageManagerZypper
 from kiwi.package_manager.apt import PackageManagerApt
 from kiwi.package_manager.dnf import PackageManagerDnf
+from kiwi.package_manager.microdnf import PackageManagerMicroDnf
 from kiwi.package_manager.pacman import PackageManagerPacman
 
 from kiwi.exceptions import (
@@ -49,6 +50,8 @@ class PackageManager:
             manager = PackageManagerZypper(repository, custom_args)
         elif package_manager == 'dnf' or package_manager == 'yum':
             manager = PackageManagerDnf(repository, custom_args)
+        elif package_manager == 'microdnf':
+            manager = PackageManagerMicroDnf(repository, custom_args)
         elif package_manager == 'apt-get':
             manager = PackageManagerApt(repository, custom_args)
         elif package_manager == 'pacman':

--- a/kiwi/package_manager/microdnf.py
+++ b/kiwi/package_manager/microdnf.py
@@ -1,0 +1,272 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import re
+import logging
+
+# project
+from kiwi.command import Command
+from kiwi.utils.rpm_database import RpmDataBase
+from kiwi.utils.rpm import Rpm
+from kiwi.package_manager.base import PackageManagerBase
+from kiwi.path import Path
+from kiwi.exceptions import KiwiRequestError
+from kiwi.defaults import Defaults
+
+log = logging.getLogger('kiwi')
+
+
+class PackageManagerMicroDnf(PackageManagerBase):
+    """
+    ***Implements base class for installation/deletion of
+    packages and collections using microdnf***
+
+    :param doct dnf_args: microdnf arguments from repository runtime configuration
+    :param dict command_env: microdnf command environment from repository runtime
+        configuration
+    """
+    def post_init(self, custom_args=None):
+        """
+        Post initialization method
+
+        :param list custom_args: custom microdnf arguments
+        """
+        self.custom_args = custom_args
+        if not custom_args:
+            self.custom_args = []
+
+        runtime_config = self.repository.runtime_config()
+        self.dnf_args = runtime_config['dnf_args']
+        self.command_env = runtime_config['command_env']
+
+    def request_package(self, name):
+        """
+        Queue a package request
+
+        :param str name: package name
+        """
+        self.package_requests.append(name)
+
+    def request_collection(self, name):
+        """
+        Queue a collection request
+
+        :param str name: dnf group name
+        """
+        log.warning(
+            'Group(%s) handling not yet supported for microdnf', name
+        )
+
+    def request_product(self, name):
+        """
+        Queue a product request
+
+        There is no product definition in the fedora repo data
+
+        :param str name: unused
+        """
+        pass
+
+    def request_package_exclusion(self, name):
+        """
+        Queue a package exclusion(skip) request
+
+        :param str name: package name
+        """
+        self.exclude_requests.append(name)
+
+    def process_install_requests_bootstrap(self, root_bind=None):
+        """
+        Process package install requests for bootstrap phase (no chroot)
+
+        :param object root_bind: unused
+
+        :return: process results in command type
+
+        :rtype: namedtuple
+        """
+        Command.run(
+            ['microdnf'] + self.dnf_args + ['makecache']
+        )
+        bash_command = [
+            'microdnf'
+        ] + self.dnf_args + [
+            '--installroot', self.root_dir
+        ] + self.custom_args + ['install'] + self.package_requests
+        self.cleanup_requests()
+        return Command.call(
+            ['bash', '-c', ' '.join(bash_command)], self.command_env
+        )
+
+    def process_install_requests(self):
+        """
+        Process package install requests for image phase (chroot)
+
+        :return: process results in command type
+
+        :rtype: namedtuple
+        """
+        if self.exclude_requests:
+            # For DNF, excluding a package means removing it from
+            # the solver operation. This is done by adding --exclude
+            # to the command line. This means that if the package is
+            # hard required by another package, it will break the transaction.
+            for package in self.exclude_requests:
+                self.custom_args.append('--exclude=' + package)
+        chroot_dnf_args = Path.move_to_root(
+            self.root_dir, self.dnf_args
+        )
+        bash_command = [
+            'chroot', self.root_dir, 'microdnf'
+        ] + chroot_dnf_args + self.custom_args + [
+            'install'
+        ] + self.package_requests
+        self.cleanup_requests()
+        return Command.call(
+            ['bash', '-c', ' '.join(bash_command)], self.command_env
+        )
+
+    def process_delete_requests(self, force=False):
+        """
+        Process package delete requests (chroot)
+
+        :param bool force: force deletion: true|false
+
+        :raises KiwiRequestError: if none of the packages to delete is
+            installed.
+        :return: process results in command type
+
+        :rtype: namedtuple
+        """
+        delete_items = []
+        for delete_item in self.package_requests:
+            try:
+                Command.run(['chroot', self.root_dir, 'rpm', '-q', delete_item])
+                delete_items.append(delete_item)
+            except Exception:
+                # ignore packages which are not installed
+                pass
+        if not delete_items:
+            raise KiwiRequestError(
+                'None of the requested packages to delete are installed'
+            )
+        self.cleanup_requests()
+        if force:
+            delete_options = ['--nodeps', '--allmatches', '--noscripts']
+            return Command.call(
+                [
+                    'chroot', self.root_dir, 'rpm', '-e'
+                ] + delete_options + delete_items,
+                self.command_env
+            )
+        else:
+            chroot_dnf_args = Path.move_to_root(self.root_dir, self.dnf_args)
+            return Command.call(
+                [
+                    'chroot', self.root_dir, 'microdnf'
+                ] + chroot_dnf_args + self.custom_args + [
+                    'remove'
+                ] + delete_items,
+                self.command_env
+            )
+
+    def update(self):
+        """
+        Process package update requests (chroot)
+
+        :return: process results in command type
+
+        :rtype: namedtuple
+        """
+        chroot_dnf_args = Path.move_to_root(self.root_dir, self.dnf_args)
+        return Command.call(
+            [
+                'chroot', self.root_dir, 'microdnf'
+            ] + chroot_dnf_args + self.custom_args + [
+                'upgrade'
+            ],
+            self.command_env
+        )
+
+    def process_only_required(self):
+        """
+        Setup package processing only for required packages
+        """
+        if '--setopt=install_weak_deps=False' not in self.custom_args:
+            self.custom_args.append('--setopt=install_weak_deps=False')
+
+    def process_plus_recommended(self):
+        """
+        Setup package processing to also include recommended dependencies.
+        """
+        if '--setopt=install_weak_deps=False' in self.custom_args:
+            self.custom_args.remove('--setopt=install_weak_deps=False')
+
+    def match_package_installed(self, package_name, dnf_output):
+        """
+        Match expression to indicate a package has been installed
+
+        This match for the package to be installed in the output
+        of the microdnf command is not 100% accurate. There might
+        be false positives due to sub package names starting with
+        the same base package name
+
+        :param list package_list: list of all packages
+        :param str log_line: microdnf status line
+
+        :returns: match or None if there isn't any match
+
+        :rtype: match object, None
+        """
+        return re.match(
+            '.*Installing  : ' + re.escape(package_name) + '.*', dnf_output
+        )
+
+    def match_package_deleted(self, package_name, dnf_output):
+        """
+        Match expression to indicate a package has been deleted
+
+        :param list package_list: list of all packages
+        :param str log_line: microdnf status line
+
+        :returns: match or None if there isn't any match
+
+        :rtype: match object, None
+        """
+        return re.match(
+            '.*Removing: ' + re.escape(package_name) + '.*', dnf_output
+        )
+
+    def post_process_install_requests_bootstrap(self, root_bind=None):
+        """
+        Move the rpm database to the place as it is expected by the
+        rpm package installed during bootstrap phase
+
+        :param object root_bind: unused
+        """
+        rpmdb = RpmDataBase(self.root_dir)
+        if rpmdb.has_rpm():
+            rpmdb.set_database_to_image_path()
+
+    def clean_leftovers(self):
+        """
+        Cleans package manager related data not needed in the
+        resulting image such as custom macros
+        """
+        Rpm(
+            self.root_dir, Defaults.get_custom_rpm_image_macro_name()
+        ).wipe_config()

--- a/kiwi/repository/__init__.py
+++ b/kiwi/repository/__init__.py
@@ -40,7 +40,7 @@ class Repository:
     def __new__(self, root_bind, package_manager, custom_args=None):
         if package_manager == 'zypper':
             return RepositoryZypper(root_bind, custom_args)
-        elif package_manager == 'dnf' or package_manager == 'yum':
+        elif package_manager == 'dnf' or package_manager == 'yum' or package_manager == 'microdnf':
             return RepositoryDnf(root_bind, custom_args)
         elif package_manager == 'apt-get':
             return RepositoryApt(root_bind, custom_args)

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -134,6 +134,10 @@ Recommends:     gnupg2
 Recommends:     dnf
 Recommends:     gpg2
 %endif
+%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?suse_version} >= 1550 || 0%{?sle_version} >= 150200
+Provides:       kiwi-packagemanager:microdnf
+Requires:       microdnf
+%endif
 %if 0%{?fedora} >= 26 || 0%{?suse_version}
 Requires:       zypper
 Provides:       kiwi-packagemanager:zypper

--- a/test/unit/package_manager/init_test.py
+++ b/test/unit/package_manager/init_test.py
@@ -31,6 +31,12 @@ class TestPackageManager:
         PackageManager(repository, 'yum')
         mock_manager.assert_called_once_with(repository, None)
 
+    @patch('kiwi.package_manager.PackageManagerMicroDnf')
+    def test_manager_microdnf(self, mock_manager):
+        repository = Mock()
+        PackageManager(repository, 'microdnf')
+        mock_manager.assert_called_once_with(repository, None)
+
     @patch('kiwi.package_manager.PackageManagerApt')
     def test_manager_apt(self, mock_manager):
         repository = Mock()

--- a/test/unit/package_manager/microdnf_test.py
+++ b/test/unit/package_manager/microdnf_test.py
@@ -1,0 +1,153 @@
+from mock import patch
+from pytest import raises
+import mock
+
+from kiwi.package_manager.microdnf import PackageManagerMicroDnf
+
+from kiwi.exceptions import KiwiRequestError
+
+
+class TestPackageManagerMicroDnf:
+    def setup(self):
+        repository = mock.Mock()
+        repository.root_dir = '/root-dir'
+
+        repository.runtime_config = mock.Mock(
+            return_value={
+                'dnf_args': ['-c', '/root-dir/dnf.conf', '-y'],
+                'command_env': ['env']
+            }
+        )
+        self.manager = PackageManagerMicroDnf(repository)
+
+    def test_request_package(self):
+        self.manager.request_package('name')
+        assert self.manager.package_requests == ['name']
+
+    def test_request_collection(self):
+        self.manager.request_collection('name')
+        assert self.manager.collection_requests == []
+
+    def test_request_product(self):
+        self.manager.request_product('name')
+        assert self.manager.product_requests == []
+
+    def test_request_package_exclusion(self):
+        self.manager.request_package_exclusion('name')
+        assert self.manager.exclude_requests == ['name']
+
+    @patch('kiwi.command.Command.call')
+    @patch('kiwi.command.Command.run')
+    def test_process_install_requests_bootstrap(self, mock_run, mock_call):
+        self.manager.request_package('vim')
+        self.manager.request_collection('collection')
+        self.manager.process_install_requests_bootstrap()
+        mock_run.assert_called_once_with(
+            ['microdnf', '-c', '/root-dir/dnf.conf', '-y', 'makecache']
+        )
+        mock_call.assert_called_once_with(
+            [
+                'bash', '-c',
+                'microdnf -c /root-dir/dnf.conf -y '
+                '--installroot /root-dir install vim'
+            ], ['env']
+        )
+
+    @patch('kiwi.command.Command.call')
+    def test_process_install_requests(self, mock_call):
+        self.manager.request_package('vim')
+        self.manager.request_collection('collection')
+        self.manager.request_package_exclusion('skipme')
+        self.manager.process_install_requests()
+        mock_call.assert_called_once_with(
+            [
+                'bash', '-c',
+                'chroot /root-dir microdnf -c /dnf.conf -y '
+                '--exclude=skipme install vim'
+            ], ['env']
+        )
+
+    @patch('kiwi.command.Command.call')
+    @patch('kiwi.command.Command.run')
+    def test_process_delete_requests_force(self, mock_run, mock_call):
+        self.manager.request_package('vim')
+        self.manager.process_delete_requests(True)
+        mock_call.assert_called_once_with(
+            [
+                'chroot', '/root-dir', 'rpm', '-e',
+                '--nodeps', '--allmatches', '--noscripts', 'vim'
+            ],
+            [
+                'env'
+            ]
+        )
+
+    @patch('kiwi.command.Command.call')
+    @patch('kiwi.command.Command.run')
+    def test_process_delete_requests_no_force(self, mock_run, mock_call):
+        self.manager.request_package('vim')
+        self.manager.process_delete_requests()
+        mock_call.assert_called_once_with(
+            [
+                'chroot', '/root-dir', 'microdnf',
+                '-c', '/dnf.conf', '-y', 'remove', 'vim'
+            ],
+            ['env']
+        )
+
+    @patch('kiwi.command.Command.run')
+    @patch('kiwi.command.Command.call')
+    def test_process_delete_requests_package_missing(
+        self, mock_call, mock_run
+    ):
+        mock_run.side_effect = Exception
+        self.manager.request_package('vim')
+        with raises(KiwiRequestError):
+            self.manager.process_delete_requests()
+        mock_run.assert_called_once_with(
+            ['chroot', '/root-dir', 'rpm', '-q', 'vim']
+        )
+
+    @patch('kiwi.command.Command.call')
+    def test_update(self, mock_call):
+        self.manager.update()
+        mock_call.assert_called_once_with(
+            [
+                'chroot', '/root-dir', 'microdnf',
+                '-c', '/dnf.conf', '-y', 'upgrade'
+            ], ['env']
+        )
+
+    def test_process_only_required(self):
+        self.manager.process_only_required()
+        assert self.manager.custom_args == ['--setopt=install_weak_deps=False']
+
+    def test_process_plus_recommended(self):
+        self.manager.process_only_required()
+        assert self.manager.custom_args == ['--setopt=install_weak_deps=False']
+        self.manager.process_plus_recommended()
+        assert \
+            '--setopt=install_weak_deps=False' not in self.manager.custom_args
+
+    def test_match_package_installed(self):
+        assert self.manager.match_package_installed('foo', 'Installing  : foo')
+
+    def test_match_package_deleted(self):
+        assert self.manager.match_package_deleted('foo', 'Removing: foo')
+
+    @patch('kiwi.package_manager.microdnf.RpmDataBase')
+    def test_post_process_install_requests_bootstrap(self, mock_RpmDataBase):
+        rpmdb = mock.Mock()
+        rpmdb.has_rpm.return_value = True
+        mock_RpmDataBase.return_value = rpmdb
+        self.manager.post_process_install_requests_bootstrap()
+        rpmdb.set_database_to_image_path.assert_called_once_with()
+
+    @patch('kiwi.package_manager.microdnf.Rpm')
+    def test_clean_leftovers(self, mock_rpm):
+        mock_rpm.return_value = mock.Mock()
+        self.manager.clean_leftovers()
+        mock_rpm.assert_called_once_with(
+            '/root-dir', 'macros.kiwi-image-config'
+        )
+        mock_rpm.return_value.wipe_config.assert_called_once_with()


### PR DESCRIPTION
Micro DNF is a minimal C implementation of DNF that is usable for
minimal appliances and containers. While it is not at parity with
DNF, it implements enough functionality that it is mostly usable
for building appliance images.

Changes proposed in this pull request:
* Add support for using Micro DNF for building appliance images
