### PR TITLE
Create relative boot link for extra boot partition

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -242,6 +242,20 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 config_file.replace(self.root_mount.mountpoint, '')
             ]
         )
+        if boot_options.get('root_device') != boot_options.get('boot_device'):
+            # Create a boot -> . link on the boot partition.
+            # The link is useful if the grub mkconfig command
+            # references all boot files from /boot/... even if
+            # an extra boot partition should cause it to read the
+            # data from the toplevel
+            bash_command = [
+                'cd', os.sep.join([self.root_mount.mountpoint, 'boot']), '&&',
+                'rm', '-f', 'boot', '&&',
+                'ln', '-s', '.', 'boot'
+            ]
+            Command.run(
+                ['bash', '-c', ' '.join(bash_command)]
+            )
 
         # Patch the written grub config file to actually work:
         # Unfortunately the grub tooling has several bugs and issues

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -678,12 +678,20 @@ class TestBootLoaderConfigGrub2:
             mock_mount_system.assert_called_once_with(
                 'rootdev', 'bootdev', None, None
             )
-            mock_Command_run.assert_called_once_with(
-                [
-                    'chroot', self.bootloader.root_mount.mountpoint,
-                    'grub2-mkconfig', '-o', '/boot/grub2/grub.cfg'
-                ]
-            )
+            assert mock_Command_run.call_args_list == [
+                call(
+                    [
+                        'chroot', self.bootloader.root_mount.mountpoint,
+                        'grub2-mkconfig', '-o', '/boot/grub2/grub.cfg'
+                    ]
+                ),
+                call(
+                    [
+                        'bash', '-c',
+                        'cd root_mount_point/boot && rm -f boot && ln -s . boot'
+                    ]
+                )
+            ]
             mock_copy_grub_config_to_efi_path.assert_called_once_with(
                 'efi_mount_point', 'earlyboot.cfg'
             )


### PR DESCRIPTION
If an extra boot partition is used the grub toolchain
still references files from that partition as /boot/...
which fails because they are now at the toplevel. To
avoid this and keep any /boot/some-file reference still
valid we create a symlink 'boot -> .' This Fixes #1611

