### PR TITLE
No bootpartition for XFS by default

### DIFF
--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -193,10 +193,9 @@ class DiskSetup:
             return True
         if self.volume_manager == 'btrfs':
             return False
-        if self.filesystem == 'xfs':
-            return True
         if self.root_filesystem_is_overlay:
             return True
+        return False
 
     def get_boot_label(self):
         """

--- a/test/unit/storage/setup_test.py
+++ b/test/unit/storage/setup_test.py
@@ -111,7 +111,7 @@ class TestDiskSetup:
     def test_need_boot_partition_xfs(self):
         self._init_bootpart_check()
         self.setup.filesystem = 'xfs'
-        assert self.setup.need_boot_partition() is True
+        assert self.setup.need_boot_partition() is False
 
     def test_boot_partition_size(self):
         self.setup.bootpart_requested = True


### PR DESCRIPTION
Selecting the xfs filesystem made kiwi to create an extra
boot partition. This is from times when grub was not able
to read from XFS. As grub doesn't have this limitation since
quite some time the bootpartition default in kiwi for XFS
should be changed. This is realted to #1611

