### PR TITLE
Added microdnf support in XML schema

### DIFF
--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -812,7 +812,7 @@ div {
 #
 div {
     k.packagemanager.content = 
-        "apt-get" | "zypper" | "yum" | "dnf" | "pacman"
+        "apt-get" | "zypper" | "yum" | "dnf" | "microdnf" | "pacman"
     k.packagemanager.attlist = empty
     k.packagemanager =
         ## Name of the Package Manager

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1250,6 +1250,7 @@ the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
         <value>zypper</value>
         <value>yum</value>
         <value>dnf</value>
+        <value>microdnf</value>
         <value>pacman</value>
       </choice>
     </define>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -730,6 +730,7 @@ class k_packagemanager_content(object):
     ZYPPER='zypper'
     YUM='yum'
     DNF='dnf'
+    MICRODNF='microdnf'
     PACMAN='pacman'
 
 


### PR DESCRIPTION
The XML schema did not allow to specify microdnf as
supported package manager

