### PR TITLE
Better error reporting if jing is missing

### DIFF
--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -161,7 +161,7 @@ class KiwiCommandError(KiwiError):
     """
 
 
-class KiwiCommandNotFound(KiwiCommandError):
+class KiwiCommandNotFound(KiwiError):
     """
     Exception raised if any executable command cannot be found in
     the evironment PATH variable.

--- a/test/unit/command_test.py
+++ b/test/unit/command_test.py
@@ -35,7 +35,7 @@ class TestCommand:
             Command.run(['command', 'args'])
 
     def test_run_invalid_environment(self):
-        with raises(KiwiCommandError):
+        with raises(KiwiCommandNotFound):
             Command.run(['command', 'args'], {'HOME': '/root'})
 
     @patch('kiwi.path.Path.which')

--- a/test/unit/xml_description_test.py
+++ b/test/unit/xml_description_test.py
@@ -8,6 +8,7 @@ from collections import namedtuple
 from kiwi.xml_description import XMLDescription
 
 from kiwi.exceptions import (
+    KiwiCommandError,
     KiwiSchemaImportError,
     KiwiValidationError,
     KiwiDescriptionInvalid,
@@ -203,14 +204,7 @@ class TestSchema:
 
         mock_relax.return_value = mock_rng_validate
         mock_schematron.return_value = mock_sch_validate
-        command_run = namedtuple(
-            'command', ['output', 'error', 'returncode']
-        )
-        mock_command.return_value = command_run(
-            output='jing output\n',
-            error='',
-            returncode=1
-        )
+        mock_command.side_effect = KiwiCommandError('jing output')
         with raises(KiwiDescriptionInvalid):
             self.description_from_file.load()
 


### PR DESCRIPTION
On validation error we use jing to report detailed error
messages. However if jing is not present no validation
errors are displayed. There is a error_log variable as
part of the relaxNG object which holds the library error
log. This information is not as good as the jing report
but better than nothing

