### PR TITLE
Set --releasever=0 for microdnf

### DIFF
--- a/kiwi/package_manager/microdnf.py
+++ b/kiwi/package_manager/microdnf.py
@@ -102,7 +102,8 @@ class PackageManagerMicroDnf(PackageManagerBase):
         bash_command = [
             'microdnf'
         ] + ['--refresh'] + self.dnf_args + [
-            '--installroot', self.root_dir, '--noplugins',
+            '--installroot', self.root_dir,
+            '--releasever=0', '--noplugins',
             '--setopt=cachedir={0}'.format(
                 self.repository.shared_dnf_dir['cache-dir']
             ),

--- a/test/unit/package_manager/microdnf_test.py
+++ b/test/unit/package_manager/microdnf_test.py
@@ -52,7 +52,7 @@ class TestPackageManagerMicroDnf:
             [
                 'bash', '-c',
                 'microdnf --refresh --config /root-dir/dnf.conf -y '
-                '--installroot /root-dir --noplugins '
+                '--installroot /root-dir --releasever=0 --noplugins '
                 '--setopt=cachedir=cache '
                 '--setopt=reposdir=repos '
                 '--setopt=varsdir=vars '


### PR DESCRIPTION
To allow microdnf to work from an empty root directory
we need to set the release version to zero

