### PR TITLE
Refactor markup and package manager factory

### DIFF
--- a/kiwi/markup/__init__.py
+++ b/kiwi/markup/__init__.py
@@ -40,7 +40,7 @@ class Markup(metaclass=ABCMeta):
         return None  # pragma: no cover
 
     @staticmethod
-    def new(description: str, name: str = 'any'):
+    def new(description: str, name: str='any'):  # noqa: E252
         try:
             markup = Markup._load_markup_by_name(name, description)
             log.info('Support for multiple markup descriptions available')

--- a/kiwi/markup/__init__.py
+++ b/kiwi/markup/__init__.py
@@ -15,29 +15,47 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import importlib
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
 import logging
 
 # project
-from kiwi.markup.any import MarkupAny
-from kiwi.markup.xml import MarkupXML
-
 from kiwi.exceptions import KiwiAnyMarkupPluginError
 
 log = logging.getLogger('kiwi')
 
 
-class Markup:
+class Markup(metaclass=ABCMeta):
     """
     **Markup factory**
 
     :param string description: path to description file
     :param string xml_content: description data as content string
     """
-    def __new__(self, description):
+    @abstractmethod
+    def __init__(self) -> None:
+        return None  # pragma: no cover
+
+    @staticmethod
+    def new(description: str, name: str = 'any'):
         try:
-            markup = MarkupAny(description)
+            markup = Markup._load_markup_by_name(name, description)
             log.info('Support for multiple markup descriptions available')
         except KiwiAnyMarkupPluginError:
-            markup = MarkupXML(description)
+            markup = Markup._load_markup_by_name('xml', description)
             log.info('Support for XML markup available')
         return markup
+
+    @staticmethod
+    def _load_markup_by_name(name, description):
+        name_map = {
+            'any': 'Any',
+            'xml': 'XML'
+        }
+        markup = importlib.import_module('kiwi.markup.{0}'.format(name))
+        return markup.__dict__['Markup{0}'.format(name_map[name])](
+            description
+        )

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -177,7 +177,7 @@ class SystemPrepare:
                 repo.delete_repo_cache(repo_alias)
             self.uri_list.append(uri)
         repo.cleanup_unused_repos()
-        return PackageManager(
+        return PackageManager.new(
             repo, package_manager
         )
 
@@ -340,7 +340,7 @@ class SystemPrepare:
             try:
                 if manager is None:
                     package_manager = self.xml_state.get_package_manager()
-                    manager = PackageManager(
+                    manager = PackageManager.new(
                         Repository(self.root_bind, package_manager),
                         package_manager
                     )
@@ -459,7 +459,7 @@ class SystemPrepare:
         at run time such as macros
         """
         package_manager = self.xml_state.get_package_manager()
-        manager = PackageManager(
+        manager = PackageManager.new(
             Repository(self.root_bind, package_manager),
             package_manager
         )

--- a/kiwi/xml_description.py
+++ b/kiwi/xml_description.py
@@ -67,7 +67,7 @@ class XMLDescription:
             raise KiwiDescriptionConflict(
                 'description and xml_content are mutually exclusive'
             )
-        self.markup = Markup(description or xml_content)
+        self.markup = Markup.new(description or xml_content)
         self.description = self.markup.get_xml_description()
         self.derived_from = derived_from
         self.description_origin = description

--- a/test/unit/markup/markup_test.py
+++ b/test/unit/markup/markup_test.py
@@ -6,14 +6,14 @@ from kiwi.exceptions import KiwiAnyMarkupPluginError
 
 
 class TestMarkup:
-    @patch('kiwi.markup.MarkupAny')
+    @patch('kiwi.markup.any.MarkupAny')
     def test_MarkupAny(self, mock_MarkupAny):
-        Markup('description')
+        Markup.new('description')
         mock_MarkupAny.assert_called_once_with('description')
 
-    @patch('kiwi.markup.MarkupXML')
-    @patch('kiwi.markup.MarkupAny')
+    @patch('kiwi.markup.xml.MarkupXML')
+    @patch('kiwi.markup.any.MarkupAny')
     def test_MarkupXML(self, mock_MarkupAny, mock_MarkupXML):
         mock_MarkupAny.side_effect = KiwiAnyMarkupPluginError('load-error')
-        Markup('description')
+        Markup.new('description')
         mock_MarkupXML.assert_called_once_with('description')

--- a/test/unit/package_manager/init_test.py
+++ b/test/unit/package_manager/init_test.py
@@ -11,40 +11,40 @@ from kiwi.exceptions import KiwiPackageManagerSetupError
 class TestPackageManager:
     def test_package_manager_not_implemented(self):
         with raises(KiwiPackageManagerSetupError):
-            PackageManager('repository', 'ms-manager')
+            PackageManager.new('repository', 'ms-manager')
 
-    @patch('kiwi.package_manager.PackageManagerZypper')
+    @patch('kiwi.package_manager.zypper.PackageManagerZypper')
     def test_manager_zypper(self, mock_manager):
         repository = Mock()
-        PackageManager(repository, 'zypper')
+        PackageManager.new(repository, 'zypper')
         mock_manager.assert_called_once_with(repository, None)
 
-    @patch('kiwi.package_manager.PackageManagerDnf')
+    @patch('kiwi.package_manager.dnf.PackageManagerDnf')
     def test_manager_dnf(self, mock_manager):
         repository = Mock()
-        PackageManager(repository, 'dnf')
+        PackageManager.new(repository, 'dnf')
         mock_manager.assert_called_once_with(repository, None)
 
-    @patch('kiwi.package_manager.PackageManagerDnf')
+    @patch('kiwi.package_manager.dnf.PackageManagerDnf')
     def test_manager_yum(self, mock_manager):
         repository = Mock()
-        PackageManager(repository, 'yum')
+        PackageManager.new(repository, 'yum')
         mock_manager.assert_called_once_with(repository, None)
 
-    @patch('kiwi.package_manager.PackageManagerMicroDnf')
+    @patch('kiwi.package_manager.microdnf.PackageManagerMicroDnf')
     def test_manager_microdnf(self, mock_manager):
         repository = Mock()
-        PackageManager(repository, 'microdnf')
+        PackageManager.new(repository, 'microdnf')
         mock_manager.assert_called_once_with(repository, None)
 
-    @patch('kiwi.package_manager.PackageManagerApt')
+    @patch('kiwi.package_manager.apt.PackageManagerApt')
     def test_manager_apt(self, mock_manager):
         repository = Mock()
-        PackageManager(repository, 'apt-get')
+        PackageManager.new(repository, 'apt-get')
         mock_manager.assert_called_once_with(repository, None)
 
-    @patch('kiwi.package_manager.PackageManagerPacman')
+    @patch('kiwi.package_manager.pacman.PackageManagerPacman')
     def test_manager_pacman(self, mock_manager):
         repository = Mock()
-        PackageManager(repository, 'pacman')
+        PackageManager.new(repository, 'pacman')
         mock_manager.assert_called_once_with(repository, None)


### PR DESCRIPTION
Refactor PackageManager and Markup
    
This commit refactors the PackageManager and Markup classes and turns them into proper factory classes which also include type hints to facilitate their use from an API POV.

Related to #1498
