### PR TITLE
Fixed spec file microdnf requirement

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -136,7 +136,7 @@ Recommends:     gnupg2
 Recommends:     dnf
 Recommends:     gpg2
 %endif
-%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?suse_version} >= 1550 || 0%{?sle_version} >= 150200
+%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?suse_version} >= 1550
 Provides:       kiwi-packagemanager:microdnf
 Requires:       microdnf
 %endif


### PR DESCRIPTION
SUSE/SLES doesn't provide microdnf within the official channels


