### PR TITLE
Refactor partitioner and repository factory

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -573,7 +573,7 @@ class DiskBuilder:
             firmware = FirmWare(self.xml_state)
             loop_provider = LoopDevice(disk_format.diskname)
             loop_provider.create(overwrite=False)
-            partitioner = Partitioner(
+            partitioner = Partitioner.new(
                 firmware.get_partition_table_type(), loop_provider
             )
             partitioner.resize_table()

--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -48,7 +48,7 @@ class Disk(DeviceProvider):
         self.partition_id_map = {}
         self.is_mapped = False
 
-        self.partitioner = Partitioner(
+        self.partitioner = Partitioner.new(
             table_type, storage_provider, start_sector
         )
 

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -122,7 +122,7 @@ class SystemPrepare:
             repository_options.append(
                 '_install_langs%{0}'.format(':'.join(rpm_locale_list))
             )
-        repo = Repository(
+        repo = Repository.new(
             self.root_bind, package_manager, repository_options
         )
         repo.setup_package_database_configuration()
@@ -341,7 +341,7 @@ class SystemPrepare:
                 if manager is None:
                     package_manager = self.xml_state.get_package_manager()
                     manager = PackageManager.new(
-                        Repository(self.root_bind, package_manager),
+                        Repository.new(self.root_bind, package_manager),
                         package_manager
                     )
                 self.delete_packages(
@@ -460,7 +460,7 @@ class SystemPrepare:
         """
         package_manager = self.xml_state.get_package_manager()
         manager = PackageManager.new(
-            Repository(self.root_bind, package_manager),
+            Repository.new(self.root_bind, package_manager),
             package_manager
         )
         manager.clean_leftovers()

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -137,7 +137,7 @@ class SystemSetup:
         root = RootInit(
             root_dir=self.root_dir, allow_existing=True
         )
-        repo = Repository(
+        repo = Repository.new(
             RootBind(root), self.xml_state.get_package_manager()
         )
         repo.use_default_location()

--- a/kiwi/tasks/image_resize.py
+++ b/kiwi/tasks/image_resize.py
@@ -122,7 +122,7 @@ class ImageResizeTask(CliTask):
         firmware = FirmWare(self.xml_state)
         loop_provider = LoopDevice(image_format.diskname)
         loop_provider.create(overwrite=False)
-        partitioner = Partitioner(
+        partitioner = Partitioner.new(
             firmware.get_partition_table_type(), loop_provider
         )
         partitioner.resize_table()

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -870,7 +870,7 @@ class TestDiskBuilder:
         )
 
     @patch('kiwi.builder.disk.LoopDevice')
-    @patch('kiwi.builder.disk.Partitioner')
+    @patch('kiwi.builder.disk.Partitioner.new')
     @patch('kiwi.builder.disk.DiskFormat.new')
     def test_append_unpartitioned_space(
         self, mock_diskformat, mock_partitioner, mock_loopdevice

--- a/test/unit/partitioner/init_test.py
+++ b/test/unit/partitioner/init_test.py
@@ -16,105 +16,35 @@ class TestPartitioner:
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
-    @patch('platform.machine')
-    def test_partitioner_not_implemented(self, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def test_partitioner_not_implemented(self):
         with raises(KiwiPartitionerSetupError):
-            Partitioner('foo', Mock())
+            Partitioner.new('foo', Mock())
 
-    @patch('platform.machine')
-    def test_partitioner_for_arch_not_implemented(self, mock_machine):
-        mock_machine.return_value = 'some-arch'
+    def test_partitioner_for_arch_not_implemented(self):
         with raises(KiwiPartitionerSetupError):
-            Partitioner('foo', Mock())
+            Partitioner.new('foo', Mock())
 
-    @patch('kiwi.partitioner.PartitionerGpt')
-    @patch('platform.machine')
-    def test_partitioner_x86_64_gpt(self, mock_machine, mock_gpt):
-        mock_machine.return_value = 'x86_64'
+    @patch('kiwi.partitioner.gpt.PartitionerGpt')
+    def test_partitioner_gpt(self, mock_gpt):
         storage_provider = Mock()
-        Partitioner('gpt', storage_provider)
+        Partitioner.new('gpt', storage_provider)
         mock_gpt.assert_called_once_with(storage_provider, None)
 
-    @patch('kiwi.partitioner.PartitionerMsDos')
-    @patch('platform.machine')
-    def test_partitioner_x86_64_msdos(self, mock_machine, mock_dos):
-        mock_machine.return_value = 'x86_64'
+    @patch('kiwi.partitioner.msdos.PartitionerMsDos')
+    def test_partitioner_msdos(self, mock_dos):
         storage_provider = Mock()
-        Partitioner('msdos', storage_provider)
+        Partitioner.new('msdos', storage_provider)
         mock_dos.assert_called_once_with(storage_provider, None)
 
-    @patch('kiwi.partitioner.PartitionerMsDos')
-    @patch('platform.machine')
-    def test_partitioner_i686_msdos(self, mock_machine, mock_dos):
-        mock_machine.return_value = 'i686'
+    @patch('kiwi.partitioner.dasd.PartitionerDasd')
+    def test_partitioner_dasd(self, mock_dasd):
         storage_provider = Mock()
-        Partitioner('msdos', storage_provider)
-        mock_dos.assert_called_once_with(storage_provider, None)
+        Partitioner.new('dasd', storage_provider)
+        mock_dasd.assert_called_once_with(storage_provider, None)
 
-    @patch('kiwi.partitioner.PartitionerMsDos')
-    @patch('platform.machine')
-    def test_partitioner_i586_msdos(self, mock_machine, mock_dos):
-        mock_machine.return_value = 'i586'
-        storage_provider = Mock()
-        Partitioner('msdos', storage_provider)
-        mock_dos.assert_called_once_with(storage_provider, None)
-
-    @patch('kiwi.partitioner.PartitionerDasd')
-    @patch('platform.machine')
-    def test_partitioner_s390_dasd(self, mock_machine, mock_dasd):
-        mock_machine.return_value = 's390'
-        storage_provider = Mock()
-        Partitioner('dasd', storage_provider)
-        mock_dasd.assert_called_once_with(storage_provider)
-
-    @patch('kiwi.partitioner.PartitionerDasd')
-    @patch('platform.machine')
-    def test_partitioner_s390_dasd_with_custom_start_sector(
-        self, mock_machine, mock_dasd
-    ):
-        mock_machine.return_value = 's390'
+    @patch('kiwi.partitioner.dasd.PartitionerDasd')
+    def test_partitioner_dasd_with_custom_start_sector(self, mock_dasd):
         storage_provider = Mock()
         with self._caplog.at_level(logging.WARNING):
-            Partitioner('dasd', storage_provider, 4096)
-            mock_dasd.assert_called_once_with(storage_provider)
-
-    @patch('kiwi.partitioner.PartitionerMsDos')
-    @patch('platform.machine')
-    def test_partitioner_s390_msdos(self, mock_machine, mock_dos):
-        mock_machine.return_value = 's390'
-        storage_provider = Mock()
-        Partitioner('msdos', storage_provider)
-        mock_dos.assert_called_once_with(storage_provider, None)
-
-    @patch('kiwi.partitioner.PartitionerMsDos')
-    @patch('platform.machine')
-    def test_partitioner_ppc_msdos(self, mock_machine, mock_dos):
-        mock_machine.return_value = 'ppc64'
-        storage_provider = Mock()
-        Partitioner('msdos', storage_provider)
-        mock_dos.assert_called_once_with(storage_provider, None)
-
-    @patch('kiwi.partitioner.PartitionerGpt')
-    @patch('platform.machine')
-    def test_partitioner_ppc_gpt(self, mock_machine, mock_gpt):
-        mock_machine.return_value = 'ppc64'
-        storage_provider = Mock()
-        Partitioner('gpt', storage_provider)
-        mock_gpt.assert_called_once_with(storage_provider, None)
-
-    @patch('kiwi.partitioner.PartitionerGpt')
-    @patch('platform.machine')
-    def test_partitioner_arm_gpt(self, mock_machine, mock_gpt):
-        mock_machine.return_value = 'aarch64'
-        storage_provider = Mock()
-        Partitioner('gpt', storage_provider)
-        mock_gpt.assert_called_once_with(storage_provider, None)
-
-    @patch('kiwi.partitioner.PartitionerMsDos')
-    @patch('platform.machine')
-    def test_partitioner_arm_msdos(self, mock_machine, mock_dos):
-        mock_machine.return_value = 'armv7l'
-        storage_provider = Mock()
-        Partitioner('msdos', storage_provider)
-        mock_dos.assert_called_once_with(storage_provider, None)
+            Partitioner.new('dasd', storage_provider, 4096)
+            mock_dasd.assert_called_once_with(storage_provider, None)

--- a/test/unit/repository/init_test.py
+++ b/test/unit/repository/init_test.py
@@ -9,34 +9,40 @@ from kiwi.exceptions import KiwiRepositorySetupError
 class TestRepository:
     def test_repository_manager_not_implemented(self):
         with raises(KiwiRepositorySetupError):
-            Repository('root_bind', 'ms-manager')
+            Repository.new('root_bind', 'ms-manager')
 
-    @patch('kiwi.repository.RepositoryZypper')
+    @patch('kiwi.repository.zypper.RepositoryZypper')
     def test_repository_zypper(self, mock_manager):
         root_bind = mock.Mock()
-        Repository(root_bind, 'zypper')
+        Repository.new(root_bind, 'zypper')
         mock_manager.assert_called_once_with(root_bind, None)
 
-    @patch('kiwi.repository.RepositoryDnf')
+    @patch('kiwi.repository.dnf.RepositoryDnf')
     def test_repository_dnf(self, mock_manager):
         root_bind = mock.Mock()
-        Repository(root_bind, 'dnf')
+        Repository.new(root_bind, 'dnf')
         mock_manager.assert_called_once_with(root_bind, None)
 
-    @patch('kiwi.repository.RepositoryDnf')
+    @patch('kiwi.repository.dnf.RepositoryDnf')
+    def test_repository_microdnf(self, mock_manager):
+        root_bind = mock.Mock()
+        Repository.new(root_bind, 'microdnf')
+        mock_manager.assert_called_once_with(root_bind, None)
+
+    @patch('kiwi.repository.dnf.RepositoryDnf')
     def test_repository_yum(self, mock_manager):
         root_bind = mock.Mock()
-        Repository(root_bind, 'yum')
+        Repository.new(root_bind, 'yum')
         mock_manager.assert_called_once_with(root_bind, None)
 
-    @patch('kiwi.repository.RepositoryApt')
+    @patch('kiwi.repository.apt.RepositoryApt')
     def test_repository_apt(self, mock_manager):
         root_bind = mock.Mock()
-        Repository(root_bind, 'apt-get')
+        Repository.new(root_bind, 'apt-get')
         mock_manager.assert_called_once_with(root_bind, None)
 
-    @patch('kiwi.repository.RepositoryPacman')
+    @patch('kiwi.repository.pacman.RepositoryPacman')
     def test_repository_pacman(self, mock_manager):
         root_bind = mock.Mock()
-        Repository(root_bind, 'pacman')
+        Repository.new(root_bind, 'pacman')
         mock_manager.assert_called_once_with(root_bind, None)

--- a/test/unit/storage/disk_test.py
+++ b/test/unit/storage/disk_test.py
@@ -14,7 +14,7 @@ class TestDisk:
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
-    @patch('kiwi.storage.disk.Partitioner')
+    @patch('kiwi.storage.disk.Partitioner.new')
     def setup(self, mock_partitioner):
         self.tempfile = mock.Mock()
         self.tempfile.name = 'tempfile'

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -164,7 +164,7 @@ class TestSystemPrepare:
         with raises(KiwiSystemDeletePackagesFailed):
             self.system.delete_packages(self.manager, ['package'])
 
-    @patch('kiwi.system.prepare.Repository')
+    @patch('kiwi.system.prepare.Repository.new')
     @patch('kiwi.system.prepare.Uri')
     @patch('kiwi.system.prepare.PackageManager')
     @patch('kiwi.xml_state.XMLState.get_package_manager')
@@ -235,7 +235,7 @@ class TestSystemPrepare:
             ['key-file-a.asc', 'key-file-b.asc']
         )
 
-    @patch('kiwi.system.prepare.Repository')
+    @patch('kiwi.system.prepare.Repository.new')
     @patch('kiwi.system.prepare.Uri')
     @patch('kiwi.system.prepare.PackageManager')
     @patch('kiwi.xml_state.XMLState.get_package_manager')
@@ -376,7 +376,7 @@ class TestSystemPrepare:
         self.manager.process_delete_requests.assert_called_once_with(False)
 
     @patch('kiwi.package_manager.zypper.PackageManagerZypper.process_delete_requests')
-    @patch('kiwi.system.prepare.Repository')
+    @patch('kiwi.system.prepare.Repository.new')
     @patch('kiwi.system.prepare.CommandProcess.poll_show_progress')
     def test_pinch_system_without_manager(
         self, mock_poll, mock_repo, mock_requests
@@ -394,7 +394,7 @@ class TestSystemPrepare:
         self.system.__del__()
         self.system.root_bind.cleanup.assert_called_once_with()
 
-    @patch('kiwi.system.prepare.Repository')
+    @patch('kiwi.system.prepare.Repository.new')
     @patch('kiwi.system.prepare.PackageManager')
     def test_clean_package_manager_leftovers(self, mock_manager, mock_repo):
         manager = Mock()

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -395,10 +395,10 @@ class TestSystemPrepare:
         self.system.root_bind.cleanup.assert_called_once_with()
 
     @patch('kiwi.system.prepare.Repository.new')
-    @patch('kiwi.system.prepare.PackageManager')
+    @patch('kiwi.system.prepare.PackageManager.new')
     def test_clean_package_manager_leftovers(self, mock_manager, mock_repo):
         manager = Mock()
-        mock_manager.new.return_value = manager
+        mock_manager.return_value = manager
         self.system.clean_package_manager_leftovers()
         manager.clean_leftovers.assert_called_once_with()
 

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -1231,7 +1231,7 @@ class TestSystemSetup:
             ]
         )
 
-    @patch('kiwi.system.setup.Repository')
+    @patch('kiwi.system.setup.Repository.new')
     @patch('kiwi.system.setup.Uri')
     def test_import_repositories_marked_as_imageinclude(
         self, mock_uri, mock_repo

--- a/test/unit/tasks/image_resize_test.py
+++ b/test/unit/tasks/image_resize_test.py
@@ -41,16 +41,12 @@ class TestImageResizeTask:
         self.firmware.get_partition_table_type = Mock(
             return_value='gpt'
         )
-        self.partitioner = Mock()
         self.loop_provider = Mock()
         kiwi.tasks.image_resize.FirmWare = Mock(
             return_value=self.firmware
         )
         kiwi.tasks.image_resize.LoopDevice = Mock(
             return_value=self.loop_provider
-        )
-        kiwi.tasks.image_resize.Partitioner = Mock(
-            return_value=self.partitioner
         )
 
         self.task = ImageResizeTask()
@@ -93,7 +89,10 @@ class TestImageResizeTask:
             self.task.process()
 
     @patch('kiwi.tasks.image_resize.DiskFormat.new')
-    def test_process_image_resize_gb(self, mock_DiskFormat):
+    @patch('kiwi.tasks.image_resize.Partitioner.new')
+    def test_process_image_resize_gb(self, mock_Partitioner, mock_DiskFormat):
+        partitioner = Mock()
+        mock_Partitioner.return_value = partitioner
         image_format = Mock()
         image_format.resize_raw_disk.return_value = True
         mock_DiskFormat.return_value = image_format
@@ -101,14 +100,17 @@ class TestImageResizeTask:
         self.task.command_args['resize'] = True
         self.task.process()
         self.loop_provider.create.assert_called_once_with(overwrite=False)
-        self.partitioner.resize_table.assert_called_once_with()
+        partitioner.resize_table.assert_called_once_with()
         image_format.resize_raw_disk.assert_called_once_with(
             42 * 1024 * 1024 * 1024
         )
         image_format.create_image_format.assert_called_once_with()
 
     @patch('kiwi.tasks.image_resize.DiskFormat.new')
-    def test_process_image_resize_mb(self, mock_DiskFormat):
+    @patch('kiwi.tasks.image_resize.Partitioner.new')
+    def test_process_image_resize_mb(self, mock_Partitioner, mock_DiskFormat):
+        partitioner = Mock()
+        mock_Partitioner.return_value = partitioner
         image_format = Mock()
         image_format.resize_raw_disk.return_value = True
         mock_DiskFormat.return_value = image_format
@@ -117,14 +119,19 @@ class TestImageResizeTask:
         self.task.command_args['--size'] = '42m'
         self.task.process()
         self.loop_provider.create.assert_called_once_with(overwrite=False)
-        self.partitioner.resize_table.assert_called_once_with()
+        partitioner.resize_table.assert_called_once_with()
         image_format.resize_raw_disk.assert_called_once_with(
             42 * 1024 * 1024
         )
         image_format.create_image_format.assert_called_once_with()
 
     @patch('kiwi.tasks.image_resize.DiskFormat.new')
-    def test_process_image_resize_bytes(self, mock_DiskFormat):
+    @patch('kiwi.tasks.image_resize.Partitioner.new')
+    def test_process_image_resize_bytes(
+        self, mock_Partitioner, mock_DiskFormat
+    ):
+        partitioner = Mock()
+        mock_Partitioner.return_value = partitioner
         image_format = Mock()
         image_format.resize_raw_disk.return_value = True
         mock_DiskFormat.return_value = image_format
@@ -133,14 +140,19 @@ class TestImageResizeTask:
         self.task.command_args['--size'] = '42'
         self.task.process()
         self.loop_provider.create.assert_called_once_with(overwrite=False)
-        self.partitioner.resize_table.assert_called_once_with()
+        partitioner.resize_table.assert_called_once_with()
         image_format.resize_raw_disk.assert_called_once_with(
             42
         )
         image_format.create_image_format.assert_called_once_with()
 
     @patch('kiwi.tasks.image_resize.DiskFormat.new')
-    def test_process_image_resize_not_needed(self, mock_DiskFormat):
+    @patch('kiwi.tasks.image_resize.Partitioner.new')
+    def test_process_image_resize_not_needed(
+        self, mock_Partitioner, mock_DiskFormat
+    ):
+        partitioner = Mock()
+        mock_Partitioner.return_value = partitioner
         image_format = Mock()
         image_format.resize_raw_disk.return_value = False
         mock_DiskFormat.return_value = image_format
@@ -150,7 +162,7 @@ class TestImageResizeTask:
         with self._caplog.at_level(logging.INFO):
             self.task.process()
             self.loop_provider.create.assert_called_once_with(overwrite=False)
-            self.partitioner.resize_table.assert_called_once_with()
+            partitioner.resize_table.assert_called_once_with()
             image_format.resize_raw_disk.assert_called_once_with(
                 42
             )


### PR DESCRIPTION
This commits refactors the Repository and Partitioner classes and turns them into proper factory classes and also includes type hints to facilitate their use from an API POV. Related to #1498
