### PR TITLE
Fixed multipath disk device assignment in kiwi lib

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
@@ -19,9 +19,34 @@ function get_root_map {
     echo "${root_map}"
 }
 
+function get_mapped_multipath_disk {
+    declare DEVICE_TIMEOUT=${DEVICE_TIMEOUT}
+    local disk_device=$1
+    local check=0
+    local limit=30
+    if [[ "${DEVICE_TIMEOUT}" =~ ^[0-9]+$ ]]; then
+        limit=$(((DEVICE_TIMEOUT + 1)/ 2))
+    fi
+    udev_pending &>/dev/null
+    while true;do
+        for wwn in $(multipath -l -v1 "${disk_device}");do
+            if [ -e "/dev/mapper/${wwn}" ];then
+                echo "/dev/mapper/${wwn}"
+                return
+            fi
+        done
+        if [ "${check}" -eq "${limit}" ]; then
+            die "Multipath map for ${disk_device} did not show up"
+        fi
+        check=$((check + 1))
+        sleep 2
+    done
+}
+
 function lookup_disk_device_from_root {
     declare root=${root}
     declare kiwi_RaidDev=${kiwi_RaidDev}
+    declare kiwi_oemmultipath_scan=${kiwi_oemmultipath_scan}
     local root_device=${root#block:}
     local disk_device
     local wwn
@@ -35,18 +60,10 @@ function lookup_disk_device_from_root {
         lsblk -p -n -r -s -o NAME,TYPE "${root_device}" |\
             grep -E "disk|raid" | cut -f1 -d ' '
     ); do
-        # Check if root_device is managed by multipath. If this
-        # is the case prefer the multipath mapped device because
-        # directly accessing the mapped devices is no longer
-        # possible
-        if type multipath &> /dev/null; then
-            for wwn in $(multipath -l -v1 "${disk_device}");do
-                if [ -e "/dev/mapper/${wwn}" ];then
-                    disk_device="/dev/mapper/${wwn}"
-                    echo "${disk_device}"
-                    return
-                fi
-            done
+        # If multipath is requested, set the disk_device to the
+        # multipath mapped device
+        if [ -n "${kiwi_oemmultipath_scan}" ];then
+            disk_device=$(get_mapped_multipath_disk "${disk_device}")
         fi
         # Check if root_device is managed by mdadm and that the md raid
         # is not created as part of the kiwi image building process. If

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -881,7 +881,7 @@ class XMLState:
     def get_oemconfig_oem_multipath_scan(self):
         """
         State value to activate multipath maps. Returns a boolean
-        value if specified or None
+        value if specified or False
 
         :return: Content of <oem-multipath-scan> section value
 
@@ -890,6 +890,7 @@ class XMLState:
         oemconfig = self.get_build_type_oemconfig_section()
         if oemconfig and oemconfig.get_oem_multipath_scan():
             return oemconfig.get_oem_multipath_scan()[0]
+        return False
 
     def get_oemconfig_swap_mbytes(self):
         """

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -498,6 +498,17 @@ class TestXMLState:
         state = XMLState(xml_data)
         assert state.get_oemconfig_oem_resize() is False
 
+    def test_get_oemconfig_oem_multipath_scan(self):
+        xml_data = self.description.load()
+        state = XMLState(xml_data, ['vmxFlavour'], 'oem')
+        assert state.get_oemconfig_oem_multipath_scan() is False
+        description = XMLDescription(
+            '../data/example_disk_config.xml'
+        )
+        xml_data = description.load()
+        state = XMLState(xml_data)
+        assert state.get_oemconfig_oem_multipath_scan() is False
+
     def test_get_oemconfig_swap_mbytes(self):
         xml_data = self.description.load()
         state = XMLState(xml_data, ['containerFlavour'], 'docker')


### PR DESCRIPTION
The former lookup of the multipath mapped disk device contained
a race condition. If the lookup of the device mapper files happened
before multipathd has finished the initialization, kiwi continues
with the unix node name and fails when the device mapper keeps
a busy state on it. This commit changes the code such that in case
of an explicit request to use multipath the lookup of the mapped
device becomes a mandatory process that runs until the
DEVICE_TIMEOUT is reached. Default timeout is set to 60 sec.
This references Issue SUSE-Enceladus/azure-li-services#255

