### PR TITLE
Fixed base setup links

### DIFF
--- a/kiwi/system/root_init.py
+++ b/kiwi/system/root_init.py
@@ -130,8 +130,7 @@ class RootInit:
             ('/proc/self/fd', '%s/dev/fd'),
             ('fd/2', '%s/dev/stderr'),
             ('fd/0', '%s/dev/stdin'),
-            ('fd/1', '%s/dev/stdout'),
-            ('/run', '%s/var/run')
+            ('fd/1', '%s/dev/stdout')
         )
         for src, target in base_system_links:
             os.symlink(src, target % root, )

--- a/test/unit/system/root_init_test.py
+++ b/test/unit/system/root_init_test.py
@@ -96,8 +96,7 @@ class TestRootInit:
             call('/proc/self/fd', 'tmpdir/dev/fd'),
             call('fd/2', 'tmpdir/dev/stderr'),
             call('fd/0', 'tmpdir/dev/stdin'),
-            call('fd/1', 'tmpdir/dev/stdout'),
-            call('/run', 'tmpdir/var/run')
+            call('fd/1', 'tmpdir/dev/stdout')
         ]
         mock_data_sync.assert_called_once_with(
             'tmpdir/', 'root_dir'


### PR DESCRIPTION
Do not create a link /var/run pointing to /run. This is unexpected
and looks like a left over from kiwi legacy which supported older
distributions who might have needed this. This Fixes #1643

