### PR TITLE
Custom swap volume name

### DIFF
--- a/doc/source/building_images/build_expandable_disk.rst
+++ b/doc/source/building_images/build_expandable_disk.rst
@@ -355,6 +355,14 @@ oemconfig.oem-swap Element
   swap partition will be created. This value is represented
   by the ``kiwi_oemswap`` variable in the initrd
 
+oemconfig.oem-swapname Element
+  Specify the name of the swap space. By default the name is set
+  to ``LVSwap``. The default already indicates that this setting
+  is only useful in combination with the LVM volume manager. In
+  this case the swapspace is setup as a volume in the volume
+  group and any volume needs a name. The name set here is used
+  to give the swap volume a name.
+
 oemconfig.oem-swapsize Element
   Set the size of the swap partition. If a swap partition is to be
   created and the size of the swap partition is not specified with

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -138,7 +138,7 @@ class RuntimeChecker:
         volume_management = self.xml_state.get_volume_management()
         if volume_management != 'lvm':
             for volume in self.xml_state.get_volumes():
-                if volume.label and volume.name != 'LVSwap':
+                if volume.label and volume.label != 'SWAP':
                     raise KiwiRuntimeError(
                         message.format(volume_management)
                     )
@@ -158,7 +158,11 @@ class RuntimeChecker:
         volume_management = self.xml_state.get_volume_management()
         if volume_management == 'lvm':
             for volume in self.xml_state.get_volumes():
-                if volume.name != 'LVSwap':
+                # A swap volume is created implicitly if oem-swap is
+                # requested. This volume detected via realpath set to
+                # swap is skipped from the reserved label check as it
+                # intentionally uses the reserved label named SWAP
+                if volume.realpath != 'swap':
                     if volume.label and volume.label in reserved_labels:
                         raise KiwiRuntimeError(
                             message.format(

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -143,6 +143,36 @@ class RuntimeChecker:
                         message.format(volume_management)
                     )
 
+    def check_swap_name_used_with_lvm(self):
+        """
+        The optional oem-swapname is only effective if used together
+        with the LVM volume manager. A name for the swap space can
+        only be set if it is created as a LVM volume. In any other
+        case the name does not apply to the system
+        """
+        message = dedent('''\n
+             Specified swap space name: {0} will not be used
+
+             The specified oem-swapname is used without the LVM volume
+             manager. This means the swap space will be created as simple
+             partition for which no name assignment can take place.
+             The name specified in oem-swapname is used to give the
+             LVM swap volume a name. Outside of LVM the setting is
+             meaningless and should be removed.
+
+             Please delete the following setting from your image
+             description:
+
+             <oem-swapname>{0}</oem-swapname>
+        ''')
+        volume_management = self.xml_state.get_volume_management()
+        if volume_management != 'lvm':
+            oemconfig = self.xml_state.get_build_type_oemconfig_section()
+            if oemconfig and oemconfig.get_oem_swapname():
+                raise KiwiRuntimeError(
+                    message.format(oemconfig.get_oem_swapname()[0])
+                )
+
     def check_volume_setup_defines_reserved_labels(self):
         message = dedent('''\n
             Reserved label name used in LVM volume setup

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -726,6 +726,24 @@ div {
 }
 
 #==========================================
+# common element <oem-swapname>
+#
+div {
+    k.oem-swapname.attlist = empty
+    k.oem-swapname =
+        ## For oem images: Set the name of the swap space
+        ## The name of the swap space is used only if the
+        ## image is configured to use the LVM volume manager.
+        ## In this case swap is a volume and the volume takes
+        ## a name. In any other case the given name will have
+        ## no effect.
+        element oem-swapname {
+            k.oem-swapname.attlist,
+            text
+        }
+}
+
+#==========================================
 # common element <oem-systemsize>
 #
 div {
@@ -2582,6 +2600,7 @@ div {
             k.oem-skip-verify? &
             k.oem-swap? &
             k.oem-swapsize? &
+            k.oem-swapname? &
             k.oem-systemsize? &
             k.oem-unattended? &
             k.oem-unattended-id?

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1114,6 +1114,28 @@ partition in MB</a:documentation>
   </div>
   <!--
     ==========================================
+    common element <oem-swapname>
+    
+  -->
+  <div>
+    <define name="k.oem-swapname.attlist">
+      <empty/>
+    </define>
+    <define name="k.oem-swapname">
+      <element name="oem-swapname">
+        <a:documentation>For oem images: Set the name of the swap space
+The name of the swap space is used only if the
+image is configured to use the LVM volume manager.
+In this case swap is a volume and the volume takes
+a name. In any other case the given name will have
+no effect.</a:documentation>
+        <ref name="k.oem-swapname.attlist"/>
+        <text/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
     common element <oem-systemsize>
     
   -->
@@ -3954,6 +3976,9 @@ and setup the system disk.</a:documentation>
           </optional>
           <optional>
             <ref name="k.oem-swapsize"/>
+          </optional>
+          <optional>
+            <ref name="k.oem-swapname"/>
           </optional>
           <optional>
             <ref name="k.oem-systemsize"/>

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -81,6 +81,7 @@ class CliTask:
             'check_volume_setup_defines_multiple_fullsize_volumes': [],
             'check_volume_setup_has_no_root_definition': [],
             'check_volume_label_used_with_lvm': [],
+            'check_swap_name_used_with_lvm': [],
             'check_xen_uniquely_setup_as_server_or_guest': [],
             'check_mediacheck_installed': [],
             'check_dracut_module_for_live_iso_in_package_list': [],

--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -75,8 +75,8 @@ class VolumeManagerLVM(VolumeManagerBase):
                 # root partition device from the disk. Therefore use
                 # the same key to put them on the same level
                 volume_name = 'root'
-            if volume_name == 'LVSwap':
-                # LVSwap volume device takes precedence over the
+            if self._is_swap_volume(volume_name):
+                # swap volume device takes precedence over the
                 # swap partition device from the disk. Therefore use
                 # the same key to put them on the same level
                 volume_name = 'swap'
@@ -176,7 +176,7 @@ class VolumeManagerLVM(VolumeManagerBase):
                 self.root_dir, volume
             )
             self._add_to_volume_map(volume.name)
-            if volume.name != 'LVSwap':
+            if volume.label != 'SWAP':
                 self._create_filesystem(
                     volume.name, volume.label, filesystem_name
                 )
@@ -346,6 +346,11 @@ class VolumeManagerLVM(VolumeManagerBase):
     def _is_root_volume(self, name):
         for volume in self.volumes:
             if name in volume.name and volume.is_root_volume:
+                return True
+
+    def _is_swap_volume(self, name):
+        for volume in self.volumes:
+            if name in volume.name and volume.label == 'SWAP':
                 return True
 
     def __del__(self):

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -5843,7 +5843,7 @@ class oemconfig(GeneratedsSuper):
     which are used to repartition and setup the system disk."""
     subclass = None
     superclass = None
-    def __init__(self, oem_boot_title=None, oem_bootwait=None, oem_resize=None, oem_resize_once=None, oem_device_filter=None, oem_nic_filter=None, oem_inplace_recovery=None, oem_kiwi_initrd=None, oem_multipath_scan=None, oem_vmcp_parmfile=None, oem_partition_install=None, oem_reboot=None, oem_reboot_interactive=None, oem_recovery=None, oem_recoveryID=None, oem_recovery_part_size=None, oem_shutdown=None, oem_shutdown_interactive=None, oem_silent_boot=None, oem_silent_install=None, oem_silent_verify=None, oem_skip_verify=None, oem_swap=None, oem_swapsize=None, oem_systemsize=None, oem_unattended=None, oem_unattended_id=None):
+    def __init__(self, oem_boot_title=None, oem_bootwait=None, oem_resize=None, oem_resize_once=None, oem_device_filter=None, oem_nic_filter=None, oem_inplace_recovery=None, oem_kiwi_initrd=None, oem_multipath_scan=None, oem_vmcp_parmfile=None, oem_partition_install=None, oem_reboot=None, oem_reboot_interactive=None, oem_recovery=None, oem_recoveryID=None, oem_recovery_part_size=None, oem_shutdown=None, oem_shutdown_interactive=None, oem_silent_boot=None, oem_silent_install=None, oem_silent_verify=None, oem_skip_verify=None, oem_swap=None, oem_swapsize=None, oem_swapname=None, oem_systemsize=None, oem_unattended=None, oem_unattended_id=None):
         self.original_tagname_ = None
         if oem_boot_title is None:
             self.oem_boot_title = []
@@ -5941,6 +5941,10 @@ class oemconfig(GeneratedsSuper):
             self.oem_swapsize = []
         else:
             self.oem_swapsize = oem_swapsize
+        if oem_swapname is None:
+            self.oem_swapname = []
+        else:
+            self.oem_swapname = oem_swapname
         if oem_systemsize is None:
             self.oem_systemsize = []
         else:
@@ -6084,6 +6088,11 @@ class oemconfig(GeneratedsSuper):
     def add_oem_swapsize(self, value): self.oem_swapsize.append(value)
     def insert_oem_swapsize_at(self, index, value): self.oem_swapsize.insert(index, value)
     def replace_oem_swapsize_at(self, index, value): self.oem_swapsize[index] = value
+    def get_oem_swapname(self): return self.oem_swapname
+    def set_oem_swapname(self, oem_swapname): self.oem_swapname = oem_swapname
+    def add_oem_swapname(self, value): self.oem_swapname.append(value)
+    def insert_oem_swapname_at(self, index, value): self.oem_swapname.insert(index, value)
+    def replace_oem_swapname_at(self, index, value): self.oem_swapname[index] = value
     def get_oem_systemsize(self): return self.oem_systemsize
     def set_oem_systemsize(self, oem_systemsize): self.oem_systemsize = oem_systemsize
     def add_oem_systemsize(self, value): self.oem_systemsize.append(value)
@@ -6125,6 +6134,7 @@ class oemconfig(GeneratedsSuper):
             self.oem_skip_verify or
             self.oem_swap or
             self.oem_swapsize or
+            self.oem_swapname or
             self.oem_systemsize or
             self.oem_unattended or
             self.oem_unattended_id
@@ -6232,6 +6242,9 @@ class oemconfig(GeneratedsSuper):
         for oem_swapsize_ in self.oem_swapsize:
             showIndent(outfile, level, pretty_print)
             outfile.write('<oem-swapsize>%s</oem-swapsize>%s' % (self.gds_format_integer(oem_swapsize_, input_name='oem-swapsize'), eol_))
+        for oem_swapname_ in self.oem_swapname:
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<oem-swapname>%s</oem-swapname>%s' % (self.gds_encode(self.gds_format_string(quote_xml(oem_swapname_), input_name='oem-swapname')), eol_))
         for oem_systemsize_ in self.oem_systemsize:
             showIndent(outfile, level, pretty_print)
             outfile.write('<oem-systemsize>%s</oem-systemsize>%s' % (self.gds_format_integer(oem_systemsize_, input_name='oem-systemsize'), eol_))
@@ -6467,6 +6480,10 @@ class oemconfig(GeneratedsSuper):
                 raise_parse_error(child_, 'requires nonNegativeInteger')
             ival_ = self.gds_validate_integer(ival_, node, 'oem_swapsize')
             self.oem_swapsize.append(ival_)
+        elif nodeName_ == 'oem-swapname':
+            oem_swapname_ = child_.text
+            oem_swapname_ = self.gds_validate_string(oem_swapname_, node, 'oem_swapname')
+            self.oem_swapname.append(oem_swapname_)
         elif nodeName_ == 'oem-systemsize' and child_.text:
             sval_ = child_.text
             try:

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -913,6 +913,28 @@ class XMLState:
                 else:
                     return Defaults.get_swapsize_mbytes()
 
+    def get_oemconfig_swap_name(self):
+        """
+        Return the swap space name
+
+        Operates on the value of oem-swapname and if set
+        returns the configured name or the default name: LVSwap
+
+        The name of the swap space is used only if the
+        image is configured to use the LVM volume manager.
+        In this case swap is a volume and the volume takes
+        a name. In any other case the given name will have
+        no effect.
+
+        :return: Content of <oem-swapname> section value or default
+
+        :rtype: str
+        """
+        oemconfig = self.get_build_type_oemconfig_section()
+        if oemconfig and oemconfig.get_oem_swapname():
+            return oemconfig.get_oem_swapname()[0]
+        return 'LVSwap'
+
     def get_build_type_containerconfig_section(self):
         """
         First containerconfig section from the build type section
@@ -1236,6 +1258,7 @@ class XMLState:
         volume_type_list = []
         systemdisk_section = self.get_build_type_system_disk_section()
         swap_mbytes = self.get_oemconfig_swap_mbytes()
+        swap_name = self.get_oemconfig_swap_name()
         if not systemdisk_section:
             return volume_type_list
 
@@ -1358,7 +1381,7 @@ class XMLState:
         if swap_mbytes and self.get_volume_management() == 'lvm':
             volume_type_list.append(
                 volume_type(
-                    name='LVSwap',
+                    name=swap_name,
                     size='size:{0}'.format(swap_mbytes),
                     fullsize=False,
                     mountpoint=None,

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -66,6 +66,7 @@
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>42</oem-swapsize>
+                <oem-swapname>swap</oem-swapname>
                 <oem-recovery>false</oem-recovery>
             </oemconfig>
             <vagrantconfig provider="libvirt" virtualsize="42"/>

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -130,6 +130,7 @@
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-swap>true</oem-swap>
                 <oem-recovery>false</oem-recovery>
+                <oem-swapname>swap</oem-swapname>
             </oemconfig>
         </type>
         <type image="iso" mediacheck="true" firmware="bios"/>

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -296,6 +296,14 @@ class TestRuntimeChecker:
         with raises(KiwiRuntimeError):
             self.runtime_checker.check_volume_label_used_with_lvm()
 
+    def test_check_swap_name_used_with_lvm(self):
+        xml_state = XMLState(
+            self.description.load(), ['vmxFlavour'], 'oem'
+        )
+        runtime_checker = RuntimeChecker(xml_state)
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_swap_name_used_with_lvm()
+
     def test_check_preferences_data_no_version(self):
         xml_state = XMLState(
             self.description.load(), ['docker'], 'docker'

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -121,6 +121,8 @@ class TestSystemBuildTask:
         self.runtime_checker.\
             check_volume_label_used_with_lvm.assert_called_once_with()
         self.runtime_checker.\
+            check_swap_name_used_with_lvm.assert_called_once_with()
+        self.runtime_checker.\
             check_xen_uniquely_setup_as_server_or_guest.\
             assert_called_once_with()
         self.runtime_checker.\

--- a/test/unit/tasks/system_prepare_test.py
+++ b/test/unit/tasks/system_prepare_test.py
@@ -110,6 +110,8 @@ class TestSystemPrepareTask:
         self.runtime_checker.\
             check_volume_label_used_with_lvm.assert_called_once_with()
         self.runtime_checker.\
+            check_swap_name_used_with_lvm.assert_called_once_with()
+        self.runtime_checker.\
             check_xen_uniquely_setup_as_server_or_guest.\
             assert_called_once_with()
         self.runtime_checker.\

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -516,6 +516,13 @@ class TestXMLState:
         state = XMLState(xml_data, ['vmxFlavour'], 'oem')
         assert state.get_oemconfig_swap_mbytes() == 42
 
+    def test_get_oemconfig_swap_name(self):
+        xml_data = self.description.load()
+        state = XMLState(xml_data, ['containerFlavour'], 'docker')
+        assert state.get_oemconfig_swap_name() == 'LVSwap'
+        state = XMLState(xml_data, ['vmxFlavour'], 'oem')
+        assert state.get_oemconfig_swap_name() == 'swap'
+
     def test_get_oemconfig_swap_mbytes_default(self):
         description = XMLDescription(
             '../data/example_btrfs_config.xml'


### PR DESCRIPTION
Added a new optional element inside ```<oemconfig>```:

```xml
<oemconfig>
    <oem-swapname>swap_volume_name</oem-swapname>
</oemconfig>
```

The setting allows to specify a name for the swap volume in case the LVM volume manager
is used. The default if not specified continuous to stay at: LVSwap.

This Fixes #1638