### PR TITLE
Use the generic Dict type

### DIFF
--- a/kiwi/container/__init__.py
+++ b/kiwi/container/__init__.py
@@ -20,6 +20,7 @@ from abc import (
     ABCMeta,
     abstractmethod
 )
+from typing import Dict
 
 from kiwi.exceptions import (
     KiwiContainerImageSetupError
@@ -39,7 +40,7 @@ class ContainerImage(metaclass=ABCMeta):
         return None  # pragma: no cover
 
     @staticmethod
-    def new(name: str, root_dir: str, custom_args: dict = None):
+    def new(name: str, root_dir: str, custom_args: Dict=None):  # noqa: E252
         name_map = {
             'docker': 'OCI',
             'oci': 'OCI',

--- a/kiwi/container/setup/__init__.py
+++ b/kiwi/container/setup/__init__.py
@@ -20,6 +20,7 @@ from abc import (
     ABCMeta,
     abstractmethod
 )
+from typing import Dict
 
 # project
 from kiwi.exceptions import (
@@ -36,7 +37,7 @@ class ContainerSetup(metaclass=ABCMeta):
         return None  # pragma: no cover
 
     @staticmethod
-    def new(name: str, root_dir: str, custom_args: dict = None):
+    def new(name: str, root_dir: str, custom_args: Dict=None):  # noqa: E252
         name_map = {
             'docker': 'Docker',
             'oci': 'OCI',


### PR DESCRIPTION
This commit makes use of the Dict type in the container factory classes
so these type hints aligned with the other dict related type hints in
KIWI code. This commit improves the refactor done in 99be52ba.
