### PR TITLE
Fixed missing provides tag

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -127,7 +127,7 @@ Provides:       kiwi-image-wsl-requires = %{version}-%{release}
 Obsoletes:      kiwi-image-wsl-requires < %{version}-%{release}
 %if "%{_vendor}" != "debbuild"
 Provides:       kiwi-image:docker
-Provides:       kiwi-image:wsl
+Provides:       kiwi-image:appx
 %endif
 %if 0%{?suse_version}
 Requires:       umoci


### PR DESCRIPTION
When building WSL images the image type is set to appx.
Therefore obs is looking for what provides kiwi-image:appx
This provides tag was missing

