### PR TITLE
Update kiwi-systemdeps-image-validation

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -277,7 +277,9 @@ Recommends:     jing
 %if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?suse_version}
 Requires:       python%{python3_pkgversion}-solv
 %endif
-Requires:       python%{python3_pkgversion}-anymarkup
+%if ! (0%{?rhel} && 0%{?rhel} < 8)
+Recommends:     python%{python3_pkgversion}-anymarkup
+%endif
 
 %description -n kiwi-systemdeps-image-validation
 Host setup helper to pull in all packages required/useful on


### PR DESCRIPTION
Make python anymarkup to be only recommended. The package
does not exist on all distributions, e.g suse does not
provide it and for kiwi it's an optional plugin

