### PR TITLE
Modify lsblk flags for a consistent output across distros

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -179,7 +179,7 @@ function get_partition_node_name {
     local part
     udev_pending
     for partnode in $(
-        lsblk -p -r -o NAME,TYPE "${disk}" | grep -E "part|md$" | cut -f1 -d ' '
+        lsblk -p -l -o NAME,TYPE "${disk}" | grep -E "part|md$" | cut -f1 -d ' '
     );do
         if [ "${index}" = "${partid}" ];then
             echo "${partnode}"


### PR DESCRIPTION
This commit modifies the lsblk flags to make use of the list format
instead of raw output. `--list` flag seams to keep the geometry order
and produces a consistent output in several distros.