### PR TITLE
force ascii encoding on checksum files

### DIFF
--- a/kiwi/utils/checksum.py
+++ b/kiwi/utils/checksum.py
@@ -18,6 +18,7 @@
 import os
 from collections import namedtuple
 import hashlib
+import encodings.ascii
 
 # project
 from kiwi.command import Command
@@ -58,7 +59,7 @@ class Checksum:
         """
         if not os.path.exists(filename):
             return False
-        with open(filename) as checksum_file:
+        with open(filename, encoding=encodings.ascii) as checksum_file:
             checksum_from_file = checksum_file.read()
             # checksum is expected to be stored in the first field
             # separated by space, other information might contain


### PR DESCRIPTION
Python open function can fail when a file is not found encoded in
utf-8, depending on the execution environment. In particular on
Debian 10 an error message regarding utf8 was encountered.

Since checksum files always use only ascii characters, force it.