### PR TITLE
Delete obsolete ddb.adapterType patching

### DIFF
--- a/kiwi/storage/subformat/base.py
+++ b/kiwi/storage/subformat/base.py
@@ -131,15 +131,6 @@ class DiskFormatBase:
         if custom_args:
             ordered_args = OrderedDict(sorted(custom_args.items()))
             for key, value in list(ordered_args.items()):
-                if key == 'adapter_type=pvscsi':
-                    # qemu does not support the pvscsi type:
-                    # To build a vmdk image with ddb.adapterType set to
-                    # pvscsi we need to manually change the header but
-                    # have to create a vmdk with lsilogic as scsi adapter
-                    # first. I don't really like this hack but it seems
-                    # there is no way around. For details see
-                    # bsc#1099569
-                    key = 'adapter_type=lsilogic'
                 options.append('-o')
                 if value:
                     options.append('{0}={1}'.format(key, value))

--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -44,10 +44,6 @@ class DiskFormatVmdk(DiskFormatBase):
         self.image_format = 'vmdk'
         self.options = self.get_qemu_option_list(custom_args)
 
-        self.patch_header_for_pvscsi = False
-        if custom_args and 'adapter_type=pvscsi' in custom_args:
-            self.patch_header_for_pvscsi = True
-
     def create_image_format(self):
         """
         Create vmdk disk format and machine settings file
@@ -60,8 +56,6 @@ class DiskFormatVmdk(DiskFormatBase):
                 self.get_target_file_path_for_format('vmdk')
             ]
         )
-        if self.patch_header_for_pvscsi:
-            self._inject_pvscsi_adapter_type()
         self._create_vmware_settings_file()
 
     def store_to_result(self, result):
@@ -176,24 +170,3 @@ class DiskFormatVmdk(DiskFormatBase):
             raise KiwiTemplateError(
                 '%s: %s' % (type(e).__name__, format(e))
             )
-
-    def _inject_pvscsi_adapter_type(self):
-        """
-        QEMU does not support the pvscsi adapter type.
-        According to suggestions VMware giving to their customers, just
-        open the VMDK file, and change ddb.adapterType directly.
-        """
-        vmdk_image_name = self.get_target_file_path_for_format('vmdk')
-        vmdk_descriptor = None
-        with open(vmdk_image_name, 'rb') as vmdk:
-            vmdk.seek(512, 0)
-            vmdk_descriptor = bytes(vmdk.read(1024))
-
-        if vmdk_descriptor:
-            vmdk_descriptor = vmdk_descriptor.replace(
-                b'"lsilogic"', b'"pvscsi"'
-            )
-            with open(vmdk_image_name, 'r+b') as vmdk:
-                vmdk.seek(512, 0)
-                vmdk.write(vmdk_descriptor)
-                vmdk.seek(0, 2)

--- a/test/unit/storage/subformat/vmdk_test.py
+++ b/test/unit/storage/subformat/vmdk_test.py
@@ -102,9 +102,8 @@ class TestDiskFormatVmdk:
             {'option': 'value', 'adapter_type=pvscsi': None}
         )
         assert self.disk_format.options == [
-            '-o', 'adapter_type=lsilogic', '-o', 'option=value'
+            '-o', 'adapter_type=pvscsi', '-o', 'option=value'
         ]
-        assert self.disk_format.patch_header_for_pvscsi is True
 
     def test_store_to_result(self):
         result = Mock()
@@ -171,25 +170,4 @@ class TestDiskFormatVmdk:
         )
         assert m_open.return_value.write.call_args_list[2] == call(
             'custom entry 2' + os.linesep
-        )
-
-    @patch('kiwi.storage.subformat.vmdk.Command.run')
-    @patch('os.path.exists')
-    def test_create_image_format_pvscsi_adapter(
-        self, mock_exists, mock_command
-    ):
-        self.disk_format.patch_header_for_pvscsi = True
-
-        m_open = mock_open(read_data=b'ddb.adapterType = "lsilogic"')
-        with patch('builtins.open', m_open, create=True):
-            self.disk_format.create_image_format()
-
-        assert m_open.call_args_list[0:2] == [
-            call('target_dir/some-disk-image.x86_64-1.2.3.vmdk', 'rb'),
-            call('target_dir/some-disk-image.x86_64-1.2.3.vmdk', 'r+b')
-        ]
-        assert m_open.return_value.seek.called_once_with(512, 0)
-        assert m_open.return_value.read.called_once_with(1024)
-        assert m_open.return_value.write.call_args_list[0] == call(
-            b'ddb.adapterType = "pvscsi"'
         )


### PR DESCRIPTION
When building a vmdk image with pvscsi as adapter type, kiwi
implicitly changed the adapter_type from pvscsi to lsilogic
because the pvscsi driver was missing. The real solution to
this problem is to include the now existing vmw_pvscsi kernel
driver into the initrd with a custom root overlay file
etc/dracut.conf.d/pvscsi.conf. This Fixes bsc#1180539


