### PR TITLE
Refactor default shared cache location

### DIFF
--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -60,7 +60,7 @@ global options for services: image, system
         specify an alternative shared cache directory. The directory
         is shared via bind mount between the build host and image
         root system and contains information about package repositories
-        and their cache and meta data. [default: /var/cache/kiwi]
+        and their cache and meta data.
     --type=<build_type>
         image build type. If not set the default XML specified
         build type will be used
@@ -81,6 +81,7 @@ from kiwi.exceptions import (
 from kiwi.path import Path
 from kiwi.version import __version__
 from kiwi.help import Help
+from kiwi.defaults import Defaults
 
 log = logging.getLogger('kiwi')
 
@@ -206,6 +207,10 @@ class Cli:
                         'vmx type is now a subset of oem, --type set to oem'
                     )
                     value = 'oem'
+                if arg == '--shared-cache-dir' and not value:
+                    value = os.sep + Defaults.get_shared_cache_location()
+                if arg == '--shared-cache-dir' and value:
+                    Defaults.set_shared_cache_location(value)
                 result[arg] = value
         return result
 

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -38,6 +38,7 @@ EDIT_BOOT_CONFIG_SCRIPT = 'edit_boot_config.sh'
 EDIT_BOOT_INSTALL_SCRIPT = 'edit_boot_install.sh'
 IMAGE_METADATA_DIR = 'image'
 ROOT_VOLUME_NAME = 'LVRoot'
+SHARED_CACHE_DIR = '/var/cache/kiwi'
 
 
 class Defaults:
@@ -182,6 +183,16 @@ class Defaults:
         return '/var/tmp/kiwi/satsolver'
 
     @staticmethod
+    def set_shared_cache_location(location):
+        """
+        Sets the shared cache location once
+
+        :param str location: a location path
+        """
+        global SHARED_CACHE_DIR
+        SHARED_CACHE_DIR = location
+
+    @staticmethod
     def get_shared_cache_location():
         """
         Provides the shared cache location
@@ -196,9 +207,8 @@ class Defaults:
 
         :rtype: str
         """
-        from .cli import Cli
         return os.path.abspath(os.path.normpath(
-            Cli().get_global_args().get('--shared-cache-dir')
+            SHARED_CACHE_DIR
         )).lstrip(os.sep)
 
     @staticmethod

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -44,15 +44,6 @@ class TestDefaults:
     def test_get_default_shared_cache_location(self):
         assert Defaults.get_shared_cache_location() == 'var/cache/kiwi'
 
-    def test_get_custom_shared_cache_location(self):
-        sys.argv = [
-            sys.argv[0],
-            '--shared-cache-dir', '/my/cachedir',
-            'system', 'prepare',
-            '--description', 'description', '--root', 'directory'
-        ]
-        assert Defaults.get_shared_cache_location() == 'my/cachedir'
-
     @patch('kiwi.defaults.Path.which')
     def test_get_grub_boot_directory_name(self, mock_which):
         mock_which.return_value = 'grub2-install-was-found'


### PR DESCRIPTION
Default shared cache location does not depend on CLI parameters
Kiwi CLI default value for shared cache directory depends on Defaults.

Fixes #1671