### PR TITLE
Set dracut modules list for install initrds

### DIFF
--- a/doc/source/building_images/build_expandable_disk.rst
+++ b/doc/source/building_images/build_expandable_disk.rst
@@ -389,3 +389,28 @@ oemconfig.oem-unattended Element
   automatically without requiring user interaction. If multiple
   possible target devices are discovered the image is deployed to
   the first device. ``kiwi_oemunattended`` in the initrd
+
+.. _installmedia_customize:
+
+Installation Media Customization
+--------------------------------
+
+The installation media created for OEM network or CD/DVD deployments can
+be customized with the `installmedia` section which is a child section of the `type`
+element as it appears in the following example:
+
+.. code:: xml
+
+   <installmedia>
+     <initrd action="omit">
+       <dracut module="network-legacy"/>
+     </initrd>
+   </installmedia>
+
+The `installmedia` is only available for OEM image types that includes the
+request to create an installation media.
+
+The `initrd` child element of `installmedia` lists dracut modules, they
+can be omitted, added or staticaly set the list of included ones. This is
+specified with the `action` attribute and can take `action="omit"`,
+`action="add"` or `action="set"` values. 

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -672,6 +672,12 @@ Used to customize the virtual machine configuration which describes
 the components of an emulated hardware.
 For details see: :ref:`disk-the-machine-element`
 
+<preferences><type><installmedia>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Used to customize the installation media images created for oem images
+deployment.
+For details see: :ref:`installmedia_customize`
+
 .. _sec.repository:
 
 <repository>

--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -120,6 +120,18 @@ class BootImageBase:
         """
         pass
 
+    def set_static_modules(self, modules, install_media=False):
+        """
+        Set static modules list for boot image
+
+        For kiwi boot no modules configuration is required. Thus in
+        such a case this method is a noop.
+
+        :param list modules: list of modules to include
+        :param bool install_media: lists the modules for install initrds
+        """
+        pass
+
     def write_system_config_file(
         self, config, config_file=None
     ):

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -388,6 +388,14 @@ class InstallImageBuilder:
                 self.boot_image_task.omit_module(
                     'multipath', install_media=True
                 )
+            for module in self.xml_state.get_installinitrd_modules('add'):
+                self.boot_image_task.include_module(module, install_media=True)
+            for module in self.xml_state.get_installinitrd_modules('omit'):
+                self.boot_image_task.omit_module(module, install_media=True)
+            self.boot_image_task.set_static_modules(
+                self.xml_state.get_installinitrd_modules('set'),
+                install_media=True
+            )
         self.boot_image_task.create_initrd(
             self.mbrid, 'initrd_kiwi_install',
             install_initrd=True
@@ -430,6 +438,14 @@ class InstallImageBuilder:
                 self.boot_image_task.omit_module(
                     'multipath', install_media=True
                 )
+            for module in self.xml_state.get_installinitrd_modules('add'):
+                self.boot_image_task.include_module(module, install_media=True)
+            for module in self.xml_state.get_installinitrd_modules('omit'):
+                self.boot_image_task.omit_module(module, install_media=True)
+            self.boot_image_task.set_static_modules(
+                self.xml_state.get_installinitrd_modules('set'),
+                install_media=True
+            )
             self._add_system_image_boot_options_to_boot_image()
         self.boot_image_task.create_initrd(
             self.mbrid, 'initrd_kiwi_install',

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -388,12 +388,12 @@ class InstallImageBuilder:
                 self.boot_image_task.omit_module(
                     'multipath', install_media=True
                 )
-            for module in self.xml_state.get_installinitrd_modules('add'):
-                self.boot_image_task.include_module(module, install_media=True)
-            for module in self.xml_state.get_installinitrd_modules('omit'):
-                self.boot_image_task.omit_module(module, install_media=True)
+            for mod in self.xml_state.get_installmedia_initrd_modules('add'):
+                self.boot_image_task.include_module(mod, install_media=True)
+            for mod in self.xml_state.get_installmedia_initrd_modules('omit'):
+                self.boot_image_task.omit_module(mod, install_media=True)
             self.boot_image_task.set_static_modules(
-                self.xml_state.get_installinitrd_modules('set'),
+                self.xml_state.get_installmedia_initrd_modules('set'),
                 install_media=True
             )
         self.boot_image_task.create_initrd(
@@ -438,12 +438,12 @@ class InstallImageBuilder:
                 self.boot_image_task.omit_module(
                     'multipath', install_media=True
                 )
-            for module in self.xml_state.get_installinitrd_modules('add'):
-                self.boot_image_task.include_module(module, install_media=True)
-            for module in self.xml_state.get_installinitrd_modules('omit'):
-                self.boot_image_task.omit_module(module, install_media=True)
+            for mod in self.xml_state.get_installmedia_initrd_modules('add'):
+                self.boot_image_task.include_module(mod, install_media=True)
+            for mod in self.xml_state.get_installmedia_initrd_modules('omit'):
+                self.boot_image_task.omit_module(mod, install_media=True)
             self.boot_image_task.set_static_modules(
-                self.xml_state.get_installinitrd_modules('set'),
+                self.xml_state.get_installmedia_initrd_modules('set'),
                 install_media=True
             )
             self._add_system_image_boot_options_to_boot_image()

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1883,7 +1883,7 @@ div {
             k.size? &
             k.systemdisk? &
             k.vagrantconfig* &
-            k.installinitrd*
+            k.installmedia?
         }
 }
 
@@ -2697,21 +2697,46 @@ div {
 }
 
 #==========================================
-# main block: <installinitrd>
+# main block: <installmedia>
 #
 div {
-    k.installinitrd.action.attribute =
+    sch:pattern [
+        id = "installation_media"
+        sch:rule [
+            context = "installmedia"
+            sch:assert [
+                test = "../@installiso='true' or ../@installpxe='true'"
+                "installmedia is only available for the oem type "~
+                "with 'installiso' or 'installpxe' set to 'true'"
+            ]
+        ]
+    ]
+    k.installmedia.attlist = empty
+    k.installmedia =
+        ## The installmedia element defined the configuration parameters
+        ## for the installation media of OEM images.
+        element installmedia {
+            k.installmedia.attlist &
+            k.initrd*
+        }
+}
+
+#==========================================
+# main block: <initrd>
+#
+div {
+    k.initrd.action.attribute =
         ## Sets weather the dracut modules list are meant to be appended,
         ## omitted or they define the static list of modules for the
         ## installation initrd.
         attribute action { "omit" | "add" | "set" }
-    k.installinitrd.attlist =
-        k.installinitrd.action.attribute
-    k.installinitrd =
-        ## The installinitrd element defines the dracut modules configuration
-        ## for the installation ISO or PXE image of OEM images.
-        element installinitrd {
-            k.installinitrd.attlist &
+    k.initrd.attlist =
+        k.initrd.action.attribute
+    k.initrd =
+        ## The initrd element defines the dracut modules configuration
+        ## for the installation media.
+        element initrd {
+            k.initrd.attlist &
             k.dracut*
         }
 }

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1882,7 +1882,8 @@ div {
             k.oemconfig? &
             k.size? &
             k.systemdisk? &
-            k.vagrantconfig*
+            k.vagrantconfig* &
+            k.installinitrd*
         }
 }
 
@@ -2692,6 +2693,42 @@ div {
         ## configuration options which are used inside a vagrant box
         element vagrantconfig {
             k.vagrantconfig.attlist
+        }
+}
+
+#==========================================
+# main block: <installinitrd>
+#
+div {
+    k.installinitrd.action.attribute =
+        ## Sets weather the dracut modules list are meant to be appended,
+        ## omitted or they define the static list of modules for the
+        ## installation initrd.
+        attribute action { "omit" | "add" | "set" }
+    k.installinitrd.attlist =
+        k.installinitrd.action.attribute
+    k.installinitrd =
+        ## The installinitrd element defines the dracut modules configuration
+        ## for the installation ISO or PXE image of OEM images.
+        element installinitrd {
+            k.installinitrd.attlist &
+            k.dracut*
+        }
+}
+
+#==========================================
+# main block: <dracut>
+#
+div {
+    k.dracut.module.attribute = 
+        ## A module name
+        attribute module { text }
+    k.dracut.attlist =
+        k.dracut.module.attribute
+    k.dracut =
+        ## A dracut module
+        element dracut {
+            k.dracut.attlist
         }
 }
 

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2844,9 +2844,9 @@ default.</a:documentation>
           <zeroOrMore>
             <ref name="k.vagrantconfig"/>
           </zeroOrMore>
-          <zeroOrMore>
-            <ref name="k.installinitrd"/>
-          </zeroOrMore>
+          <optional>
+            <ref name="k.installmedia"/>
+          </optional>
         </interleave>
       </element>
     </define>
@@ -4100,11 +4100,38 @@ configuration options which are used inside a vagrant box</a:documentation>
   </div>
   <!--
     ==========================================
-    main block: <installinitrd>
+    main block: <installmedia>
     
   -->
   <div>
-    <define name="k.installinitrd.action.attribute">
+    <sch:pattern id="installation_media">
+      <sch:rule context="installmedia">
+        <sch:assert test="../@installiso='true' or ../@installpxe='true'">installmedia is only available for the oem type with 'installiso' or 'installpxe' set to 'true'</sch:assert>
+      </sch:rule>
+    </sch:pattern>
+    <define name="k.installmedia.attlist">
+      <empty/>
+    </define>
+    <define name="k.installmedia">
+      <element name="installmedia">
+        <a:documentation>The installmedia element defined the configuration parameters
+for the installation media of OEM images.</a:documentation>
+        <interleave>
+          <ref name="k.installmedia.attlist"/>
+          <zeroOrMore>
+            <ref name="k.initrd"/>
+          </zeroOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <initrd>
+    
+  -->
+  <div>
+    <define name="k.initrd.action.attribute">
       <attribute name="action">
         <a:documentation>Sets weather the dracut modules list are meant to be appended,
 omitted or they define the static list of modules for the
@@ -4116,15 +4143,15 @@ installation initrd.</a:documentation>
         </choice>
       </attribute>
     </define>
-    <define name="k.installinitrd.attlist">
-      <ref name="k.installinitrd.action.attribute"/>
+    <define name="k.initrd.attlist">
+      <ref name="k.initrd.action.attribute"/>
     </define>
-    <define name="k.installinitrd">
-      <element name="installinitrd">
-        <a:documentation>The installinitrd element defines the dracut modules configuration
-for the installation ISO or PXE image of OEM images.</a:documentation>
+    <define name="k.initrd">
+      <element name="initrd">
+        <a:documentation>The initrd element defines the dracut modules configuration
+for the installation media.</a:documentation>
         <interleave>
-          <ref name="k.installinitrd.attlist"/>
+          <ref name="k.initrd.attlist"/>
           <zeroOrMore>
             <ref name="k.dracut"/>
           </zeroOrMore>

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2844,6 +2844,9 @@ default.</a:documentation>
           <zeroOrMore>
             <ref name="k.vagrantconfig"/>
           </zeroOrMore>
+          <zeroOrMore>
+            <ref name="k.installinitrd"/>
+          </zeroOrMore>
         </interleave>
       </element>
     </define>
@@ -4092,6 +4095,61 @@ If not specified the image name is used</a:documentation>
         <a:documentation>The vagrantconfig element specifies the Vagrant meta
 configuration options which are used inside a vagrant box</a:documentation>
         <ref name="k.vagrantconfig.attlist"/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <installinitrd>
+    
+  -->
+  <div>
+    <define name="k.installinitrd.action.attribute">
+      <attribute name="action">
+        <a:documentation>Sets weather the dracut modules list are meant to be appended,
+omitted or they define the static list of modules for the
+installation initrd.</a:documentation>
+        <choice>
+          <value>omit</value>
+          <value>add</value>
+          <value>set</value>
+        </choice>
+      </attribute>
+    </define>
+    <define name="k.installinitrd.attlist">
+      <ref name="k.installinitrd.action.attribute"/>
+    </define>
+    <define name="k.installinitrd">
+      <element name="installinitrd">
+        <a:documentation>The installinitrd element defines the dracut modules configuration
+for the installation ISO or PXE image of OEM images.</a:documentation>
+        <interleave>
+          <ref name="k.installinitrd.attlist"/>
+          <zeroOrMore>
+            <ref name="k.dracut"/>
+          </zeroOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <dracut>
+    
+  -->
+  <div>
+    <define name="k.dracut.module.attribute">
+      <attribute name="module">
+        <a:documentation>A module name</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.dracut.attlist">
+      <ref name="k.dracut.module.attribute"/>
+    </define>
+    <define name="k.dracut">
+      <element name="dracut">
+        <a:documentation>A dracut module</a:documentation>
+        <ref name="k.dracut.attlist"/>
       </element>
     </define>
   </div>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2583,7 +2583,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, vagrantconfig=None, installinitrd=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, vagrantconfig=None, installmedia=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2674,10 +2674,10 @@ class type_(GeneratedsSuper):
             self.vagrantconfig = []
         else:
             self.vagrantconfig = vagrantconfig
-        if installinitrd is None:
-            self.installinitrd = []
+        if installmedia is None:
+            self.installmedia = []
         else:
-            self.installinitrd = installinitrd
+            self.installmedia = installmedia
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -2724,11 +2724,11 @@ class type_(GeneratedsSuper):
     def add_vagrantconfig(self, value): self.vagrantconfig.append(value)
     def insert_vagrantconfig_at(self, index, value): self.vagrantconfig.insert(index, value)
     def replace_vagrantconfig_at(self, index, value): self.vagrantconfig[index] = value
-    def get_installinitrd(self): return self.installinitrd
-    def set_installinitrd(self, installinitrd): self.installinitrd = installinitrd
-    def add_installinitrd(self, value): self.installinitrd.append(value)
-    def insert_installinitrd_at(self, index, value): self.installinitrd.insert(index, value)
-    def replace_installinitrd_at(self, index, value): self.installinitrd[index] = value
+    def get_installmedia(self): return self.installmedia
+    def set_installmedia(self, installmedia): self.installmedia = installmedia
+    def add_installmedia(self, value): self.installmedia.append(value)
+    def insert_installmedia_at(self, index, value): self.installmedia.insert(index, value)
+    def replace_installmedia_at(self, index, value): self.installmedia[index] = value
     def get_boot(self): return self.boot
     def set_boot(self, boot): self.boot = boot
     def get_bootfilesystem(self): return self.bootfilesystem
@@ -2888,7 +2888,7 @@ class type_(GeneratedsSuper):
             self.size or
             self.systemdisk or
             self.vagrantconfig or
-            self.installinitrd
+            self.installmedia
         ):
             return True
         else:
@@ -3117,8 +3117,8 @@ class type_(GeneratedsSuper):
             systemdisk_.export(outfile, level, namespaceprefix_, name_='systemdisk', pretty_print=pretty_print)
         for vagrantconfig_ in self.vagrantconfig:
             vagrantconfig_.export(outfile, level, namespaceprefix_, name_='vagrantconfig', pretty_print=pretty_print)
-        for installinitrd_ in self.installinitrd:
-            installinitrd_.export(outfile, level, namespaceprefix_, name_='installinitrd', pretty_print=pretty_print)
+        for installmedia_ in self.installmedia:
+            installmedia_.export(outfile, level, namespaceprefix_, name_='installmedia', pretty_print=pretty_print)
     def build(self, node):
         already_processed = set()
         self.buildAttributes(node, node.attrib, already_processed)
@@ -3553,11 +3553,11 @@ class type_(GeneratedsSuper):
             obj_.build(child_)
             self.vagrantconfig.append(obj_)
             obj_.original_tagname_ = 'vagrantconfig'
-        elif nodeName_ == 'installinitrd':
-            obj_ = installinitrd.factory()
+        elif nodeName_ == 'installmedia':
+            obj_ = installmedia.factory()
             obj_.build(child_)
-            self.installinitrd.append(obj_)
-            obj_.original_tagname_ = 'installinitrd'
+            self.installmedia.append(obj_)
+            obj_.original_tagname_ = 'installmedia'
 # end class type_
 
 
@@ -6665,9 +6665,91 @@ class vagrantconfig(GeneratedsSuper):
 # end class vagrantconfig
 
 
-class installinitrd(GeneratedsSuper):
-    """The installinitrd element defines the dracut modules configuration
-    for the installation ISO or PXE image of OEM images."""
+class installmedia(GeneratedsSuper):
+    """The installmedia element defined the configuration parameters for
+    the installation media of OEM images."""
+    subclass = None
+    superclass = None
+    def __init__(self, initrd=None):
+        self.original_tagname_ = None
+        if initrd is None:
+            self.initrd = []
+        else:
+            self.initrd = initrd
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, installmedia)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if installmedia.subclass:
+            return installmedia.subclass(*args_, **kwargs_)
+        else:
+            return installmedia(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_initrd(self): return self.initrd
+    def set_initrd(self, initrd): self.initrd = initrd
+    def add_initrd(self, value): self.initrd.append(value)
+    def insert_initrd_at(self, index, value): self.initrd.insert(index, value)
+    def replace_initrd_at(self, index, value): self.initrd[index] = value
+    def hasContent_(self):
+        if (
+            self.initrd
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', name_='installmedia', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('installmedia')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='installmedia')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='installmedia', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='installmedia'):
+        pass
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='installmedia', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for initrd_ in self.initrd:
+            initrd_.export(outfile, level, namespaceprefix_, name_='initrd', pretty_print=pretty_print)
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        pass
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        if nodeName_ == 'initrd':
+            obj_ = initrd.factory()
+            obj_.build(child_)
+            self.initrd.append(obj_)
+            obj_.original_tagname_ = 'initrd'
+# end class installmedia
+
+
+class initrd(GeneratedsSuper):
+    """The initrd element defines the dracut modules configuration for the
+    installation media."""
     subclass = None
     superclass = None
     def __init__(self, action=None, dracut=None):
@@ -6680,13 +6762,13 @@ class installinitrd(GeneratedsSuper):
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
-                CurrentSubclassModule_, installinitrd)
+                CurrentSubclassModule_, initrd)
             if subclass is not None:
                 return subclass(*args_, **kwargs_)
-        if installinitrd.subclass:
-            return installinitrd.subclass(*args_, **kwargs_)
+        if initrd.subclass:
+            return initrd.subclass(*args_, **kwargs_)
         else:
-            return installinitrd(*args_, **kwargs_)
+            return initrd(*args_, **kwargs_)
     factory = staticmethod(factory)
     def get_dracut(self): return self.dracut
     def set_dracut(self, dracut): self.dracut = dracut
@@ -6702,8 +6784,8 @@ class installinitrd(GeneratedsSuper):
             return True
         else:
             return False
-    def export(self, outfile, level, namespaceprefix_='', name_='installinitrd', namespacedef_='', pretty_print=True):
-        imported_ns_def_ = GenerateDSNamespaceDefs_.get('installinitrd')
+    def export(self, outfile, level, namespaceprefix_='', name_='initrd', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('initrd')
         if imported_ns_def_ is not None:
             namespacedef_ = imported_ns_def_
         if pretty_print:
@@ -6715,19 +6797,19 @@ class installinitrd(GeneratedsSuper):
         showIndent(outfile, level, pretty_print)
         outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
         already_processed = set()
-        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='installinitrd')
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='initrd')
         if self.hasContent_():
             outfile.write('>%s' % (eol_, ))
-            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='installinitrd', pretty_print=pretty_print)
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='initrd', pretty_print=pretty_print)
             showIndent(outfile, level, pretty_print)
             outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
         else:
             outfile.write('/>%s' % (eol_, ))
-    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='installinitrd'):
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='initrd'):
         if self.action is not None and 'action' not in already_processed:
             already_processed.add('action')
             outfile.write(' action=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.action), input_name='action')), ))
-    def exportChildren(self, outfile, level, namespaceprefix_='', name_='installinitrd', fromsubclass_=False, pretty_print=True):
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='initrd', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
         else:
@@ -6753,7 +6835,7 @@ class installinitrd(GeneratedsSuper):
             obj_.build(child_)
             self.dracut.append(obj_)
             obj_.original_tagname_ = 'dracut'
-# end class installinitrd
+# end class initrd
 
 
 class dracut(GeneratedsSuper):
@@ -7920,7 +8002,8 @@ __all__ = [
     "history",
     "ignore",
     "image",
-    "installinitrd",
+    "initrd",
+    "installmedia",
     "k_source",
     "label",
     "labels",

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2583,7 +2583,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, vagrantconfig=None, installinitrd=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2674,6 +2674,10 @@ class type_(GeneratedsSuper):
             self.vagrantconfig = []
         else:
             self.vagrantconfig = vagrantconfig
+        if installinitrd is None:
+            self.installinitrd = []
+        else:
+            self.installinitrd = installinitrd
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -2720,6 +2724,11 @@ class type_(GeneratedsSuper):
     def add_vagrantconfig(self, value): self.vagrantconfig.append(value)
     def insert_vagrantconfig_at(self, index, value): self.vagrantconfig.insert(index, value)
     def replace_vagrantconfig_at(self, index, value): self.vagrantconfig[index] = value
+    def get_installinitrd(self): return self.installinitrd
+    def set_installinitrd(self, installinitrd): self.installinitrd = installinitrd
+    def add_installinitrd(self, value): self.installinitrd.append(value)
+    def insert_installinitrd_at(self, index, value): self.installinitrd.insert(index, value)
+    def replace_installinitrd_at(self, index, value): self.installinitrd[index] = value
     def get_boot(self): return self.boot
     def set_boot(self, boot): self.boot = boot
     def get_bootfilesystem(self): return self.bootfilesystem
@@ -2878,7 +2887,8 @@ class type_(GeneratedsSuper):
             self.oemconfig or
             self.size or
             self.systemdisk or
-            self.vagrantconfig
+            self.vagrantconfig or
+            self.installinitrd
         ):
             return True
         else:
@@ -3107,6 +3117,8 @@ class type_(GeneratedsSuper):
             systemdisk_.export(outfile, level, namespaceprefix_, name_='systemdisk', pretty_print=pretty_print)
         for vagrantconfig_ in self.vagrantconfig:
             vagrantconfig_.export(outfile, level, namespaceprefix_, name_='vagrantconfig', pretty_print=pretty_print)
+        for installinitrd_ in self.installinitrd:
+            installinitrd_.export(outfile, level, namespaceprefix_, name_='installinitrd', pretty_print=pretty_print)
     def build(self, node):
         already_processed = set()
         self.buildAttributes(node, node.attrib, already_processed)
@@ -3541,6 +3553,11 @@ class type_(GeneratedsSuper):
             obj_.build(child_)
             self.vagrantconfig.append(obj_)
             obj_.original_tagname_ = 'vagrantconfig'
+        elif nodeName_ == 'installinitrd':
+            obj_ = installinitrd.factory()
+            obj_.build(child_)
+            self.installinitrd.append(obj_)
+            obj_.original_tagname_ = 'installinitrd'
 # end class type_
 
 
@@ -6648,6 +6665,167 @@ class vagrantconfig(GeneratedsSuper):
 # end class vagrantconfig
 
 
+class installinitrd(GeneratedsSuper):
+    """The installinitrd element defines the dracut modules configuration
+    for the installation ISO or PXE image of OEM images."""
+    subclass = None
+    superclass = None
+    def __init__(self, action=None, dracut=None):
+        self.original_tagname_ = None
+        self.action = _cast(None, action)
+        if dracut is None:
+            self.dracut = []
+        else:
+            self.dracut = dracut
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, installinitrd)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if installinitrd.subclass:
+            return installinitrd.subclass(*args_, **kwargs_)
+        else:
+            return installinitrd(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_dracut(self): return self.dracut
+    def set_dracut(self, dracut): self.dracut = dracut
+    def add_dracut(self, value): self.dracut.append(value)
+    def insert_dracut_at(self, index, value): self.dracut.insert(index, value)
+    def replace_dracut_at(self, index, value): self.dracut[index] = value
+    def get_action(self): return self.action
+    def set_action(self, action): self.action = action
+    def hasContent_(self):
+        if (
+            self.dracut
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', name_='installinitrd', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('installinitrd')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='installinitrd')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='installinitrd', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='installinitrd'):
+        if self.action is not None and 'action' not in already_processed:
+            already_processed.add('action')
+            outfile.write(' action=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.action), input_name='action')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='installinitrd', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for dracut_ in self.dracut:
+            dracut_.export(outfile, level, namespaceprefix_, name_='dracut', pretty_print=pretty_print)
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('action', node)
+        if value is not None and 'action' not in already_processed:
+            already_processed.add('action')
+            self.action = value
+            self.action = ' '.join(self.action.split())
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        if nodeName_ == 'dracut':
+            obj_ = dracut.factory()
+            obj_.build(child_)
+            self.dracut.append(obj_)
+            obj_.original_tagname_ = 'dracut'
+# end class installinitrd
+
+
+class dracut(GeneratedsSuper):
+    """A dracut module"""
+    subclass = None
+    superclass = None
+    def __init__(self, module=None):
+        self.original_tagname_ = None
+        self.module = _cast(None, module)
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, dracut)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if dracut.subclass:
+            return dracut.subclass(*args_, **kwargs_)
+        else:
+            return dracut(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_module(self): return self.module
+    def set_module(self, module): self.module = module
+    def hasContent_(self):
+        if (
+
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', name_='dracut', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('dracut')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='dracut')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='dracut', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='dracut'):
+        if self.module is not None and 'module' not in already_processed:
+            already_processed.add('module')
+            outfile.write(' module=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.module), input_name='module')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='dracut', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('module', node)
+        if value is not None and 'module' not in already_processed:
+            already_processed.add('module')
+            self.module = value
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        pass
+# end class dracut
+
+
 class machine(GeneratedsSuper):
     """The machine element specifies VM guest configuration options which
     are used by the virtual machine when running the image."""
@@ -7731,6 +7909,7 @@ __all__ = [
     "bootloader",
     "containerconfig",
     "description",
+    "dracut",
     "drivers",
     "entrypoint",
     "env",
@@ -7741,6 +7920,7 @@ __all__ = [
     "history",
     "ignore",
     "image",
+    "installinitrd",
     "k_source",
     "label",
     "labels",

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1012,7 +1012,7 @@ class XMLState:
             return container_config_sections[0]
         return None
 
-    def get_installinitrd_modules(self, action: str) -> List[str]:
+    def get_installmedia_initrd_modules(self, action: str) -> List[str]:
         """
         Gets the list of modules to append in installation initrds
 
@@ -1021,10 +1021,13 @@ class XMLState:
         :rtype: list
         """
         modules = []
-        installinitrd_sections = self.build_type.get_installinitrd()
-        for installinitrd_section in installinitrd_sections:
-            if installinitrd_section.get_action() == action:
-                for module in installinitrd_section.get_dracut():
+        installmedia = self.build_type.get_installmedia()
+        if not installmedia:
+            return modules
+        initrd_sections = installmedia[0].get_initrd()
+        for initrd_section in initrd_sections:
+            if initrd_section.get_action() == action:
+                for module in initrd_section.get_dracut():
                     modules.append(module.get_module())
         return modules
 

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1012,6 +1012,22 @@ class XMLState:
             return container_config_sections[0]
         return None
 
+    def get_installinitrd_modules(self, action: str) -> List[str]:
+        """
+        Gets the list of modules to append in installation initrds
+
+        :return: a list of dracut module names
+
+        :rtype: list
+        """
+        modules = []
+        installinitrd_sections = self.build_type.get_installinitrd()
+        for installinitrd_section in installinitrd_sections:
+            if installinitrd_section.get_action() == action:
+                for module in installinitrd_section.get_dracut():
+                    modules.append(module.get_module())
+        return modules
+
     def get_build_type_size(
         self, include_unpartitioned: bool = False
     ) -> Optional[size_type]:

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -57,7 +57,7 @@
         <type image="iso" firmware="efi"/>
     </preferences>
     <preferences profiles="vmxFlavour">
-        <type image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" fscreateoptions="-O ^has_journal" btrfs_root_is_snapshot="true" spare_part="200M" spare_part_fs_attributes="no-copy-on-write" xen_server="true" formatoptions="force_size,super=man" filesystem="ext4">
+        <type image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" fscreateoptions="-O ^has_journal" btrfs_root_is_snapshot="true" spare_part="200M" spare_part_fs_attributes="no-copy-on-write" xen_server="true" formatoptions="force_size,super=man" filesystem="ext4" installiso="true">
             <size unit="G" additive="true">1</size>
             <systemdisk name="mydisk"/>
             <machine memory="512" xen_loader="hvmloader">
@@ -73,6 +73,9 @@
                 <oem-recovery>false</oem-recovery>
             </oemconfig>
             <vagrantconfig provider="libvirt" virtualsize="42"/>
+            <installinitrd action="add">
+                <dracut module="network-legacy"/>
+            </installinitrd>
         </type>
     </preferences>
     <preferences profiles="ec2Flavour">

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -73,9 +73,11 @@
                 <oem-recovery>false</oem-recovery>
             </oemconfig>
             <vagrantconfig provider="libvirt" virtualsize="42"/>
-            <installinitrd action="add">
-                <dracut module="network-legacy"/>
-            </installinitrd>
+            <installmedia>
+                 <initrd action="add">
+                    <dracut module="network-legacy"/>
+                </initrd>
+            </installmedia>
         </type>
     </preferences>
     <preferences profiles="ec2Flavour">

--- a/test/unit/boot/image/base_test.py
+++ b/test/unit/boot/image/base_test.py
@@ -187,5 +187,6 @@ class TestBootImageBase:
     def test_noop_methods(self):
         self.boot_image.include_module('module')
         self.boot_image.omit_module('module')
+        self.boot_image.set_static_modules(['module'])
         self.boot_image.write_system_config_file({'config_key': 'value'})
         self.boot_image.cleanup()

--- a/test/unit/boot/image/dracut_test.py
+++ b/test/unit/boot/image/dracut_test.py
@@ -50,14 +50,14 @@ class TestBootImageKiwi:
 
     def test_include_module(self):
         self.boot_image.include_module('foobar')
-        assert self.boot_image.modules == ['foobar']
-        assert self.boot_image.install_modules == []
+        assert self.boot_image.add_modules == ['foobar']
+        assert self.boot_image.add_install_modules == []
 
         self.boot_image.include_module('module', install_media=True)
         self.boot_image.include_module('foobar')
         self.boot_image.include_module('not_available')
-        assert self.boot_image.modules == ['foobar']
-        assert self.boot_image.install_modules == ['module']
+        assert self.boot_image.add_modules == ['foobar']
+        assert self.boot_image.add_install_modules == ['module']
 
     def test_omit_module(self):
         self.boot_image.omit_module('foobar')
@@ -68,6 +68,17 @@ class TestBootImageKiwi:
         self.boot_image.omit_module('foobar')
         assert self.boot_image.omit_modules == ['foobar']
         assert self.boot_image.omit_install_modules == ['module']
+
+    def test_set_static_modules(self):
+        modules = ['foobar', 'module']
+        install_modules = ['foo']
+        self.boot_image.set_static_modules(modules)
+        assert self.boot_image.modules == modules
+        assert self.boot_image.install_modules == []
+
+        self.boot_image.set_static_modules(install_modules, install_media=True)
+        assert self.boot_image.modules == modules
+        assert self.boot_image.install_modules == install_modules
 
     def test_write_system_config_file(self):
         with patch('builtins.open', create=True) as mock_write:

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -75,7 +75,7 @@ class TestInstallImageBuilder:
         self.xml_state.get_oemconfig_oem_multipath_scan = mock.Mock(
             return_value=False
         )
-        self.xml_state.get_installinitrd_modules = mock.Mock(
+        self.xml_state.get_installmedia_initrd_modules = mock.Mock(
             return_value=['module1', 'module2']
         )
         self.boot_image_task = mock.Mock()

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -75,6 +75,9 @@ class TestInstallImageBuilder:
         self.xml_state.get_oemconfig_oem_multipath_scan = mock.Mock(
             return_value=False
         )
+        self.xml_state.get_installinitrd_modules = mock.Mock(
+            return_value=['module1', 'module2']
+        )
         self.boot_image_task = mock.Mock()
         self.boot_image_task.boot_root_directory = 'initrd_dir'
         self.boot_image_task.initrd_filename = 'initrd'
@@ -215,8 +218,13 @@ class TestInstallImageBuilder:
         self.boot_image_task.include_module.assert_any_call(
             'kiwi-dump-reboot', install_media=True
         )
-        self.boot_image_task.omit_module.assert_called_once_with(
-            'multipath', install_media=True
+        self.boot_image_task.omit_module.call_args_list == [
+            call('multipath', install_media=True),
+            call('module1', install_media=True),
+            call('module2', install_media=True),
+        ]
+        self.boot_image_task.set_static_modules.assert_called_once_with(
+            ['module1', 'module2'], install_media=True
         )
 
         self.boot_image_task.include_file.assert_called_once_with(
@@ -410,8 +418,13 @@ class TestInstallImageBuilder:
         self.boot_image_task.include_module.assert_any_call(
             'kiwi-dump-reboot', install_media=True
         )
-        self.boot_image_task.omit_module.assert_called_once_with(
-            'multipath', install_media=True
+        self.boot_image_task.omit_module.call_args_list == [
+            call('multipath', install_media=True),
+            call('module1', install_media=True),
+            call('module2', install_media=True),
+        ]
+        self.boot_image_task.set_static_modules.assert_called_once_with(
+            ['module1', 'module2'], install_media=True
         )
 
     @patch('kiwi.builder.install.Path.wipe')

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -980,6 +980,9 @@ class TestXMLState:
             'some-target'
 
     def test_get_installintrd_modules(self):
-        self.state.get_installinitrd_modules('add') == ['network-legacy']
-        self.state.get_installinitrd_modules('set') == []
-        self.state.get_installinitrd_modules('omit') == []
+        self.state.get_installmedia_initrd_modules('add') == ['network-legacy']
+        self.state.get_installmedia_initrd_modules('set') == []
+        self.state.get_installmedia_initrd_modules('omit') == []
+        xml_data = self.description.load()
+        state = XMLState(xml_data, ['vmxSimpleFlavour'], 'oem')
+        state.get_installmedia_initrd_modules('add') == []

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -978,3 +978,8 @@ class TestXMLState:
         mock_bootloader.return_value = [self.bootloader]
         assert self.state.get_build_type_bootloader_targettype() == \
             'some-target'
+
+    def test_get_installintrd_modules(self):
+        self.state.get_installinitrd_modules('add') == ['network-legacy']
+        self.state.get_installinitrd_modules('set') == []
+        self.state.get_installinitrd_modules('omit') == []


### PR DESCRIPTION
This commit makes the installation initrds to include only the
dracut modules that are required by kiwi installation process.

Fixes #1676
Fixes #1683
