### PR TITLE
Only write GRUB_CMDLINE_LINUX_DEFAULT with content

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -616,15 +616,18 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             'GRUB_GFXMODE': self.gfxmode,
             'GRUB_TERMINAL': '"{0}"'.format(self.terminal)
         }
+        grub_final_cmdline = re.sub(
+            r'root=.* |root=.*$', '', self.cmdline
+        ).strip()
         if self.displayname:
             grub_default_entries['GRUB_DISTRIBUTOR'] = '"{0}"'.format(
                 self.displayname
             )
         if self.timeout_style:
             grub_default_entries['GRUB_TIMEOUT_STYLE'] = self.timeout_style
-        if self.cmdline:
+        if grub_final_cmdline:
             grub_default_entries['GRUB_CMDLINE_LINUX_DEFAULT'] = '"{0}"'.format(
-                re.sub(r'root=.* |root=.*$', '', self.cmdline).strip()
+                grub_final_cmdline
             )
         if self.terminal and 'serial' in self.terminal and \
            self.serial_line_setup:

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -553,6 +553,45 @@ class TestBootLoaderConfigGrub2:
 
     @patch('os.path.exists')
     @patch('kiwi.bootloader.config.grub2.SysConfig')
+    @patch('kiwi.bootloader.config.grub2.Command.run')
+    def test_setup_default_grub_empty_kernelcmdline(
+        self, mock_Command_run, mock_sysconfig, mock_exists
+    ):
+        grep_grub_option = Mock()
+        grep_grub_option.returncode = 0
+        mock_Command_run.return_value = grep_grub_option
+        grub_default = MagicMock()
+        mock_sysconfig.return_value = grub_default
+        mock_exists.return_value = True
+        self.bootloader.terminal = 'serial'
+        self.bootloader.theme = 'openSUSE'
+        self.bootloader.displayname = 'Bob'
+        self.bootloader.cmdline = 'root=UUID=foo'
+
+        self.bootloader._setup_default_grub()
+
+        # Must not contain GRUB_CMDLINE_LINUX_DEFAULT
+        assert grub_default.__setitem__.call_args_list == [
+            call(
+                'GRUB_BACKGROUND',
+                '/boot/grub2/themes/openSUSE/background.png'
+            ),
+            call('GRUB_DISTRIBUTOR', '"Bob"'),
+            call('GRUB_ENABLE_BLSCFG', 'true'),
+            call('GRUB_ENABLE_CRYPTODISK', 'y'),
+            call('GRUB_GFXMODE', '800x600'),
+            call(
+                'GRUB_SERIAL_COMMAND', '"serial --speed=38400"'
+            ),
+            call('GRUB_TERMINAL', '"serial"'),
+            call('GRUB_THEME', '/boot/grub2/themes/openSUSE/theme.txt'),
+            call('GRUB_TIMEOUT', 10),
+            call('GRUB_TIMEOUT_STYLE', 'countdown'),
+            call('SUSE_BTRFS_SNAPSHOT_BOOTING', 'true')
+        ]
+
+    @patch('os.path.exists')
+    @patch('kiwi.bootloader.config.grub2.SysConfig')
     def test_setup_sysconfig_bootloader(self, mock_sysconfig, mock_exists):
         sysconfig_bootloader = MagicMock()
         mock_sysconfig.return_value = sysconfig_bootloader


### PR DESCRIPTION
Only write GRUB_CMDLINE_LINUX_DEFAULT in the grub defaults
file if there are custom options set via the kernelcmdline
attribute. This Fixes #1650


