### PR TITLE
Mark Micro DNF as a RPM based package manager

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1546,7 +1546,7 @@ class Defaults:
 
         :rtype: str
         """
-        rpm_based = ['zypper', 'yum', 'dnf']
+        rpm_based = ['zypper', 'yum', 'dnf', 'microdnf']
         deb_based = ['apt-get']
         if package_manager in rpm_based:
             return 'rpm'


### PR DESCRIPTION
Without doing this, KIWI won't generate the correct output files
for verification of image content.