### PR TITLE
Handle checksum files in ascii encoding

### DIFF
--- a/kiwi/utils/checksum.py
+++ b/kiwi/utils/checksum.py
@@ -127,7 +127,9 @@ class Checksum:
             blocks = self._block_list(
                 os.path.getsize(self.source_filename)
             )
-        with open(filename, 'w') as checksum_file:
+        with open(
+            filename, encoding=encodings.ascii, mode='w'
+        ) as checksum_file:
             if compressed_blocks:
                 checksum_file.write(
                     '%s %s %s %s %s\n' % (
@@ -151,7 +153,7 @@ class Checksum:
         :param int digest_blocks: Number of blocks processed at a time
         """
         chunk_size = digest_blocks * digest.block_size
-        with open(filename, 'rb') as source:
+        with open(filename, encoding=encodings.ascii, mode='rb') as source:
             for chunk in iter(lambda: source.read(chunk_size), b''):
                 digest.update(chunk)
         return digest.hexdigest()

--- a/test/unit/utils/checksum_test.py
+++ b/test/unit/utils/checksum_test.py
@@ -1,4 +1,5 @@
 from builtins import bytes
+import encodings.ascii
 from mock import (
     patch, call, Mock, mock_open
 )
@@ -42,7 +43,9 @@ class TestChecksum:
         with patch('builtins.open', self.m_open, create=True):
             assert self.checksum.matches('sum', 'some-file') is True
 
-        self.m_open.assert_called_once_with('some-file')
+        self.m_open.assert_called_once_with(
+            'some-file', encoding=encodings.ascii
+        )
 
         with patch('builtins.open', self.m_open, create=True):
             assert self.checksum.matches('foo', 'some-file') is False
@@ -75,9 +78,9 @@ class TestChecksum:
             self.checksum.md5('outfile')
 
         assert self.m_open.call_args_list == [
-            call('some-file', 'rb'),
-            call('some-file-uncompressed', 'rb'),
-            call('outfile', 'w')
+            call('some-file', encoding=encodings.ascii, mode='rb'),
+            call('some-file-uncompressed', encoding=encodings.ascii, mode='rb'),
+            call('outfile', encoding=encodings.ascii, mode='w')
         ]
         self.m_open.return_value.write.assert_called_once_with(
             'sum 163968 8192 163968 8192\n'
@@ -108,8 +111,8 @@ class TestChecksum:
             self.checksum.md5('outfile')
 
         assert self.m_open.call_args_list == [
-            call('some-file', 'rb'),
-            call('outfile', 'w')
+            call('some-file', encoding=encodings.ascii, mode='rb'),
+            call('outfile', encoding=encodings.ascii, mode='w')
         ]
         self.m_open.return_value.write.assert_called_once_with(
             'sum 163968 8192\n'
@@ -140,8 +143,8 @@ class TestChecksum:
             self.checksum.sha256('outfile')
 
         assert self.m_open.call_args_list == [
-            call('some-file', 'rb'),
-            call('outfile', 'w')
+            call('some-file', encoding=encodings.ascii, mode='rb'),
+            call('outfile', encoding=encodings.ascii, mode='w')
         ]
         self.m_open.return_value.write.assert_called_once_with(
             'sum 163968 8192\n'


### PR DESCRIPTION
Follow up fix for #1673. Handle reading/writing of all
supported checksum variants in ascii encoding

