### PR TITLE
Fixed use of encoding in open calls

### DIFF
--- a/kiwi/utils/checksum.py
+++ b/kiwi/utils/checksum.py
@@ -18,7 +18,7 @@
 import os
 from collections import namedtuple
 import hashlib
-import encodings.ascii
+import encodings.ascii as encoding
 
 # project
 from kiwi.command import Command
@@ -43,6 +43,7 @@ class Checksum:
             )
         self.source_filename = source_filename
         self.checksum_filename = None
+        self.ascii = encoding.getregentry().name
 
     def matches(self, checksum, filename):
         """
@@ -59,7 +60,7 @@ class Checksum:
         """
         if not os.path.exists(filename):
             return False
-        with open(filename, encoding=encodings.ascii) as checksum_file:
+        with open(filename, encoding=self.ascii) as checksum_file:
             checksum_from_file = checksum_file.read()
             # checksum is expected to be stored in the first field
             # separated by space, other information might contain
@@ -127,9 +128,7 @@ class Checksum:
             blocks = self._block_list(
                 os.path.getsize(self.source_filename)
             )
-        with open(
-            filename, encoding=encodings.ascii, mode='w'
-        ) as checksum_file:
+        with open(filename, encoding=self.ascii, mode='w') as checksum_file:
             if compressed_blocks:
                 checksum_file.write(
                     '%s %s %s %s %s\n' % (
@@ -153,7 +152,7 @@ class Checksum:
         :param int digest_blocks: Number of blocks processed at a time
         """
         chunk_size = digest_blocks * digest.block_size
-        with open(filename, encoding=encodings.ascii, mode='rb') as source:
+        with open(filename, 'rb') as source:
             for chunk in iter(lambda: source.read(chunk_size), b''):
                 digest.update(chunk)
         return digest.hexdigest()

--- a/test/unit/utils/checksum_test.py
+++ b/test/unit/utils/checksum_test.py
@@ -1,5 +1,5 @@
 from builtins import bytes
-import encodings.ascii
+import encodings.ascii as encoding
 from mock import (
     patch, call, Mock, mock_open
 )
@@ -13,6 +13,7 @@ from kiwi.exceptions import KiwiFileNotFound
 class TestChecksum:
     @patch('os.path.exists')
     def setup(self, mock_exists):
+        self.ascii = encoding.getregentry().name
         read_results = [bytes(b''), bytes(b'data'), bytes(b''), bytes(b'data')]
 
         def side_effect(arg):
@@ -44,7 +45,7 @@ class TestChecksum:
             assert self.checksum.matches('sum', 'some-file') is True
 
         self.m_open.assert_called_once_with(
-            'some-file', encoding=encodings.ascii
+            'some-file', encoding=self.ascii
         )
 
         with patch('builtins.open', self.m_open, create=True):
@@ -78,9 +79,9 @@ class TestChecksum:
             self.checksum.md5('outfile')
 
         assert self.m_open.call_args_list == [
-            call('some-file', encoding=encodings.ascii, mode='rb'),
-            call('some-file-uncompressed', encoding=encodings.ascii, mode='rb'),
-            call('outfile', encoding=encodings.ascii, mode='w')
+            call('some-file', 'rb'),
+            call('some-file-uncompressed', 'rb'),
+            call('outfile', encoding=self.ascii, mode='w')
         ]
         self.m_open.return_value.write.assert_called_once_with(
             'sum 163968 8192 163968 8192\n'
@@ -111,8 +112,8 @@ class TestChecksum:
             self.checksum.md5('outfile')
 
         assert self.m_open.call_args_list == [
-            call('some-file', encoding=encodings.ascii, mode='rb'),
-            call('outfile', encoding=encodings.ascii, mode='w')
+            call('some-file', 'rb'),
+            call('outfile', encoding=self.ascii, mode='w')
         ]
         self.m_open.return_value.write.assert_called_once_with(
             'sum 163968 8192\n'
@@ -143,8 +144,8 @@ class TestChecksum:
             self.checksum.sha256('outfile')
 
         assert self.m_open.call_args_list == [
-            call('some-file', encoding=encodings.ascii, mode='rb'),
-            call('outfile', encoding=encodings.ascii, mode='w')
+            call('some-file', 'rb'),
+            call('outfile', encoding=self.ascii, mode='w')
         ]
         self.m_open.return_value.write.assert_called_once_with(
             'sum 163968 8192\n'


### PR DESCRIPTION
The use of encodings.ascii in open calls was wrong. Open expects
an encoding string but encodings.ascii returns a module reference


