### PR TITLE
Explicitly set lvm device source

### DIFF
--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -58,6 +58,10 @@ class VolumeManagerLVM(VolumeManagerBase):
         else:
             self.mount_options = 'defaults'
 
+        self.lvm_tool_options = [
+            '--config', 'devices/external_device_info_source=none'
+        ]
+
     def get_device(self):
         """
         Dictionary of MappedDevice instances per volume
@@ -105,15 +109,22 @@ class VolumeManagerLVM(VolumeManagerBase):
             'Creating volume group %s', volume_group_name
         )
         Command.run(
-            command=['vgremove', '--force', volume_group_name],
-            raise_on_error=False
+            command=['vgremove'] + self.lvm_tool_options + [
+                '--force', volume_group_name
+            ], raise_on_error=False
         )
-        Command.run(['pvcreate', self.device])
-        Command.run(['vgcreate', volume_group_name, self.device])
+        Command.run(
+            ['pvcreate'] + self.lvm_tool_options + [self.device]
+        )
+        Command.run(
+            ['vgcreate'] + self.lvm_tool_options + [
+                volume_group_name, self.device
+            ]
+        )
         self.volume_group = volume_group_name
 
     @staticmethod
-    def _create_volume_no_zero(lvcreate_args):
+    def _create_volume_no_zero(lvm_tool_options, lvcreate_args):
         """
         Create an LV using specified arguments to lvcreate
 
@@ -135,13 +146,13 @@ class VolumeManagerLVM(VolumeManagerBase):
             '--> running "lvcreate -Zn %s"', " ".join(lvcreate_args)
         )
         Command.run(
-            ['lvcreate', '-Zn'] + lvcreate_args
+            ['lvcreate'] + lvm_tool_options + ['-Zn'] + lvcreate_args
         )
         log.debug(
             '--> running "vgscan --mknodes" to create missing nodes'
         )
         Command.run(
-            ['vgscan', '--mknodes']
+            ['vgscan'] + lvm_tool_options + ['--mknodes']
         )
 
     def create_volumes(self, filesystem_name):
@@ -167,7 +178,7 @@ class VolumeManagerLVM(VolumeManagerBase):
                 '--> volume %s with %s MB', volume.name, volume_mbsize
             )
             self._create_volume_no_zero(
-                [
+                self.lvm_tool_options, [
                     '-L', format(volume_mbsize), '-n',
                     volume.name, self.volume_group
                 ]
@@ -188,7 +199,7 @@ class VolumeManagerLVM(VolumeManagerBase):
             full_size_volume = canonical_volume_list.full_size_volume
             log.info('--> fullsize volume %s', full_size_volume.name)
             self._create_volume_no_zero(
-                [
+                self.lvm_tool_options, [
                     '-l', '+100%FREE', '-n',
                     full_size_volume.name, self.volume_group
                 ]
@@ -359,7 +370,11 @@ class VolumeManagerLVM(VolumeManagerBase):
             if self.umount_volumes():
                 Path.wipe(self.mountpoint)
                 try:
-                    Command.run(['vgchange', '-an', self.volume_group])
+                    Command.run(
+                        ['vgchange'] + self.lvm_tool_options + [
+                            '-an', self.volume_group
+                        ]
+                    )
                 except Exception:
                     log.warning(
                         'volume group %s still busy', self.volume_group

--- a/test/unit/volume_manager/lvm_test.py
+++ b/test/unit/volume_manager/lvm_test.py
@@ -115,25 +115,27 @@ class TestVolumeManagerLVM:
         mock_command.return_value = command
         self.volume_manager.setup('volume_group')
         call = mock_command.call_args_list[0]
-        assert mock_command.call_args_list[0] == \
-            call([
-                'vgs', '--noheadings', '--select', 'vg_name=volume_group'
-            ])
+        assert mock_command.call_args_list[0] == call(
+            ['vgs', '--noheadings', '--select', 'vg_name=volume_group']
+        )
         call = mock_command.call_args_list[1]
-        assert mock_command.call_args_list[1] == \
-            call(
-                command=['vgremove', '--force', 'volume_group'],
-                raise_on_error=False)
+        assert mock_command.call_args_list[1] == call(
+            command=['vgremove'] + self.volume_manager.lvm_tool_options + [
+                '--force', 'volume_group'
+            ], raise_on_error=False
+        )
         call = mock_command.call_args_list[2]
-        assert mock_command.call_args_list[2] == \
-            call([
-                'pvcreate', '/dev/storage'
-            ])
+        assert mock_command.call_args_list[2] == call(
+            ['pvcreate'] + self.volume_manager.lvm_tool_options + [
+                '/dev/storage'
+            ]
+        )
         call = mock_command.call_args_list[3]
-        assert mock_command.call_args_list[3] == \
-            call([
-                'vgcreate', 'volume_group', '/dev/storage'
-            ])
+        assert mock_command.call_args_list[3] == call(
+            ['vgcreate'] + self.volume_manager.lvm_tool_options + [
+                'volume_group', '/dev/storage'
+            ]
+        )
         assert self.volume_manager.volume_group == 'volume_group'
         self.volume_manager.volume_group = None
 
@@ -217,49 +219,57 @@ class TestVolumeManagerLVM:
         ]
         assert mock_command.call_args_list == [
             call(
-                [
-                    'lvcreate', '-Zn', '-L', '100', '-n', 'LVSwap',
+                ['lvcreate'] + self.volume_manager.lvm_tool_options + [
+                    '-Zn', '-L', '100', '-n', 'LVSwap', 'volume_group'
+                ]
+            ),
+            call(
+                ['vgscan'] + self.volume_manager.lvm_tool_options + [
+                    '--mknodes'
+                ]
+            ),
+            call(
+                ['lvcreate'] + self.volume_manager.lvm_tool_options + [
+                    '-Zn', '-L', format(root_size), '-n', 'LVRoot',
                     'volume_group'
                 ]
             ),
             call(
-                ['vgscan', '--mknodes']
+                ['vgscan'] + self.volume_manager.lvm_tool_options + [
+                    '--mknodes'
+                ]
             ),
             call(
-                [
-                    'lvcreate', '-Zn', '-L', format(root_size), '-n', 'LVRoot',
+                ['lvcreate'] + self.volume_manager.lvm_tool_options + [
+                    '-Zn', '-L', format(myvol_size), '-n', 'myvol',
                     'volume_group'
                 ]
             ),
             call(
-                ['vgscan', '--mknodes']
+                ['vgscan'] + self.volume_manager.lvm_tool_options + [
+                    '--mknodes'
+                ]
             ),
             call(
-                [
-                    'lvcreate', '-Zn', '-L', format(myvol_size), '-n', 'myvol',
+                ['lvcreate'] + self.volume_manager.lvm_tool_options + [
+                    '-Zn', '-L', format(etc_size), '-n', 'LVetc',
                     'volume_group'
                 ]
             ),
             call(
-                ['vgscan', '--mknodes']
-            ),
-            call(
-                [
-                    'lvcreate', '-Zn', '-L', format(etc_size), '-n', 'LVetc',
-                    'volume_group'
+                ['vgscan'] + self.volume_manager.lvm_tool_options + [
+                    '--mknodes'
                 ]
             ),
             call(
-                ['vgscan', '--mknodes']
-            ),
-            call(
-                [
-                    'lvcreate', '-Zn', '-l', '+100%FREE', '-n', 'LVhome',
-                    'volume_group'
+                ['lvcreate'] + self.volume_manager.lvm_tool_options + [
+                    '-Zn', '-l', '+100%FREE', '-n', 'LVhome', 'volume_group'
                 ]
             ),
             call(
-                ['vgscan', '--mknodes']
+                ['vgscan'] + self.volume_manager.lvm_tool_options + [
+                    '--mknodes'
+                ]
             )
         ]
         assert mock_fs.call_args_list == [
@@ -367,6 +377,8 @@ class TestVolumeManagerLVM:
             mock_umount_volumes.assert_called_once_with()
             mock_wipe.assert_called_once_with('tmpdir')
             mock_command.assert_called_once_with(
-                ['vgchange', '-an', 'volume_group']
+                ['vgchange'] + self.volume_manager.lvm_tool_options + [
+                    '-an', 'volume_group'
+                ]
             )
             self.volume_manager.volume_group = None


### PR DESCRIPTION
Set external_device_info_source=none for pvcreate call
This is related to Issue #1665

