### PR TITLE
Include missing qemu-tools dependency for iso images

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -156,6 +156,15 @@ Requires:       xorriso
 %ifarch %{ix86} x86_64
 Requires:       syslinux
 %endif
+%if "%{_vendor}" == "debbuild"
+Requires:       qemu-utils
+%else
+%if 0%{?suse_version}
+Requires:       qemu-tools
+%else
+Requires:       qemu-img
+%endif
+%endif
 Requires:       kiwi-systemdeps-core = %{version}-%{release}
 Requires:       kiwi-systemdeps-filesystems = %{version}-%{release}
 Requires:       kiwi-systemdeps-bootloaders = %{version}-%{release}


### PR DESCRIPTION
This commit includes a missing qemu-tools dependency for iso
image type.
