### PR TITLE
Added strong typing for the following API methods

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1536,6 +1536,18 @@ class Defaults:
         return 'macros.kiwi-image-config'
 
     @staticmethod
+    def get_default_package_manager() -> str:
+        """
+        Returns the default package manager name if none
+        is configured in the image description
+
+        :return: package manager name
+
+        :rtype: str
+        """
+        return 'dnf'
+
+    @staticmethod
     def get_default_packager_tool(package_manager):
         """
         Provides the packager tool according to the package manager

--- a/kiwi/logger_color_formatter.py
+++ b/kiwi/logger_color_formatter.py
@@ -109,10 +109,6 @@ class ColorFormatter(logging.Formatter):
 
         ColorFormatter(message_format, '%H:%M:%S')
     """
-    def __init__(self, *args: str, **kwargs: str):
-        # can't do super(...) here because Formatter is an old school class
-        logging.Formatter.__init__(self, *args, **kwargs)
-
     def format(self, record: logging.LogRecord) -> str:
         """
         Creates a logging Formatter with support for color messages

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -796,22 +796,11 @@ class RuntimeChecker:
                     message_tool_not_found.format(name=tool)
                 )
 
-    def check_minimal_required_preferences(self):
+    def check_image_version_provided(self):
         """
-        Kiwi requires some of the elements of the `preferences` element
-        to be present at least in one of the preferences section. This
-        runtime check validates <version> and <packagemanager> are
-        provided.
+        Kiwi requires a <version> element to be specified as part
+        of at least one <preferences> section.
         """
-        message_missing_package_manager = dedent('''\n
-            No package manager is defined in any of the <preferences>
-            sections. Please add
-
-                <packagemanager>desired_package_manager<packagemanager/>
-
-            inside the <preferences> section.
-        ''')
-
         message_missing_version = dedent('''\n
             No version is defined in any of the <preferences>
             sections. Please add
@@ -820,9 +809,6 @@ class RuntimeChecker:
 
             inside the <preferences> section.
         ''')
-
-        if not self.xml_state.get_package_manager():
-            raise KiwiRuntimeError(message_missing_package_manager)
 
         if not self.xml_state.get_image_version():
             raise KiwiRuntimeError(message_missing_version)

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -17,14 +17,19 @@
 #
 import os
 import logging
+from typing import (
+    List, Any
+)
 from textwrap import dedent
 
 # project
+from kiwi.xml_state import XMLState
 from kiwi.system.root_init import RootInit
 from kiwi.system.root_import import RootImport
 from kiwi.system.root_bind import RootBind
 from kiwi.repository import Repository
 from kiwi.package_manager import PackageManager
+from kiwi.package_manager.base import PackageManagerBase
 from kiwi.command_process import CommandProcess
 from kiwi.system.uri import Uri
 from kiwi.archive.tar import ArchiveTar
@@ -38,7 +43,7 @@ from kiwi.exceptions import (
     KiwiPackagesDeletePhaseFailed
 )
 
-log = logging.getLogger('kiwi')
+log: Any = logging.getLogger('kiwi')
 
 
 class SystemPrepare:
@@ -46,12 +51,11 @@ class SystemPrepare:
     Implements preparation and installation of a new root system
 
     :param object xml_state: instance of :class:`XMLState`
-    :param list profiles: list of configured profiles
-    :param object root_bind: instance of :class:`RootBind`
-    :param list uri_list: a list of Uri references
+    :param str root_dir: Path to new root directory
+    :param bool allow_existing: Allow using an existing root_dir
     """
     def __init__(
-        self, xml_state, root_dir, allow_existing=False
+        self, xml_state: XMLState, root_dir: str, allow_existing: bool = False
     ):
         """
         Setup and host bind new root system at given root_dir directory
@@ -94,18 +98,21 @@ class SystemPrepare:
         # in order to delay the Uri destructors until the System instance
         # dies. This is needed to keep bind mounted Uri locations alive
         # for System operations
-        self.uri_list = []
+        self.uri_list: List[Uri] = []
 
-    def setup_repositories(self, clear_cache=False, signing_keys=None):
+    def setup_repositories(
+        self, clear_cache: bool = False, signing_keys: List[str] = None
+    ) -> PackageManagerBase:
         """
         Set up repositories for software installation and return a
         package manager for performing software installation tasks
 
-        :param bool clear_cache: flag the clear cache before configure
-            anything
-        :param list signing_keys: keys imported to the package manager
+        :param bool clear_cache:
+            Flag the clear cache before configure anything
+        :param list signing_keys:
+            Keys imported to the package manager
 
-        :return: instance of :class:`PackageManager`
+        :return: instance of :class:`PackageManager` subclass
 
         :rtype: PackageManager
         """
@@ -183,7 +190,9 @@ class SystemPrepare:
             repo, package_manager
         )
 
-    def install_bootstrap(self, manager, plus_packages=None):
+    def install_bootstrap(
+        self, manager: PackageManagerBase, plus_packages: List = None
+    ) -> None:
         """
         Install system software using the package manager
         from the host, also known as bootstrapping
@@ -191,8 +200,9 @@ class SystemPrepare:
         :param object manager: instance of a :class:`PackageManager` subclass
         :param list plus_packages: list of additional packages
 
-        :raises KiwiBootStrapPhaseFailed: if the bootstrapping process fails
-            either installing packages or including bootstrap archives
+        :raises KiwiBootStrapPhaseFailed:
+            if the bootstrapping process fails either installing
+            packages or including bootstrap archives
         """
         if not self.xml_state.get_bootstrap_packages_sections() \
            and not plus_packages:
@@ -252,7 +262,7 @@ class SystemPrepare:
                     )
                 )
 
-    def install_system(self, manager):
+    def install_system(self, manager: PackageManagerBase) -> None:
         """
         Install system software using the package manager inside
         of the new root directory. This is done via a chroot operation
@@ -261,8 +271,9 @@ class SystemPrepare:
 
         :param object manager: instance of a :class:`PackageManager` subclass
 
-        :raises KiwiInstallPhaseFailed: if the install process fails
-            either installing packages or including any archive
+        :raises KiwiInstallPhaseFailed:
+            if the install process fails either installing
+            packages or including any archive
         """
         log.info(
             'Installing system (chroot) for build type: %s',
@@ -318,18 +329,20 @@ class SystemPrepare:
                     )
                 )
 
-    def pinch_system(self, manager=None, force=False):
+    def pinch_system(
+        self, manager: PackageManagerBase = None, force: bool = False
+    ) -> None:
         """
         Delete packages marked for deletion in the XML description. If force
         param is set to False uninstalls packages marked with
         `type="uninstall"` if any; if force is set to True deletes packages
         marked with `type="delete"` if any.
 
-        :param object manager: instance of :class:`PackageManager`
+        :param object manager: instance of :class:`PackageManager` subclass
         :param bool force: Forced deletion True|False
 
-        :raises KiwiPackagesDeletePhaseFailed: if the deletion packages
-            process fails
+        :raises KiwiPackagesDeletePhaseFailed:
+            if the deletion packages process fails
         """
         to_become_deleted_packages = \
             self.xml_state.get_to_become_deleted_packages(force)
@@ -357,7 +370,9 @@ class SystemPrepare:
                     )
                 )
 
-    def install_packages(self, manager, packages):
+    def install_packages(
+        self, manager: PackageManagerBase, packages: List
+    ) -> None:
         """
         Install one or more packages using the package manager inside
         of the new root directory
@@ -390,7 +405,9 @@ class SystemPrepare:
                     )
                 )
 
-    def delete_packages(self, manager, packages, force=False):
+    def delete_packages(
+        self, manager: PackageManagerBase, packages: List, force: bool = False
+    ) -> None:
         """
         Delete one or more packages using the package manager inside
         of the new root directory. If the removal is set with `force` flag
@@ -431,7 +448,7 @@ class SystemPrepare:
                     )
                 )
 
-    def update_system(self, manager):
+    def update_system(self, manager: PackageManagerBase) -> None:
         """
         Install package updates from the used repositories.
         the process uses the package manager from inside of the
@@ -455,7 +472,7 @@ class SystemPrepare:
                 )
             )
 
-    def clean_package_manager_leftovers(self):
+    def clean_package_manager_leftovers(self) -> None:
         """
         This methods cleans some package manager artifacts created
         at run time such as macros

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -18,9 +18,11 @@
 import os
 import logging
 import collections
+from typing import Dict
 from tempfile import NamedTemporaryFile
 
 # project
+from kiwi.xml_state import XMLState
 from kiwi.system.shell import Shell
 from kiwi.defaults import Defaults
 
@@ -29,17 +31,13 @@ log = logging.getLogger('kiwi')
 
 class Profile:
     """
-    **Create bash readable .profile environment from the XML
-    description**
-
-    The information is used by the kiwi first boot code.
+    **Create bash readable .profile environment from the XML description**
 
     :param object xml_state: instance of :class`XMLState`
-    :param dict dot_profile: profile dictionary
     """
-    def __init__(self, xml_state):
+    def __init__(self, xml_state: XMLState):
         self.xml_state = xml_state
-        self.dot_profile = {}
+        self.dot_profile: Dict = {}
 
         self._image_names_to_profile()
         self._profile_names_to_profile()
@@ -53,7 +51,7 @@ class Profile:
         self._drivers_to_profile()
         self._root_partition_uuid_to_profile()
 
-    def get_settings(self):
+    def get_settings(self) -> Dict:
         """
         Return all profile elements that has a value
         """
@@ -64,7 +62,7 @@ class Profile:
             sorted(profile.items())
         )
 
-    def add(self, key, value):
+    def add(self, key: str, value: str) -> None:
         """
         Add key/value pair to profile dictionary
 
@@ -73,11 +71,11 @@ class Profile:
         """
         self.dot_profile[key] = value
 
-    def delete(self, key):
+    def delete(self, key: str) -> None:
         if key in self.dot_profile:
             del self.dot_profile[key]
 
-    def create(self, filename):
+    def create(self, filename: str) -> None:
         """
         Create bash quoted profile
 

--- a/kiwi/system/root_import/__init__.py
+++ b/kiwi/system/root_import/__init__.py
@@ -23,6 +23,7 @@ from abc import (
 )
 
 # project
+from kiwi.system.uri import Uri
 from kiwi.exceptions import KiwiRootImportError
 
 log = logging.getLogger('kiwi')
@@ -38,7 +39,7 @@ class RootImport(metaclass=ABCMeta):
         root directory path name
 
     * :attr:`image_uri`
-        a uri to an image containing a the root system
+        an instance of :class:`Uri` to an image containing a the root system
 
     * :attr:`image_type`
         type of the image to import
@@ -47,7 +48,8 @@ class RootImport(metaclass=ABCMeta):
     def __init__(self) -> None:
         return None  # pragma: no cover
 
-    def new(root_dir: str, image_uri: str, image_type: str):
+    @staticmethod
+    def new(root_dir: str, image_uri: Uri, image_type: str):
         name_map = {
             'docker': 'OCI',
             'oci': 'OCI'

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -71,7 +71,7 @@ class CliTask:
 
         # initialize generic runtime check dicts
         self.checks_before_command_args = {
-            'check_minimal_required_preferences': [],
+            'check_image_version_provided': [],
             'check_efi_mode_for_disk_overlay_correctly_setup': [],
             'check_initrd_selection_required': [],
             'check_boot_description_exists': [],

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -267,7 +267,7 @@ class XMLState:
                 return check_signatures[0]
         return False
 
-    def get_package_manager(self) -> Optional[str]:
+    def get_package_manager(self) -> str:
         """
         Get configured package manager from selected preferences section
 
@@ -279,7 +279,7 @@ class XMLState:
             package_manager = preferences.get_packagemanager()
             if package_manager:
                 return package_manager[0]
-        return None
+        return Defaults.get_default_package_manager()
 
     def get_packages_sections(self, section_types: List) -> List:
         """

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -310,15 +310,7 @@ class TestRuntimeChecker:
         )
         runtime_checker = RuntimeChecker(xml_state)
         with raises(KiwiRuntimeError):
-            runtime_checker.check_minimal_required_preferences()
-
-    def test_check_preferences_data_no_packagemanager(self):
-        xml_state = XMLState(
-            self.description.load(), ['xenDom0Flavour'], 'oem'
-        )
-        runtime_checker = RuntimeChecker(xml_state)
-        with raises(KiwiRuntimeError):
-            runtime_checker.check_minimal_required_preferences()
+            runtime_checker.check_image_version_provided()
 
     @patch('platform.machine')
     def test_check_architecture_supports_iso_firmware_setup(

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -954,6 +954,24 @@ class TestSystemSetup:
             options=['-a']
         )
 
+    @patch('kiwi.defaults.Defaults.get_default_packager_tool')
+    def test_export_package_list_unknown_packager(
+        self, mock_get_default_packager_tool
+    ):
+        assert self.setup.export_package_list('target_dir') is None
+
+    @patch('kiwi.defaults.Defaults.get_default_packager_tool')
+    def test_export_package_changes_unknown_packager(
+        self, mock_get_default_packager_tool
+    ):
+        assert self.setup.export_package_changes('target_dir') is None
+
+    @patch('kiwi.defaults.Defaults.get_default_packager_tool')
+    def test_export_package_verification_unknown_packager(
+        self, mock_get_default_packager_tool
+    ):
+        assert self.setup.export_package_verification('target_dir') is None
+
     @patch('kiwi.system.setup.Command.run')
     @patch('kiwi.system.setup.RpmDataBase')
     @patch('kiwi.system.setup.MountManager')

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -97,6 +97,11 @@ class TestXMLState:
     def test_get_package_manager(self):
         assert self.state.get_package_manager() == 'zypper'
 
+    @patch('kiwi.xml_state.XMLState.get_preferences_sections')
+    def test_get_default_package_manager(self, mock_preferences):
+        mock_preferences.return_value = []
+        assert self.state.get_package_manager() == 'dnf'
+
     def test_get_image_version(self):
         assert self.state.get_image_version() == '1.13.2'
 


### PR DESCRIPTION
* kiwi/system/prepare.py
* kiwi/system/profile.py
* kiwi/system/setup.py

The changes here also lead to a small refactoring for the handling
of the package manager. In my opinion it doesn't make sense to allow
a None type package manager from the stateful XML instance. As without
any package manager nothing can be done. As it also turns into an
issue for the PackageManager API which does not allow for an empty
value here I thought it's better to come up with a default package
manager (set to dnf) if no one is explicitly specified

This references Issue #1644


