### PR TITLE
Fixed creation of custom bios grub image

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -854,6 +854,11 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         self._create_early_boot_script_for_mbrid_search(
             early_boot_script, mbrid
         )
+        shutil.copy(
+            early_boot_script, os.sep.join(
+                [self.root_dir, 'boot', self.boot_directory_name]
+            )
+        )
         mkimage_call = Command.run(
             [
                 'chroot', self.root_dir,
@@ -861,14 +866,12 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                     self._get_grub2_mkimage_tool()
                 ) or 'grub2-mkimage',
                 '-O', Defaults.get_bios_module_directory_name(),
-                '-o', self._get_bios_image_name(
-                    lookup_path
-                ).replace(self.boot_dir, ''),
+                '-o', self._get_bios_image_name(os.sep),
                 '-c', early_boot_script.replace(self.boot_dir, ''),
-                '-p', self.get_boot_path() + '/' + self.boot_directory_name,
-                '-d', self._get_bios_modules_path(
-                    lookup_path
-                ).replace(self.boot_dir, '')
+                '-p', os.sep.join(
+                    [self.get_boot_path(), self.boot_directory_name]
+                ),
+                '-d', self._get_bios_modules_path(os.sep)
             ] + Defaults.get_grub_bios_modules(multiboot=self.xen_guest)
         )
         log.debug(mkimage_call.output)

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -558,8 +558,8 @@ class Defaults:
         lookup_list = []
         for grub_name in ['grub2', 'grub']:
             for install_dir in install_dirs:
-                grub_path = os.sep.join(
-                    [root_path, install_dir, grub_name, filename]
+                grub_path = os.path.join(
+                    root_path, install_dir, grub_name, filename
                 )
                 if os.path.exists(grub_path):
                     return grub_path

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -144,8 +144,9 @@ class TestBootLoaderConfigGrub2:
     @patch('kiwi.bootloader.config.grub2.Path.which')
     @patch('os.path.exists')
     @patch('platform.machine')
+    @patch('shutil.copy')
     def test_setup_install_boot_images_raises_no_efigrub(
-        self, mock_machine, mock_exists, mock_Path_which,
+        self, mock_shutil_copy, mock_machine, mock_exists, mock_Path_which,
         mock_sync, mock_command, mock_grub, mock_shim
     ):
         self.firmware.efi_mode = Mock(
@@ -162,6 +163,7 @@ class TestBootLoaderConfigGrub2:
         self.os_exists['root_dir/usr/lib/grub/themes/some-theme'] = False
         self.os_exists['root_dir/boot/grub2/themes/some-theme'] = False
         self.os_exists['root_dir/usr/share/grub2/i386-pc'] = True
+        self.os_exists['/usr/share/grub2/i386-pc'] = True
         self.os_exists['root_dir/usr/share/grub2/x86_64-efi'] = True
         self.os_exists['root_dir/usr/share/grub2/unicode.pf2'] = True
 
@@ -1430,9 +1432,10 @@ class TestBootLoaderConfigGrub2:
     @patch('kiwi.bootloader.config.grub2.DataSync')
     @patch('os.path.exists')
     @patch('platform.machine')
+    @patch('shutil.copy')
     def test_setup_install_boot_images_efi(
-        self, mock_machine, mock_exists, mock_sync, mock_Path_which,
-        mock_command, mock_get_grub_bios_core_loader,
+        self, mock_shutil_copy, mock_machine, mock_exists, mock_sync,
+        mock_Path_which, mock_command, mock_get_grub_bios_core_loader,
         mock_get_unsigned_grub_loader, mock_get_boot_path
     ):
         mock_Path_which.return_value = '/path/to/grub2-mkimage'
@@ -1448,6 +1451,7 @@ class TestBootLoaderConfigGrub2:
         self.os_exists['root_dir/boot/grub2/fonts/unicode.pf2'] = False
         self.os_exists['root_dir/usr/share/grub2/unicode.pf2'] = True
         self.os_exists['root_dir/usr/share/grub2/i386-pc'] = True
+        self.os_exists['/usr/share/grub2/i386-pc'] = True
         self.os_exists['root_dir/usr/share/grub2/x86_64-efi'] = True
         self.os_exists['root_dir/usr/share/grub2/x86_64-efi/linuxefi.mod'] = \
             True
@@ -1783,8 +1787,9 @@ class TestBootLoaderConfigGrub2:
     @patch('os.path.exists')
     @patch('platform.machine')
     @patch('kiwi.defaults.Defaults.get_grub_path')
+    @patch('shutil.copy')
     def test_setup_install_boot_images_with_theme_not_existing(
-        self, mock_get_grub_path, mock_machine,
+        self, mock_shutil_copy, mock_get_grub_path, mock_machine,
         mock_exists, mock_sync, mock_Path_which, mock_command
     ):
         mock_Path_which.return_value = '/path/to/grub2-mkimage'


### PR DESCRIPTION
The last commit moved the grub mkimage call into the chroot.
As a side effect and when creating install media the earlyboot
script could no longer be found. This commit fixes it

