### PR TITLE
Update MicroOS build test

### DIFF
--- a/build-tests/x86/suse/test-image-MicroOS/appliance.kiwi
+++ b/build-tests/x86/suse/test-image-MicroOS/appliance.kiwi
@@ -7,16 +7,12 @@
         <specification>MicroOS disk test build</specification>
     </description>
     <preferences>
-        <version>1.42.1</version>
+        <version>16.0.0</version>
         <packagemanager>zypper</packagemanager>
-        <locale>en_US</locale>
-        <keytable>us</keytable>
-        <timezone>Europe/Berlin</timezone>
-        <rpm-excludedocs>true</rpm-excludedocs>
-        <rpm-check-signatures>false</rpm-check-signatures>
-        <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" format="qcow2" firmware="uefi" kernelcmdline="plymouth.enable=0 console=ttyS0 net.ifnames=0 swapaccount=1" bootpartition="false" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true" btrfs_quota_groups="false" spare_part="5G" spare_part_mountpoint="/var" spare_part_fs="ext4" spare_part_is_last="true">
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <locale>en_US</locale>
+        <type image="oem" filesystem="btrfs" firmware="uefi" installiso="true" kernelcmdline="quiet systemd.show_status=yes console=ttyS0,115200 console=tty0 net.ifnames=0 \$ignition_firstboot ignition.platform.id=qemu" bootpartition="false" bootkernel="custom" devicepersistency="by-uuid" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true" btrfs_quota_groups="true" format="qcow2" spare_part="5G" spare_part_mountpoint="/var" spare_part_fs="btrfs" spare_part_is_last="true" spare_part_fs_attributes="no-copy-on-write">
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
@@ -29,9 +25,16 @@
                 <volume name="srv"/>
                 <volume name="boot/grub2/i386-pc"/>
                 <volume name="boot/grub2/x86_64-efi" mountpoint="boot/grub2/x86_64-efi"/>
+                <volume name="boot/writable"/>
                 <volume name="usr/local"/>
             </systemdisk>
-            <size unit="G">24</size>
+            <size unit="G">20</size>
+            <installmedia>
+                <initrd action="omit">
+                    <dracut module="combustion"/>
+                    <dracut module="ignition"/>
+                </initrd>
+            </installmedia>
         </type>
     </preferences>
     <users>
@@ -41,40 +44,27 @@
         <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
-        <package name="patterns-base-minimal_base"/>
-        <package name="bind-utils"/>
-        <package name="systemd"/>
-        <package name="plymouth-theme-bgrt"/>
-        <package name="grub2-branding-openSUSE"/>
-        <package name="iputils"/>
-        <package name="vim"/>
-        <package name="grub2"/>
-        <package name="grub2-x86_64-efi" arch="x86_64"/>
-        <package name="grub2-i386-pc"/>
-        <package name="syslinux"/>
-        <package name="lvm2"/>
-        <package name="plymouth"/>
-        <package name="fontconfig"/>
-        <package name="fonts-config"/>
-        <package name="tar"/>
-        <package name="parted"/>
-        <package name="openssh"/>
-        <package name="iproute2"/>
-        <package name="less"/>
-        <package name="bash-completion"/>
-        <package name="dhcp-client"/>
-        <package name="which"/>
+        <package name="live-add-yast-repos"/>
+        <package name="patterns-microos-basesystem"/>
+        <package name="patterns-base-bootloader"/>
+        <package name="patterns-microos-defaults"/>
         <package name="kernel-default"/>
-        <package name="shim"/>
-        <package name="timezone"/>
-        <package name="read-only-root-fs"/>
+        <package name="ignition-dracut"/>
+        <package name="combustion"/>
+        <package name="growpart-generator"/>
+        <package name="xen-tools-domU" arch="x86_64"/>
+        <package name="qemu-guest-agent"/>
+        <package name="dracut-kiwi-oem-repart"/>
+        <package name="dracut-kiwi-oem-dump"/>
     </packages>
     <packages type="bootstrap">
-        <package name="udev"/>
+        <package name="coreutils"/>
+        <package name="gzip"/>
+        <package name="gawk"/>
+        <package name="openssl"/>
         <package name="filesystem"/>
-        <package name="glibc-locale"/>
-        <package name="cracklib-dict-full"/>
-        <package name="ca-certificates"/>
-        <package name="openSUSE-release"/>
+        <package name="glibc-locale-base"/>
+        <package name="ca-certificates-mozilla"/>
+        <package name="MicroOS-release-dvd"/>
     </packages>
 </image>

--- a/build-tests/x86/suse/test-image-MicroOS/config.sh
+++ b/build-tests/x86/suse/test-image-MicroOS/config.sh
@@ -21,32 +21,87 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-#======================================
-# Greeting...
-#--------------------------------------
-echo "Configure image: [$kiwi_iname]..."
+set -euxo pipefail
+
+echo "Configure image: [$kiwi_iname]-[$kiwi_profiles]..."
+
+# Systemd controls the console font now
+echo FONT="eurlatgr.psfu" >> /etc/vconsole.conf
 
 #======================================
-# Setup baseproduct link
+# prepare for setting root pw, timezone
 #--------------------------------------
-suseSetupProduct
+echo "** reset machine settings"
+rm -f /etc/machine-id \
+      /var/lib/zypp/AnonymousUniqueId \
+      /var/lib/systemd/random-seed \
+      /var/lib/dbus/machine-id
 
 #======================================
-# Install overlay systemd mount props
+# Specify default systemd target
 #--------------------------------------
-cp /usr/sbin/setup-fstab-for-overlayfs /etc/fstab.script
+baseSetRunlevel multi-user.target
 
 #======================================
-# Activate services
+# Import trusted rpm keys
 #--------------------------------------
-suseInsertService sshd
+suseImportBuildKey
 
 #======================================
-# Setup default target, multi-user
+# Set hostname by DHCP
 #--------------------------------------
-baseSetRunlevel 3
+baseUpdateSysConfig /etc/sysconfig/network/dhcp DHCLIENT_SET_HOSTNAME yes
 
 #======================================
-# SuSEconfig
+# Enable DHCP on eth0
 #--------------------------------------
-suseConfig
+cat >/etc/sysconfig/network/ifcfg-eth0 <<EOF
+BOOTPROTO='dhcp'
+STARTMODE='auto'
+EOF
+
+# Add repos from /etc/YaST2/control.xml
+if [ -x /usr/sbin/add-yast-repos ]; then
+	add-yast-repos
+	zypper --non-interactive rm -u live-add-yast-repos
+fi
+
+# Adjust zypp conf
+sed -i 's/^multiversion =.*/multiversion =/g' /etc/zypp/zypp.conf
+
+#=====================================
+# Configure snapper
+#-------------------------------------
+if [ "${kiwi_btrfs_root_is_snapshot-false}" = 'true' ]; then
+        echo "creating initial snapper config ..."
+        cp /etc/snapper/config-templates/default /etc/snapper/configs/root
+        baseUpdateSysConfig /etc/sysconfig/snapper SNAPPER_CONFIGS root
+
+	# Adjust parameters
+	sed -i'' 's/^TIMELINE_CREATE=.*$/TIMELINE_CREATE="no"/g' /etc/snapper/configs/root
+	sed -i'' 's/^NUMBER_LIMIT=.*$/NUMBER_LIMIT="2-10"/g' /etc/snapper/configs/root
+	sed -i'' 's/^NUMBER_LIMIT_IMPORTANT=.*$/NUMBER_LIMIT_IMPORTANT="4-10"/g' /etc/snapper/configs/root
+fi
+
+#=====================================
+# Enable chrony if installed
+#-------------------------------------
+if [ -f /etc/chrony.conf ]; then
+	systemctl enable chronyd
+fi
+
+
+# To make x-systemd.growfs work from inside the initrd
+cat >/etc/dracut.conf.d/50-microos-growfs.conf <<"EOF"
+install_items+=" /usr/lib/systemd/systemd-growfs "
+EOF
+
+#======================================
+# Disable recommends on virtual images
+#--------------------------------------
+sed -i 's/.*solver.onlyRequires.*/solver.onlyRequires = true/g' /etc/zypp/zypp.conf
+
+#======================================
+# Disable installing documentation
+#--------------------------------------
+sed -i 's/.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/g' /etc/zypp/zypp.conf

--- a/build-tests/x86/suse/test-image-MicroOS/root/etc/fstab.script
+++ b/build-tests/x86/suse/test-image-MicroOS/root/etc/fstab.script
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eux
+
+/usr/sbin/setup-fstab-for-overlayfs
+# If /var is on a different partition than /...
+if [ "$(findmnt -snT / -o SOURCE)" != "$(findmnt -snT /var -o SOURCE)" ]; then
+    # ... set options for autoexpanding /var
+    gawk -i inplace '$2 == "/var" { $4 = $4",x-growpart.grow,x-systemd.growfs" } { print $0 }' /etc/fstab
+fi


### PR DESCRIPTION
This commit alignes the MicroOS tests with the MicroOS images build
for kvm and xen. In addition it adds the installation media request and
custom initrd modules configuration for the installation media.