### PR TITLE
Fixed debootstrap device node conflict

### DIFF
--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -139,8 +139,13 @@ class PackageManagerApt(PackageManagerBase):
         # chroot environment, thus we need to umount the kernel file systems
         # before calling debootstrap and remount them afterwards.
         root_bind.umount_kernel_file_systems()
-        # debootsrap will create its own dev/fd device
-        os.unlink(os.path.normpath(os.sep.join([self.root_dir, 'dev/fd'])))
+        # debootsrap will create its own dev/fd devices
+        debootstrap_device_node_conflicts = [
+            'dev/fd',
+            'dev/pts'
+        ]
+        for node in debootstrap_device_node_conflicts:
+            os.unlink(os.path.normpath(os.sep.join([self.root_dir, node])))
 
         if 'apt-get' in self.package_requests:
             # debootstrap takes care to install apt-get


### PR DESCRIPTION
debootstrap creates its own device node tree and fails
if a node it creates itself already exists. This commit
introduces a list of conflicting device nodes and deletes
them prior kiwi calling debootstrap. This Fixes #1675

