### PR TITLE
Added option to allow reading obs project repos

### DIFF
--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -30,6 +30,7 @@ SYNOPSIS
    kiwi-ng system build --obs-image=<path> --obs-user=<name> --target-dir=<directory>
        [--obs-arch=<arch>]
        [--obs-repo=<repo>]
+       [--obs-ssl-no-verify]
    kiwi-ng system build help
 
 .. _db_kiwi_system_build_desc:
@@ -139,6 +140,10 @@ OPTIONS
   set to any custom name, it's only required to specify the
   used repository name if another than the OBS default
   name is used.
+
+--obs-ssl-no-verify
+
+  Dont't verify SSL server certificate when connecting to OBS
 
 --set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>
 

--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -27,6 +27,9 @@ SYNOPSIS
        [--set-container-tag=<name>]
        [--add-container-label=<label>...]
        [--signing-key=<key-file>...]
+   kiwi-ng system build --obs-image=<path> --obs-user=<name> --target-dir=<directory>
+       [--obs-arch=<arch>]
+       [--obs-repo=<repo>]
    kiwi-ng system build help
 
 .. _db_kiwi_system_build_desc:
@@ -109,6 +112,33 @@ OPTIONS
   Works the same way as --ignore-repos except that repository
   configurations which has the imageonly attribute set to true
   will not be ignored.
+
+--obs-image=<project_package_path>
+
+  Image location for an image description in the Open Build Service.
+  The specification consists out of the project and package name
+  specified like a storage path, e.g `OBS:project:name/package`
+
+--obs-user=<name>
+
+  Open Build Service account user name. KIWI will ask for the
+  user credentials which blocks stdin until entered
+
+--obs-arch=<arch>
+
+  Optional architecture reference for the specifified `--obs-image`
+  image. This defaults to `x86_64`
+
+--obs-repo=<repo>
+
+  Optional repository name. In OBS a package build is connected
+  to a repository name. This repository name groups a collection
+  of software repositories to be used for the package build
+  process. If the package build is a KIWI image build this
+  repository name defaults to `images`. As the name can be
+  set to any custom name, it's only required to specify the
+  used repository name if another than the OBS default
+  name is used.
 
 --set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>
 

--- a/kiwi/credentials.py
+++ b/kiwi/credentials.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2021 SUSE Software Solutions Germany GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+from typing import Optional
+from getpass import getpass
+
+
+class Credentials:
+    def __init__(self):
+        self.obs_pass: Optional[str] = None
+
+    def get_obs_credentials(self, user: str) -> str:
+        if not self.obs_pass:
+            self.obs_pass = getpass(f'Enter OBS password for {user}: ')
+        return self.obs_pass

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -802,3 +802,25 @@ class KiwiShellVariableValueError(KiwiError):
     Exception raised if a given python value cannot be converted
     into a string representation for use in shell scripts
     """
+
+
+class KiwiOBSBuildInfoError(KiwiError):
+    """
+    Exception raised if the OBS buildinfo request did not provide
+    the expected information
+    """
+
+
+class KiwiOBSProjectError(KiwiError):
+    """
+    Exception raised if the given OBS project/package path is
+    not a path with two elements separated by the linux path
+    delimiter(/)
+    """
+
+
+class KiwiOBSSourceError(KiwiError):
+    """
+    Exception raised if the OBS image sources cannot be used
+    for building the image
+    """

--- a/kiwi/obs.py
+++ b/kiwi/obs.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2021 SUSE Software Solutions Germany GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+import logging
+from lxml import etree
+import requests
+from requests.auth import HTTPBasicAuth
+from tempfile import NamedTemporaryFile
+from typing import List
+
+# project
+from kiwi.xml_state import XMLState
+from kiwi.runtime_config import RuntimeConfig
+from kiwi.solver.repository.base import SolverRepositoryBase
+from kiwi.system.uri import Uri
+from kiwi.command import Command
+
+from kiwi.exceptions import (
+    KiwiUriOpenError,
+    KiwiOBSBuildInfoError,
+    KiwiOBSProjectError,
+    KiwiOBSSourceError
+)
+
+log = logging.getLogger('kiwi')
+
+
+class OBS:
+    """
+    **Implements methods to access the Open Build Service API**
+    """
+    def __init__(
+        self, image_path: str, user: str, password: str,
+        profiles: List[str], arch: str, repo: str
+    ):
+        """
+        Initialize OBS API access for a given project and package
+
+        :param str image_path: OBS project/package path
+        :param str user: OBS account user name
+        :param str password: OBS account password
+        :param list profiles: OBS image multibuild profile list
+        :param str arch: OBS architecture
+        :param str repo: OBS image package build repository name
+        :param str api_server:
+            OBS api server to use, defaults to https://api.opensuse.org/build
+        """
+        runtime_config = RuntimeConfig()
+        try:
+            (self.project, self.package) = image_path.split(os.sep)
+        except ValueError:
+            raise KiwiOBSProjectError(f'Invalid image path: {image_path}')
+        self.user = user
+        self.profile = profiles[0] if profiles else None
+        self.password = password
+        self.arch = arch or 'x86_64'
+        self.repo = repo or 'images'
+        self.api_server = runtime_config.get_obs_api_server_url()
+
+    def fetch_obs_image(self, checkout_dir) -> str:
+        """
+        Fetch image description from the obs project
+
+        :return: temp local path to image description
+
+        :return: path to local image checkout
+
+        :rtype: str
+        """
+        log.info('Checking out OBS project:')
+        if os.path.exists(checkout_dir):
+            raise KiwiOBSSourceError(
+                f'OBS source checkout dir: {checkout_dir!r} already exists'
+            )
+        log.info(f'--> {self.project}/{self.package}')
+        package_link = os.sep.join(
+            [
+                self.api_server, 'source',
+                self.project, self.package
+            ]
+        )
+        request = self._create_request(package_link)
+        package_source_xml_tree = OBS._import_xml_request(request)
+        package_source_contents = package_source_xml_tree.getroot().xpath(
+            '/directory/entry'
+        )
+        if not package_source_contents:
+            raise KiwiOBSSourceError(
+                f'OBS source for {self.package!r} package is empty'
+            )
+        source_files = []
+        for entry in package_source_contents:
+            source_files.append(entry.get('name'))
+
+        if '_service' in source_files:
+            raise KiwiOBSSourceError(
+                f'OBS source for {self.package!r} package is a source service'
+            )
+        Command.run(['mkdir', '-p', checkout_dir])
+        for source_file in source_files:
+            log.info(f'--> {source_file}')
+            request = self._create_request(
+                os.sep.join([package_link, source_file])
+            )
+            with open(os.sep.join([checkout_dir, source_file]), 'wb') as fd:
+                fd.write(request.content)
+        return checkout_dir
+
+    def add_obs_repositories(self, xml_state: XMLState) -> None:
+        """
+        Add repositories from the obs project to the provided XMLState
+
+        :param XMLState xml_state: XMLState object reference
+        """
+        if not OBS._delete_obsrepositories_placeholder_repo(xml_state):
+            # The repo list does not contain the obsrepositories flag
+            # Therefore it's not needed to look for repos in the OBS
+            # project configuration
+            return None
+
+        package_name = self.package if not self.profile \
+            else f'{self.package}:{self.profile}'
+        log.info(f'Using OBS repositories from {self.project}/{package_name}')
+        buildinfo_link = os.sep.join(
+            [
+                self.api_server, 'build',
+                self.project, self.repo, self.arch,
+                package_name, '_buildinfo'
+            ]
+        )
+        request = self._create_request(buildinfo_link)
+        buildinfo_xml_tree = OBS._import_xml_request(request)
+        repo_paths = buildinfo_xml_tree.getroot().xpath(
+            '/buildinfo/path'
+        )
+        if not repo_paths:
+            raise KiwiOBSBuildInfoError(
+                f'OBS buildinfo for {package_name} has no repo paths'
+            )
+        repo_prio_ascending = 0
+        repo_prio_descending = 501
+        repo_alias = None
+        for repo_path in repo_paths:
+            repo_url = repo_path.get('url')
+            if not repo_url:
+                repo_url = 'obs://{0}/{1}'.format(
+                    repo_path.get('project'), repo_path.get('repository')
+                )
+            if repo_url:
+                log.info(f'OBS Repo: {repo_url}')
+                try:
+                    repo_uri = Uri(repo_url)
+                    repo_url = repo_uri.translate(
+                        check_build_environment=False
+                    )
+                    request = requests.get(repo_url)
+                    request.raise_for_status()
+                except Exception as issue:
+                    log.warn(
+                        f'--> Unreachable repo ignored: {issue}'
+                    )
+                    continue
+
+                repo_check = SolverRepositoryBase(repo_uri)
+                repo_type = repo_check.get_repo_type()
+                if not repo_type:
+                    log.warn('--> Unknown repo type ignored')
+                    continue
+
+                if repo_type == 'rpm-md':
+                    repo_prio_ascending += 1
+                    repo_prio = repo_prio_ascending
+                else:
+                    repo_prio_descending -= 1
+                    repo_prio = repo_prio_descending
+
+                log.info('--> OK')
+                xml_state.add_repository(
+                    repo_url, repo_type, repo_alias, f'{repo_prio}'
+                )
+
+    def _create_request(self, url):
+        try:
+            request = requests.get(
+                url, auth=HTTPBasicAuth(self.user, self.password)
+            )
+            request.raise_for_status()
+        except Exception as issue:
+            raise KiwiUriOpenError(
+                f'{type(issue).__name__}: {issue}'
+            )
+        return request
+
+    @staticmethod
+    def _delete_obsrepositories_placeholder_repo(xml_state):
+        """
+        Delete repository sections which uses the obsrepositories
+        placeholder repo and keep the rest for the configured profiles
+
+        :return:
+            Returns True if a placeholder repo got deleted
+            otherwise False
+
+        :rtype: bool
+        """
+        has_obsrepositories = False
+        repository_sections_to_keep = []
+        repository_sections = xml_state.get_repository_sections()
+        for xml_repo in repository_sections:
+            repo_source = xml_repo.get_source().get_path()
+            if 'obsrepositories' in repo_source:
+                has_obsrepositories = True
+            else:
+                repository_sections_to_keep.append(xml_repo)
+        xml_state.xml_data.set_repository(repository_sections_to_keep)
+        return has_obsrepositories
+
+    @staticmethod
+    def _import_xml_request(request):
+        download = NamedTemporaryFile()
+        with open(download.name, 'wb') as request_info:
+            request_info.write(request.content)
+        return etree.parse(download.name)

--- a/kiwi/obs.py
+++ b/kiwi/obs.py
@@ -46,7 +46,7 @@ class OBS:
     """
     def __init__(
         self, image_path: str, user: str, password: str,
-        profiles: List[str], arch: str, repo: str
+        ssl_verify: bool, profiles: List[str], arch: str, repo: str
     ):
         """
         Initialize OBS API access for a given project and package
@@ -68,6 +68,7 @@ class OBS:
         self.user = user
         self.profile = profiles[0] if profiles else None
         self.password = password
+        self.ssl_verify = ssl_verify or True
         self.arch = arch or 'x86_64'
         self.repo = repo or 'images'
         self.api_server = runtime_config.get_obs_api_server_url()
@@ -197,7 +198,8 @@ class OBS:
     def _create_request(self, url):
         try:
             request = requests.get(
-                url, auth=HTTPBasicAuth(self.user, self.password)
+                url, auth=HTTPBasicAuth(self.user, self.password),
+                verify=self.ssl_verify
             )
             request.raise_for_status()
         except Exception as issue:

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -22,6 +22,7 @@ from operator import attrgetter
 
 # project
 from kiwi.cli import Cli
+from kiwi.credentials import Credentials
 from kiwi.xml_state import XMLState
 from kiwi.xml_description import XMLDescription
 from kiwi.runtime_checker import RuntimeChecker
@@ -50,6 +51,9 @@ class CliTask:
     """
     def __init__(self, should_perform_task_setup=True):
         self.cli = Cli()
+
+        # initialize credentials manager
+        self.credentials = Credentials()
 
         # initialize runtime checker
         self.runtime_checker = None

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -34,6 +34,7 @@ usage: kiwi-ng system build -h | --help
        kiwi-ng system build --obs-image=<path> --obs-user=<name> --target-dir=<directory>
            [--obs-arch=<arch>]
            [--obs-repo=<repo>]
+           [--obs-ssl-no-verify]
        kiwi-ng system build help
 
 commands:
@@ -100,6 +101,8 @@ options:
     --obs-repo=<repo>
         repository reference for the specifified Open Build Service image
         This defaults to: 'images'
+    --obs-ssl-no-verify
+        dont't verify SSL server certificate when connecting to OBS
     --target-dir=<directory>
         the target directory to store the system image file(s)
 """
@@ -154,12 +157,16 @@ class SystemBuildTask(CliTask):
             )
 
         if self.command_args['--obs-image']:
+            ssl_verify = bool(
+                self.command_args['--obs-ssl-no-verify']
+            )
             self.obs = OBS(
                 self.command_args['--obs-image'],
                 self.command_args['--obs-user'],
                 self.credentials.get_obs_credentials(
                     self.command_args['--obs-user']
                 ),
+                ssl_verify,
                 self.global_args['--profile'],
                 self.command_args['--obs-arch'],
                 self.command_args['--obs-repo']

--- a/test/unit/credentials_test.py
+++ b/test/unit/credentials_test.py
@@ -1,0 +1,16 @@
+from mock import patch
+
+from kiwi.credentials import Credentials
+
+
+class TestCredentials:
+    def setup(self):
+        self.credentials = Credentials()
+
+    @patch('kiwi.credentials.getpass')
+    def test_get_obs_credentials(self, mock_getpass):
+        assert self.credentials.get_obs_credentials('user') == \
+            mock_getpass.return_value
+        mock_getpass.assert_called_once_with(
+            'Enter OBS password for user: '
+        )

--- a/test/unit/obs_test.py
+++ b/test/unit/obs_test.py
@@ -1,0 +1,195 @@
+import io
+from mock import (
+    patch, Mock, MagicMock, call
+)
+from pytest import (
+    raises, fixture
+)
+
+from kiwi.obs import OBS
+from kiwi.defaults import Defaults
+
+from kiwi.exceptions import (
+    KiwiUriOpenError,
+    KiwiOBSBuildInfoError,
+    KiwiOBSProjectError,
+    KiwiOBSSourceError
+)
+
+
+class TestOBS:
+    @fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self._caplog = caplog
+
+    @patch('kiwi.obs.RuntimeConfig')
+    def setup(self, mock_RuntimeConfig):
+        runtime_config = Mock()
+        runtime_config.get_obs_api_server_url.return_value = \
+            Defaults.get_obs_api_server_url()
+        mock_RuntimeConfig.return_value = runtime_config
+        self.obs = OBS(
+            'Virtualization:Appliances:SelfContained:suse/box',
+            'bob', 'secret', ['Kernel'], None, None
+        )
+
+    @patch('kiwi.obs.RuntimeConfig')
+    def test_init_raises_invalid_project_path(self, mock_RuntimeConfig):
+        with raises(KiwiOBSProjectError):
+            self.obs = OBS('OBS:Project', 'user', 'pwd', None, None, None)
+
+    @patch.object(OBS, '_delete_obsrepositories_placeholder_repo')
+    @patch.object(OBS, '_create_request')
+    def test_fetch_obs_image_return_early(
+        self, mock_create_request, mock_delete_obsrepositories_placeholder_repo
+    ):
+        mock_delete_obsrepositories_placeholder_repo.return_value = False
+        # return early because obsrepositories flag is not used
+        self.obs.add_obs_repositories(Mock())
+        assert not mock_create_request.called
+
+    @patch('requests.get')
+    @patch('kiwi.obs.HTTPBasicAuth')
+    @patch('kiwi.obs.NamedTemporaryFile')
+    @patch('kiwi.obs.etree')
+    @patch('os.path.exists')
+    @patch('kiwi.obs.Command.run')
+    def test_fetch_obs_image(
+        self, mock_Command_run, mock_os_path_exists, mock_etree,
+        mock_NamedTemporaryFile, mock_HTTPBasicAuth, mock_requests_get
+    ):
+        # check exception on existing checkout dir
+        mock_os_path_exists.return_value = True
+        with raises(KiwiOBSSourceError):
+            self.obs.fetch_obs_image('checkout_dir')
+
+        # check Exception on valid request but unexpected content
+        mock_os_path_exists.return_value = False
+        xml_root = MagicMock()
+        xml_root.xpath.return_value = []
+        buildinfo_xml_tree = MagicMock()
+        buildinfo_xml_tree.getroot.return_value = xml_root
+        mock_etree.parse.return_value = buildinfo_xml_tree
+        with patch('builtins.open', create=True):
+            with raises(KiwiOBSSourceError):
+                self.obs.fetch_obs_image('checkout_dir')
+
+        # check Exception on source service
+        entry = Mock()
+        entry.get.return_value = '_service'
+        xml_root.xpath.return_value = [entry]
+        with patch('builtins.open', create=True):
+            with raises(KiwiOBSSourceError):
+                self.obs.fetch_obs_image('checkout_dir')
+
+        # check correct checkout of one source file
+        mock_requests_get.reset_mock()
+        entry.get.return_value = 'some_source_file'
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            self.obs.fetch_obs_image('checkout_dir')
+            mock_Command_run.assert_called_once_with(
+                ['mkdir', '-p', 'checkout_dir']
+            )
+            assert mock_open.call_args_list == [
+                call(mock_NamedTemporaryFile.return_value.name, 'wb'),
+                call('checkout_dir/some_source_file', 'wb')
+            ]
+
+    @patch('requests.get')
+    @patch('kiwi.obs.HTTPBasicAuth')
+    @patch('kiwi.obs.NamedTemporaryFile')
+    @patch('kiwi.obs.etree')
+    @patch('kiwi.obs.SolverRepositoryBase')
+    @patch('kiwi.obs.Uri')
+    def test_add_obs_repositories(
+        self, mock_Uri, mock_SolverRepositoryBase,
+        mock_etree, mock_NamedTemporaryFile, mock_HTTPBasicAuth,
+        mock_requests_get
+    ):
+        xml_state = MagicMock()
+        repository_section_std = MagicMock()
+        repository_section_std.get_source().get_path.return_value = \
+            'http://foo'
+        repository_section_obs = MagicMock()
+        repository_section_obs.get_source().get_path.return_value = \
+            'obsrepositories'
+
+        xml_state.get_repository_sections.return_value = \
+            [repository_section_std, repository_section_obs]
+
+        # check Exception on request
+        mock_requests_get.side_effect = Exception
+        with raises(KiwiUriOpenError):
+            self.obs.add_obs_repositories(xml_state)
+
+        # check Exception on valid request but unexpected content
+        mock_requests_get.side_effect = None
+        xml_root = MagicMock()
+        xml_root.xpath.return_value = []
+        buildinfo_xml_tree = MagicMock()
+        buildinfo_xml_tree.getroot.return_value = xml_root
+        mock_etree.parse.return_value = buildinfo_xml_tree
+        with patch('builtins.open', create=True):
+            with raises(KiwiOBSBuildInfoError):
+                self.obs.add_obs_repositories(xml_state)
+
+        # check on unreachable repo
+        repo_uri = Mock()
+        mock_Uri.return_value = repo_uri
+        repo_path = Mock()
+        repo_path.get.return_value = 'some-repo-url'
+        xml_root.xpath.return_value = [
+            repo_path
+        ]
+        mock_requests_get.side_effect = [Mock(), Exception]
+        with patch('builtins.open', create=True):
+            self.obs.add_obs_repositories(xml_state)
+            mock_Uri.assert_called_once_with('some-repo-url')
+            assert not xml_state.add_repository.called
+
+        # check on reachable repo with unknown repo type
+        repo_path.get.side_effect = [
+            None, 'project', 'repository'
+        ]
+        repo_check = Mock()
+        repo_check.get_repo_type.return_value = None
+        mock_SolverRepositoryBase.return_value = repo_check
+        mock_requests_get.side_effect = None
+        mock_Uri.reset_mock()
+        with patch('builtins.open', create=True):
+            self.obs.add_obs_repositories(xml_state)
+            mock_Uri.assert_called_once_with('obs://project/repository')
+            assert not xml_state.add_repository.called
+
+        # check on valid processing of one repo
+        repo_path.get.side_effect = None
+        repo_check.get_repo_type.return_value = 'rpm-md'
+        mock_requests_get.reset_mock()
+        mock_HTTPBasicAuth.reset_mock()
+        mock_Uri.reset_mock()
+        with patch('builtins.open', create=True):
+            self.obs.add_obs_repositories(xml_state)
+            mock_HTTPBasicAuth.assert_called_once_with('bob', 'secret')
+
+            assert mock_requests_get.call_args_list == [
+                call(
+                    'https://api.opensuse.org/build/Virtualization:'
+                    'Appliances:SelfContained:suse/images/x86_64/'
+                    'box:Kernel/_buildinfo',
+                    auth=mock_HTTPBasicAuth.return_value),
+                call(repo_uri.translate.return_value)
+            ]
+
+            # ascending priority starting at 1
+            xml_state.add_repository.assert_called_once_with(
+                repo_uri.translate.return_value, 'rpm-md', None, '1'
+            )
+
+            # descending priority starting at 500
+            xml_state.add_repository.reset_mock()
+            repo_check.get_repo_type.return_value = 'deb'
+            self.obs.add_obs_repositories(xml_state)
+            xml_state.add_repository.assert_called_once_with(
+                repo_uri.translate.return_value, 'deb', None, '500'
+            )

--- a/test/unit/obs_test.py
+++ b/test/unit/obs_test.py
@@ -30,13 +30,13 @@ class TestOBS:
         mock_RuntimeConfig.return_value = runtime_config
         self.obs = OBS(
             'Virtualization:Appliances:SelfContained:suse/box',
-            'bob', 'secret', ['Kernel'], None, None
+            'bob', 'secret', None, ['Kernel'], None, None
         )
 
     @patch('kiwi.obs.RuntimeConfig')
     def test_init_raises_invalid_project_path(self, mock_RuntimeConfig):
         with raises(KiwiOBSProjectError):
-            self.obs = OBS('OBS:Project', 'user', 'pwd', None, None, None)
+            self.obs = OBS('OBS:Project', 'user', 'pwd', True, None, None, None)
 
     @patch.object(OBS, '_delete_obsrepositories_placeholder_repo')
     @patch.object(OBS, '_create_request')
@@ -177,8 +177,12 @@ class TestOBS:
                     'https://api.opensuse.org/build/Virtualization:'
                     'Appliances:SelfContained:suse/images/x86_64/'
                     'box:Kernel/_buildinfo',
-                    auth=mock_HTTPBasicAuth.return_value),
-                call(repo_uri.translate.return_value)
+                    auth=mock_HTTPBasicAuth.return_value,
+                    verify=True
+                ),
+                call(
+                    repo_uri.translate.return_value
+                )
             ]
 
             # ascending priority starting at 1

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -109,6 +109,7 @@ class TestSystemBuildTask:
         self.task.command_args['--signing-key'] = None
         self.task.command_args['--obs-image'] = None
         self.task.command_args['--obs-user'] = None
+        self.task.command_args['--obs-ssl-no-verify'] = None
         self.task.command_args['--obs-arch'] = None
         self.task.command_args['--obs-repo'] = None
 


### PR DESCRIPTION
If kiwi is used in OBS many people setup the repositories
in the OBS project metadata. In the KIWI image description
only a placeholder called obsrepositories needs to be added
to indicate that OBS is managing the repositories. This is
nice but prevents people from simply building this image
outside of OBS. This commit adds a new caller option:

```
    --set-obs-repos=<user,password,project,name,profile,arch,repo>
```

which allows to read and use the list of repositories as OBS
would use it but in a local build process. KIWI will send a _buildinfo
request to the OBS API and reads the provided result. For this
call to work the user needs to provide its obs account information.
The account data is only used in a HTTPBasicAuth request and
not stored or used in any other way.


