### PR TITLE
Fixed use of BIOS grub image on ISO media

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -883,11 +883,14 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             early_boot_script, mbrid
         )
         early_boot_script_on_media = os.sep.join(
-            [self.root_dir, 'boot', self.boot_directory_name]
+            [self.root_dir, 'boot', self.boot_directory_name, 'earlyboot.cfg']
         )
         if early_boot_script != early_boot_script_on_media:
             log.debug(
                 f'Copy earlyboot to media path: {early_boot_script_on_media}'
+            )
+            Path.create(
+                os.path.dirname(early_boot_script_on_media)
             )
             shutil.copy(
                 early_boot_script, early_boot_script_on_media


### PR DESCRIPTION
Not all systems (e.g Debian) creates the boot/grub|grub2 directory.
In kiwi when we need to create a custom grub image because we did
not find the distro provided one, an earlyboot.cfg file is created
and embedded into the grub image. The locaton to store that file
is below boot/grub|grub2. However if the directory does not exist
the build will fail as with the current Debian Live integration
test.

