### PR TITLE
Followup fix for RuntimeConfig refactor

### DIFF
--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -50,7 +50,7 @@ class RuntimeConfig:
     def __init__(self, reread=False):
         global RUNTIME_CONFIG
 
-        if not RUNTIME_CONFIG or reread:
+        if RUNTIME_CONFIG is None or reread:
             cli = Cli()
             config_file = None
             custom_config_file = cli.get_global_args().get('--config')
@@ -72,7 +72,7 @@ class RuntimeConfig:
                     f'Reading runtime config file: {config_file!r}'
                 )
                 with open(config_file, 'r') as config:
-                    RUNTIME_CONFIG = yaml.safe_load(config)
+                    RUNTIME_CONFIG = yaml.safe_load(config) or {}
 
     def get_obs_download_server_url(self):
         """


### PR DESCRIPTION
The refactor of the RuntimeConfig made sure the runtime config
file is read in only once. But if the file exists and is empty
after yaml.safe_load like in the kiwi package provided
/etc/kiwi.yml which contains all config options as comments,
the code still reads in the file with every new instance of
RuntimeConfig. This commit fixes this condition


