### PR TITLE
Allow to specify OBS credentials in runtime config

### DIFF
--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -114,6 +114,22 @@ class RuntimeConfig:
         return obs_api_server_url if obs_api_server_url else \
             Defaults.get_obs_api_server_url()
 
+    def get_obs_api_credentials(self):
+        """
+        Return OBS API credentials if configured:
+
+        obs:
+          - user:
+              - user_name: user_credentials
+
+        :return: List of Dicts with credentials per user
+
+        :rtype: list
+        """
+        obs_users = self._get_attribute(element='obs', attribute='user') or []
+        if obs_users:
+            return obs_users
+
     def is_obs_public(self):
         """
         Check if the buildservice configuration is public or private in:

--- a/test/data/kiwi_config/ok/.config/kiwi/config.yml
+++ b/test/data/kiwi_config/ok/.config/kiwi/config.yml
@@ -8,6 +8,8 @@ obs:
   - download_url: http://example.com
   - api_url: https://api.example.com
   - public: true
+  - user:
+      - user_name: user_credentials
 
 iso:
   - tool_category: cdrtools

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -84,6 +84,9 @@ class TestRuntimeConfig:
             'check_dracut_module_for_oem_install_in_package_list',
             'check_container_tool_chain_installed'
         ]
+        assert runtime_config.get_obs_api_credentials() == [
+            {'user_name': 'user_credentials'}
+        ]
 
     @patch('kiwi.runtime_config.Cli')
     @patch('kiwi.runtime_checker.Defaults.is_buildservice_worker')


### PR DESCRIPTION
In preparation to the new obs kiwi plugin this commit adds
an opportunity to store obs credentials such that the plugin
could also be used in a non-interactive way

