### PR TITLE
Include a note about rpm's curl requirement to import remote keys

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -60,6 +60,17 @@ To install {kiwi}, follow these steps:
             F7E82012C74FD0B85F5334DC994B195474CBE823
       uid           Virtualization:Appliances OBS Project <Virtualization:Appliances@build.opensuse.org>
 
+.. note::
+
+   :command:`rpm` requires network utilities in order to download and
+   import remote keys. Make sure :command:`curl` is installed before
+   trying to import remote keys using :command:`rpm`. 
+   
+   Alternatively, the package manager, if not executed in non-interactive mode,
+   will ask you to trust or not the public key of the new repository when
+   refreshing repositories or installing new packages. If trusted the package
+   manager will automatically import it.
+
 5. Install {kiwi}:
 
    .. code:: shell-session


### PR DESCRIPTION
This commits add a note in the KIWI installation page to warn users rpm
requires curl utility in order to import remote keys from a URI.

Fixes #1680