### PR TITLE
Fixed kiwi-systemdeps-filesystems requires

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -245,6 +245,7 @@ Requires:       squashfs-tools
 Requires:       lvm2
 Requires:       parted
 Requires:       kpartx
+Requires:       cryptsetup
 Requires:       kiwi-systemdeps-core = %{version}-%{release}
 
 %description -n kiwi-systemdeps-filesystems


### PR DESCRIPTION
The filesystems requires list also contains low level
tools to manage partitions, loops and subsystems. The tools
to manage LUKS(cryptsetup) are missing and imho belongs there
along with the LVM tools which are listed

