### PR TITLE
Fix lsblk flags to get sorted output

### DIFF
--- a/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
@@ -224,7 +224,7 @@ function preparePersistentOverlayDiskBoot {
             return 1
         fi
         local write_partition
-        write_partition=$(lsblk "${isodiskdev}" -p -r -n -o NAME | tail -n1)
+        write_partition=$(lsblk "${isodiskdev}" -p -l -n -o NAME | tail -n1)
         if ! mkfs."${cow_filesystem}" -L cow "${write_partition}"; then
             return 1
         fi

--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -255,7 +255,7 @@ function get_free_disk_bytes {
     local part_uuids
     udev_pending
     for part in $(
-        lsblk -p -r -o NAME,TYPE "${disk}" | grep -E "part|md$" | cut -f1 -d ' '
+        lsblk -p -l -o NAME,TYPE "${disk}" | grep -E "part|md$" | cut -f1 -d ' '
     );do
         current_part_uuid=$(get_partition_uuid "${part}")
         for part_uuid in ${part_uuids[*]};do


### PR DESCRIPTION
This commit modifies the lsblk command flags to get a sorted output
according to the disk layout.

This is related to 176c7eab commita and it fixes bsc#1182264