### PR TITLE
Deprecate iso source type

### DIFF
--- a/doc/source/working_with_images.rst
+++ b/doc/source/working_with_images.rst
@@ -12,19 +12,24 @@ Working with Images
 
    working_with_images/iso_to_usb_stick_deployment
    working_with_images/iso_to_usb_stick_file_based_deployment
+
    working_with_images/disk_setup_for_ec2
    working_with_images/disk_setup_for_azure
    working_with_images/disk_setup_for_google
-   working_with_images/setup_network_bootserver
-   working_with_images/setup_yast_on_first_boot
    working_with_images/disk_setup_for_vagrant
-   working_with_images/network_live_iso_boot
+   working_with_images/disk_setup_for_luks
    working_with_images/disk_ramdisk_deployment
+
    working_with_images/custom_partitions
    working_with_images/custom_volumes
-   working_with_images/custom_fstab_extension
-   working_with_images/disk_setup_for_luks
-   working_with_images/build_with_profiles
-   working_with_images/build_in_buildservice
+
+   working_with_images/setup_network_bootserver
    working_with_images/legacy_netboot_root_filesystem
    working_with_images/network_overlay_boot
+   working_with_images/network_live_iso_boot
+
+   working_with_images/setup_yast_on_first_boot
+   working_with_images/custom_fstab_extension
+   working_with_images/build_with_profiles
+   working_with_images/build_in_buildservice
+   working_with_images/use_suse_media

--- a/doc/source/working_with_images/use_suse_media.rst
+++ b/doc/source/working_with_images/use_suse_media.rst
@@ -1,0 +1,59 @@
+.. _suse_media:
+
+Using SUSE Product ISO To Build
+===============================
+
+.. sidebar:: Abstract
+
+    This page provides information how to use the SUSE
+    media ISO with {kiwi}
+
+When building an image with {kiwi}, the image description usually
+points to a number of public/private package source repositories
+from which the new image root tree will be created. Alternatively
+the vendor provided product ISO image(s) can be used. The contents
+of the ISO (DVD) media also provides package source repositories
+but organized in a vendor specific structure. As a user it's
+important to know about this structure such that the {kiwi}
+image description can consume it.
+
+To use a SUSE product media the following steps are required:
+
+1. Mount the ISO media from file or DVD drive:
+
+.. code:: bash
+
+    $ sudo mount Product_ISO_file.iso|DVD_drive /media/suse
+
+2. Lookup all `Product` and `Module` directories:
+
+   Below `/media/suse` there is a directory structure which
+   provides package repositories in directories starting
+   with `Product-XXX` and `Module-XXX`. It depends on the
+   package list in the {kiwi} image description from which
+   location a package or a dependency of the package is
+   taken. Therefore it is best practice to browse through
+   all the directories and create a `<repository>` definition
+   for each of them in the {kiwi} image description like
+   the following example shows:
+
+   .. code:: xml
+
+       <repository alias="DVD-1-Product-SLES">
+           <source path="file:///media/suse/Product-SLES"/>
+       </repository>
+
+       <repository alias="DVD-1-Module-Basesystem">
+           <source path="file:///media/suse/Module-Basesystem"/>
+       </repository>
+
+Once all the individual product and module repos has been created
+in the {kiwi} image description, the build process can be started
+as usual.
+
+.. note::
+
+    Because of the manual mount process the `/media/suse` location
+    stays busy after {kiwi} has created the image. The cleanup of
+    this resource is a responsibility of the user and not done
+    by {kiwi}


### PR DESCRIPTION
This patch is two fold

**Document use of SUSE media**
    
Add chapter to describe how to use the SUSE product media in a kiwi build process. This Fixes #1678

**Delete support for generic iso:// source type**
    
The generic iso:// media type mounts the given iso file and expect its root to provide a repository that can be used 1:1 with a package manager. This concept is broken since some time and it can't be fixed in a generic way. All distribution media comes with a certain layout and basically needs extra handling to become fully usable as repository. The current implementation of the iso type which simply mounts the iso and expects its root to be a known repo is not useful. Therefore the support for it will be decommissioned. Instead we will provide a documentation chapter that documents how to incorporate distro ISO media for building images.

When using kiwi with this patch and a user has a repo definition like this

```xml
<repository>
    <source path="iso:///path/to/file.iso"/>
</repository>
```

The following error will be raised

```
[ INFO    ]: 11:35:11 | Setting up repository iso://path/to/file.iso
[ INFO    ]: 11:35:11 | --> Type: None
[ ERROR   ]: 11:35:11 | KiwiUriStyleUnknown: URI schema iso://path/to/file.iso not supported
[ INFO    ]: 11:35:11 | Cleaning up SystemPrepare instance
```

and the build stops. From my perspective the error is good information but we can also try to add some reference to the docs about the use of ISO images. However we currently prevented to use doc links in code as they can also change. I would leave it that way but am eager to get your feedback. Thanks
