### PR TITLE
Added deb support to sat solver module

### DIFF
--- a/kiwi/solver/repository/__init__.py
+++ b/kiwi/solver/repository/__init__.py
@@ -37,11 +37,12 @@ class SolverRepository(metaclass=ABCMeta):
         return None  # pragma: no cover
 
     @staticmethod
-    def new(uri: Uri, user: str=None, secret: str=None):  # noqa: E252
+    def new(uri: Uri, user: str = None, secret: str = None):
         name_map = {
             'yast2': ['SolverRepositorySUSE', 'suse'],
             'rpm-md': ['SolverRepositoryRpmMd', 'rpm_md'],
-            'rpm-dir': ['SolverRepositoryRpmDir', 'rpm_dir']
+            'rpm-dir': ['SolverRepositoryRpmDir', 'rpm_dir'],
+            'apt-deb': ['SolverRepositoryDeb', 'deb']
         }
         try:
             module_name = name_map[uri.repo_type][0]

--- a/kiwi/solver/repository/deb.py
+++ b/kiwi/solver/repository/deb.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+# project
+from kiwi.solver.repository.base import SolverRepositoryBase
+
+
+class SolverRepositoryDeb(SolverRepositoryBase):
+    """
+    **Class for SAT solvable creation for apt-deb type repositories.**
+    """
+    def _setup_repository_metadata(self):
+        """
+        Download repo metadata for rpm-md specific repositories
+        and create SAT solvables from all solver relevant files
+        """
+        # Download Packages metadata for the deb2solv solvable
+        # creation. This includes the files named Packages.gz in
+        # the repo definition
+        deb_dir = self._create_temporary_metadata_dir()
+        self._get_deb_packages(download_dir=deb_dir)
+        self._create_solvables(
+            deb_dir, 'deb2solv'
+        )

--- a/test/data/image_info/config.xml
+++ b/test/data/image_info/config.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="7.3" name="LimeJeOS" displayname="Bob">
+    <description type="system">
+        <author>Marcus</author>
+        <contact>ms@suse.com</contact>
+        <specification>
+            Testing image info module
+        </specification>
+    </description>
+    <preferences>
+        <version>1.13.2</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>true</rpm-check-signatures>
+        <bootsplash-theme>openSUSE</bootsplash-theme>
+        <bootloader-theme>openSUSE</bootloader-theme>
+    </preferences>
+    <preferences>
+        <type image="iso" mediacheck="true"/>
+    </preferences>
+    <repository alias="Focal" distribution="focal" components="main multiverse restricted universe" repository_gpgcheck="false">
+        <source path="http://us.archive.ubuntu.com/ubuntu/"/>
+    </repository>
+    <repository type="rpm-md" imageinclude="true">
+        <source path="obs://Devel:PubCloud:AmazonEC2/SLE_12_GA"/>
+    </repository>
+    <repository type="rpm-md" imageonly="true">
+        <source path="obs://Devel:Docker:Images:SLE12SP2/SLE_12_SP2_Docker"/>
+    </repository>
+    <packages type="image" patternType="plusRecommended">
+        <namedCollection name="base"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="filesystem"/>
+    </packages>
+</image>

--- a/test/unit/solver/repository/deb_test.py
+++ b/test/unit/solver/repository/deb_test.py
@@ -1,0 +1,26 @@
+from mock import (
+    patch, Mock
+)
+from kiwi.solver.repository.deb import SolverRepositoryDeb
+from kiwi.solver.repository.base import SolverRepositoryBase
+
+
+class TestSolverRepositoryDeb:
+    def setup(self):
+        self.uri = Mock()
+        self.solver = SolverRepositoryDeb(self.uri)
+
+    @patch.object(SolverRepositoryBase, '_get_deb_packages')
+    @patch.object(SolverRepositoryBase, '_create_solvables')
+    @patch.object(SolverRepositoryBase, '_create_temporary_metadata_dir')
+    def test__setup_repository_metadata(
+        self, mock_mkdtemp, mock_create_solvables, mock_get_deb_packages
+    ):
+        mock_mkdtemp.return_value = 'metadata_dir.XX'
+        self.solver._setup_repository_metadata()
+        mock_get_deb_packages.assert_called_once_with(
+            download_dir='metadata_dir.XX'
+        )
+        mock_create_solvables.assert_called_once_with(
+            'metadata_dir.XX', 'deb2solv'
+        )

--- a/test/unit/solver/repository/init_test.py
+++ b/test/unit/solver/repository/init_test.py
@@ -34,3 +34,9 @@ class TestSolverRepository:
         self.uri.repo_type = 'rpm-dir'
         SolverRepository.new(self.uri)
         mock_rpm_dir.assert_called_once_with(self.uri, None, None)
+
+    @patch('kiwi.solver.repository.deb.SolverRepositoryDeb')
+    def test_solver_repository_apt(self, mock_deb):
+        self.uri.repo_type = 'apt-deb'
+        SolverRepository.new(self.uri)
+        mock_deb.assert_called_once_with(self.uri, None, None)

--- a/test/unit/solver/sat_test.py
+++ b/test/unit/solver/sat_test.py
@@ -39,12 +39,34 @@ class TestSat:
             return_value=self.selection
         )
         mock_import_module.assert_called_once_with('solv')
+        self.solv = mock_import_module.return_value
+        self.sat.pool.setarch.assert_called_once_with()
+        self.sat.pool.setarch.reset_mock()
 
     @patch('importlib.import_module')
     def test_setup_no_sat_plugin(self, mock_import_module):
         mock_import_module.side_effect = Exception
         with raises(KiwiSatSolverPluginError):
             Sat()
+
+    @patch('platform.machine')
+    def test_set_dist_type_raises(self, mock_platform_machine):
+        mock_platform_machine.return_value = 'x86_64'
+        self.sat.pool.setdisttype.return_value = -1
+        with raises(KiwiSatSolverPluginError):
+            self.sat.set_dist_type('deb')
+
+    @patch('platform.machine')
+    def test_set_dist_type_deb(self, mock_platform_machine):
+        mock_platform_machine.return_value = 'x86_64'
+        self.sat.pool.setdisttype.return_value = 0
+        self.sat.set_dist_type('deb')
+        self.sat.pool.setdisttype.assert_called_once_with(
+            self.solv.Pool.DISTTYPE_DEB
+        )
+        self.sat.pool.setarch.assert_called_once_with(
+            'amd64'
+        )
 
     def test_add_repository(self):
         solver_repository = Mock()
@@ -117,6 +139,32 @@ class TestSat:
         )
         with raises(KiwiSatSolverJobError):
             self.sat.solve(packages)
+
+    def test_solve_apt_get(self):
+        # There is a special handling for apt-get. In kiwi the
+        # package manager for debian based distros is selected
+        # by the name apt-get. That name is added to the package
+        # list, but apt-get does not really exist in Debian based
+        # distros. The name of the package manager from a packaging
+        # perspective is just: apt not apt-get. We should change
+        # this in the schema and code in kiwi. But so far we
+        # have the hack here
+        packages = ['apt-get']
+        self.solver.solve = Mock(
+            return_value=None
+        )
+        self.selection.isempty = Mock(
+            return_value=False
+        )
+        self.selection.jobs = Mock(
+            return_value=packages
+        )
+        self.sat.solve(packages)
+        selection_name = self.solv.Selection.SELECTION_NAME
+        selection_provides = self.solv.Selection.SELECTION_PROVIDES
+        self.sat.pool.select.assert_called_once_with(
+            'apt', selection_name | selection_provides
+        )
 
     def test_solve(self):
         packages = ['vim']


### PR DESCRIPTION
Add support to create SAT solvables from Debian repos via
deb2solv tool from libsolv. This allows image info --resolve-package-list
to work with Debian/Ubuntu image descriptions. Please note
by default libsolv is not compiled with support for Debian.
Therefore the following compile flags must be set on libsolv

* -DENABLE_DEBIAN=1
* -DMULTI_SEMANTICS=1

If libsolv does not provide the needed capabilities kiwi will
fail on either the repository solvable creation due to missing
deb2solv or on call of setdisttype() due to missing MULTI_SEMANTICS
feature in libsolv

