### PR TITLE
Added strong typing for the following API methods

### DIFF
--- a/kiwi/storage/subformat/vagrant_base.py
+++ b/kiwi/storage/subformat/vagrant_base.py
@@ -19,7 +19,12 @@ import json
 import os.path
 
 from tempfile import mkdtemp
+from typing import (
+    Dict, Optional, List
+)
 
+from kiwi import xml_parse
+from kiwi.system.result import Result
 from kiwi.storage.subformat.base import DiskFormatBase
 from kiwi.storage.subformat.template.vagrant_config import VagrantConfigTemplate
 from kiwi.command import Command
@@ -69,7 +74,7 @@ class DiskFormatVagrantBase(DiskFormatBase):
     * :meth:`get_additional_vagrant_config_settings`
 
     """
-    def post_init(self, custom_args):
+    def post_init(self, custom_args: Dict['str', xml_parse.vagrantconfig]):
         """
         vagrant disk format post initialization method
 
@@ -94,7 +99,7 @@ class DiskFormatVagrantBase(DiskFormatBase):
         self.vagrantconfig = custom_args['vagrantconfig']
         self.vagrant_post_init()
 
-    def vagrant_post_init(self):
+    def vagrant_post_init(self) -> None:
         """
         Vagrant provider specific post initialization method
 
@@ -103,24 +108,17 @@ class DiskFormatVagrantBase(DiskFormatBase):
         make the this base class methods effective
         """
         self.image_format = None
-        self.provider = None
+        self.provider: Optional[str] = None
 
-    def create_box_img(self, temp_image_dir):
+    def create_box_img(self, temp_image_dir: str) -> List[str]:
         """
-        Provider specific image creation step: this function creates the actual
-        box image. It must be implemented by a child class.
-
-        :param str temp_image_dir:
-            path to a temporary directory inside which the image
-            should be built
-        :return:
-            A list of files that were created by this function
-            and that should be included in the vagrant box
-        :rtype: list
+        Provider specific image creation step: this function
+        creates the actual box image. It must be implemented by a
+        child class.
         """
         raise NotImplementedError
 
-    def create_image_format(self):
+    def create_image_format(self) -> None:
         """
         Create a vagrant box for any provider. This includes:
 
@@ -172,7 +170,7 @@ class DiskFormatVagrantBase(DiskFormatBase):
             ]
         )
 
-    def store_to_result(self, result):
+    def store_to_result(self, result: Result) -> None:
         """
         Store result file of the vagrant format conversion into the
         provided result instance. In this case compression is unwanted
@@ -195,7 +193,7 @@ class DiskFormatVagrantBase(DiskFormatBase):
             shasum=True
         )
 
-    def get_additional_metadata(self):
+    def get_additional_metadata(self) -> Dict:
         """
         Provide :meth:`create_image_format` with additional metadata
         that will be included in ``metadata.json``.
@@ -205,9 +203,9 @@ class DiskFormatVagrantBase(DiskFormatBase):
         :return: A dictionary that is serializable to JSON
         :rtype: dict
         """
-        pass
+        return {}
 
-    def get_additional_vagrant_config_settings(self):
+    def get_additional_vagrant_config_settings(self) -> str:
         """
         Supply additional configuration settings for vagrant to be included in
         the resulting box.
@@ -222,7 +220,7 @@ class DiskFormatVagrantBase(DiskFormatBase):
         :return: additional vagrant settings
         :rtype: str
         """
-        pass
+        return ''
 
     def _create_box_metadata(self):
         metadata = self.get_additional_metadata() or {}

--- a/kiwi/storage/subformat/vagrant_libvirt.py
+++ b/kiwi/storage/subformat/vagrant_libvirt.py
@@ -17,6 +17,9 @@
 #
 import os
 from textwrap import dedent
+from typing import (
+    List, Dict
+)
 
 # project
 from kiwi.storage.subformat.vagrant_base import DiskFormatVagrantBase
@@ -28,13 +31,22 @@ class DiskFormatVagrantLibVirt(DiskFormatVagrantBase):
     """
     **Create a vagrant box for the libvirt provider**
     """
-    def vagrant_post_init(self):
+    def vagrant_post_init(self) -> None:
         self.image_format = 'vagrant.libvirt.box'
         self.provider = 'libvirt'
 
-    def create_box_img(self, temp_image_dir):
+    def create_box_img(self, temp_image_dir: str) -> List[str]:
         """
         Creates the qcow2 disk image box for libvirt vagrant provider
+
+        :param str temp_image_dir:
+            Path to the temporary directory used to build the box image
+
+        :return:
+            A list of files relevant for the libvirt box to be
+            included in the vagrant box
+
+        :rtype: list
         """
         qcow = DiskFormatQcow2(
             self.xml_state, self.root_dir, self.target_dir
@@ -49,19 +61,29 @@ class DiskFormatVagrantLibVirt(DiskFormatVagrantBase):
         )
         return [box_img]
 
-    def get_additional_metadata(self):
+    def get_additional_metadata(self) -> Dict:
         """
-        Returns a dictionary containing the virtual image format and the size
-        of the image.
+        Provide box metadata needed to create the box in vagrant
+
+        :return:
+            Returns a dictionary containing the virtual image format
+            and the size of the image.
+
+        :rtype: dict
         """
         return {
             'format': 'qcow2',
             'virtual_size': int(self.vagrantconfig.get_virtualsize() or 42)
         }
 
-    def get_additional_vagrant_config_settings(self):
+    def get_additional_vagrant_config_settings(self) -> str:
         """
         Returns settings for the libvirt provider telling vagrant to use kvm.
+
+        :return:
+            ruby code to be evaluated as string
+
+        :rtype: str
         """
         return dedent('''
             config.vm.synced_folder ".", "/vagrant", type: "rsync"

--- a/kiwi/storage/subformat/vagrant_virtualbox.py
+++ b/kiwi/storage/subformat/vagrant_virtualbox.py
@@ -15,11 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-
 import os
 import random
-
 from textwrap import dedent
+from typing import List
 
 # project
 from kiwi.storage.subformat.template.virtualbox_ovf import (
@@ -35,14 +34,19 @@ class DiskFormatVagrantVirtualBox(DiskFormatVagrantBase):
     **Create a vagrant box for the virtualbox provider**
     """
 
-    def vagrant_post_init(self):
+    def vagrant_post_init(self) -> None:
         self.provider = 'virtualbox'
         self.image_format = 'vagrant.virtualbox.box'
 
-    def get_additional_vagrant_config_settings(self):
+    def get_additional_vagrant_config_settings(self) -> str:
         """
         Configure the default shared folder to use rsync when guest additions
         are not present inside the box.
+
+        :return:
+            ruby code to be evaluated as string
+
+        :rtype: str
         """
         extra_settings = dedent('''
             config.vm.base_mac = "{mac_address}"
@@ -55,13 +59,21 @@ class DiskFormatVagrantVirtualBox(DiskFormatVagrantBase):
 
         return extra_settings
 
-    def create_box_img(self, temp_image_dir):
+    def create_box_img(self, temp_image_dir: str) -> List[str]:
         """
-        Create the virtual machine image for the Virtualbox vagrant provider.
+        Create the vmdk image for the Virtualbox vagrant provider.
 
-        This function creates the vmdk disk image and the ovf file. The latter
-        is created via the class
-        :class:`kiwi.storage.subformat.template.virtualbox_ovf.VirtualboxOvfTemplate`.
+        This function creates the vmdk disk image and the ovf file.
+        The latter is created via the class :class:`VirtualboxOvfTemplate`.
+
+        :param str temp_image_dir:
+            Path to the temporary directory used to build the box image
+
+        :return:
+            A list of files relevant for the virtualbox box to be
+            included in the vagrant box
+
+        :rtype: list
         """
         vmdk = DiskFormatVmdk(self.xml_state, self.root_dir, self.target_dir)
         vmdk.create_image_format()

--- a/kiwi/storage/subformat/vdi.py
+++ b/kiwi/storage/subformat/vdi.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
-
+from typing import Dict
 
 # project
 from kiwi.storage.subformat.base import DiskFormatBase
@@ -25,7 +25,7 @@ class DiskFormatVdi(DiskFormatBase):
     """
     **Create vdi disk format**
     """
-    def post_init(self, custom_args):
+    def post_init(self, custom_args: Dict) -> None:
         """
         vdi disk format post initialization method
 
@@ -36,7 +36,7 @@ class DiskFormatVdi(DiskFormatBase):
         self.image_format = 'vdi'
         self.options = self.get_qemu_option_list(custom_args)
 
-    def create_image_format(self):
+    def create_image_format(self) -> None:
         """
         Create vdi disk format
         """

--- a/kiwi/storage/subformat/vhd.py
+++ b/kiwi/storage/subformat/vhd.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+from typing import Dict
+
 # project
 from kiwi.storage.subformat.base import DiskFormatBase
 from kiwi.command import Command
@@ -24,7 +26,7 @@ class DiskFormatVhd(DiskFormatBase):
     """
     **Create vhd disk format**
     """
-    def post_init(self, custom_args):
+    def post_init(self, custom_args: Dict) -> None:
         """
         vhd disk format post initialization method
 
@@ -35,7 +37,7 @@ class DiskFormatVhd(DiskFormatBase):
         self.image_format = 'vhd'
         self.options = self.get_qemu_option_list(custom_args)
 
-    def create_image_format(self):
+    def create_image_format(self) -> None:
         """
         Create vhd disk format
         """

--- a/kiwi/storage/subformat/vhdfixed.py
+++ b/kiwi/storage/subformat/vhdfixed.py
@@ -15,24 +15,24 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+from typing import Dict
 import struct
 from binascii import unhexlify
 import re
 
 # project
+from kiwi.system.result import Result
 from kiwi.storage.subformat.base import DiskFormatBase
 from kiwi.command import Command
 
-from kiwi.exceptions import (
-    KiwiVhdTagError
-)
+from kiwi.exceptions import KiwiVhdTagError
 
 
 class DiskFormatVhdFixed(DiskFormatBase):
     """
     **Create vhd image format in fixed subformat**
     """
-    def post_init(self, custom_args):
+    def post_init(self, custom_args: Dict) -> None:
         """
         vhd disk format post initialization method
 
@@ -56,7 +56,7 @@ class DiskFormatVhdFixed(DiskFormatBase):
         self.options.append('-o')
         self.options.append('subformat=fixed')
 
-    def create_image_format(self):
+    def create_image_format(self) -> None:
         """
         Create vhd fixed disk format
         """
@@ -71,7 +71,7 @@ class DiskFormatVhdFixed(DiskFormatBase):
         if self.tag:
             self._write_vhd_tag(self.tag)
 
-    def store_to_result(self, result):
+    def store_to_result(self, result: Result) -> None:
         """
         Store result file of the vhdfixed format conversion into the
         provided result instance. In this case compressing the result

--- a/kiwi/storage/subformat/vhdx.py
+++ b/kiwi/storage/subformat/vhdx.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+from typing import Dict
+
 # project
 from kiwi.storage.subformat.base import DiskFormatBase
 from kiwi.command import Command
@@ -24,7 +26,7 @@ class DiskFormatVhdx(DiskFormatBase):
     """
     **Create vhdx image format in dynamic subformat**
     """
-    def post_init(self, custom_args):
+    def post_init(self, custom_args: Dict) -> None:
         """
         vhdx disk format post initialization method
 
@@ -37,7 +39,7 @@ class DiskFormatVhdx(DiskFormatBase):
         self.options.append('-o')
         self.options.append('subformat=dynamic')
 
-    def create_image_format(self):
+    def create_image_format(self) -> None:
         """
         Create vhdx dynamic disk format
         """

--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -15,9 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+from typing import Dict
 import os
 
 # project
+from kiwi.system.result import Result
 from kiwi.storage.subformat.base import DiskFormatBase
 from kiwi.command import Command
 from kiwi.storage.subformat.template.vmware_settings import (
@@ -33,7 +35,7 @@ class DiskFormatVmdk(DiskFormatBase):
     """
     Create vmdk disk format
     """
-    def post_init(self, custom_args):
+    def post_init(self, custom_args: Dict) -> None:
         """
         vmdk disk format post initialization method
 
@@ -48,7 +50,7 @@ class DiskFormatVmdk(DiskFormatBase):
         if custom_args and 'adapter_type=pvscsi' in custom_args:
             self.patch_header_for_pvscsi = True
 
-    def create_image_format(self):
+    def create_image_format(self) -> None:
         """
         Create vmdk disk format and machine settings file
         """
@@ -64,7 +66,7 @@ class DiskFormatVmdk(DiskFormatBase):
             self._inject_pvscsi_adapter_type()
         self._create_vmware_settings_file()
 
-    def store_to_result(self, result):
+    def store_to_result(self, result: Result) -> None:
         """
         Store result files of the vmdk format conversion into the
         provided result instance. This includes the vmdk image file

--- a/test/unit/storage/subformat/vagrant_base_test.py
+++ b/test/unit/storage/subformat/vagrant_base_test.py
@@ -146,8 +146,10 @@ class TestDiskFormatVagrantBase:
             )
 
     def test_get_additional_vagrant_config_settings(self):
-        assert self.disk_format.get_additional_vagrant_config_settings() \
-            is None
+        assert self.disk_format.get_additional_vagrant_config_settings() == ''
+
+    def test_get_additional_metadata(self):
+        assert self.disk_format.get_additional_metadata() == {}
 
     def test_store_to_result(self):
         # select an example provider


### PR DESCRIPTION
* storage/subformat/vagrant_base.py
* storage/subformat/vagrant_libvirt.py
* storage/subformat/vagrant_virtualbox.py
* storage/subformat/vdi.py
* storage/subformat/vhd.py
* storage/subformat/vhdfixed.py
* storage/subformat/vhdx.py
* storage/subformat/vmdk.py

This references Issue #1644


