### PR TITLE
Add a version to dracut modules

### DIFF
--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -144,7 +144,9 @@ class SystemBuildTask(CliTask):
         build_checks.update(
             {
                 'check_target_directory_not_in_shared_cache':
-                    [abs_target_dir_path]
+                    [abs_target_dir_path],
+                'check_dracut_module_versions_compatible_to_kiwi':
+                    [image_root]
             }
         )
         self.run_checks(build_checks)

--- a/kiwi/tasks/system_create.py
+++ b/kiwi/tasks/system_create.py
@@ -83,7 +83,12 @@ class SystemCreateTask(CliTask):
         )
 
         self.run_checks(
-            {'check_target_directory_not_in_shared_cache': [abs_root_path]}
+            {
+                'check_target_directory_not_in_shared_cache':
+                    [abs_root_path],
+                'check_dracut_module_versions_compatible_to_kiwi':
+                    [abs_root_path]
+            }
         )
 
         log.info('Creating system image')

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -129,6 +129,11 @@ class TestSystemBuildTask:
             check_target_directory_not_in_shared_cache.\
             assert_called_once_with(self.abs_target_dir)
         self.runtime_checker.\
+            check_dracut_module_versions_compatible_to_kiwi.\
+            assert_called_once_with(
+                self.abs_target_dir + '/build/image-root'
+            )
+        self.runtime_checker.\
             check_mediacheck_installed.assert_called_once_with()
         self.runtime_checker.\
             check_dracut_module_for_live_iso_in_package_list.\

--- a/test/unit/tasks/system_create_test.py
+++ b/test/unit/tasks/system_create_test.py
@@ -69,9 +69,12 @@ class TestSystemCreateTask:
         self._init_command_args()
         self.task.command_args['create'] = True
         self.task.process()
-        self.runtime_checker.check_target_directory_not_in_shared_cache.called_once_with(
-            self.abs_target_dir
-        )
+        self.runtime_checker.\
+            check_target_directory_not_in_shared_cache.\
+            called_once_with(self.abs_target_dir)
+        self.runtime_checker.\
+            check_dracut_module_versions_compatible_to_kiwi.\
+            called_once_with(self.abs_target_dir)
         self.setup.call_image_script.assert_called_once_with()
         self.builder.create.assert_called_once_with()
         self.result.print_results.assert_called_once_with()


### PR DESCRIPTION
Add version to dracut modules aligned with the kiwi version and
managed via bumpversion. In addition create a runtime check at
the create stage to compare the new version information if present.
This is related to Issue #1734

