### PR TITLE
Fail non-XML descriptions if anymarkup not available

### DIFF
--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -195,6 +195,12 @@ class KiwiConfigFileNotFound(KiwiError):
     """
 
 
+class KiwiConfigFileFormatNotSupported(KiwiError):
+    """
+    Exception raised if kiwi description file format is not supported.
+    """
+
+
 class KiwiContainerSetupError(KiwiError):
     """
     Exception raised if an error in the creation of the

--- a/test/unit/markup/base_test.py
+++ b/test/unit/markup/base_test.py
@@ -29,5 +29,5 @@ class TestMarkupBase:
         mock_parse.side_effect = etree.XMLSyntaxError('not-XML', '<', 1, 1)
         with raises(KiwiConfigFileFormatNotSupported):
             self.markup.apply_xslt_stylesheets(
-                '../data/example_config.xml'
+                'artificial_and_invalid_XML_markup'
             )

--- a/test/unit/markup/base_test.py
+++ b/test/unit/markup/base_test.py
@@ -1,6 +1,10 @@
+from lxml import etree
+from mock import patch
 from pytest import raises
 
 from kiwi.markup.base import MarkupBase
+
+from kiwi.exceptions import KiwiConfigFileFormatNotSupported
 
 
 class TestMarkupBase:
@@ -19,3 +23,11 @@ class TestMarkupBase:
         assert 'xslt-' in self.markup.apply_xslt_stylesheets(
             '../data/example_config.xml'
         )
+
+    @patch('kiwi.markup.base.etree.parse')
+    def test_apply_xslt_stylesheets_nonXML(self, mock_parse):
+        mock_parse.side_effect = etree.XMLSyntaxError('not-XML', '<', 1, 1)
+        with raises(KiwiConfigFileFormatNotSupported):
+            self.markup.apply_xslt_stylesheets(
+                '../data/example_config.xml'
+            )


### PR DESCRIPTION
If the anymarkup Python module is not available, and a non-XML format
description file has been provided, then fail with an error indicating
that non-XML format config files require anymarkup.

Adds a new exception, KiwiConfigFileFormatNotSupported, to be raised
for this scenario.

Added a new test_MarkupXML_NotXML() test case to test this scenario.
Also updated the existing test_MarkupXML() test case to reflect the
impact of these changes, e.g. need to mock etree.parse() so that it
doesn't trying to parse a non-existant file.