### PR TITLE
Refactor grub2 installation

### DIFF
--- a/kiwi/bootloader/install/base.py
+++ b/kiwi/bootloader/install/base.py
@@ -58,3 +58,11 @@ class BootLoaderInstallBase:
         Implementation in specialized bootloader install class required
         """
         raise NotImplementedError
+
+    def secure_boot_install(self):
+        """
+        Run shim-install in self.device for secure boots
+
+        Implementation in specialized bootloader install class required
+        """
+        raise NotImplementedError

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1114,6 +1114,7 @@ class DiskBuilder:
             )
             if bootloader.install_required():
                 bootloader.install()
+            bootloader.secure_boot_install()
 
         self.system_setup.call_edit_boot_install_script(
             self.diskname, boot_device.get_device()

--- a/test/unit/bootloader/install/base_test.py
+++ b/test/unit/bootloader/install/base_test.py
@@ -17,3 +17,7 @@ class TestBootLoaderInstallBase:
     def test_install_required(self):
         with raises(NotImplementedError):
             self.bootloader.install_required()
+
+    def test_secure_boot_install(self):
+        with raises(NotImplementedError):
+            self.bootloader.secure_boot_install()


### PR DESCRIPTION
This commit refactors grub2 installation method to split it in two
parts. Former grub2.install method was meant to run the grub2-install
tool, however, in addition it was also running the secure boot
installation shim-install. The install method in KIWI is skipped for
those architectures and firmware combinations for which bios support
doesn't exist. This was leading to skip the secure boot installation.

The current approach strips the secure boot installation logic from the
grub2.install method, so skipping the install method does not
automatically result in skipping the secure boot installation.

Fixes bsc#1182211
