### PR TITLE
Make sure man pages are part of sdist tarball

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -174,7 +174,7 @@ pypi_upload:
   script:
     - base64 --decode "$PYPI_CONFIG" > .pypirc
     - export PYTHON=python3.6
-    - tox -e release
+    - tox -e doc_man,release
   cache:
     key: "$CI_JOB_NAME"
     paths:

--- a/tox.ini
+++ b/tox.ini
@@ -27,12 +27,12 @@ description =
     devel: Test KIWI
 whitelist_externals = *
 basepython =
-    {check,devel,packagedoc,doc,doc_gh_pages,doc_suse}: python3
+    {check,devel,packagedoc,doc,doc_gh_pages,doc_suse,doc_man}: python3
     unit_py3_8: python3.8
     unit_py3_6: python3.6
     release: python3.6
 envdir =
-    {check,devel,packagedoc,doc,doc_gh_pages,doc_suse}: {toxworkdir}/3
+    {check,devel,packagedoc,doc,doc_gh_pages,doc_suse,doc_man}: {toxworkdir}/3
     unit_py3_8: {toxworkdir}/3.8
     unit_py3_6: {toxworkdir}/3.6
     release: {toxworkdir}/3.6
@@ -91,6 +91,15 @@ commands =
     {[testenv:doc.html]commands}
     {[testenv:doc.man]commands}
 
+
+[testenv:doc_man]
+description = Documentation build run suitable for PyPi release
+skip_install = True
+usedevelop = True
+deps = {[testenv]deps}
+changedir=doc
+commands =
+    {[testenv:doc.man]commands}
 
 [testenv:packagedoc]
 description = Documentation build run suitable for doc deployment in package(rpm)


### PR DESCRIPTION
The current tarball when uploaded to pypi via gitlab does
not contain the manual pages because the doc target to build
them is not called. This commit adds a doc_man tox target
which is called prior pypi release. This Fixes #1746

