### PR TITLE
Fixed API vs. CLI inconsistency

### DIFF
--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -218,6 +218,8 @@ class Cli:
                     value = os.sep + Defaults.get_shared_cache_location()
                 if arg == '--shared-cache-dir' and value:
                     Defaults.set_shared_cache_location(value)
+                if arg == '--config' and value:
+                    Defaults.set_custom_runtime_config_file(value)
                 result[arg] = value
         return result
 

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -39,6 +39,7 @@ EDIT_BOOT_INSTALL_SCRIPT = 'edit_boot_install.sh'
 IMAGE_METADATA_DIR = 'image'
 ROOT_VOLUME_NAME = 'LVRoot'
 SHARED_CACHE_DIR = '/var/cache/kiwi'
+CUSTOM_RUNTIME_CONFIG_FILE = None
 
 
 class Defaults:
@@ -203,6 +204,16 @@ class Defaults:
         """
         global SHARED_CACHE_DIR
         SHARED_CACHE_DIR = location
+
+    @staticmethod
+    def set_custom_runtime_config_file(filename):
+        """
+        Sets the runtime config file once
+
+        :param str filename: a file path name
+        """
+        global CUSTOM_RUNTIME_CONFIG_FILE
+        CUSTOM_RUNTIME_CONFIG_FILE = filename
 
     @staticmethod
     def get_shared_cache_location():

--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -20,7 +20,8 @@ import logging
 import yaml
 
 # project
-from kiwi.cli import Cli
+import kiwi.defaults as defaults
+
 from kiwi.defaults import Defaults
 from kiwi.utils.size import StringToSize
 from kiwi.exceptions import (
@@ -51,9 +52,8 @@ class RuntimeConfig:
         global RUNTIME_CONFIG
 
         if RUNTIME_CONFIG is None or reread:
-            cli = Cli()
             config_file = None
-            custom_config_file = cli.get_global_args().get('--config')
+            custom_config_file = defaults.CUSTOM_RUNTIME_CONFIG_FILE
 
             if custom_config_file:
                 config_file = custom_config_file

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -54,9 +54,6 @@ class CliTask:
         # initialize runtime checker
         self.runtime_checker = None
 
-        # initialize runtime configuration
-        self.runtime_config = RuntimeConfig()
-
         # help requested
         self.cli.show_and_exit_on_help_request()
 
@@ -68,6 +65,9 @@ class CliTask:
 
         # get global args
         self.global_args = self.cli.get_global_args()
+
+        # initialize runtime configuration
+        self.runtime_config = RuntimeConfig()
 
         # initialize generic runtime check dicts
         self.checks_before_command_args = {

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -22,7 +22,7 @@ class TestCli:
         self._caplog = caplog
 
     def setup(self):
-        self.help_global_args = {
+        self.expected_global_args = {
             'help': False,
             '--compat': False,
             'compat': False,
@@ -39,7 +39,7 @@ class TestCli:
             '--profile': [],
             '--shared-cache-dir': '/var/cache/kiwi',
             '--help': False,
-            '--config': None
+            '--config': 'config-file'
         }
         self.command_args = {
             '--add-repo': [],
@@ -141,7 +141,16 @@ class TestCli:
         assert self.cli.get_command_args() == self.command_args
 
     def test_get_global_args(self):
-        assert self.cli.get_global_args() == self.help_global_args
+        self.cli.all_args['--config'] = 'config-file'
+        sys.argv = [
+            sys.argv[0],
+            '--config', 'config-file',
+            'system', 'build',
+            '--description', 'description',
+            '--target-dir', 'directory'
+        ]
+        cli = Cli()
+        assert cli.get_global_args() == self.expected_global_args
 
     def test_load_command(self):
         assert self.cli.load_command() == self.loaded_command

--- a/test/unit/system/uri_test.py
+++ b/test/unit/system/uri_test.py
@@ -117,15 +117,24 @@ class TestUri:
 
     @patch('kiwi.system.uri.requests')
     def test_is_public(self, mock_request):
+        # unknown uri schema is considered not public
         uri = Uri('xxx', 'rpm-md')
         assert uri.is_public() is False
+
+        # https is public
         uri = Uri('https://example.com', 'rpm-md')
         assert uri.is_public() is True
+
+        # obs is private with obs_public set to false in config
         uri = Uri('obs://openSUSE:Leap:42.2/standard', 'yast2')
         self.runtime_config.is_obs_public = mock.Mock(
             return_value=False
         )
         uri.runtime_config = self.runtime_config
+        assert uri.is_public() is False
+
+        # unknown uri type considered not public
+        uri = Uri('httpx://example.com', 'rpm-md')
         assert uri.is_public() is False
 
     def test_alias(self):


### PR DESCRIPTION
when using kiwi as API the program fails with a usage message
from the Cli class. The kiwi.cli module should not be imported
except for kiwi comandline tasks. It has turned out that the
RuntimeConfig class which is used in several places in different
API classes imports Cli and creates an instance of it to check
for a global option. This causes major issues for all programs
which uses the kiwi API but not the command line interface because
the docopt call in Cli() expects a valid docstring which only
exists in kiwi's cli.py. This commit fixes the inconsistency
and allows people to use the kiwi API independent of any
command line interface. Fixes #1755

