### PR TITLE
Fix use of by-label device persistency in grub

### DIFF
--- a/kiwi/utils/block.py
+++ b/kiwi/utils/block.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import re
 
 # project
 from kiwi.command import Command
@@ -25,11 +26,20 @@ class BlockID:
     """
     **Get information from a block device**
 
-    :param str device: block device node name name
+    :param str device:
+        block device node name name. The device can
+        also be specified as UUID=<uuid>
 
     """
     def __init__(self, device):
-        self.device = device
+        uuid_format = re.match(r'^UUID=(.*)', device)
+        if uuid_format:
+            blkid_result = Command.run(
+                ['blkid', '--uuid', uuid_format.group(1)]
+            )
+            self.device = blkid_result.output.strip(os.linesep)
+        else:
+            self.device = device
 
     def get_label(self):
         """

--- a/test/unit/bootloader/config/base_test.py
+++ b/test/unit/bootloader/config/base_test.py
@@ -109,34 +109,32 @@ class TestBootLoaderConfigBase:
         mock_cmdline.return_value = 'root=/dev/myroot'
         assert self.bootloader.get_boot_cmdline() == 'root=/dev/myroot'
 
-    @patch('kiwi.xml_parse.type_.get_firmware')
-    def test_get_boot_cmdline_firmware_ec2(self, mock_firmware):
-        mock_firmware.return_value = 'ec2'
-        assert self.bootloader.get_boot_cmdline('uuid') == \
-            'splash root=UUID=uuid rw'
-
     @patch('kiwi.xml_parse.type_.get_initrd_system')
-    def test_get_boot_cmdline_initrd_system_is_dracut(self, mock_initrd):
+    @patch('kiwi.bootloader.config.base.BlockID')
+    def test_get_boot_cmdline_initrd_system_is_dracut(
+        self, mock_BlockID, mock_initrd
+    ):
+        block_operation = Mock()
+        block_operation.get_blkid.return_value = 'uuid'
+        mock_BlockID.return_value = block_operation
         mock_initrd.return_value = 'dracut'
         assert self.bootloader.get_boot_cmdline('uuid') == \
             'splash root=UUID=uuid rw'
 
     @patch('kiwi.xml_parse.type_.get_initrd_system')
+    @patch('kiwi.bootloader.config.base.BlockID')
     def test_get_boot_cmdline_initrd_system_is_dracut_with_overlay(
-        self, mock_initrd
+        self, mock_BlockID, mock_initrd
     ):
+        block_operation = Mock()
+        block_operation.get_blkid.return_value = 'uuid'
+        mock_BlockID.return_value = block_operation
         mock_initrd.return_value = 'dracut'
         self.state.build_type.get_overlayroot = Mock(
             return_value=True
         )
         assert self.bootloader.get_boot_cmdline('uuid') == \
             'splash root=overlay:UUID=uuid'
-
-    @patch('kiwi.xml_parse.type_.get_firmware')
-    def test_get_boot_cmdline_firmware_ec2_no_uuid(self, mock_firmware):
-        mock_firmware.return_value = 'ec2'
-        with self._caplog.at_level(logging.WARNING):
-            self.bootloader.get_boot_cmdline()
 
     @patch('kiwi.xml_parse.type_.get_installboot')
     def test_get_install_image_boot_default(self, mock_installboot):

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -539,6 +539,7 @@ class TestBootLoaderConfigGrub2:
                 '/boot/grub2/themes/openSUSE/background.png'
             ),
             call('GRUB_CMDLINE_LINUX_DEFAULT', '"some-cmdline"'),
+            call('GRUB_DISABLE_LINUX_UUID', 'true'),
             call('GRUB_DISTRIBUTOR', '"Bob"'),
             call('GRUB_ENABLE_BLSCFG', 'true'),
             call('GRUB_ENABLE_CRYPTODISK', 'y'),
@@ -580,6 +581,7 @@ class TestBootLoaderConfigGrub2:
                 'GRUB_BACKGROUND',
                 '/boot/grub2/themes/openSUSE/background.png'
             ),
+            call('GRUB_DISABLE_LINUX_UUID', 'true'),
             call('GRUB_DISTRIBUTOR', '"Bob"'),
             call('GRUB_ENABLE_BLSCFG', 'true'),
             call('GRUB_ENABLE_CRYPTODISK', 'y'),

--- a/test/unit/utils/block_test.py
+++ b/test/unit/utils/block_test.py
@@ -8,6 +8,13 @@ class TestBlockID:
         self.blkid = BlockID('device')
 
     @patch('kiwi.utils.block.Command.run')
+    def test_setup_with_uuid_format(self, mock_command):
+        BlockID('UUID=uuid')
+        mock_command.assert_called_once_with(
+            ['blkid', '--uuid', 'uuid']
+        )
+
+    @patch('kiwi.utils.block.Command.run')
     def test_get_blkid(self, mock_command):
         self.blkid.get_blkid('LABEL')
         mock_command.assert_called_once_with(


### PR DESCRIPTION
If devicepersistency="by-label" is set in the KIWI description
it will correctly operate on the fstab values but still uses
the UUID based setting for root= in the grub config. This commit
allows to set root=LABEL=... in the grub config in case the
devicepersistency requested it. In order for this to work this
commit also had to increase the scope of the grub helper
method _fix_grub_root_device_reference which is now called in
any case. This Fixes #1757

