### PR TITLE
Exclude /run and /tmp to be synched into the image

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -246,7 +246,7 @@ class Defaults:
         :rtype: list
         """
         exclude_list = [
-            'image', '.profile', '.kconfig',
+            'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
             Defaults.get_buildservice_env_name(),
             Defaults.get_shared_cache_location()
         ]

--- a/test/unit/builder/archive_test.py
+++ b/test/unit/builder/archive_test.py
@@ -61,7 +61,8 @@ class TestArchiveBuilder:
         )
         archive.create_xz_compressed.assert_called_once_with(
             'root_dir', exclude=[
-                'image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi'
+                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                '.buildenv', 'var/cache/kiwi'
             ], xz_options=None
         )
         self.setup.export_package_verification.assert_called_once_with(

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -352,8 +352,9 @@ class TestDiskBuilder:
         call = filesystem.sync_data.call_args_list[2]
         assert filesystem.sync_data.call_args_list[2] == \
             call([
-                'image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi',
-                'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
+                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                '.buildenv', 'var/cache/kiwi', 'boot/*', 'boot/.*',
+                'boot/efi/*', 'boot/efi/.*'
             ])
         assert m_open.call_args_list[0:4] == [
             call('boot_dir/config.partids', 'w'),
@@ -480,8 +481,9 @@ class TestDiskBuilder:
         call = filesystem.sync_data.call_args_list[2]
         assert filesystem.sync_data.call_args_list[2] == \
             call([
-                'image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi',
-                'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
+                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                '.buildenv', 'var/cache/kiwi', 'boot/*', 'boot/.*',
+                'boot/efi/*', 'boot/efi/.*'
             ])
         assert m_open.call_args_list == [
             call('boot_dir/config.partids', 'w'),
@@ -560,7 +562,8 @@ class TestDiskBuilder:
         assert squashfs.create_on_file.call_args_list == [
             call(exclude=['var/cache/kiwi'], filename='tempname'),
             call(exclude=[
-                'image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi',
+                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                '.buildenv', 'var/cache/kiwi',
                 'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
             ], filename='tempname')
         ]
@@ -753,7 +756,8 @@ class TestDiskBuilder:
         ]
         volume_manager.sync_data.assert_called_once_with(
             [
-                'image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi',
+                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                '.buildenv', 'var/cache/kiwi',
                 'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
             ]
         )
@@ -844,8 +848,8 @@ class TestDiskBuilder:
         )
         assert filesystem.sync_data.call_args_list.pop() == call(
             [
-                'image', '.profile', '.kconfig', '.buildenv',
-                'var/cache/kiwi', 'var/*', 'var/.*',
+                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                '.buildenv', 'var/cache/kiwi', 'var/*', 'var/.*',
                 'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
             ]
         )

--- a/test/unit/builder/filesystem_test.py
+++ b/test/unit/builder/filesystem_test.py
@@ -113,9 +113,10 @@ class TestFileSystemBuilder:
             }
         )
         self.filesystem.create_on_device.assert_called_once_with(None)
-        self.filesystem.sync_data.assert_called_once_with(
-            ['image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi']
-        )
+        self.filesystem.sync_data.assert_called_once_with([
+            'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+            '.buildenv', 'var/cache/kiwi'
+        ])
         self.setup.export_package_verification.assert_called_once_with(
             'target_dir'
         )
@@ -149,7 +150,10 @@ class TestFileSystemBuilder:
         )
         self.filesystem.create_on_file.assert_called_once_with(
             'target_dir/myimage.x86_64-1.2.3.squashfs', None,
-            ['image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi']
+            [
+                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                '.buildenv', 'var/cache/kiwi'
+            ]
         )
         self.setup.export_package_verification.assert_called_once_with(
             'target_dir'

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -195,9 +195,10 @@ class TestLiveImageBuilder:
         ]
 
         filesystem.create_on_device.assert_called_once_with()
-        filesystem.sync_data.assert_called_once_with(
-            ['image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi']
-        )
+        filesystem.sync_data.assert_called_once_with([
+            'image', '.profile', '.kconfig',
+            'run/*', 'tmp/*', '.buildenv', 'var/cache/kiwi'
+        ])
         filesystem.create_on_file.assert_called_once_with('tmpfile')
 
         assert mock_shutil.copy.call_args_list == [

--- a/test/unit/container/oci_test.py
+++ b/test/unit/container/oci_test.py
@@ -137,8 +137,8 @@ class TestContainerImageOCI:
         mock_oci.unpack.assert_called_once_with()
         mock_oci.sync_rootfs.assert_called_once_with(
             'root_dir', [
-                'image', '.profile', '.kconfig', '.buildenv',
-                'var/cache/kiwi', 'dev/*', 'sys/*', 'proc/*'
+                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                '.buildenv', 'var/cache/kiwi', 'dev/*', 'sys/*', 'proc/*'
             ]
         )
         mock_oci.repack.assert_called_once_with({
@@ -180,8 +180,8 @@ class TestContainerImageOCI:
         mock_oci.unpack.assert_called_once_with()
         mock_oci.sync_rootfs.assert_called_once_with(
             'root_dir', [
-                'image', '.profile', '.kconfig', '.buildenv',
-                'var/cache/kiwi', 'dev/*', 'sys/*', 'proc/*'
+                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                '.buildenv', 'var/cache/kiwi', 'dev/*', 'sys/*', 'proc/*'
             ]
         )
         mock_oci.repack.assert_called_once_with({


### PR DESCRIPTION
This commit makes sure the contents of /run and /tmp are ignored when
synchronizing the generated root tree into the image.

Fixes #1744
