### PR TITLE
Add a requirement for kiwi-systemdeps-iso-media on disk images

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -274,6 +274,7 @@ Requires:       qemu-img
 %endif
 Requires:       kiwi-systemdeps-filesystems = %{version}-%{release}
 Requires:       kiwi-systemdeps-bootloaders = %{version}-%{release}
+Requires:       kiwi-systemdeps-iso-media = %{version}-%{release}
 
 %description -n kiwi-systemdeps-disk-images
 Host setup helper to pull in all packages required/useful on


### PR DESCRIPTION
This commit adds a requirement for `kiwi-systemdeps-iso-media` in
`kiwi-systemdeps-disk-images`. This is to ensure that installing
`kiwi-systemdeps-disk-images` is enough to build OEM images including
install media.