### PR TITLE
Fix apt package manager setting

### DIFF
--- a/build-tests/arm/fedora/test-image-live/appliance.kiwi
+++ b/build-tests/arm/fedora/test-image-live/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-live">
+<image schemaversion="7.4" name="kiwi-test-image-live">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/arm/rawhide/test-image-live-disk/appliance.kiwi
+++ b/build-tests/arm/rawhide/test-image-live-disk/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="kiwi-test-image-live-disk">
+<image schemaversion="7.4" name="kiwi-test-image-live-disk">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>
@@ -29,7 +29,7 @@
     </preferences>
     <preferences profiles="Disk">
         <type image="oem" firmware="uefi" kernelcmdline="console=ttyS0" installiso="true" filesystem="ext4">
-            <bootloader name="grub2" console="serial" />
+            <bootloader name="grub2" console="serial"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>200</oem-swapsize>

--- a/build-tests/arm/tumbleweed/test-image-live-disk/appliance.kiwi
+++ b/build-tests/arm/tumbleweed/test-image-live-disk/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="kiwi-test-image-live-disk">
+<image schemaversion="7.4" name="kiwi-test-image-live-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -28,7 +28,7 @@
     </preferences>
     <preferences profiles="Disk">
         <type image="oem" firmware="uefi" kernelcmdline="console=ttyS0" installiso="true" filesystem="ext4">
-            <bootloader name="grub2" console="serial" />
+            <bootloader name="grub2" console="serial"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>200</oem-swapsize>

--- a/build-tests/arm/tumbleweed/test-image-rpi-overlay/appliance.kiwi
+++ b/build-tests/arm/tumbleweed/test-image-rpi-overlay/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-rpi-overlay">
+<image schemaversion="7.4" name="kiwi-test-image-rpi-overlay">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/arm/tumbleweed/test-image-rpi/appliance.kiwi
+++ b/build-tests/arm/tumbleweed/test-image-rpi/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-rpi">
+<image schemaversion="7.4" name="kiwi-test-image-rpi">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/ppc/fedora/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/ppc/fedora/test-image-disk-simple/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-disk-simple">
+<image schemaversion="7.4" name="kiwi-test-image-disk-simple">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/ppc/sle15/test-image-disk/appliance.kiwi
+++ b/build-tests/ppc/sle15/test-image-disk/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="kiwi-test-image-disk">
+<image schemaversion="7.4" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/ppc/tumbleweed/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/ppc/tumbleweed/test-image-disk-simple/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-disk-simple">
+<image schemaversion="7.4" name="kiwi-test-image-disk-simple">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/ppc/tumbleweed/test-image-disk/appliance.kiwi
+++ b/build-tests/ppc/tumbleweed/test-image-disk/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="kiwi-test-image-disk">
+<image schemaversion="7.4" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/s390/sle15/test-image-disk/appliance.kiwi
+++ b/build-tests/s390/sle15/test-image-disk/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="kiwi-test-image-disk">
+<image schemaversion="7.4" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/s390/tumbleweed/test-image-disk/appliance.kiwi
+++ b/build-tests/s390/tumbleweed/test-image-disk/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="kiwi-test-image-disk">
+<image schemaversion="7.4" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
+++ b/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="kiwi-test-image-live-disk-kis">
+<image schemaversion="7.4" name="kiwi-test-image-live-disk-kis">
     <description type="system">
         <author>David Cassany</author>
         <contact>dcassany@suse.com</contact>

--- a/build-tests/x86/centos/test-image-live-disk-v7/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-live-disk-v7/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="kiwi-test-image-live-disk-v7">
+<image schemaversion="7.4" name="kiwi-test-image-live-disk-v7">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/centos/test-image-live-disk-v8/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-live-disk-v8/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="kiwi-test-image-live-disk-v8">
+<image schemaversion="7.4" name="kiwi-test-image-live-disk-v8">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/debian/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/debian/test-image-live-disk/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="kiwi-test-image-live-disk">
+<image schemaversion="7.4" name="kiwi-test-image-live-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>
@@ -16,7 +16,7 @@
     </profiles>
     <preferences>
         <version>10.4</version>
-        <packagemanager>apt-get</packagemanager>
+        <packagemanager>apt</packagemanager>
         <bootsplash-theme>fade-in</bootsplash-theme>
         <bootloader-theme>starfield</bootloader-theme>
         <rpm-check-signatures>false</rpm-check-signatures>

--- a/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="kiwi-test-image-live-disk">
+<image schemaversion="7.4" name="kiwi-test-image-live-disk">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/fedora/test-image-microdnf/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-microdnf/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-microdnf">
+<image schemaversion="7.4" name="kiwi-test-image-microdnf">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-custom-partitions/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-custom-partitions/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-custom-partitions">
+<image schemaversion="7.4" name="kiwi-test-image-custom-partitions">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/leap/test-image-disk-ramdisk/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-disk-ramdisk/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-disk-ramdisk">
+<image schemaversion="7.4" name="kiwi-test-image-disk-ramdisk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-disk-simple/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-disk-simple" displayname="Simple Disk">
+<image schemaversion="7.4" name="kiwi-test-image-disk-simple" displayname="Simple Disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-disk/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-disk/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-disk">
+<image schemaversion="7.4" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-docker-derived/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-docker-derived/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-docker-derived">
+<image schemaversion="7.4" name="kiwi-test-image-docker-derived">
     <description type="system">
         <author>David Cassany</author>
         <contact>dcassany@suse.de</contact>

--- a/build-tests/x86/leap/test-image-docker/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-docker/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-docker">
+<image schemaversion="7.4" name="kiwi-test-image-docker">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-live/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-live/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-live">
+<image schemaversion="7.4" name="kiwi-test-image-live">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-luks/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-luks/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-luks">
+<image schemaversion="7.4" name="kiwi-test-image-luks">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-lvm/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-lvm/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-lvm">
+<image schemaversion="7.4" name="kiwi-test-image-lvm">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-overlayroot/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-overlayroot">
+<image schemaversion="7.4" name="kiwi-test-image-overlayroot">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-tbz/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-tbz/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-tbz">
+<image schemaversion="7.4" name="kiwi-test-image-tbz">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-vagrant/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-vagrant/appliance.kiwi
@@ -4,7 +4,7 @@
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 <!-- OBS-ExclusiveArch: x86_64 -->
 
-<image schemaversion="7.3" name="kiwi-test-image-vagrant">
+<image schemaversion="7.4" name="kiwi-test-image-vagrant">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="kiwi-test-image-live-disk">
+<image schemaversion="7.4" name="kiwi-test-image-live-disk">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/rawhide/test-image-microdnf/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-microdnf/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-microdnf">
+<image schemaversion="7.4" name="kiwi-test-image-microdnf">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-MicroOS/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-MicroOS/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-MicroOS">
+<image schemaversion="7.4" name="kiwi-test-image-MicroOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-azure/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-azure/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-azure">
+<image schemaversion="7.4" name="kiwi-test-image-azure">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/tumbleweed/test-image-custom-partitions/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-custom-partitions/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-custom-partitions">
+<image schemaversion="7.4" name="kiwi-test-image-custom-partitions">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/tumbleweed/test-image-disk-legacy/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-legacy/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-disk-legacy">
+<image schemaversion="7.4" name="kiwi-test-image-disk-legacy">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-disk-ramdisk/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-ramdisk/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-disk-ramdisk">
+<image schemaversion="7.4" name="kiwi-test-image-disk-ramdisk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-simple/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-disk-simple" displayname="Simple Disk">
+<image schemaversion="7.4" name="kiwi-test-image-disk-simple" displayname="Simple Disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-disk/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-disk">
+<image schemaversion="7.4" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-docker-derived/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-docker-derived/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-docker-derived">
+<image schemaversion="7.4" name="kiwi-test-image-docker-derived">
     <description type="system">
         <author>David Cassany</author>
         <contact>dcassany@suse.de</contact>

--- a/build-tests/x86/tumbleweed/test-image-docker/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-docker/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-docker">
+<image schemaversion="7.4" name="kiwi-test-image-docker">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-ec2/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-ec2/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-ec2">
+<image schemaversion="7.4" name="kiwi-test-image-ec2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/tumbleweed/test-image-gce/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-gce/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-gce">
+<image schemaversion="7.4" name="kiwi-test-image-gce">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-live">
+<image schemaversion="7.4" name="kiwi-test-image-live">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-luks">
+<image schemaversion="7.4" name="kiwi-test-image-luks">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-lvm/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-lvm/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-lvm">
+<image schemaversion="7.4" name="kiwi-test-image-lvm">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-orthos/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-orthos/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-orthos">
+<image schemaversion="7.4" name="kiwi-test-image-orthos">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-overlayroot">
+<image schemaversion="7.4" name="kiwi-test-image-overlayroot">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-pxe/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-pxe/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="kiwi-test-image-pxe">
+<image schemaversion="7.4" name="kiwi-test-image-pxe">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-qcow-openstack/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-qcow-openstack/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-qcow-openstack">
+<image schemaversion="7.4" name="kiwi-test-image-qcow-openstack">
     <description type="system">
         <author>KIWI Team</author>
         <contact>kiwi-images@googlegroups.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-suse-on-dnf/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-suse-on-dnf/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-suse-on-dnf">
+<image schemaversion="7.4" name="kiwi-test-image-suse-on-dnf">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-tbz/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-tbz/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-tbz">
+<image schemaversion="7.4" name="kiwi-test-image-tbz">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-vagrant/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-vagrant/appliance.kiwi
@@ -4,7 +4,7 @@
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 <!-- OBS-ExclusiveArch: x86_64 -->
 
-<image schemaversion="7.3" name="kiwi-test-image-vagrant">
+<image schemaversion="7.4" name="kiwi-test-image-vagrant">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-wsl/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-wsl/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="kiwi-test-image-wsl">
+<image schemaversion="7.4" name="kiwi-test-image-wsl">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/ubuntu/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/ubuntu/test-image-live-disk/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.3" name="kiwi-test-image-live-disk">
+<image schemaversion="7.4" name="kiwi-test-image-live-disk">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>
@@ -16,7 +16,7 @@
     </profiles>
     <preferences>
         <version>1.16.4</version>
-        <packagemanager>apt-get</packagemanager>
+        <packagemanager>apt</packagemanager>
         <bootsplash-theme>sabily</bootsplash-theme>
         <bootloader-theme>ubuntu-mate</bootloader-theme>
         <locale>en_US</locale>

--- a/doc/source/concept_and_workflow.rst
+++ b/doc/source/concept_and_workflow.rst
@@ -106,7 +106,7 @@ installed during the image creation process.
 
 For the package installation, {kiwi} relies on the package manager specified
 in the ``packagemanager`` element in :file:`config.xml`. {kiwi} supports the
-following package managers: ``dnf``, ``zypper`` (default) and ``apt-get``.
+following package managers: ``dnf``, ``zypper`` (default) and ``apt``.
 
 The prepare step consists of the following substeps:
 

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -118,7 +118,7 @@ table shows which package manager is connected to which distributor:
 +--------------+-----------------+
 | RedHat       | dnf             |
 +--------------+-----------------+
-| Debian Based | apt-get         |
+| Debian Based | apt             |
 +--------------+-----------------+ 
 | Arch Linux   | pacman          |
 +--------------+-----------------+

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1582,7 +1582,7 @@ class Defaults:
         :rtype: str
         """
         rpm_based = ['zypper', 'yum', 'dnf', 'microdnf']
-        deb_based = ['apt-get']
+        deb_based = ['apt']
         if package_manager in rpm_based:
             return 'rpm'
         elif package_manager in deb_based:

--- a/kiwi/package_manager/__init__.py
+++ b/kiwi/package_manager/__init__.py
@@ -58,7 +58,7 @@ class PackageManager(metaclass=ABCMeta):
             'yum': ['dnf', 'Dnf'],
             'microdnf': ['microdnf', 'MicroDnf'],
             'pacman': ['pacman', 'Pacman'],
-            'apt-get': ['apt', 'Apt']
+            'apt': ['apt', 'Apt']
         }
         try:
             (module_namespace, module_name) = name_map[package_manager_name]

--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -147,9 +147,9 @@ class PackageManagerApt(PackageManagerBase):
         for node in debootstrap_device_node_conflicts:
             Path.wipe(os.path.normpath(os.sep.join([self.root_dir, node])))
 
-        if 'apt-get' in self.package_requests:
-            # debootstrap takes care to install apt-get
-            self.package_requests.remove('apt-get')
+        if 'apt' in self.package_requests:
+            # debootstrap takes care to install apt
+            self.package_requests.remove('apt')
         try:
             cmd = ['debootstrap']
             if self.repository.unauthenticated == 'false' and \

--- a/kiwi/repository/__init__.py
+++ b/kiwi/repository/__init__.py
@@ -51,7 +51,7 @@ class Repository(metaclass=ABCMeta):
             'dnf': ['dnf', 'Dnf'],
             'yum': ['dnf', 'Dnf'],
             'microdnf': ['dnf', 'Dnf'],
-            'apt-get': ['apt', 'Apt'],
+            'apt': ['apt', 'Apt'],
             'pacman': ['pacman', 'Pacman']
         }
         try:

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -62,7 +62,7 @@ div {
         attribute xsi:schemaLocation { xsd:anyURI }
     k.image.schemaversion.attribute =
         ## The allowed Schema version (fixed value)
-        attribute schemaversion { "7.3" }
+        attribute schemaversion { "7.4" }
     k.image.id =
         ## An identification number which is represented in a file
         ## named /etc/ImageID
@@ -830,7 +830,7 @@ div {
 #
 div {
     k.packagemanager.content = 
-        "apt-get" | "zypper" | "yum" | "dnf" | "microdnf" | "pacman"
+        "apt" | "zypper" | "yum" | "dnf" | "microdnf" | "pacman"
     k.packagemanager.attlist = empty
     k.packagemanager =
         ## Name of the Package Manager

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -130,7 +130,7 @@ second the location of the XSD Schema
     <define name="k.image.schemaversion.attribute">
       <attribute name="schemaversion">
         <a:documentation>The allowed Schema version (fixed value)</a:documentation>
-        <value>7.3</value>
+        <value>7.4</value>
       </attribute>
     </define>
     <define name="k.image.id">
@@ -1268,7 +1268,7 @@ the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
   <div>
     <define name="k.packagemanager.content">
       <choice>
-        <value>apt-get</value>
+        <value>apt</value>
         <value>zypper</value>
         <value>yum</value>
         <value>dnf</value>

--- a/kiwi/solver/sat.py
+++ b/kiwi/solver/sat.py
@@ -221,18 +221,6 @@ class Sat:
         """
         jobs = []
         for job_name in job_names:
-            # There is a special handling for apt-get. In kiwi the
-            # package manager for debian based distros is selected
-            # by the name apt-get. That name is added to the package
-            # list, but apt-get does not really exist in Debian based
-            # distros. The name of the package manager from a packaging
-            # perspective is just: apt not apt-get. We should change
-            # this in the schema and code in kiwi. But so far we
-            # have the hack here. The reason why we don't see an issue
-            # by this when building debian based images is because
-            # the bootstrap phase is handled by debootstrap
-            if job_name == 'apt-get':
-                job_name = 'apt'
             selection_name = self.solv.Selection.SELECTION_NAME
             selection_provides = self.solv.Selection.SELECTION_PROVIDES
             selection = self.pool.select(

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/david/work/kiwi/.tox/3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/ms/Project/kiwi/.tox/3.6/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -726,7 +726,7 @@ def _cast(typ, value):
 
 
 class k_packagemanager_content(object):
-    APTGET='apt-get'
+    APT='apt'
     ZYPPER='zypper'
     YUM='yum'
     DNF='dnf'

--- a/kiwi/xsl/convert73to74.xsl
+++ b/kiwi/xsl/convert73to74.xsl
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv73to74">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv73to74"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>7.3</literal> to <literal>7.4</literal>.
+</para>
+<xsl:template match="image" mode="conv73to74">
+    <xsl:choose>
+        <!-- nothing to do if already at 7.4 -->
+        <xsl:when test="@schemaversion > 7.3">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="7.4">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv73to74"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- change packagemanager to apt if set to apt-get -->
+<xsl:template match="packagemanager" mode="conv73to74">
+    <xsl:choose>
+        <xsl:when test="text()='apt-get'">
+            <packagemanager>apt</packagemanager>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:copy-of select="."/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/kiwi/xsl/master.xsl
+++ b/kiwi/xsl/master.xsl
@@ -44,6 +44,7 @@
 <xsl:import href="convert70to71.xsl"/>
 <xsl:import href="convert71to72.xsl"/>
 <xsl:import href="convert72to73.xsl"/>
+<xsl:import href="convert73to74.xsl"/>
 <xsl:import href="pretty.xsl"/>
 
 
@@ -206,8 +207,12 @@
         <xsl:apply-templates select="exslt:node-set($v72)" mode="conv72to73"/>
     </xsl:variable>
 
+    <xsl:variable name="v74">
+        <xsl:apply-templates select="exslt:node-set($v73)" mode="conv73to74"/>
+    </xsl:variable>
+
     <xsl:apply-templates
-        select="exslt:node-set($v73)" mode="pretty"
+        select="exslt:node-set($v74)" mode="pretty"
     />
 </xsl:template>
 

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -44,7 +44,7 @@
 
 Name:           python-kiwi
 Version:        %%VERSION
-Provides:       kiwi-schema = 7.3
+Provides:       kiwi-schema = 7.4
 Release:        0
 Url:            https://github.com/OSInside/kiwi
 Summary:        KIWI - Appliance Builder Next Generation

--- a/test/data/example_arm_disk_size_config.xml
+++ b/test/data/example_arm_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_btrfs_config.xml
+++ b/test/data/example_btrfs_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS" displayname="Bob">
+<image schemaversion="7.4" name="LimeJeOS" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>
@@ -74,7 +74,7 @@
             </oemconfig>
             <vagrantconfig provider="libvirt" virtualsize="42"/>
             <installmedia>
-                 <initrd action="add">
+                <initrd action="add">
                     <dracut module="network-legacy"/>
                 </initrd>
             </installmedia>

--- a/test/data/example_disk_config.xml
+++ b/test/data/example_disk_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_config.xml
+++ b/test/data/example_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_empty_vol_config.xml
+++ b/test/data/example_disk_size_empty_vol_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_oem_volume_config.xml
+++ b/test/data/example_disk_size_oem_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_vol_root_config.xml
+++ b/test/data/example_disk_size_vol_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_volume_config.xml
+++ b/test/data/example_disk_size_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_dot_profile_config.xml
+++ b/test/data/example_dot_profile_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_custom_rootvol_config.xml
+++ b/test/data/example_lvm_custom_rootvol_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="custom-root-volume-setup">
+<image schemaversion="7.4" name="custom-root-volume-setup">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_default_config.xml
+++ b/test/data/example_lvm_default_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_config.xml
+++ b/test/data/example_lvm_no_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_full_usr_config.xml
+++ b/test/data/example_lvm_no_root_full_usr_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_preferred_config.xml
+++ b/test/data/example_lvm_preferred_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_multiple_users_config.xml
+++ b/test/data/example_multiple_users_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_default_type.xml
+++ b/test/data/example_no_default_type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_image_packages_config.xml
+++ b/test/data/example_no_image_packages_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_imageinclude_config.xml
+++ b/test/data/example_no_imageinclude_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_ppc_disk_size_config.xml
+++ b/test/data/example_ppc_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_pxe_config.xml
+++ b/test/data/example_pxe_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_boot_desc_not_found.xml
+++ b/test/data/example_runtime_checker_boot_desc_not_found.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="JeOS">
+<image schemaversion="7.4" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>

--- a/test/data/example_runtime_checker_conflicting_types.xml
+++ b/test/data/example_runtime_checker_conflicting_types.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="TypeConflict">
+<image schemaversion="7.4" name="TypeConflict">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/test/data/example_runtime_checker_no_boot_reference.xml
+++ b/test/data/example_runtime_checker_no_boot_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="JeOS">
+<image schemaversion="7.4" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_no_initrd_system_reference.xml
+++ b/test/data/example_runtime_checker_no_initrd_system_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="JeOS">
+<image schemaversion="7.4" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/image_info/config.xml
+++ b/test/data/image_info/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="LimeJeOS" displayname="Bob">
+<image schemaversion="7.4" name="LimeJeOS" displayname="Bob">
     <description type="system">
         <author>Marcus</author>
         <contact>ms@suse.com</contact>

--- a/test/data/isoboot/example-distribution-no-delete-section/config.xml
+++ b/test/data/isoboot/example-distribution-no-delete-section/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="initrd-isoboot-suse-13.2">
+<image schemaversion="7.4" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/isoboot/example-distribution/config.xml
+++ b/test/data/isoboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="initrd-isoboot-suse-13.2">
+<image schemaversion="7.4" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/oemboot/example-distribution/config.xml
+++ b/test/data/oemboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.3" name="initrd-oemboot-suse-13.2">
+<image schemaversion="7.4" name="initrd-oemboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/unit/package_manager/apt_test.py
+++ b/test/unit/package_manager/apt_test.py
@@ -75,7 +75,7 @@ class TestPackageManagerApt:
     def test_process_install_requests_bootstrap_failed_debootstrap(
         self, mock_wipe, mock_exists, mock_call
     ):
-        self.manager.request_package('apt-get')
+        self.manager.request_package('apt')
         mock_call.side_effect = Exception
         mock_exists.return_value = True
         mock_root_bind = Mock()
@@ -88,7 +88,7 @@ class TestPackageManagerApt:
     def test_process_install_requests_bootstrap(
         self, mock_exists, mock_wipe, mock_call
     ):
-        self.manager.request_package('apt-get')
+        self.manager.request_package('apt')
         self.manager.request_package('vim')
         call_result = Mock()
         call_result.process.communicate.return_value = ('stdout', 'stderr')
@@ -121,7 +121,7 @@ class TestPackageManagerApt:
     def test_process_install_requests_bootstrap_no_gpg_check(
         self, mock_exists, mock_wipe, mock_call
     ):
-        self.manager.request_package('apt-get')
+        self.manager.request_package('apt')
         self.manager.request_package('vim')
         call_result = Mock()
         call_result.process.communicate.return_value = ('stdout', 'stderr')

--- a/test/unit/package_manager/init_test.py
+++ b/test/unit/package_manager/init_test.py
@@ -40,7 +40,7 @@ class TestPackageManager:
     @patch('kiwi.package_manager.apt.PackageManagerApt')
     def test_manager_apt(self, mock_manager):
         repository = Mock()
-        PackageManager.new(repository, 'apt-get')
+        PackageManager.new(repository, 'apt')
         mock_manager.assert_called_once_with(repository, None)
 
     @patch('kiwi.package_manager.pacman.PackageManagerPacman')

--- a/test/unit/repository/init_test.py
+++ b/test/unit/repository/init_test.py
@@ -38,7 +38,7 @@ class TestRepository:
     @patch('kiwi.repository.apt.RepositoryApt')
     def test_repository_apt(self, mock_manager):
         root_bind = mock.Mock()
-        Repository.new(root_bind, 'apt-get')
+        Repository.new(root_bind, 'apt')
         mock_manager.assert_called_once_with(root_bind, None)
 
     @patch('kiwi.repository.pacman.RepositoryPacman')

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -98,7 +98,7 @@ class TestRuntimeChecker:
                 '--qf', '%{VERSION}', 'dracut-kiwi-oem-dump'
             ]
         )
-        package_manager.return_value = 'apt-get'
+        package_manager.return_value = 'apt'
         mock_Command_run.reset_mock()
         with raises(KiwiRuntimeError) as exception_data:
             self.runtime_checker.\

--- a/test/unit/solver/sat_test.py
+++ b/test/unit/solver/sat_test.py
@@ -140,32 +140,6 @@ class TestSat:
         with raises(KiwiSatSolverJobError):
             self.sat.solve(packages)
 
-    def test_solve_apt_get(self):
-        # There is a special handling for apt-get. In kiwi the
-        # package manager for debian based distros is selected
-        # by the name apt-get. That name is added to the package
-        # list, but apt-get does not really exist in Debian based
-        # distros. The name of the package manager from a packaging
-        # perspective is just: apt not apt-get. We should change
-        # this in the schema and code in kiwi. But so far we
-        # have the hack here
-        packages = ['apt-get']
-        self.solver.solve = Mock(
-            return_value=None
-        )
-        self.selection.isempty = Mock(
-            return_value=False
-        )
-        self.selection.jobs = Mock(
-            return_value=packages
-        )
-        self.sat.solve(packages)
-        selection_name = self.solv.Selection.SELECTION_NAME
-        selection_provides = self.solv.Selection.SELECTION_PROVIDES
-        self.sat.pool.select.assert_called_once_with(
-            'apt', selection_name | selection_provides
-        )
-
     def test_solve(self):
         packages = ['vim']
         self.solver.solve = Mock(

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -1053,7 +1053,7 @@ class TestSystemSetup:
         command.output = 'packages_data'
         mock_command.return_value = command
         self.xml_state.get_package_manager = Mock(
-            return_value='apt-get'
+            return_value='apt'
         )
 
         with patch('builtins.open') as m_open:
@@ -1131,7 +1131,7 @@ class TestSystemSetup:
         command.output = 'changes'
         mock_command.return_value = command
         self.xml_state.get_package_manager = Mock(
-            return_value='apt-get'
+            return_value='apt'
         )
         mock_os_listdir.return_value = ['package_b', 'package_a']
         mock_os_path_exists.return_value = True
@@ -1220,7 +1220,7 @@ class TestSystemSetup:
         command.output = 'verification_data'
         mock_command.return_value = command
         self.xml_state.get_package_manager = Mock(
-            return_value='apt-get'
+            return_value='apt'
         )
 
         with patch('builtins.open') as m_open:


### PR DESCRIPTION
**Change packagemanager setting from apt-get to apt**
    
In kiwi we use the name of the section as package name to install this
package manager capability. However on Debian based distros there is
no package named apt-get. There is only a package named apt which
provides a tool named apt-get. To avoid inconsistencies like we had it
in Issue #1735 and to bring this setting in line with all other
packagemanager settings the setting was moved to just apt.
This Fixes #1738

**Added XSLT transformation schema v73 -> v74**
    
Update schema version and change to package manager 'apt' if 'apt-get' was set

**Update unit- integration tests to schema v74**
