### PR TITLE
Drop by-path devicepersistency setting

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -465,7 +465,7 @@ spare_part_is_last="true|false":
   if oem-resize is switched off. There is a runtime
   check in the {kiwi} code to check this condition
 
-devicepersistency="by-uuid|by-label|by-path":
+devicepersistency="by-uuid|by-label":
   Specifies which method to use for persistent device names.
   This will affect all files written by kiwi that includes
   device references for example `etc/fstab` or the `root=`

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1420,7 +1420,7 @@ div {
     k.type.devicepersistency.attribute =
         ## Specifies which method to use in order to get persistent
         ## storage device names. By default by-uuid is used.
-        attribute devicepersistency { "by-uuid" | "by-label" | "by-path" }
+        attribute devicepersistency { "by-uuid" | "by-label" }
     k.type.editbootconfig.attribute =
         ## Specifies the path to a script which is called right
         ## before the bootloader is installed. The script runs

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2083,7 +2083,6 @@ storage device names. By default by-uuid is used.</a:documentation>
         <choice>
           <value>by-uuid</value>
           <value>by-label</value>
-          <value>by-path</value>
         </choice>
       </attribute>
     </define>


### PR DESCRIPTION
The dev/disk/by-path device representation is a host specific
PCI location. For image building which happens disconnected from
the later target device this setting is useless.
This Fixes #1747

