### PR TITLE
Add Strong Typing to builder APIs

### DIFF
--- a/kiwi/builder/archive.py
+++ b/kiwi/builder/archive.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import logging
+from typing import Dict
 
 # project
 from kiwi.defaults import Defaults
@@ -23,6 +24,7 @@ from kiwi.archive.tar import ArchiveTar
 from kiwi.system.setup import SystemSetup
 from kiwi.system.result import Result
 from kiwi.runtime_config import RuntimeConfig
+from kiwi.xml_state import XMLState
 
 from kiwi.exceptions import (
     KiwiArchiveSetupError
@@ -35,13 +37,13 @@ class ArchiveBuilder:
     """
     **Root archive image builder**
 
-    :param obsject xml_state: Instance of :class:`XMLState`
+    :param object xml_state: Instance of :class:`XMLState`
     :param str target_dir: target directory path name
     :param str root_dir: root directory path name
     :param dict custom_args: Custom processing arguments defined as hash keys:
         * xz_options: string of XZ compression parameters
     """
-    def __init__(self, xml_state, target_dir, root_dir, custom_args=None):
+    def __init__(self, xml_state: XMLState, target_dir: str, root_dir: str, custom_args: Dict = None):
         self.root_dir = root_dir
         self.target_dir = target_dir
         self.xml_state = xml_state
@@ -56,7 +58,7 @@ class ArchiveBuilder:
 
         self.runtime_config = RuntimeConfig()
 
-    def create(self):
+    def create(self) -> None:
         """
         Create a root archive tarball
 
@@ -125,7 +127,7 @@ class ArchiveBuilder:
             )
         return self.result
 
-    def _target_file_for(self, suffix):
+    def _target_file_for(self, suffix: str) -> str:
         return ''.join(
             [
                 self.target_dir, '/',

--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -17,6 +17,7 @@
 #
 import logging
 import os
+from typing import Dict
 
 # project
 from kiwi.container import ContainerImage
@@ -27,6 +28,7 @@ from kiwi.utils.checksum import Checksum
 from kiwi.defaults import Defaults
 from kiwi.exceptions import KiwiContainerBuilderError
 from kiwi.runtime_config import RuntimeConfig
+from kiwi.xml_state import XMLState
 
 log = logging.getLogger('kiwi')
 
@@ -41,7 +43,7 @@ class ContainerBuilder:
     :param dict custom_args: Custom processing arguments defined as hash keys:
         * xz_options: string of XZ compression parameters
     """
-    def __init__(self, xml_state, target_dir, root_dir, custom_args=None):
+    def __init__(self, xml_state: XMLState, target_dir: str, root_dir: str, custom_args: Dict = None):
         self.custom_args = custom_args or {}
         self.root_dir = root_dir
         self.target_dir = target_dir
@@ -94,7 +96,7 @@ class ContainerBuilder:
         self.result = Result(xml_state)
         self.runtime_config = RuntimeConfig()
 
-    def create(self):
+    def create(self) -> Result:
         """
         Builds a container image which is usually a data archive
         including container specific metadata.

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -19,6 +19,7 @@ import os
 import logging
 import pickle
 from tempfile import NamedTemporaryFile
+from typing import Dict, List
 
 # project
 import kiwi.defaults as defaults
@@ -48,6 +49,7 @@ from kiwi.utils.fstab import Fstab
 from kiwi.path import Path
 from kiwi.runtime_config import RuntimeConfig
 from kiwi.partitioner import Partitioner
+from kiwi.xml_state import XMLState
 
 from kiwi.exceptions import (
     KiwiDiskBootImageError,
@@ -70,7 +72,7 @@ class DiskBuilder:
         * xz_options: string of XZ compression parameters
     """
 
-    def __init__(self, xml_state, target_dir, root_dir, custom_args=None):
+    def __init__(self, xml_state: XMLState, target_dir: str, root_dir: str, custom_args: Dict = None):
         self.arch = Defaults.get_platform_name()
         self.root_dir = root_dir
         self.target_dir = target_dir
@@ -166,7 +168,7 @@ class DiskBuilder:
         self.result = Result(xml_state)
         self.runtime_config = RuntimeConfig()
 
-    def create(self):
+    def create(self) -> Result:
         """
         Build a bootable disk image and optional installation image
         The installation image is a bootable hybrid ISO image which
@@ -203,7 +205,7 @@ class DiskBuilder:
 
         return result
 
-    def create_disk(self):
+    def create_disk(self) -> Result:
         """
         Build a bootable raw disk image
 
@@ -498,7 +500,7 @@ class DiskBuilder:
 
         return self.result
 
-    def create_disk_format(self, result_instance):
+    def create_disk_format(self, result_instance: Result) -> Result:
         """
         Create a bootable disk format from a previously
         created raw disk image
@@ -520,7 +522,7 @@ class DiskBuilder:
 
         return result_instance
 
-    def append_unpartitioned_space(self):
+    def append_unpartitioned_space(self) -> None:
         """
         Extends the raw disk if an unpartitioned area is specified
         """
@@ -541,7 +543,7 @@ class DiskBuilder:
             )
             partitioner.resize_table()
 
-    def create_install_media(self, result_instance):
+    def create_install_media(self, result_instance: Result) -> Result:
         """
         Build an installation image. The installation image is a
         bootable hybrid ISO image which embeds the raw disk image
@@ -583,7 +585,7 @@ class DiskBuilder:
 
         return result_instance
 
-    def _load_boot_image_instance(self):
+    def _load_boot_image_instance(self) -> BootImage:
         boot_image_dump_file = self.target_dir + '/boot_image.pickledump'
         if not os.path.exists(boot_image_dump_file):
             raise KiwiInstallMediaError(
@@ -599,18 +601,17 @@ class DiskBuilder:
             )
         return boot_image
 
-    def _setup_selinux_file_contexts(self):
+    def _setup_selinux_file_contexts(self) -> None:
         security_context = '/etc/selinux/targeted/contexts/files/file_contexts'
         if os.path.exists(self.root_dir + security_context):
             self.system_setup.set_selinux_file_contexts(
                 security_context
             )
 
-    def _install_image_requested(self):
-        if self.install_iso or self.install_stick or self.install_pxe:
-            return True
+    def _install_image_requested(self) -> bool:
+        return True if (self.install_iso or self.install_stick or self.install_pxe) else False
 
-    def _get_exclude_list_for_root_data_sync(self, device_map):
+    def _get_exclude_list_for_root_data_sync(self, device_map: Dict) -> list:
         exclude_list = Defaults.get_exclude_list_for_root_data_sync()
         if 'spare' in device_map and self.spare_part_mountpoint:
             exclude_list.append(
@@ -630,10 +631,11 @@ class DiskBuilder:
             exclude_list.append('boot/efi/.*')
         return exclude_list
 
-    def _get_exclude_list_for_boot_data_sync(self):
+    @staticmethod
+    def _get_exclude_list_for_boot_data_sync() -> list:
         return ['efi/*']
 
-    def _build_spare_filesystem(self, device_map):
+    def _build_spare_filesystem(self, device_map: Dict) -> None:
         if 'spare' in device_map and self.spare_part_fs:
             spare_part_data_path = None
             spare_part_custom_parameters = {
@@ -655,7 +657,7 @@ class DiskBuilder:
             )
             self.system_spare = filesystem
 
-    def _build_boot_filesystems(self, device_map):
+    def _build_boot_filesystems(self, device_map: Dict) -> None:
         if 'efi' in device_map:
             log.info(
                 'Creating EFI(fat16) filesystem on %s',
@@ -688,7 +690,7 @@ class DiskBuilder:
             )
             self.system_boot = filesystem
 
-    def _build_and_map_disk_partitions(self, disksize_mbytes):
+    def _build_and_map_disk_partitions(self, disksize_mbytes: float) -> Dict:
         self.disk.wipe()
         disksize_used_mbytes = 0
         if self.firmware.legacy_bios_mode():
@@ -803,7 +805,7 @@ class DiskBuilder:
 
         return self.disk.get_device()
 
-    def _write_partition_id_config_to_boot_image(self):
+    def _write_partition_id_config_to_boot_image(self) -> None:
         log.info('Creating config.partids in boot system')
         filename = ''.join(
             [self.boot_image.boot_root_directory, '/config.partids']
@@ -818,7 +820,7 @@ class DiskBuilder:
             os.sep + os.path.basename(filename)
         )
 
-    def _write_raid_config_to_boot_image(self):
+    def _write_raid_config_to_boot_image(self) -> None:
         if self.mdraid:
             log.info('Creating etc/mdadm.conf in boot system')
             filename = ''.join(
@@ -829,7 +831,7 @@ class DiskBuilder:
                 os.sep + os.sep.join(['etc', os.path.basename(filename)])
             )
 
-    def _write_crypttab_to_system_image(self):
+    def _write_crypttab_to_system_image(self) -> None:
         if self.luks:
             log.info('Creating etc/crypttab')
             filename = ''.join(
@@ -840,16 +842,16 @@ class DiskBuilder:
                 os.sep + os.sep.join(['etc', os.path.basename(filename)])
             )
 
-    def _write_generic_fstab_to_system_image(self, device_map):
+    def _write_generic_fstab_to_system_image(self, device_map: Dict) -> None:
         log.info('Creating generic system etc/fstab')
         self._write_generic_fstab(device_map, self.system_setup)
 
-    def _write_generic_fstab_to_boot_image(self, device_map):
+    def _write_generic_fstab_to_boot_image(self, device_map: Dict) -> None:
         if self.initrd_system == 'kiwi':
             log.info('Creating generic boot image etc/fstab')
             self._write_generic_fstab(device_map, self.boot_image.setup)
 
-    def _write_generic_fstab(self, device_map, setup):
+    def _write_generic_fstab(self, device_map: Dict, setup: DiskSetup) -> None:
         root_is_snapshot = \
             self.xml_state.build_type.get_btrfs_root_is_snapshot()
         root_is_readonly_snapshot = \
@@ -902,8 +904,8 @@ class DiskBuilder:
         )
 
     def _add_simple_fstab_entry(
-        self, device, mount_point, filesystem, options=None, check='0 0'
-    ):
+        self, device: str, mount_point: str, filesystem: str, options: List = None, check: str = '0 0'
+    ) -> None:
         if not options:
             options = ['defaults']
         fstab_entry = ' '.join(
@@ -914,8 +916,8 @@ class DiskBuilder:
         self.fstab.add_entry(fstab_entry)
 
     def _add_generic_fstab_entry(
-        self, device, mount_point, options=None, check='0 0'
-    ):
+        self, device: str, mount_point: str, options: List = None, check: str = '0 0'
+    ) -> None:
         if not options:
             options = ['defaults']
         block_operation = BlockID(device)
@@ -929,7 +931,7 @@ class DiskBuilder:
         )
         self.fstab.add_entry(fstab_entry)
 
-    def _preserve_root_partition_uuid(self, device_map):
+    def _preserve_root_partition_uuid(self, device_map: Dict) -> None:
         block_operation = BlockID(
             device_map['root'].get_device()
         )
@@ -939,7 +941,7 @@ class DiskBuilder:
                 partition_uuid
             )
 
-    def _preserve_root_filesystem_uuid(self, device_map):
+    def _preserve_root_filesystem_uuid(self, device_map: Dict) -> None:
         block_operation = BlockID(
             device_map['root'].get_device()
         )
@@ -949,13 +951,13 @@ class DiskBuilder:
                 rootfs_uuid
             )
 
-    def _write_image_identifier_to_system_image(self):
+    def _write_image_identifier_to_system_image(self) -> None:
         log.info('Creating image identifier: %s', self.mbrid.get_id())
         self.mbrid.write(
             self.root_dir + '/boot/mbrid'
         )
 
-    def _write_recovery_metadata_to_boot_image(self):
+    def _write_recovery_metadata_to_boot_image(self) -> None:
         if os.path.exists(self.root_dir + '/recovery.partition.size'):
             log.info('Copying recovery metadata to boot image')
             recovery_metadata = ''.join(
@@ -968,7 +970,7 @@ class DiskBuilder:
                 os.sep + os.path.basename(recovery_metadata)
             )
 
-    def _write_bootloader_meta_data_to_system_image(self, device_map):
+    def _write_bootloader_meta_data_to_system_image(self, device_map: Dict) -> None:
         if self.bootloader != 'custom':
             log.info('Creating %s bootloader configuration', self.bootloader)
             boot_options = []
@@ -1004,8 +1006,8 @@ class DiskBuilder:
                     self.bootloader_config.get_boot_cmdline(root_uuid)
                 ] + boot_options
             )
-            with open(filename, 'w') as boot_options:
-                boot_options.write(
+            with open(filename, 'w') as boot_optionsfp:
+                boot_optionsfp.write(
                     '{0}{1}'.format(kexec_boot_options, os.linesep)
                 )
 
@@ -1018,7 +1020,7 @@ class DiskBuilder:
             self.requested_filesystem, boot_partition_id
         )
 
-    def _sync_system_to_image(self, device_map):
+    def _sync_system_to_image(self, device_map: Dict) -> None:
         log.info('Syncing system to image')
         if self.system_spare:
             self.system_spare.sync_data()
@@ -1059,7 +1061,7 @@ class DiskBuilder:
                 self._get_exclude_list_for_root_data_sync(device_map)
             )
 
-    def _install_bootloader(self, device_map):
+    def _install_bootloader(self, device_map: Dict) -> None:
         root_device = device_map['root']
         boot_device = root_device
         if 'boot' in device_map:
@@ -1120,7 +1122,7 @@ class DiskBuilder:
             self.diskname, boot_device.get_device()
         )
 
-    def _setup_property_root_is_readonly_snapshot(self):
+    def _setup_property_root_is_readonly_snapshot(self) -> None:
         if self.volume_manager_name:
             root_is_snapshot = \
                 self.xml_state.build_type.get_btrfs_root_is_snapshot()
@@ -1134,7 +1136,7 @@ class DiskBuilder:
                 self.system.set_property_readonly_root()
                 self.system.umount_volumes()
 
-    def _copy_first_boot_files_to_system_image(self):
+    def _copy_first_boot_files_to_system_image(self) -> None:
         boot_names = self.boot_image.get_boot_names()
         if self.initrd_system == 'kiwi':
             log.info('Copy boot files to system image')

--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -17,6 +17,7 @@
 #
 import logging
 import os
+from typing import Dict
 
 # project
 from kiwi.filesystem import FileSystem
@@ -27,6 +28,7 @@ from kiwi.system.setup import SystemSetup
 from kiwi.defaults import Defaults
 from kiwi.system.result import Result
 from kiwi.runtime_config import RuntimeConfig
+from kiwi.xml_state import XMLState
 
 from kiwi.exceptions import (
     KiwiFileSystemSetupError
@@ -45,7 +47,7 @@ class FileSystemBuilder:
     :param dict custom_args: Custom processing arguments defined as hash keys:
         * None
     """
-    def __init__(self, xml_state, target_dir, root_dir, custom_args=None):
+    def __init__(self, xml_state: XMLState, target_dir: str, root_dir: str, custom_args: Dict = None):
         self.label = None
         self.root_uuid = None
         self.root_dir = root_dir
@@ -88,7 +90,7 @@ class FileSystemBuilder:
         self.result = Result(xml_state)
         self.runtime_config = RuntimeConfig()
 
-    def create(self):
+    def create(self) -> Result:
         """
         Build a mountable filesystem image
 
@@ -158,7 +160,7 @@ class FileSystemBuilder:
         )
         return self.result
 
-    def _operate_on_loop(self):
+    def _operate_on_loop(self) -> None:
         filesystem = None
         loop_provider = LoopDevice(
             self.filename,
@@ -179,7 +181,7 @@ class FileSystemBuilder:
             Defaults.get_exclude_list_for_root_data_sync()
         )
 
-    def _operate_on_file(self):
+    def _operate_on_file(self) -> None:
         default_provider = DeviceProvider()
         filesystem = FileSystem.new(
             self.requested_filesystem, default_provider,

--- a/kiwi/builder/kis.py
+++ b/kiwi/builder/kis.py
@@ -17,6 +17,7 @@
 #
 import os
 import logging
+from typing import Dict
 
 # project
 from kiwi.defaults import Defaults
@@ -29,6 +30,7 @@ from kiwi.system.kernel import Kernel
 from kiwi.system.result import Result
 from kiwi.runtime_config import RuntimeConfig
 from kiwi.archive.tar import ArchiveTar
+from kiwi.xml_state import XMLState
 
 from kiwi.exceptions import (
     KiwiKisBootImageError
@@ -48,7 +50,7 @@ class KisBuilder:
         * signing_keys: list of package signing keys
         * xz_options: string of XZ compression parameters
     """
-    def __init__(self, xml_state, target_dir, root_dir, custom_args=None):
+    def __init__(self, xml_state: XMLState, target_dir: str, root_dir: str, custom_args: Dict = None):
         self.target_dir = target_dir
         self.compressed = xml_state.build_type.get_compressed()
         self.xen_server = xml_state.is_xen_server()
@@ -81,16 +83,16 @@ class KisBuilder:
                 '-' + xml_state.get_image_version()
             ]
         )
-        self.image = None
+        self.image: str = None
         self.append_file = ''.join([self.image_name, '.append'])
         self.archive_name = ''.join([self.image_name, '.tar'])
         self.checksum_name = ''.join([self.image_name, '.md5'])
-        self.kernel_filename = None
-        self.hypervisor_filename = None
+        self.kernel_filename: str = None
+        self.hypervisor_filename: str = None
         self.result = Result(xml_state)
         self.runtime_config = RuntimeConfig()
 
-    def create(self):
+    def create(self) -> Result:
         """
         Build a component image consisting out of a boot image(initrd)
         plus its appropriate kernel files and the root filesystem

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -19,6 +19,7 @@ import os
 import logging
 from tempfile import mkdtemp
 from tempfile import NamedTemporaryFile
+from typing import Dict
 import shutil
 
 # project
@@ -39,6 +40,8 @@ from kiwi.system.identifier import SystemIdentifier
 from kiwi.system.kernel import Kernel
 from kiwi.runtime_config import RuntimeConfig
 from kiwi.iso_tools.base import IsoToolsBase
+from kiwi.xml_state import XMLState
+
 
 from kiwi.exceptions import (
     KiwiLiveBootImageError
@@ -56,9 +59,9 @@ class LiveImageBuilder:
     :param str root_dir: root directory path name
     :param dict custom_args: Custom processing arguments
     """
-    def __init__(self, xml_state, target_dir, root_dir, custom_args=None):
-        self.media_dir = None
-        self.live_container_dir = None
+    def __init__(self, xml_state: XMLState, target_dir: str, root_dir: str, custom_args: Dict = None):
+        self.media_dir: str = None
+        self.live_container_dir: str = None
         self.arch = Defaults.get_platform_name()
         self.root_dir = root_dir
         self.target_dir = target_dir
@@ -96,7 +99,7 @@ class LiveImageBuilder:
         self.result = Result(xml_state)
         self.runtime_config = RuntimeConfig()
 
-    def create(self):
+    def create(self) -> Result:
         """
         Build a bootable hybrid live ISO image
 
@@ -321,7 +324,7 @@ class LiveImageBuilder:
         )
         return self.result
 
-    def _setup_live_iso_kernel_and_initrd(self):
+    def _setup_live_iso_kernel_and_initrd(self) -> None:
         """
         Copy kernel and initrd from the root tree into the iso boot structure
         """
@@ -363,7 +366,7 @@ class LiveImageBuilder:
                 )
             )
 
-    def __del__(self):
+    def __del__(self) -> None:
         if self.media_dir or self.live_container_dir:
             log.info(
                 'Cleaning up {0} instance'.format(type(self).__name__)


### PR DESCRIPTION
This PR add Strong Typing for the builder API to the following files:

builder/container.py
 builder/kis.py
 builder/filesystem.py
 builder/disk.py
 builder/live.py
 builder/install.py
 builder/archive.py


References #1644.

