### PR TITLE
Delete yum from packagemanager in schema

### DIFF
--- a/build-tests/x86/centos/test-image-live-disk-v7/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-live-disk-v7/appliance.kiwi
@@ -16,7 +16,7 @@
     </profiles>
     <preferences>
         <version>1.3.0</version>
-        <packagemanager>yum</packagemanager>
+        <packagemanager>dnf</packagemanager>
         <bootsplash-theme>charge</bootsplash-theme>
         <locale>en_US</locale>
         <keytable>us</keytable>

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1581,7 +1581,7 @@ class Defaults:
 
         :rtype: str
         """
-        rpm_based = ['zypper', 'yum', 'dnf', 'microdnf']
+        rpm_based = ['zypper', 'dnf', 'microdnf']
         deb_based = ['apt']
         if package_manager in rpm_based:
             return 'rpm'

--- a/kiwi/package_manager/__init__.py
+++ b/kiwi/package_manager/__init__.py
@@ -55,7 +55,6 @@ class PackageManager(metaclass=ABCMeta):
         name_map = {
             'zypper': ['zypper', 'Zypper'],
             'dnf': ['dnf', 'Dnf'],
-            'yum': ['dnf', 'Dnf'],
             'microdnf': ['microdnf', 'MicroDnf'],
             'pacman': ['pacman', 'Pacman'],
             'apt': ['apt', 'Apt']

--- a/kiwi/repository/__init__.py
+++ b/kiwi/repository/__init__.py
@@ -49,7 +49,6 @@ class Repository(metaclass=ABCMeta):
         name_map = {
             'zypper': ['zypper', 'Zypper'],
             'dnf': ['dnf', 'Dnf'],
-            'yum': ['dnf', 'Dnf'],
             'microdnf': ['dnf', 'Dnf'],
             'apt': ['apt', 'Apt'],
             'pacman': ['pacman', 'Pacman']

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -830,7 +830,7 @@ div {
 #
 div {
     k.packagemanager.content = 
-        "apt" | "zypper" | "yum" | "dnf" | "microdnf" | "pacman"
+        "apt" | "zypper" | "dnf" | "microdnf" | "pacman"
     k.packagemanager.attlist = empty
     k.packagemanager =
         ## Name of the Package Manager

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1270,7 +1270,6 @@ the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
       <choice>
         <value>apt</value>
         <value>zypper</value>
-        <value>yum</value>
         <value>dnf</value>
         <value>microdnf</value>
         <value>pacman</value>

--- a/kiwi/solver/repository/rpm_md.py
+++ b/kiwi/solver/repository/rpm_md.py
@@ -51,7 +51,7 @@ class SolverRepositoryRpmMd(SolverRepositoryBase):
         # creation. This includes the files marked as group_gz
         # This component information is like the SUSE pattern
         # information but for RHEL. In order to allow resolving
-        # yum group id names this information needs to be present
+        # group id names this information needs to be present
         rpm_comps_dir = self._create_temporary_metadata_dir()
         rpm_comps_data = self._find_repomd_files(
             ['group_gz'], 'comps2solv'

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -728,7 +728,6 @@ def _cast(typ, value):
 class k_packagemanager_content(object):
     APT='apt'
     ZYPPER='zypper'
-    YUM='yum'
     DNF='dnf'
     MICRODNF='microdnf'
     PACMAN='pacman'

--- a/kiwi/xsl/convert73to74.xsl
+++ b/kiwi/xsl/convert73to74.xsl
@@ -34,10 +34,14 @@
 </xsl:template>
 
 <!-- change packagemanager to apt if set to apt-get -->
+<!-- change packagemanager to dnf if set to yum -->
 <xsl:template match="packagemanager" mode="conv73to74">
     <xsl:choose>
         <xsl:when test="text()='apt-get'">
             <packagemanager>apt</packagemanager>
+        </xsl:when>
+        <xsl:when test="text()='yum'">
+            <packagemanager>dnf</packagemanager>
         </xsl:when>
         <xsl:otherwise>
             <xsl:copy-of select="."/>

--- a/test/unit/package_manager/init_test.py
+++ b/test/unit/package_manager/init_test.py
@@ -25,12 +25,6 @@ class TestPackageManager:
         PackageManager.new(repository, 'dnf')
         mock_manager.assert_called_once_with(repository, None)
 
-    @patch('kiwi.package_manager.dnf.PackageManagerDnf')
-    def test_manager_yum(self, mock_manager):
-        repository = Mock()
-        PackageManager.new(repository, 'yum')
-        mock_manager.assert_called_once_with(repository, None)
-
     @patch('kiwi.package_manager.microdnf.PackageManagerMicroDnf')
     def test_manager_microdnf(self, mock_manager):
         repository = Mock()

--- a/test/unit/repository/init_test.py
+++ b/test/unit/repository/init_test.py
@@ -29,12 +29,6 @@ class TestRepository:
         Repository.new(root_bind, 'microdnf')
         mock_manager.assert_called_once_with(root_bind, None)
 
-    @patch('kiwi.repository.dnf.RepositoryDnf')
-    def test_repository_yum(self, mock_manager):
-        root_bind = mock.Mock()
-        Repository.new(root_bind, 'yum')
-        mock_manager.assert_called_once_with(root_bind, None)
-
     @patch('kiwi.repository.apt.RepositoryApt')
     def test_repository_apt(self, mock_manager):
         root_bind = mock.Mock()


### PR DESCRIPTION
Auto convert yum to dnf if set as packagemanager. This allows
to delete the yum handling from code parts in kiwi where this
was still present. In addition this fixes the inclusion of yum
into the packagelist. This Fixes #1768


