### PR TITLE
Refactor building of root cmdline setting

### DIFF
--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -77,11 +77,11 @@ class BootLoaderConfigBase:
         """
         raise NotImplementedError
 
-    def write_meta_data(self, root_uuid=None, boot_options=''):
+    def write_meta_data(self, root_device=None, boot_options=''):
         """
         Write bootloader setup meta data files
 
-        :param string root_uuid: root device UUID
+        :param string root_device: root device node
         :param string boot_options: kernel options as string
 
         Implementation in specialized bootloader class optional
@@ -261,11 +261,11 @@ class BootLoaderConfigBase:
             return False
         return True
 
-    def get_boot_cmdline(self, uuid=None):
+    def get_boot_cmdline(self, boot_device=None):
         """
         Boot commandline arguments passed to the kernel
 
-        :param string uuid: boot device UUID
+        :param string boot_device: boot device node
 
         :return: kernel boot arguments
 
@@ -275,7 +275,7 @@ class BootLoaderConfigBase:
         custom_cmdline = self.xml_state.build_type.get_kernelcmdline()
         if custom_cmdline:
             cmdline += ' ' + custom_cmdline
-        custom_root = self._get_root_cmdline_parameter(uuid)
+        custom_root = self._get_root_cmdline_parameter(boot_device)
         if custom_root and custom_root not in cmdline:
             cmdline += ' ' + custom_root
         return cmdline.strip()
@@ -548,7 +548,7 @@ class BootLoaderConfigBase:
         self.device_mount.bind_mount()
         self.proc_mount.bind_mount()
 
-    def _get_root_cmdline_parameter(self, uuid):
+    def _get_root_cmdline_parameter(self, boot_device):
         cmdline = self.xml_state.build_type.get_kernelcmdline()
         persistency_type = self.xml_state.build_type.get_devicepersistency()
         if cmdline and 'root=' in cmdline:
@@ -558,17 +558,17 @@ class BootLoaderConfigBase:
             root_search = re.search(r'(root=(.*)[ ]+|root=(.*)$)', cmdline)
             if root_search:
                 return root_search.group(1)
-
-        if uuid and self.xml_state.build_type.get_overlayroot():
-            return 'root=overlay:UUID={0}'.format(uuid)
-        elif uuid:
-            block_operation = BlockID(f'UUID={uuid}')
+        if boot_device:
+            block_operation = BlockID(boot_device)
             blkid_type = 'LABEL' if persistency_type == 'by-label' else 'UUID'
             location = block_operation.get_blkid(blkid_type)
-            return f'root={blkid_type}={location} rw'
+            if self.xml_state.build_type.get_overlayroot():
+                return f'root=overlay:{blkid_type}={location}'
+            else:
+                return f'root={blkid_type}={location} rw'
         else:
             log.warning(
-                'root setup based on UUID requested, but uuid is not provided'
+                'No explicit root= cmdline provided'
             )
 
     def __del__(self):

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -172,7 +172,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 if self.iso_boot:
                     self._create_embedded_fat_efi_image()
 
-    def write_meta_data(self, root_uuid=None, boot_options=''):
+    def write_meta_data(self, root_device=None, boot_options=''):
         """
         Write bootloader setup meta data files
 
@@ -181,17 +181,17 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         * etc/default/zipl2grub.conf.in (s390 only)
         * etc/sysconfig/bootloader
 
-        :param string root_uuid: root device UUID
+        :param string root_device: root device node
         :param string boot_options: kernel options as string
         :param bool iso_boot: indicate target is an ISO
         """
         self.cmdline = ' '.join(
-            [self.get_boot_cmdline(root_uuid), boot_options]
+            [self.get_boot_cmdline(root_device), boot_options]
         )
         self.cmdline_failsafe = ' '.join(
             [self.cmdline, Defaults.get_failsafe_kernel_options(), boot_options]
         )
-        self.root_reference = self._get_root_cmdline_parameter(root_uuid)
+        self.root_reference = self._get_root_cmdline_parameter(root_device)
 
         self._setup_default_grub()
         self._setup_sysconfig_bootloader()

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -986,9 +986,6 @@ class DiskBuilder:
             if 'boot' in device_map:
                 boot_device = device_map['boot']
 
-            root_uuid = self.disk.get_uuid(
-                device_map['root'].get_device()
-            )
             boot_uuid = self.disk.get_uuid(
                 boot_device.get_device()
             )
@@ -999,7 +996,8 @@ class DiskBuilder:
                 boot_uuid_unmapped
             )
             self.bootloader_config.write_meta_data(
-                root_uuid=root_uuid, boot_options=' '.join(boot_options)
+                root_device=device_map['root'].get_device(),
+                boot_options=' '.join(boot_options)
             )
 
             log.info('Creating config.bootoptions')
@@ -1008,7 +1006,9 @@ class DiskBuilder:
             )
             kexec_boot_options = ' '.join(
                 [
-                    self.bootloader_config.get_boot_cmdline(root_uuid)
+                    self.bootloader_config.get_boot_cmdline(
+                        device_map['root'].get_device()
+                    )
                 ] + boot_options
             )
             with open(filename, 'w') as boot_optionsfp:

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -310,7 +310,7 @@ class TestDiskBuilder:
             '0815'
         )
         self.bootloader_config.write_meta_data.assert_called_once_with(
-            boot_options='', root_uuid='0815'
+            root_device='/dev/root-device', boot_options=''
         )
         self.bootloader_config.setup_disk_image_config.assert_called_once_with(
             boot_options={
@@ -438,7 +438,7 @@ class TestDiskBuilder:
             '0815'
         )
         self.bootloader_config.write_meta_data.assert_called_once_with(
-            boot_options='', root_uuid='0815'
+            root_device='/dev/root-device', boot_options=''
         )
         self.bootloader_config.setup_disk_image_config.assert_called_once_with(
             boot_options={


### PR DESCRIPTION
Creating the root= cmdline parameter was based on methods
that deals with the uuid. However, it's also possible to
use a label information for the root= cmdline. To support
this kiwi issued a 'blkid --uuid' command but that requires
udev device names to be present on the host. The open
buildservice workers do not run udev and fails apart the
standard. This commit refactors the root cmdline setup
to work with the device node as it exists during build
time such that the blkid call runs against that device
node.

