### PR TITLE
Allow to enable volumes for filesystem check

### DIFF
--- a/doc/source/working_with_images/custom_volumes.rst
+++ b/doc/source/working_with_images/custom_volumes.rst
@@ -73,6 +73,13 @@ attributes:
 - `copy_on_write`: Optional attribute to set the filesystem copy-on-write
   attribute for this volume.
 
+- `filesystem_check`: Optional attribute to indicate that this
+  filesystem should perform the validation to become filesystem checked.
+  The actual constraints if the check is performed or not depends on
+  systemd and filesystem specific components. If not set or set to
+  `false` no system component will be triggered to run an eventual
+  filesystem check, which results in this filesystem to be never checked.
+  The latter is the default.
 
 .. warning::
    The size attributes for filesystem volumes, as for btrfs, are

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2082,11 +2082,21 @@ div {
     k.volume.copy_on_write.attribute =
         ## Apply the filesystem copy-on-write attribute for this volume
         attribute copy_on_write { xsd:boolean }
+    k.volume.filesystem_check =
+        ## Indicate that this filesystem should perform the validation
+        ## to become filesystem checked. The actual constraints if the
+        ## check is performed or not depends on systemd and filesystem
+        ## specific components. If not set or set to false no system
+        ## component will be triggered to run an eventual filesystem
+        ## check, which results in this filesystem to be never checked.
+        ## The latter is the default.
+        attribute filesystem_check { xsd:boolean }
     k.volume.label.attribute =
         ## filesystem label name of the volume.
         attribute label { text }
     k.volume.attlist =
         k.volume.copy_on_write.attribute? &
+        k.volume.filesystem_check? &
         k.volume.freespace.attribute? &
         k.volume.mountpoint.attribute? &
         k.volume.label.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -3180,6 +3180,18 @@ add "M" and/or "G" as postfix</a:documentation>
         <data type="boolean"/>
       </attribute>
     </define>
+    <define name="k.volume.filesystem_check">
+      <attribute name="filesystem_check">
+        <a:documentation>Indicate that this filesystem should perform the validation
+to become filesystem checked. The actual constraints if the
+check is performed or not depends on systemd and filesystem
+specific components. If not set or set to false no system
+component will be triggered to run an eventual filesystem
+check, which results in this filesystem to be never checked.
+The latter is the default.</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+    </define>
     <define name="k.volume.label.attribute">
       <attribute name="label">
         <a:documentation>filesystem label name of the volume.</a:documentation>
@@ -3189,6 +3201,9 @@ add "M" and/or "G" as postfix</a:documentation>
       <interleave>
         <optional>
           <ref name="k.volume.copy_on_write.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.volume.filesystem_check"/>
         </optional>
         <optional>
           <ref name="k.volume.freespace.attribute"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -4032,9 +4032,10 @@ class volume(GeneratedsSuper):
     """Specify which parts of the filesystem should be on an extra volume."""
     subclass = None
     superclass = None
-    def __init__(self, copy_on_write=None, freespace=None, mountpoint=None, label=None, name=None, size=None):
+    def __init__(self, copy_on_write=None, filesystem_check=None, freespace=None, mountpoint=None, label=None, name=None, size=None):
         self.original_tagname_ = None
         self.copy_on_write = _cast(bool, copy_on_write)
+        self.filesystem_check = _cast(bool, filesystem_check)
         self.freespace = _cast(None, freespace)
         self.mountpoint = _cast(None, mountpoint)
         self.label = _cast(None, label)
@@ -4053,6 +4054,8 @@ class volume(GeneratedsSuper):
     factory = staticmethod(factory)
     def get_copy_on_write(self): return self.copy_on_write
     def set_copy_on_write(self, copy_on_write): self.copy_on_write = copy_on_write
+    def get_filesystem_check(self): return self.filesystem_check
+    def set_filesystem_check(self, filesystem_check): self.filesystem_check = filesystem_check
     def get_freespace(self): return self.freespace
     def set_freespace(self, freespace): self.freespace = freespace
     def get_mountpoint(self): return self.mountpoint
@@ -4101,6 +4104,9 @@ class volume(GeneratedsSuper):
         if self.copy_on_write is not None and 'copy_on_write' not in already_processed:
             already_processed.add('copy_on_write')
             outfile.write(' copy_on_write="%s"' % self.gds_format_boolean(self.copy_on_write, input_name='copy_on_write'))
+        if self.filesystem_check is not None and 'filesystem_check' not in already_processed:
+            already_processed.add('filesystem_check')
+            outfile.write(' filesystem_check="%s"' % self.gds_format_boolean(self.filesystem_check, input_name='filesystem_check'))
         if self.freespace is not None and 'freespace' not in already_processed:
             already_processed.add('freespace')
             outfile.write(' freespace=%s' % (quote_attrib(self.freespace), ))
@@ -4133,6 +4139,15 @@ class volume(GeneratedsSuper):
                 self.copy_on_write = True
             elif value in ('false', '0'):
                 self.copy_on_write = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
+        value = find_attr_value_('filesystem_check', node)
+        if value is not None and 'filesystem_check' not in already_processed:
+            already_processed.add('filesystem_check')
+            if value in ('true', '1'):
+                self.filesystem_check = True
+            elif value in ('false', '0'):
+                self.filesystem_check = False
             else:
                 raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('freespace', node)

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1379,6 +1379,12 @@ class XMLState:
                     # the attribute is handled
                     attributes.append('no-copy-on-write')
 
+                if volume.get_filesystem_check() is True:
+                    # by default filesystem check is switched off for any
+                    # filesystem except the rootfs. Thus only if filesystem
+                    # check is requested the attribute is handled
+                    attributes.append('enable-for-filesystem-check')
+
                 if '@root' in name:
                     # setup root volume, it takes an optional volume
                     # name if specified as @root=name and has no specific

--- a/test/data/example_lvm_default_config.xml
+++ b/test/data/example_lvm_default_config.xml
@@ -22,7 +22,7 @@
             <systemdisk>
                 <volume name="usr/lib" size="1G" label="library"/>
                 <volume name="@root" freespace="500M"/>
-                <volume name="etc_volume" mountpoint="etc" copy_on_write="false"/>
+                <volume name="etc_volume" mountpoint="etc" copy_on_write="false" filesystem_check="true"/>
                 <volume name="bin_volume" size="all" mountpoint="/usr/bin"/>
             </systemdisk>
             <oemconfig>

--- a/test/unit/utils/fstab_test.py
+++ b/test/unit/utils/fstab_test.py
@@ -5,6 +5,7 @@ from unittest.mock import (
     MagicMock, patch, call
 )
 from kiwi.utils.fstab import Fstab
+from kiwi.utils.fstab import fstab_entry_type
 
 
 class TestFstab(object):
@@ -23,56 +24,70 @@ class TestFstab(object):
 
     def test_get_devices(self):
         assert self.fstab.get_devices() == [
-            self.fstab.fstab_entry_type(
+            fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/',
                 device_path='/dev/disk/'
                 'by-uuid/bd604632-663b-4d4c-b5b0-8d8686267ea2',
                 device_spec='UUID=bd604632-663b-4d4c-b5b0-8d8686267ea2',
-                options='acl,user_xattr'
+                options='acl,user_xattr',
+                dump='0',
+                fs_passno='1'
             ),
-            self.fstab.fstab_entry_type(
+            fstab_entry_type(
                 fstype='swap',
                 mountpoint='swap',
                 device_path='/dev/disk/'
                 'by-uuid/daa5a8c3-5c72-4343-a1d4-bb74ec4e586e',
                 device_spec='UUID=daa5a8c3-5c72-4343-a1d4-bb74ec4e586e',
-                options='defaults'
+                options='defaults',
+                dump='0',
+                fs_passno='0'
             ),
-            self.fstab.fstab_entry_type(
+            fstab_entry_type(
                 fstype='vfat',
                 mountpoint='/boot/efi',
                 device_path='/dev/disk/by-uuid/FCF7-B051',
                 device_spec='UUID=FCF7-B051',
-                options='defaults'
+                options='defaults',
+                dump='0',
+                fs_passno='0'
             ),
-            self.fstab.fstab_entry_type(
+            fstab_entry_type(
                 fstype='xfs',
                 mountpoint='/boot',
                 device_path='/dev/disk/by-label/BOOT',
                 device_spec='LABEL=BOOT',
-                options='defaults'
+                options='defaults',
+                dump='0',
+                fs_passno='0'
             ),
-            self.fstab.fstab_entry_type(
+            fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/home',
                 device_path='/dev/disk/by-label/foo',
                 device_spec='LABEL=foo',
-                options='defaults'
+                options='defaults',
+                dump='0',
+                fs_passno='0'
             ),
-            self.fstab.fstab_entry_type(
+            fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/bar',
                 device_path='/dev/disk/by-partuuid/3c8bd108-01',
                 device_spec='PARTUUID=3c8bd108-01',
-                options='defaults'
+                options='defaults',
+                dump='0',
+                fs_passno='0'
             ),
-            self.fstab.fstab_entry_type(
+            fstab_entry_type(
                 fstype='ext4',
                 mountpoint='/foo',
                 device_path='/dev/mynode',
                 device_spec='/dev/mynode',
-                options='defaults'
+                options='defaults',
+                dump='0',
+                fs_passno='0'
             )
         ]
 
@@ -91,7 +106,7 @@ class TestFstab(object):
                 ),
                 call(
                     'UUID=bd604632-663b-4d4c-b5b0-8d8686267ea2 / '
-                    'ext4 acl,user_xattr 0 0\n'
+                    'ext4 acl,user_xattr 0 1\n'
                 ),
                 call('PARTUUID=3c8bd108-01 /bar ext4 defaults 0 0\n'),
                 call('LABEL=BOOT /boot xfs defaults 0 0\n'),

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -379,7 +379,7 @@ class TestXMLState:
                 realpath='etc',
                 mountpoint='etc', fullsize=False,
                 label=None,
-                attributes=['no-copy-on-write'],
+                attributes=['no-copy-on-write', 'enable-for-filesystem-check'],
                 is_root_volume=False
             ),
             volume_type(


### PR DESCRIPTION
The new attribute

```xml
<systemdisk>
    <volume ... filesystem_check="true|false"/>
</systemdisk>
```

allows to change the default value for the ```fs_passno``` field in the generated fstab file. By default kiwi sets ```0``` in this field and leaves it up to the user to customize this as appropriate via script code. Coding changes to the fstab file via scripts are not very user friendly and with respect that systemd takes over control and generates checkers depending on the value of ```fs_passno``` it would be good if there is a way to explicitly specify if checks to the filesystem are wanted or not. Therefore the new attribute now exists. If set to: true this results in a value of ```2``` for the fs_passno field. Please note the ```root```, ```boot``` and ```efi``` entries are excluded from this setup.

This Fixes #1728


