### PR TITLE
Added optional post_bootstrap.sh script hook

### DIFF
--- a/doc/source/concept_and_workflow.rst
+++ b/doc/source/concept_and_workflow.rst
@@ -112,10 +112,12 @@ The prepare step consists of the following substeps:
 
 #. **Create Target Root Directory**
 
-   {kiwi} aborts with an error if the target root tree already exists to
-   avoid accidental deletion of an existing unpacked image.
+   By default {kiwi} aborts with an error if the target root tree
+   already exists to avoid accidental deletion of an existing
+   unpacked image. The option `--allow-existing-root` can be used
+   to work based on an existing root tree
 
-#. **Install Packages**
+#. **Bootstrap Target Root Directory**
 
    First, {kiwi} configures the package manager to use the repositories
    specified in the configuration file, via the command line, or
@@ -123,20 +125,34 @@ The prepare step consists of the following substeps:
    ``bootstrap`` section of the image description are installed in a
    temporary directory external to the target root tree. This establishes
    the initial environment to support the completion of the process in a
-   chroot setting. The essential packages are ``filesystem`` and
-   ``glibc-locale`` to specify as part of the bootstrap. The dependency
-   chain of these two packages is usually sufficient to populate the
-   bootstrap environment with all required software to support the
-   installation of packages into the new root tree. The aforementioned two
-   packages might not be enough for every distribution.  Consult the
-   `kiwi-descriptions repository
-   <https://github.com/OSInside/kiwi-descriptions/>`_ containing examples for
-   various Linux distributions.
+   chroot setting. At the end of the ``bootstrap`` phase the script
+   :file:`post_bootstrap.sh` is executed, if present.
 
-   The installation of software packages through the selected package
-   manager may install unwanted packages. Removing these packages can be
-   accomplished by marking them for deletion in the image description, see
-   :ref:`uninstall-system-packages`.
+   .. note::
+
+      The essential bootstrap packages are usually ``filesystem`` and
+      ``glibc-locale`` to specify as part of the bootstrap. The dependency
+      chain of these two packages is usually sufficient to populate the
+      bootstrap environment with all required software to support the
+      installation of packages into the new root tree. The aforementioned two
+      packages might not be enough for every distribution. Consult the
+      `kiwi-descriptions repository
+      <https://github.com/OSInside/kiwi-descriptions/>`_ containing examples
+      for various Linux distributions.
+
+#. **Install Packages**
+
+   After the ``bootstrap`` phase all other `<packages>` sections are
+   used to complete the installation as chroot operation. {kiwi} uses
+   the package manager as installed in the ``bootstrap`` phase and
+   installs all other packages as configured.
+
+   .. note::
+
+      The installation of software packages through the selected package
+      manager may install unwanted packages. Removing these packages can be
+      accomplished by marking them for deletion in the image description, see
+      :ref:`uninstall-system-packages`.
 
 #. **Apply the Overlay Tree**
 

--- a/doc/source/concept_and_workflow/shell_scripts.rst
+++ b/doc/source/concept_and_workflow/shell_scripts.rst
@@ -13,6 +13,14 @@ User Defined Scripts
 {kiwi} supports the following optional scripts that it runs in a
 root environment (chroot) containing your new appliance:
 
+post_bootstrap.sh
+  runs at the end of the `bootstrap` phase as part of the
+  :ref:`prepare step <prepare-step>`. The script can be used to
+  configure the package manager with additional settings that
+  should apply in the following chroot based installation step
+  which completes the installation. The script is not dedicated to
+  this use and can also be used for other tasks.
+
 config.sh
   runs at the end of the :ref:`prepare step <prepare-step>`
   and after users have been set and the *overlay tree directory*

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -32,6 +32,7 @@ from kiwi.exceptions import KiwiBootLoaderGrubDataError
 
 # Default module variables
 POST_DISK_SYNC_SCRIPT = 'disk.sh'
+POST_BOOTSTRAP_SCRIPT = 'post_bootstrap.sh'
 POST_PREPARE_SCRIPT = 'config.sh'
 PRE_CREATE_SCRIPT = 'images.sh'
 EDIT_BOOT_CONFIG_SCRIPT = 'edit_boot_config.sh'

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -589,6 +589,14 @@ class SystemSetup:
             defaults.POST_DISK_SYNC_SCRIPT
         )
 
+    def call_post_bootstrap_script(self) -> None:
+        """
+        Call post_bootstrap.sh script chrooted
+        """
+        self._call_script(
+            defaults.POST_BOOTSTRAP_SCRIPT
+        )
+
     def call_config_script(self) -> None:
         """
         Call config.sh script chrooted
@@ -915,6 +923,10 @@ class SystemSetup:
             'script_type', ['filepath', 'raise_if_not_exists']
         )
         custom_scripts = {
+            defaults.POST_BOOTSTRAP_SCRIPT: script_type(
+                filepath=defaults.POST_BOOTSTRAP_SCRIPT,
+                raise_if_not_exists=False
+            ),
             defaults.POST_PREPARE_SCRIPT: script_type(
                 filepath=defaults.POST_PREPARE_SCRIPT,
                 raise_if_not_exists=False

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -201,6 +201,15 @@ class SystemBuildTask(CliTask):
         system.install_bootstrap(
             manager, self.command_args['--add-bootstrap-package']
         )
+
+        setup = SystemSetup(
+            self.xml_state, image_root
+        )
+        setup.import_description()
+
+        # call post_bootstrap.sh script if present
+        setup.call_post_bootstrap_script()
+
         system.install_system(
             manager
         )
@@ -221,11 +230,6 @@ class SystemBuildTask(CliTask):
             Defaults.get_profile_file(image_root)
         )
 
-        setup = SystemSetup(
-            self.xml_state, image_root
-        )
-
-        setup.import_description()
         setup.import_overlay_files()
         setup.import_image_identifier()
         setup.setup_groups()
@@ -241,6 +245,8 @@ class SystemBuildTask(CliTask):
 
         # setup permanent image repositories after cleanup
         setup.import_repositories_marked_as_imageinclude()
+
+        # call config.sh script if present
         setup.call_config_script()
 
         # handle uninstall package requests, gracefully uninstall

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -185,6 +185,15 @@ class SystemPrepareTask(CliTask):
         system.install_bootstrap(
             manager, self.command_args['--add-bootstrap-package']
         )
+
+        setup = SystemSetup(
+            self.xml_state, abs_root_path
+        )
+        setup.import_description()
+
+        # call post_bootstrap.sh script if present
+        setup.call_post_bootstrap_script()
+
         system.install_system(
             manager
         )
@@ -203,15 +212,10 @@ class SystemPrepareTask(CliTask):
         defaults = Defaults()
         defaults.to_profile(profile)
 
-        setup = SystemSetup(
-            self.xml_state, abs_root_path
-        )
-
         profile.create(
             Defaults.get_profile_file(abs_root_path)
         )
 
-        setup.import_description()
         setup.import_overlay_files()
         setup.import_image_identifier()
         setup.setup_groups()
@@ -227,6 +231,8 @@ class SystemPrepareTask(CliTask):
 
         # setup permanent image repositories after cleanup
         setup.import_repositories_marked_as_imageinclude()
+
+        # call config.sh script if present
         setup.call_config_script()
 
         # handle uninstall package requests, gracefully uninstall

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -171,6 +171,7 @@ class TestSystemBuildTask:
         self.setup.import_overlay_files.assert_called_once_with()
         self.setup.import_repositories_marked_as_imageinclude.\
             assert_called_once_with()
+        self.setup.call_post_bootstrap_script.assert_called_once_with()
         self.setup.call_config_script.assert_called_once_with()
         self.setup.import_image_identifier.assert_called_once_with()
         self.setup.setup_groups.assert_called_once_with()

--- a/test/unit/tasks/system_prepare_test.py
+++ b/test/unit/tasks/system_prepare_test.py
@@ -156,6 +156,7 @@ class TestSystemPrepareTask:
         self.setup.import_overlay_files.assert_called_once_with()
         self.setup.import_repositories_marked_as_imageinclude.\
             assert_called_once_with()
+        self.setup.call_post_bootstrap_script.assert_called_once_with()
         self.setup.call_config_script.assert_called_once_with()
         self.setup.import_image_identifier.assert_called_once_with()
         self.setup.setup_groups.assert_called_once_with()


### PR DESCRIPTION
After the bootstrap phase a script post_bootstrap.sh is executed
in a chroot process which allows to add/modify system settings
prior the completion of the system installation. This helps
users for example with custom package manager settings and
Fixes #1763 as well as Fixes #1782

