### PR TITLE
Complete static type checks

### DIFF
--- a/kiwi/boot/image/__init__.py
+++ b/kiwi/boot/image/__init__.py
@@ -23,9 +23,9 @@ from abc import (
     abstractmethod
 )
 
-from kiwi.exceptions import (
-    KiwiBootImageSetupError
-)
+from kiwi.xml_state import XMLState
+
+from kiwi.exceptions import KiwiBootImageSetupError
 
 
 class BootImage(metaclass=ABCMeta):
@@ -43,20 +43,17 @@ class BootImage(metaclass=ABCMeta):
 
     @staticmethod
     def new(
-        xml_state: object, target_dir: str,
+        xml_state: XMLState, target_dir: str,
         root_dir: str=None, signing_keys: List=None  # noqa: E252
     ):
         initrd_system = xml_state.get_initrd_system()
         name_map = {
-            'builtin_kiwi':
-                'BootImageKiwi' if initrd_system == 'kiwi' else None,
-            'dracut':
-                'BootImageDracut' if initrd_system == 'dracut' else None
+            'kiwi': {'builtin_kiwi': 'BootImageKiwi'},
+            'dracut': {'dracut': 'BootImageDracut'}
         }
-        for boot_image_namespace, boot_image_name in list(name_map.items()):
-            if boot_image_name:
-                break
         try:
+            (boot_image_namespace, boot_image_name) = \
+                list(name_map[initrd_system].items())[0]
             boot_image = importlib.import_module(
                 'kiwi.boot.image.{0}'.format(boot_image_namespace)
             )

--- a/kiwi/bootloader/config/__init__.py
+++ b/kiwi/bootloader/config/__init__.py
@@ -46,17 +46,13 @@ class BootLoaderConfig(metaclass=ABCMeta):
         boot_dir: str = None, custom_args: Dict = None
     ):
         name_map = {
-            'grub2': 'BootLoaderConfigGrub2'
-            if name == 'grub2' or name == 'grub2_s390x_emu' else None,
-
-            'isolinux': 'BootLoaderConfigIsoLinux'
-            if name == 'isolinux' else None
+            'grub2': {'grub2': 'BootLoaderConfigGrub2'},
+            'grub2_s390x_emu': {'grub2': 'BootLoaderConfigGrub2'},
+            'isolinux': {'isolinux': 'BootLoaderConfigIsoLinux'}
         }
-
-        for bootloader_namespace, bootloader_name in list(name_map.items()):
-            if bootloader_name:
-                break
         try:
+            (bootloader_namespace, bootloader_name) = \
+                list(name_map[name].items())[0]
             booloader_config = importlib.import_module(
                 'kiwi.bootloader.config.{}'.format(bootloader_namespace)
             )
@@ -65,5 +61,5 @@ class BootLoaderConfig(metaclass=ABCMeta):
             )
         except Exception:
             raise KiwiBootLoaderConfigSetupError(
-                'Support for {} bootloader config not implemented'.format(name)
+                f'Support for {name} bootloader config not implemented'
             )

--- a/kiwi/bootloader/install/__init__.py
+++ b/kiwi/bootloader/install/__init__.py
@@ -46,14 +46,12 @@ class BootLoaderInstall(metaclass=ABCMeta):
         custom_args: Dict = None
     ):
         name_map = {
-            'grub2': 'BootLoaderInstallGrub2'
-            if name == 'grub2' or name == 'grub2_s390x_emu' else None
+            'grub2': {'grub2': 'BootLoaderInstallGrub2'},
+            'grub2_s390x_emu': {'grub2': 'BootLoaderInstallGrub2'}
         }
-
-        for bootloader_namespace, bootloader_name in list(name_map.items()):
-            if bootloader_name:
-                break
         try:
+            (bootloader_namespace, bootloader_name) = \
+                list(name_map[name].items())[0]
             bootloader_install = importlib.import_module(
                 'kiwi.bootloader.install.{}'.format(bootloader_namespace)
             )
@@ -62,6 +60,5 @@ class BootLoaderInstall(metaclass=ABCMeta):
             )
         except Exception:
             raise KiwiBootLoaderInstallSetupError(
-                'Support for {} bootloader installation '
-                'not implemented'.format(name)
+                f'Support for {name} bootloader installation not implemented'
             )

--- a/kiwi/builder/archive.py
+++ b/kiwi/builder/archive.py
@@ -43,7 +43,10 @@ class ArchiveBuilder:
     :param dict custom_args: Custom processing arguments defined as hash keys:
         * xz_options: string of XZ compression parameters
     """
-    def __init__(self, xml_state: XMLState, target_dir: str, root_dir: str, custom_args: Dict = None):
+    def __init__(
+        self, xml_state: XMLState, target_dir: str,
+        root_dir: str, custom_args: Dict = None
+    ):
         self.root_dir = root_dir
         self.target_dir = target_dir
         self.xml_state = xml_state
@@ -58,7 +61,7 @@ class ArchiveBuilder:
 
         self.runtime_config = RuntimeConfig()
 
-    def create(self) -> None:
+    def create(self) -> Result:
         """
         Create a root archive tarball
 

--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -47,9 +47,12 @@ class FileSystemBuilder:
     :param dict custom_args: Custom processing arguments defined as hash keys:
         * None
     """
-    def __init__(self, xml_state: XMLState, target_dir: str, root_dir: str, custom_args: Dict = None):
+    def __init__(
+        self, xml_state: XMLState, target_dir: str,
+        root_dir: str, custom_args: Dict = None
+    ):
         self.label = None
-        self.root_uuid = None
+        self.root_uuid = ''
         self.root_dir = root_dir
         self.target_dir = target_dir
         self.requested_image_type = xml_state.get_build_type_name()
@@ -175,7 +178,7 @@ class FileSystemBuilder:
         filesystem.create_on_device(self.label)
         self.root_uuid = loop_provider.get_uuid(loop_provider.get_device())
         log.info(
-            '--> Syncing data to filesystem on %s', loop_provider.get_device()
+            f'--> Syncing data to filesystem on {loop_provider.get_device()}'
         )
         filesystem.sync_data(
             Defaults.get_exclude_list_for_root_data_sync()

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -23,7 +23,8 @@ import shutil
 
 # project
 from kiwi.command import Command
-from kiwi.boot.image import BootImage
+from kiwi.storage.device_provider import DeviceProvider
+from kiwi.boot.image.base import BootImageBase
 from kiwi.bootloader.config import BootLoaderConfig
 from kiwi.filesystem.squashfs import FileSystemSquashFs
 from kiwi.filesystem.isofs import FileSystemIsoFs
@@ -59,7 +60,8 @@ class InstallImageBuilder:
         * xz_options: string of XZ compression parameters
     """
     def __init__(
-        self, xml_state: XMLState, root_dir: str, target_dir: str, boot_image_task: BootImage,
+        self, xml_state: XMLState, root_dir: str, target_dir: str,
+        boot_image_task: BootImageBase,
         custom_args: Dict = None
     ) -> None:
         self.arch = Defaults.get_platform_name()
@@ -121,10 +123,10 @@ class InstallImageBuilder:
         self.mbrid = SystemIdentifier()
         self.mbrid.calculate_id()
 
-        self.media_dir: str = None
-        self.pxe_dir: str = None
-        self.squashed_contents: str = None
-        self.custom_iso_args: Dict = None
+        self.media_dir: str = ''
+        self.pxe_dir: str = ''
+        self.squashed_contents: str = ''
+        self.custom_iso_args: Dict = {}
 
     def create_install_iso(self) -> None:
         """
@@ -179,7 +181,7 @@ class InstallImageBuilder:
             ]
         )
         squashed_image = FileSystemSquashFs(
-            device_provider=None,
+            device_provider=DeviceProvider(),
             root_dir=self.squashed_contents,
             custom_args={
                 'compression':
@@ -238,7 +240,7 @@ class InstallImageBuilder:
         # create iso filesystem from media_dir
         log.info('Creating ISO filesystem')
         iso_image = FileSystemIsoFs(
-            device_provider=None, root_dir=self.media_dir,
+            device_provider=DeviceProvider(), root_dir=self.media_dir,
             custom_args=self.custom_iso_args
         )
         iso_image.create_on_file(self.isoname)

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -28,6 +28,7 @@ from kiwi.filesystem import FileSystem
 from kiwi.filesystem.isofs import FileSystemIsoFs
 from kiwi.filesystem.setup import FileSystemSetup
 from kiwi.storage.loop_device import LoopDevice
+from kiwi.storage.device_provider import DeviceProvider
 from kiwi.boot.image.dracut import BootImageDracut
 from kiwi.system.size import SystemSize
 from kiwi.system.setup import SystemSetup
@@ -42,10 +43,7 @@ from kiwi.runtime_config import RuntimeConfig
 from kiwi.iso_tools.base import IsoToolsBase
 from kiwi.xml_state import XMLState
 
-
-from kiwi.exceptions import (
-    KiwiLiveBootImageError
-)
+from kiwi.exceptions import KiwiLiveBootImageError
 
 log = logging.getLogger('kiwi')
 
@@ -59,9 +57,12 @@ class LiveImageBuilder:
     :param str root_dir: root directory path name
     :param dict custom_args: Custom processing arguments
     """
-    def __init__(self, xml_state: XMLState, target_dir: str, root_dir: str, custom_args: Dict = None):
-        self.media_dir: str = None
-        self.live_container_dir: str = None
+    def __init__(
+        self, xml_state: XMLState, target_dir: str,
+        root_dir: str, custom_args: Dict = None
+    ):
+        self.media_dir: str = ''
+        self.live_container_dir: str = ''
         self.arch = Defaults.get_platform_name()
         self.root_dir = root_dir
         self.target_dir = target_dir
@@ -256,7 +257,7 @@ class LiveImageBuilder:
         )
         live_container_image = FileSystem.new(
             name='squashfs',
-            device_provider=None,
+            device_provider=DeviceProvider(),
             root_dir=self.live_container_dir,
             custom_args={
                 'compression':
@@ -275,7 +276,7 @@ class LiveImageBuilder:
         # create iso filesystem from media_dir
         log.info('Creating live ISO image')
         iso_image = FileSystemIsoFs(
-            device_provider=None, root_dir=self.media_dir,
+            device_provider=DeviceProvider(), root_dir=self.media_dir,
             custom_args=custom_iso_args
         )
         iso_image.create_on_file(self.isoname)

--- a/kiwi/command.py
+++ b/kiwi/command.py
@@ -15,11 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+from typing import NamedTuple
 import select
 import os
 import logging
 import subprocess
-from collections import namedtuple
 
 # project
 from kiwi.utils.codec import Codec
@@ -31,8 +31,22 @@ from kiwi.exceptions import (
 
 log = logging.getLogger('kiwi')
 
-command_type = namedtuple(
-    'command_type', ['output', 'error', 'returncode']
+command_type = NamedTuple(
+    'command_type', [
+        ('output', str),
+        ('error', str),
+        ('returncode', int)
+    ]
+)
+
+command_call_type = NamedTuple(
+    'command_call_type', [
+        ('output', str),
+        ('output_available', bool),
+        ('error', str),
+        ('error_available', bool),
+        ('process', subprocess.Popen)
+    ]
 )
 
 
@@ -203,14 +217,7 @@ class Command:
                     return True
             return _select
 
-        command = namedtuple(
-            'command', [
-                'output', 'output_available',
-                'error', 'error_available',
-                'process'
-            ]
-        )
-        return command(
+        return command_call_type(
             output=process.stdout,
             output_available=output_available(),
             error=process.stderr,

--- a/kiwi/filesystem/__init__.py
+++ b/kiwi/filesystem/__init__.py
@@ -23,6 +23,7 @@ from abc import (
 )
 
 # project
+from kiwi.storage.device_provider import DeviceProvider
 from kiwi.exceptions import KiwiFileSystemSetupError
 
 
@@ -41,7 +42,7 @@ class FileSystem(metaclass=ABCMeta):
 
     @staticmethod
     def new(
-        name: str, device_provider: object,
+        name: str, device_provider: DeviceProvider,
         root_dir: str=None, custom_args: Dict=None  # noqa: E252
     ):
         name_map = {

--- a/kiwi/filesystem/base.py
+++ b/kiwi/filesystem/base.py
@@ -49,13 +49,13 @@ class FileSystemBase:
     """
     def __init__(
         self, device_provider: DeviceProvider,
-        root_dir: str = None, custom_args: Dict = None
+        root_dir: str = None, custom_args: Dict = {}
     ):
         # filesystems created with a block device stores the mountpoint
         # here. The file name of the file containing the filesystem is
         # stored in the device_provider if the filesystem is represented
         # as a file there
-        self.filesystem_mount = None
+        self.filesystem_mount: Optional[MountManager] = None
 
         # bind the block device providing class instance to this object.
         # This is done to guarantee the correct destructor order when
@@ -69,7 +69,7 @@ class FileSystemBase:
         # filesystem file name here
         self.filename = None
 
-        self.custom_args = {}
+        self.custom_args: Dict = {}
         self.post_init(custom_args)
 
     def post_init(self, custom_args: Dict):
@@ -144,6 +144,7 @@ class FileSystemBase:
         """
         if self.filesystem_mount:
             return self.filesystem_mount.mountpoint
+        return None
 
     def sync_data(self, exclude: List[str] = None):
         """

--- a/kiwi/filesystem/clicfs.py
+++ b/kiwi/filesystem/clicfs.py
@@ -17,7 +17,7 @@
 #
 from tempfile import mkdtemp
 from typing import (
-    Dict, List
+    Dict, List, Optional
 )
 import logging
 
@@ -45,7 +45,7 @@ class FileSystemClicFs(FileSystemBase):
 
         :param dict custom_args: unused
         """
-        self.container_dir = None
+        self.container_dir: Optional[str] = None
 
     def create_on_file(
         self, filename: str, label: str = None, exclude: List[str] = None

--- a/kiwi/filesystem/setup.py
+++ b/kiwi/filesystem/setup.py
@@ -64,9 +64,10 @@ class FileSystemSetup:
 
         :rtype: int
         """
+        fstype = self.requested_filesystem if not filesystem else filesystem
         root_dir_mbytes = self.size.accumulate_mbyte_file_sizes()
         filesystem_mbytes = self.size.customize(
-            root_dir_mbytes, self.requested_filesystem or filesystem
+            root_dir_mbytes, fstype
         )
 
         if not self.configured_size:

--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -21,10 +21,13 @@ import logging
 from typing import List
 
 # project
+from kiwi.command import command_call_type
 from kiwi.command import Command
 from kiwi.path import Path
 from kiwi.package_manager.base import PackageManagerBase
 from kiwi.system.root_bind import RootBind
+from kiwi.repository.apt import RepositoryApt
+
 from kiwi.exceptions import (
     KiwiDebootstrapError,
     KiwiRequestError
@@ -35,15 +38,15 @@ log = logging.getLogger('kiwi')
 
 class PackageManagerApt(PackageManagerBase):
     """
-    **Implements base class for installation/deletion of
-    packages and collections using apt-get**
+    **Implements Installation/Deletion of packages/collections with apt-get**
 
-    :param list apt_get_args: apt-get arguments from repository runtime
-        configuration
-    :param dict command_env: apt-get command environment from repository
+    :param list apt_get_args:
+        apt-get arguments from repository runtime configuration
+    :param dict command_env:
+        apt-get command environment from repository
         runtime configuration
     """
-    def post_init(self, custom_args: List = None) -> None:
+    def post_init(self, custom_args: List = []) -> None:
         """
         Post initialization method
 
@@ -51,9 +54,9 @@ class PackageManagerApt(PackageManagerBase):
 
         :param list custom_args: custom apt-get arguments
         """
+        self.repository: RepositoryApt = self.repository
         self.custom_args = custom_args
-        if not custom_args:
-            self.custom_args = []
+
         self.deboostrap_minbase: bool = True
 
         runtime_config = self.repository.runtime_config()
@@ -106,7 +109,9 @@ class PackageManagerApt(PackageManagerBase):
             'Package exclusion for (%s) not supported for apt-get', name
         )
 
-    def process_install_requests_bootstrap(self, root_bind: RootBind = None) -> None:
+    def process_install_requests_bootstrap(
+        self, root_bind: RootBind = None
+    ) -> command_call_type:
         """
         Process package install requests for bootstrap phase (no chroot)
         The debootstrap program is used to bootstrap a new system with
@@ -140,7 +145,9 @@ class PackageManagerApt(PackageManagerBase):
         # debootstrap. Debootstrap manages itself the kernel file systems for
         # chroot environment, thus we need to umount the kernel file systems
         # before calling debootstrap and remount them afterwards.
-        root_bind.umount_kernel_file_systems()
+        if root_bind:
+            root_bind.umount_kernel_file_systems()
+
         # debootsrap will create its own dev/fd devices
         debootstrap_device_node_conflicts = [
             'dev/fd',
@@ -182,7 +189,9 @@ class PackageManagerApt(PackageManagerBase):
                 '%s: %s' % (type(e).__name__, format(e))
             )
 
-    def post_process_install_requests_bootstrap(self, root_bind: RootBind = None) -> None:
+    def post_process_install_requests_bootstrap(
+        self, root_bind: RootBind = None
+    ) -> None:
         """
         Mounts the kernel file systems to the chroot environment is
         ready after the bootstrap procedure
@@ -190,9 +199,10 @@ class PackageManagerApt(PackageManagerBase):
         :param object root_bind:
             instance of RootBind to manage kernel file systems
         """
-        root_bind.mount_kernel_file_systems()
+        if root_bind:
+            root_bind.mount_kernel_file_systems()
 
-    def process_install_requests(self) -> None:
+    def process_install_requests(self) -> command_call_type:
         """
         Process package install requests for image phase (chroot)
 
@@ -220,7 +230,7 @@ class PackageManagerApt(PackageManagerBase):
             apt_get_command, self.command_env
         )
 
-    def process_delete_requests(self, force: bool = False) -> None:
+    def process_delete_requests(self, force: bool = False) -> command_call_type:
         """
         Process package delete requests (chroot)
 
@@ -264,7 +274,7 @@ class PackageManagerApt(PackageManagerBase):
             apt_get_command, self.command_env
         )
 
-    def update(self) -> None:
+    def update(self) -> command_call_type:
         """
         Process package update requests (chroot)
 
@@ -299,7 +309,9 @@ class PackageManagerApt(PackageManagerBase):
             self.custom_args.remove('--no-install-recommends')
         self.deboostrap_minbase = False
 
-    def match_package_installed(self, package_name: str, package_manager_output: str) -> bool:
+    def match_package_installed(
+        self, package_name: str, package_manager_output: str
+    ) -> bool:
         """
         Match expression to indicate a package has been installed
 
@@ -315,11 +327,16 @@ class PackageManagerApt(PackageManagerBase):
 
         :rtype: bool
         """
-        return bool(re.match(
-            '.*Unpacking ' + re.escape(package_name) + '.*', package_manager_output
-        ))
+        return bool(
+            re.match(
+                '.*Unpacking {0}.*'.format(re.escape(package_name)),
+                package_manager_output
+            )
+        )
 
-    def match_package_deleted(self, package_name: str, package_manager_output: str) -> bool:
+    def match_package_deleted(
+        self, package_name: str, package_manager_output: str
+    ) -> bool:
         """
         Match expression to indicate a package has been deleted
 
@@ -330,9 +347,12 @@ class PackageManagerApt(PackageManagerBase):
 
         :rtype: bool
         """
-        return bool(re.match(
-            '.*Removing ' + re.escape(package_name) + '.*', package_manager_output
-        ))
+        return bool(
+            re.match(
+                '.*Removing {0}.*'.format(re.escape(package_name)),
+                package_manager_output
+            )
+        )
 
     def _package_requests(self) -> List:
         items = self.package_requests[:]

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -17,6 +17,7 @@
 #
 from typing import List
 
+from kiwi.api_helper import decommissioned
 from kiwi.command import command_call_type
 from kiwi.system.root_bind import RootBind
 from kiwi.repository.base import RepositoryBase
@@ -84,15 +85,9 @@ class PackageManagerBase:
         """
         raise NotImplementedError
 
+    @decommissioned
     def request_package_lock(self, name: str) -> None:
-        """
-        Queue a package exclusion(skip) request
-
-        OBSOLETE: Will be removed 2019-06-05
-
-        Kept for API compatbility Method calls: request_package_exclusion
-        """
-        return self.request_package_exclusion(name)
+        pass  # pragma: no cover
 
     def request_package_exclusion(self, name: str) -> None:
         """
@@ -190,17 +185,13 @@ class PackageManagerBase:
         """
         raise NotImplementedError
 
+    @decommissioned
     def database_consistent(self) -> None:
-        """
-        OBSOLETE: Will be removed 2019-06-05
-        """
-        pass
+        pass  # pragma: no cover
 
+    @decommissioned
     def dump_reload_package_database(self, version: int = 45) -> None:
-        """
-        OBSOLETE: Will be removed 2019-06-05
-        """
-        pass
+        pass  # pragma: no cover
 
     def post_process_install_requests_bootstrap(
         self, root_bind: RootBind = None

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -17,14 +17,14 @@
 #
 from typing import List
 
+from kiwi.command import command_call_type
 from kiwi.system.root_bind import RootBind
 from kiwi.repository.base import RepositoryBase
 
 
 class PackageManagerBase:
     """
-    **Implements base class for installation/deletion of
-    packages and collections using a package manager**
+    **Implements base class for Package Management**
 
     :param object repository: instance of :class:`Repository`
     :param str root_dir: root directory path name
@@ -32,8 +32,9 @@ class PackageManagerBase:
     :param list collection_requests: list of collections to install
     :param list product_requests: list of products to install
     """
-
-    def __init__(self, repository: RepositoryBase, custom_args: List = None) -> None:
+    def __init__(
+        self, repository: RepositoryBase, custom_args: List = []
+    ) -> None:
         self.repository = repository
         self.root_dir = repository.root_dir
         self.package_requests: List[str] = []
@@ -41,9 +42,9 @@ class PackageManagerBase:
         self.product_requests: List[str] = []
         self.exclude_requests: List[str] = []
 
-        self.post_init(custom_args)
+        self.post_init(custom_args or [])
 
-    def post_init(self, custom_args: List = None) -> None:
+    def post_init(self, custom_args: List = []) -> None:
         """
         Post initialization method
 
@@ -103,7 +104,9 @@ class PackageManagerBase:
         """
         raise NotImplementedError
 
-    def process_install_requests_bootstrap(self, root_bind: RootBind = None) -> None:
+    def process_install_requests_bootstrap(
+        self, root_bind: RootBind = None
+    ) -> command_call_type:
         """
         Process package install requests for bootstrap phase (no chroot)
 
@@ -111,7 +114,7 @@ class PackageManagerBase:
         """
         raise NotImplementedError
 
-    def process_install_requests(self) -> None:
+    def process_install_requests(self) -> command_call_type:
         """
         Process package install requests for image phase (chroot)
 
@@ -119,7 +122,7 @@ class PackageManagerBase:
         """
         raise NotImplementedError
 
-    def process_delete_requests(self, force: bool = False) -> None:
+    def process_delete_requests(self, force: bool = False) -> command_call_type:
         """
         Process package delete requests (chroot)
 
@@ -129,7 +132,7 @@ class PackageManagerBase:
         """
         raise NotImplementedError
 
-    def update(self) -> None:
+    def update(self) -> command_call_type:
         """
         Process package update requests (chroot)
 
@@ -153,7 +156,9 @@ class PackageManagerBase:
         """
         raise NotImplementedError
 
-    def match_package_installed(self, package_name: str, package_manager_output: str) -> bool:
+    def match_package_installed(
+        self, package_name: str, package_manager_output: str
+    ) -> bool:
         """
         Match expression to indicate a package has been installed
 
@@ -168,7 +173,9 @@ class PackageManagerBase:
         """
         raise NotImplementedError
 
-    def match_package_deleted(self, package_name: str, package_manager_output: str) -> bool:
+    def match_package_deleted(
+        self, package_name: str, package_manager_output: str
+    ) -> bool:
         """
         Match expression to indicate a package has been deleted
 
@@ -195,7 +202,9 @@ class PackageManagerBase:
         """
         pass
 
-    def post_process_install_requests_bootstrap(self, root_bind: RootBind = None) -> None:
+    def post_process_install_requests_bootstrap(
+        self, root_bind: RootBind = None
+    ) -> None:
         """
         Process extra code required after bootstrapping
 

--- a/kiwi/package_manager/pacman.py
+++ b/kiwi/package_manager/pacman.py
@@ -20,6 +20,7 @@ import logging
 from typing import List
 
 # project
+from kiwi.command import command_call_type
 from kiwi.command import Command
 from kiwi.package_manager.base import PackageManagerBase
 from kiwi.system.root_bind import RootBind
@@ -31,12 +32,12 @@ log = logging.getLogger('kiwi')
 
 class PackageManagerPacman(PackageManagerBase):
     """
-    **Implements base class for installation/deletion of
-    packages and collections using pacman**
+    **Implements Installation/Deletion of packages/collections with pacman**
 
-    :param list pacman_args: pacman arguments from repository runtime
-        configuration
-    :param dict command_env: pacman command environment from repository
+    :param list pacman_args:
+        pacman arguments from repository runtime configuration
+    :param dict command_env:
+        pacman command environment from repository
         runtime configuration
     """
     def post_init(self, custom_args: List = None) -> None:
@@ -96,7 +97,9 @@ class PackageManagerPacman(PackageManagerBase):
         """
         self.exclude_requests.append(name)
 
-    def process_install_requests_bootstrap(self, root_bind: RootBind = None) -> None:
+    def process_install_requests_bootstrap(
+        self, root_bind: RootBind = None
+    ) -> command_call_type:
         """
         Process package install requests for bootstrap phase (no chroot)
 
@@ -124,7 +127,7 @@ class PackageManagerPacman(PackageManagerBase):
             ['bash', '-c', ' '.join(bash_command)], self.command_env
         )
 
-    def process_install_requests(self) -> None:
+    def process_install_requests(self) -> command_call_type:
         """
         Process package install requests for image phase (chroot)
 
@@ -143,7 +146,7 @@ class PackageManagerPacman(PackageManagerBase):
             ['bash', '-c', ' '.join(bash_command)], self.command_env
         )
 
-    def process_delete_requests(self, force: bool = False) -> None:
+    def process_delete_requests(self, force: bool = False) -> command_call_type:
         """
         Process package delete requests (chroot)
 
@@ -158,7 +161,9 @@ class PackageManagerPacman(PackageManagerBase):
         delete_items = []
         for delete_item in self.package_requests:
             try:
-                Command.run(['chroot', self.root_dir, 'pacman', '-Qi', delete_item])
+                Command.run(
+                    ['chroot', self.root_dir, 'pacman', '-Qi', delete_item]
+                )
                 delete_items.append(delete_item)
             except Exception:
                 # ignore packages which are not installed
@@ -178,7 +183,7 @@ class PackageManagerPacman(PackageManagerBase):
             self.command_env
         )
 
-    def update(self) -> None:
+    def update(self) -> command_call_type:
         """
         Process package update requests (chroot)
 
@@ -212,7 +217,9 @@ class PackageManagerPacman(PackageManagerBase):
         """
         pass
 
-    def match_package_installed(self, package_name: str, package_manager_output: str) -> bool:
+    def match_package_installed(
+        self, package_name: str, package_manager_output: str
+    ) -> bool:
         """
         Match expression to indicate a package has been installed
 
@@ -228,11 +235,16 @@ class PackageManagerPacman(PackageManagerBase):
 
         :rtype: bool
         """
-        return bool(re.match(
-            '.* installing ' + re.escape(package_name) + '.*', package_manager_output
-        ))
+        return bool(
+            re.match(
+                '.* installing {0}.*'.format(re.escape(package_name)),
+                package_manager_output
+            )
+        )
 
-    def match_package_deleted(self, package_name: str, package_manager_output: str) -> bool:
+    def match_package_deleted(
+        self, package_name: str, package_manager_output: str
+    ) -> bool:
         """
         Match expression to indicate a package has been deleted
 
@@ -243,6 +255,9 @@ class PackageManagerPacman(PackageManagerBase):
 
         :rtype: bool
         """
-        return bool(re.match(
-            '.* removing ' + re.escape(package_name) + '.*', package_manager_output
-        ))
+        return bool(
+            re.match(
+                '.* removing {0}.*'.format(re.escape(package_name)),
+                package_manager_output
+            )
+        )

--- a/kiwi/package_manager/zypper.py
+++ b/kiwi/package_manager/zypper.py
@@ -21,6 +21,7 @@ from typing import List
 
 
 # project
+from kiwi.command import command_call_type
 from kiwi.command import Command
 from kiwi.package_manager.base import PackageManagerBase
 from kiwi.system.root_bind import RootBind
@@ -33,15 +34,15 @@ from kiwi.defaults import Defaults
 
 class PackageManagerZypper(PackageManagerBase):
     """
-    **Implements base class for installation/deletion of
-    packages and collections using zypper**
+    **Implements Installation/Deletion of packages/collections with zypper**
 
-    :param list zypper_args: zypper arguments from repository runtime
-        configuration
-    :param dict command_env: zypper command environment from repository
+    :param list zypper_args:
+        zypper arguments from repository runtime configuration
+    :param dict command_env:
+        zypper command environment from repository
         runtime configuration
     """
-    def post_init(self, custom_args: list = None) -> None:
+    def post_init(self, custom_args: List = []) -> None:
         """
         Post initialization method
 
@@ -51,8 +52,6 @@ class PackageManagerZypper(PackageManagerBase):
         """
         self.anonymousId_file = '/var/lib/zypp/AnonymousUniqueId'
         self.custom_args = custom_args
-        if not custom_args:
-            self.custom_args = []
 
         runtime_config = self.repository.runtime_config()
 
@@ -100,7 +99,9 @@ class PackageManagerZypper(PackageManagerBase):
         """
         self.exclude_requests.append(name)
 
-    def process_install_requests_bootstrap(self, root_bind: RootBind = None) -> None:
+    def process_install_requests_bootstrap(
+        self, root_bind: RootBind = None
+    ) -> command_call_type:
         """
         Process package install requests for bootstrap phase (no chroot)
 
@@ -118,7 +119,7 @@ class PackageManagerZypper(PackageManagerBase):
             command, self.command_env
         )
 
-    def process_install_requests(self) -> None:
+    def process_install_requests(self) -> command_call_type:
         """
         Process package install requests for image phase (chroot)
 
@@ -148,7 +149,7 @@ class PackageManagerZypper(PackageManagerBase):
             self.chroot_command_env
         )
 
-    def process_delete_requests(self, force: bool = False) -> None:
+    def process_delete_requests(self, force: bool = False) -> command_call_type:
         """
         Process package delete requests (chroot)
 
@@ -190,7 +191,7 @@ class PackageManagerZypper(PackageManagerBase):
                 self.chroot_command_env
             )
 
-    def update(self) -> None:
+    def update(self) -> command_call_type:
         """
         Process package update requests (chroot)
 
@@ -219,7 +220,9 @@ class PackageManagerZypper(PackageManagerBase):
         if '--no-recommends' in self.custom_args:
             self.custom_args.remove('--no-recommends')
 
-    def match_package_installed(self, package_name: str, package_manager_output: str) -> bool:
+    def match_package_installed(
+        self, package_name: str, package_manager_output: str
+    ) -> bool:
         """
         Match expression to indicate a package has been installed
 
@@ -235,11 +238,16 @@ class PackageManagerZypper(PackageManagerBase):
 
         :rtype: bool
         """
-        return bool(re.match(
-            '.*Installing: ' + re.escape(package_name) + '.*', package_manager_output
-        ))
+        return bool(
+            re.match(
+                '.*Installing: {0}.*'.format(re.escape(package_name)),
+                package_manager_output
+            )
+        )
 
-    def match_package_deleted(self, package_name: str, package_manager_output: str) -> bool:
+    def match_package_deleted(
+        self, package_name: str, package_manager_output: str
+    ) -> bool:
         """
         Match expression to indicate a package has been deleted
 
@@ -250,11 +258,16 @@ class PackageManagerZypper(PackageManagerBase):
 
         :rtype: bool
         """
-        return bool(re.match(
-            '.*Removing: ' + re.escape(package_name) + '.*', package_manager_output
-        ))
+        return bool(
+            re.match(
+                '.*Removing: {0}.*'.format(re.escape(package_name)),
+                package_manager_output
+            )
+        )
 
-    def post_process_install_requests_bootstrap(self, root_bind: RootBind = None) -> None:
+    def post_process_install_requests_bootstrap(
+        self, root_bind: RootBind = None
+    ) -> None:
         """
         Move the rpm database to the place as it is expected by the
         rpm package installed during bootstrap phase

--- a/kiwi/partitioner/dasd.py
+++ b/kiwi/partitioner/dasd.py
@@ -64,7 +64,7 @@ class PartitionerDasd(PartitionerBase):
             if mbsize == 'all_free':
                 partition.write('n\np\n\n\nw\nq\n')
             else:
-                partition.write('n\np\n\n+%dM\nw\nq\n' % mbsize)
+                partition.write(f'n\np\n\n+{mbsize}M\nw\nq\n')
         bash_command = ' '.join(
             ['cat', fdasd_input.name, '|', 'fdasd', '-f', self.disk_device]
         )

--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -43,7 +43,7 @@ class RepositoryApt(RepositoryBase):
         host and image
     """
 
-    def post_init(self, custom_args: List = None) -> None:
+    def post_init(self, custom_args: List = []) -> None:
         """
         Post initialization method
 
@@ -55,8 +55,6 @@ class RepositoryApt(RepositoryBase):
         self.custom_args = custom_args
         self.exclude_docs = False
         self.signing_keys: List = []
-        if not custom_args:
-            self.custom_args = []
 
         # extract custom arguments used for apt config only
         if 'exclude_docs' in self.custom_args:
@@ -69,8 +67,8 @@ class RepositoryApt(RepositoryBase):
         else:
             self.unauthenticated = 'true'
 
-        self.distribution: str = None
-        self.distribution_path: str = None
+        self.distribution: str = ''
+        self.distribution_path: str = ''
         self.debootstrap_repo_set = False
         self.repo_names: List = []
         self.components: List = []

--- a/kiwi/repository/base.py
+++ b/kiwi/repository/base.py
@@ -15,8 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-
-from typing import List, Dict
+from typing import (
+    List, Dict
+)
 
 from kiwi.system.root_bind import RootBind
 
@@ -33,14 +34,16 @@ class RepositoryBase:
         and build system root
     """
 
-    def __init__(self, root_bind: RootBind = None, custom_args: List = None) -> None:
+    def __init__(
+        self, root_bind: RootBind, custom_args: List = []
+    ) -> None:
         self.root_bind = root_bind
         self.root_dir = root_bind.root_dir
         self.shared_location = root_bind.shared_location
 
-        self.post_init(custom_args)
+        self.post_init(custom_args or [])
 
-    def post_init(self, custom_args: List = None) -> None:
+    def post_init(self, custom_args: List = []) -> None:
         """
         Post initialization method
 
@@ -67,9 +70,10 @@ class RepositoryBase:
         raise NotImplementedError
 
     def add_repo(
-        self, name: str, uri: str, repo_type: str, prio: int, dist: str, components: str,
-        user: str, secret: str, credentials_file: str, repo_gpgcheck: bool,
-        pkg_gpgcheck: bool, sourcetype: str, use_for_bootstrap: bool = False
+        self, name: str, uri: str, repo_type: str, prio: int, dist: str,
+        components: str, user: str, secret: str, credentials_file: str,
+        repo_gpgcheck: bool, pkg_gpgcheck: bool, sourcetype: str,
+        use_for_bootstrap: bool = False
     ) -> None:
         """
         Add repository

--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -40,7 +40,7 @@ class RepositoryDnf(RepositoryBase):
     :param str runtime_dnf_config: instance of :class:`ConfigParser`
     """
 
-    def post_init(self, custom_args: List = None) -> None:
+    def post_init(self, custom_args: List = []) -> None:
         """
         Post initialization method
 
@@ -51,8 +51,6 @@ class RepositoryDnf(RepositoryBase):
         """
         self.custom_args = custom_args
         self.exclude_docs = False
-        if not custom_args:
-            self.custom_args = []
 
         # extract custom arguments not used in dnf call
         if 'exclude_docs' in self.custom_args:
@@ -185,7 +183,7 @@ class RepositoryDnf(RepositoryBase):
         self, name: str, uri: str, repo_type: str = 'rpm-md',
         prio: int = None, dist: str = None, components: str = None,
         user: str = None, secret: str = None, credentials_file: str = None,
-        repo_gpgcheck: bool = None, pkg_gpgcheck: bool = None,
+        repo_gpgcheck: bool = False, pkg_gpgcheck: bool = False,
         sourcetype: str = None, use_for_bootstrap: bool = False
     ) -> None:
         """
@@ -223,18 +221,17 @@ class RepositoryDnf(RepositoryBase):
             repo_config.set(
                 name, 'priority', format(prio)
             )
-        if repo_gpgcheck is not None:
-            repo_config.set(
-                name, 'repo_gpgcheck', '1' if repo_gpgcheck else '0'
-            )
-        if pkg_gpgcheck is not None:
-            repo_config.set(
-                name, 'gpgcheck', '1' if pkg_gpgcheck else '0'
-            )
+        repo_config.set(
+            name, 'repo_gpgcheck', '1' if repo_gpgcheck else '0'
+        )
+        repo_config.set(
+            name, 'gpgcheck', '1' if pkg_gpgcheck else '0'
+        )
         if Defaults.is_buildservice_worker():
-            # when building in the build service, modular metadata is inaccessible...
-            # in order to use modular content in the build service, we need to disable
-            # modular filtering, which is done with module_hotfixes option
+            # when building in the build service, modular metadata is
+            # inaccessible. In order to use modular content in the build
+            # service, we need to disable modular filtering, which is
+            # done with module_hotfixes option
             repo_config.set(
                 name, 'module_hotfixes', '1'
             )

--- a/kiwi/repository/pacman.py
+++ b/kiwi/repository/pacman.py
@@ -18,8 +18,9 @@
 import os
 from configparser import ConfigParser
 from tempfile import NamedTemporaryFile
-from typing import List, Dict
-
+from typing import (
+    List, Dict
+)
 
 # project
 from kiwi.repository.base import RepositoryBase
@@ -38,7 +39,7 @@ class RepositoryPacman(RepositoryBase):
     :param dict command_env: customized os.environ for pacman
     """
 
-    def post_init(self, custom_args: List = None) -> None:
+    def post_init(self, custom_args: List = []) -> None:
         """
         Post initialization method
 
@@ -50,8 +51,6 @@ class RepositoryPacman(RepositoryBase):
         self.custom_args = custom_args
         self.check_signatures = False
         self.repo_names: List = []
-        if not custom_args:
-            self.custom_args = []
 
         self.runtime_pacman_config_file = NamedTemporaryFile(
             dir=self.root_dir
@@ -94,8 +93,9 @@ class RepositoryPacman(RepositoryBase):
         }
 
     def _add_repo_section(
-        self, config_parser: ConfigParser, name: str, uri: str, repo_gpgcheck: bool = False,
-            pkg_gpgcheck: bool = False) -> None:
+        self, config_parser: ConfigParser, name: str, uri: str,
+        repo_gpgcheck: bool = False, pkg_gpgcheck: bool = False
+    ) -> None:
         config_parser.add_section(name)
         if uri.startswith(os.sep) and os.path.exists(uri):
             uri = 'file://{}'.format(uri)
@@ -111,7 +111,7 @@ class RepositoryPacman(RepositoryBase):
         self, name: str, uri: str, repo_type: str = None,
         prio: int = None, dist: str = None, components: str = None,
         user: str = None, secret: str = None, credentials_file: str = None,
-        repo_gpgcheck: bool = None, pkg_gpgcheck: bool = None,
+        repo_gpgcheck: bool = False, pkg_gpgcheck: bool = False,
         sourcetype: str = None, use_for_bootstrap: bool = False
     ) -> None:
         """
@@ -136,7 +136,7 @@ class RepositoryPacman(RepositoryBase):
         )
         self.repo_names.append(name + '.repo')
         repo_config = ConfigParser()
-        repo_config.optionxform = str
+        repo_config.optionxform = str  # type: ignore
         if not components:
             self._add_repo_section(
                 repo_config, name, uri, repo_gpgcheck,
@@ -216,7 +216,7 @@ class RepositoryPacman(RepositoryBase):
 
     def _write_runtime_config(self) -> None:
         runtime_pacman_config = ConfigParser()
-        runtime_pacman_config.optionxform = str
+        runtime_pacman_config.optionxform = str  # type: ignore
         runtime_pacman_config.add_section('options')
 
         runtime_pacman_config.set(

--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -88,14 +88,14 @@ class Disk(DeviceProvider):
         """
         return self.storage_provider.is_loop()
 
-    def create_root_partition(self, mbsize: int):
+    def create_root_partition(self, mbsize: str):
         """
         Create root partition
 
         Populates kiwi_RootPart(id) and kiwi_BootPart(id) if no extra
         boot partition is requested
 
-        :param int mbsize: partition size
+        :param str mbsize: partition size NumberString or 'all_free'
         """
         self.partitioner.create('p.lxroot', mbsize, 't.linux')
         self._add_to_map('root')
@@ -105,19 +105,19 @@ class Disk(DeviceProvider):
         if 'kiwi_BootPart' not in self.public_partition_id_map:
             self._add_to_public_id_map('kiwi_BootPart')
 
-    def create_root_lvm_partition(self, mbsize: int):
+    def create_root_lvm_partition(self, mbsize: str):
         """
         Create root partition for use with LVM
 
         Populates kiwi_RootPart(id)
 
-        :param int mbsize: partition size
+        :param str mbsize: partition size NumberString or 'all_free'
         """
         self.partitioner.create('p.lxlvm', mbsize, 't.lvm')
         self._add_to_map('root')
         self._add_to_public_id_map('kiwi_RootPart')
 
-    def create_root_raid_partition(self, mbsize: int):
+    def create_root_raid_partition(self, mbsize: str):
         """
         Create root partition for use with MD Raid
 
@@ -125,14 +125,14 @@ class Disk(DeviceProvider):
         as the default raid device node at boot time which is
         configured to be kiwi_RaidDev(/dev/mdX)
 
-        :param int mbsize: partition size
+        :param str mbsize: partition size NumberString or 'all_free'
         """
         self.partitioner.create('p.lxraid', mbsize, 't.raid')
         self._add_to_map('root')
         self._add_to_public_id_map('kiwi_RootPart')
         self._add_to_public_id_map('kiwi_RaidPart')
 
-    def create_root_readonly_partition(self, mbsize: int):
+    def create_root_readonly_partition(self, mbsize: str):
         """
         Create root readonly partition for use with overlayfs
 
@@ -141,79 +141,79 @@ class Disk(DeviceProvider):
         should be the size of the squashfs filesystem in order to
         avoid wasting disk space
 
-        :param int mbsize: partition size
+        :param str mbsize: partition size NumberString or 'all_free'
         """
         self.partitioner.create('p.lxreadonly', mbsize, 't.linux')
         self._add_to_map('readonly')
         self._add_to_public_id_map('kiwi_ROPart')
 
-    def create_boot_partition(self, mbsize: int):
+    def create_boot_partition(self, mbsize: str):
         """
         Create boot partition
 
         Populates kiwi_BootPart(id)
 
-        :param int mbsize: partition size
+        :param str mbsize: partition size NumberString or 'all_free'
         """
         self.partitioner.create('p.lxboot', mbsize, 't.linux')
         self._add_to_map('boot')
         self._add_to_public_id_map('kiwi_BootPart')
 
-    def create_prep_partition(self, mbsize: int):
+    def create_prep_partition(self, mbsize: str):
         """
         Create prep partition
 
         Populates kiwi_PrepPart(id)
 
-        :param int mbsize: partition size
+        :param str mbsize: partition size NumberString or 'all_free'
         """
         self.partitioner.create('p.prep', mbsize, 't.prep')
         self._add_to_map('prep')
         self._add_to_public_id_map('kiwi_PrepPart')
 
-    def create_spare_partition(self, mbsize: int):
+    def create_spare_partition(self, mbsize: str):
         """
         Create spare partition for custom use
 
         Populates kiwi_SparePart(id)
 
-        :param int mbsize: partition size
+        :param str mbsize: partition size NumberString or 'all_free'
         """
         self.partitioner.create('p.spare', mbsize, 't.linux')
         self._add_to_map('spare')
         self._add_to_public_id_map('kiwi_SparePart')
 
-    def create_swap_partition(self, mbsize: int):
+    def create_swap_partition(self, mbsize: str):
         """
         Create swap partition
 
         Populates kiwi_SwapPart(id)
 
-        :param int mbsize: partition size
+        :param str mbsize: partition size NumberString or 'all_free'
         """
         self.partitioner.create('p.swap', mbsize, 't.swap')
         self._add_to_map('swap')
         self._add_to_public_id_map('kiwi_SwapPart')
 
-    def create_efi_csm_partition(self, mbsize: int):
+    def create_efi_csm_partition(self, mbsize: str):
         """
         Create EFI bios grub partition
 
         Populates kiwi_BiosGrub(id)
 
-        :param int mbsize: partition size
+        :param str mbsize: partition size NumberString or 'all_free'
         """
         self.partitioner.create('p.legacy', mbsize, 't.csm')
         self._add_to_map('efi_csm')
         self._add_to_public_id_map('kiwi_BiosGrub')
 
-    def create_efi_partition(self, mbsize: int):
+    def create_efi_partition(self, mbsize: str):
         """
         Create EFI partition
 
         Populates kiwi_EfiPart(id)
 
-        :param int mbsize: partition size
+        :param str mbsize: partition size NumberString or 'all_free'
         """
         self.partitioner.create('p.UEFI', mbsize, 't.efi')
         self._add_to_map('efi')

--- a/kiwi/storage/loop_device.py
+++ b/kiwi/storage/loop_device.py
@@ -17,7 +17,6 @@
 #
 import os
 import logging
-from typing import Optional
 
 # project
 from kiwi.command import Command
@@ -43,7 +42,7 @@ class LoopDevice(DeviceProvider):
         self, filename: str, filesize_mbytes: int = None,
         blocksize_bytes: int = None
     ):
-        self.node_name = None
+        self.node_name = ''
         if not os.path.exists(filename) and not filesize_mbytes:
             raise KiwiLoopSetupError(
                 'Can not create loop file without a size'
@@ -52,7 +51,7 @@ class LoopDevice(DeviceProvider):
         self.filesize_mbytes = filesize_mbytes
         self.blocksize_bytes = blocksize_bytes
 
-    def get_device(self) -> Optional[str]:
+    def get_device(self) -> str:
         """
         Device node name
 
@@ -97,7 +96,7 @@ class LoopDevice(DeviceProvider):
         loop_call = Command.run(
             ['losetup'] + loop_options + ['-f', '--show', self.filename]
         )
-        self.node_name = loop_call.output.rstrip('\n')
+        self.node_name = loop_call.output.rstrip(os.linesep)
 
     def __del__(self):
         if self.node_name:

--- a/kiwi/storage/subformat/vagrant_base.py
+++ b/kiwi/storage/subformat/vagrant_base.py
@@ -107,7 +107,6 @@ class DiskFormatVagrantBase(DiskFormatBase):
         be set by the specialized provider class implementation to
         make the this base class methods effective
         """
-        self.image_format = None
         self.provider: Optional[str] = None
 
     def create_box_img(self, temp_image_dir: str) -> List[str]:

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -99,7 +99,6 @@ class Profile:
         # kiwi_oemmultipath_scan
         # kiwi_oemswapMB
         # kiwi_oemrootMB
-        # kiwi_oemswap
         # kiwi_oemresizeonce
         # kiwi_oempartition_install
         # kiwi_oemdevicefilter
@@ -131,16 +130,6 @@ class Profile:
                 self._text(oemconfig.get_oem_swapsize())
             self.dot_profile['kiwi_oemrootMB'] = \
                 self._text(oemconfig.get_oem_systemsize())
-
-            # kiwi_oemconfig is used in older boot code to run the swap
-            # creation and setup code at boot time. This version of kiwi
-            # handles swap as part of the build process and therefore
-            # has to disable swap handling such that we stay backward
-            # compatbile for some time.
-            # OBSOLETE: to be removed at: 2020-05-25
-            self.dot_profile['kiwi_oemswap'] = \
-                self._text(False)
-
             self.dot_profile['kiwi_oemresizeonce'] = \
                 self._text(oemconfig.get_oem_resize_once())
             self.dot_profile['kiwi_oempartition_install'] = \

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -22,9 +22,7 @@ import copy
 from collections import OrderedDict
 from collections import namedtuple
 from tempfile import NamedTemporaryFile
-from typing import (
-    Any, Optional
-)
+from typing import Any
 
 # project
 import kiwi.defaults as defaults
@@ -493,7 +491,7 @@ class SystemSetup:
                 options=['-a']
             )
 
-    def export_package_list(self, target_dir: str) -> Optional[str]:
+    def export_package_list(self, target_dir: str) -> str:
         """
         Export image package list as metadata reference
         used by the open buildservice
@@ -522,9 +520,9 @@ class SystemSetup:
         elif packager == 'pacman':
             self._export_pacman_package_list(filename)
             return filename
-        return None
+        return ''
 
-    def export_package_changes(self, target_dir: str) -> Optional[str]:
+    def export_package_changes(self, target_dir: str) -> str:
         """
         Export image package changelog for comparision of
         actual changes of the installed packages
@@ -551,9 +549,9 @@ class SystemSetup:
             elif packager == 'dpkg':
                 self._export_deb_package_changes(filename)
                 return filename
-        return None
+        return ''
 
-    def export_package_verification(self, target_dir: str) -> Optional[str]:
+    def export_package_verification(self, target_dir: str) -> str:
         """
         Export package verification result as metadata reference
         used by the open buildservice
@@ -579,7 +577,7 @@ class SystemSetup:
         elif packager == 'dpkg':
             self._export_deb_package_verification(filename)
             return filename
-        return None
+        return ''
 
     def call_disk_script(self) -> None:
         """

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -297,7 +297,7 @@ class TestDiskBuilder:
             self.disk_setup.boot_partition_size()
         )
         self.disk.create_swap_partition.assert_called_once_with(
-            128
+            '128'
         )
         self.disk.create_prep_partition.assert_called_once_with(
             self.firmware.get_prep_partition_size()
@@ -522,6 +522,7 @@ class TestDiskBuilder:
         assert self.boot_image_task.write_system_config_file.call_args_list == \
             []
 
+    @patch('kiwi.builder.disk.DeviceProvider')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.FileSystemSquashFs')
     @patch('kiwi.builder.disk.Command.run')
@@ -532,7 +533,8 @@ class TestDiskBuilder:
     @patch('random.randrange')
     def test_create_disk_standard_root_is_overlay(
         self, mock_rand, mock_temp, mock_getsize, mock_exists,
-        mock_grub_dir, mock_command, mock_squashfs, mock_fs
+        mock_grub_dir, mock_command, mock_squashfs, mock_fs,
+        mock_DeviceProvider
     ):
         mock_rand.return_value = 15
         self.disk_builder.root_filesystem_is_overlay = True
@@ -553,10 +555,12 @@ class TestDiskBuilder:
         assert mock_squashfs.call_args_list == [
             call(
                 custom_args={'compression': None},
-                device_provider=None, root_dir='root_dir'
+                device_provider=mock_DeviceProvider.return_value,
+                root_dir='root_dir'
             ), call(
                 custom_args={'compression': None},
-                device_provider=None, root_dir='root_dir'
+                device_provider=mock_DeviceProvider.return_value,
+                root_dir='root_dir'
             )
         ]
         assert squashfs.create_on_file.call_args_list == [
@@ -839,7 +843,7 @@ class TestDiskBuilder:
         with patch('builtins.open'):
             self.disk_builder.create_disk()
 
-        self.disk.create_spare_partition.assert_called_once_with(42)
+        self.disk.create_spare_partition.assert_called_once_with('42')
         assert mock_fs.call_args_list[0] == call(
             self.disk_builder.spare_part_fs,
             self.device_map['spare'],

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -113,6 +113,7 @@ class TestInstallImageBuilder:
         )
         assert install_image.arch == 'ix86'
 
+    @patch('kiwi.builder.install.DeviceProvider')
     @patch('kiwi.builder.install.BootLoaderConfig.new')
     @patch('kiwi.builder.install.IsoToolsBase.setup_media_loader_directory')
     @patch('kiwi.builder.install.shutil.copy')
@@ -121,7 +122,8 @@ class TestInstallImageBuilder:
     @patch('kiwi.builder.install.Defaults.get_grub_boot_directory_name')
     def test_create_install_iso(
         self, mock_grub_dir, mock_command, mock_dtemp, mock_copy,
-        mock_setup_media_loader_directory, mock_BootLoaderConfig
+        mock_setup_media_loader_directory, mock_BootLoaderConfig,
+        mock_DeviceProvider
     ):
         tmpdir_name = ['temp-squashfs', 'temp_media_dir']
 
@@ -155,7 +157,8 @@ class TestInstallImageBuilder:
         ]
         kiwi.builder.install.FileSystemSquashFs.assert_called_once_with(
             custom_args={'compression': mock.ANY},
-            device_provider=None, root_dir='temp-squashfs'
+            device_provider=mock_DeviceProvider.return_value,
+            root_dir='temp-squashfs'
         )
         self.squashed_image.create_on_file.assert_called_once_with(
             'target_dir/result-image.raw.squashfs'

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -129,6 +129,7 @@ class TestLiveImageBuilder:
         )
         assert live_image.arch == 'ix86'
 
+    @patch('kiwi.builder.live.DeviceProvider')
     @patch('kiwi.builder.live.IsoToolsBase.setup_media_loader_directory')
     @patch('kiwi.builder.live.mkdtemp')
     @patch('kiwi.builder.live.NamedTemporaryFile')
@@ -142,7 +143,7 @@ class TestLiveImageBuilder:
     def test_create_overlay_structure(
         self, mock_exists, mock_grub_dir, mock_size, mock_filesystem,
         mock_isofs, mock_tag, mock_shutil, mock_tmpfile, mock_dtemp,
-        mock_setup_media_loader_directory
+        mock_setup_media_loader_directory, mock_DeviceProvider
     ):
         tempfile = mock.Mock()
         tempfile.name = 'tmpfile'
@@ -188,7 +189,8 @@ class TestLiveImageBuilder:
                 }
             ),
             call(
-                device_provider=None, name='squashfs',
+                device_provider=mock_DeviceProvider.return_value,
+                name='squashfs',
                 root_dir='temp-squashfs',
                 custom_args={'compression': 'lzo'}
             )
@@ -269,7 +271,9 @@ class TestLiveImageBuilder:
                     'efi_mode': 'uefi',
                     'udf': True
                 }
-            }, device_provider=None, root_dir='temp_media_dir'
+            },
+            device_provider=mock_DeviceProvider.return_value,
+            root_dir='temp_media_dir'
         )
         iso_image.create_on_file.assert_called_once_with(
             'target_dir/result-image.x86_64-1.2.3.iso'

--- a/test/unit/package_manager/base_test.py
+++ b/test/unit/package_manager/base_test.py
@@ -1,5 +1,4 @@
 import mock
-from mock import patch
 from pytest import raises
 
 from kiwi.package_manager.base import PackageManagerBase
@@ -23,10 +22,9 @@ class TestPackageManagerBase:
         with raises(NotImplementedError):
             self.manager.request_product('name')
 
-    @patch.object(PackageManagerBase, 'request_package_exclusion')
-    def test_request_package_lock(self, mock_exclude):
-        self.manager.request_package_lock('name')
-        mock_exclude.assert_called_once_with('name')
+    def test_request_package_lock(self):
+        with raises(DeprecationWarning):
+            self.manager.request_package_lock('name')
 
     def test_request_package_exclusion(self):
         with raises(NotImplementedError):
@@ -68,10 +66,12 @@ class TestPackageManagerBase:
             self.manager.match_package_deleted('package_name', 'log')
 
     def test_database_consistent(self):
-        self.manager.database_consistent()
+        with raises(DeprecationWarning):
+            self.manager.database_consistent()
 
     def test_dump_reload_package_database(self):
-        self.manager.dump_reload_package_database()
+        with raises(DeprecationWarning):
+            self.manager.dump_reload_package_database()
 
     def test_has_failed(self):
         assert self.manager.has_failed(0) is False

--- a/test/unit/partitioner/dasd_test.py
+++ b/test/unit/partitioner/dasd_test.py
@@ -38,7 +38,7 @@ class TestPartitionerDasd:
         m_open = mock_open()
         with patch('builtins.open', m_open, create=True):
             with self._caplog.at_level(logging.DEBUG):
-                self.partitioner.create('name', 100, 't.linux', ['f.active'])
+                self.partitioner.create('name', '100', 't.linux', ['f.active'])
 
         m_open.return_value.write.assert_called_once_with(
             'n\np\n\n+100M\nw\nq\n'

--- a/test/unit/repository/dnf_test.py
+++ b/test/unit/repository/dnf_test.py
@@ -114,7 +114,9 @@ class TestRepositoryDnf:
             assert repo_config.set.call_args_list == [
                 call('foo', 'name', 'foo'),
                 call('foo', 'baseurl', 'file://kiwi_iso_mount/uri'),
-                call('foo', 'priority', '42')
+                call('foo', 'priority', '42'),
+                call('foo', 'repo_gpgcheck', '0'),
+                call('foo', 'gpgcheck', '0'),
             ]
             mock_open.assert_called_once_with(
                 '/shared-dir/dnf/repos/foo.repo', 'w'
@@ -131,7 +133,9 @@ class TestRepositoryDnf:
             repo_config.add_section.assert_called_once_with('bar')
             assert repo_config.set.call_args_list == [
                 call('bar', 'name', 'bar'),
-                call('bar', 'metalink', 'https://metalink')
+                call('bar', 'metalink', 'https://metalink'),
+                call('bar', 'repo_gpgcheck', '0'),
+                call('bar', 'gpgcheck', '0')
             ]
             mock_open.assert_called_once_with(
                 '/shared-dir/dnf/repos/bar.repo', 'w'
@@ -156,6 +160,8 @@ class TestRepositoryDnf:
                 call('foo', 'name', 'foo'),
                 call('foo', 'baseurl', 'file://kiwi_iso_mount/uri'),
                 call('foo', 'priority', '42'),
+                call('foo', 'repo_gpgcheck', '0'),
+                call('foo', 'gpgcheck', '0'),
                 call('foo', 'module_hotfixes', '1')
             ]
             mock_open.assert_called_once_with(

--- a/test/unit/repository/zypper_test.py
+++ b/test/unit/repository/zypper_test.py
@@ -136,9 +136,11 @@ class TestRepositoryZypper:
             repo_config.read.assert_called_once_with(
                 '../data/shared-dir/zypper/repos/foo.repo'
             )
-            repo_config.set.assert_called_once_with(
-                'foo', 'priority', '42'
-            )
+            assert repo_config.set.call_args_list == [
+                call('foo', 'repo_gpgcheck', '0'),
+                call('foo', 'pkg_gpgcheck', '0'),
+                call('foo', 'priority', '42')
+            ]
             mock_open.assert_called_once_with(
                 '../data/shared-dir/zypper/repos/foo.repo', 'w'
             )
@@ -293,12 +295,14 @@ class TestRepositoryZypper:
             call('key-file-b.asc')
         ]
 
+    @patch('kiwi.repository.zypper.ConfigParser')
     @patch('kiwi.command.Command.run')
     @patch('kiwi.repository.zypper.Path.wipe')
     @patch('os.path.exists')
     @patch('kiwi.repository.zypper.Uri')
     def test_add_repo_with_credentials(
-        self, mock_uri, mock_exists, mock_wipe, mock_command
+        self, mock_uri, mock_exists, mock_wipe, mock_command,
+        mock_config
     ):
         exists_results = [False, False, False, True]
 
@@ -317,9 +321,10 @@ class TestRepositoryZypper:
             mock_wipe.assert_called_once_with(
                 '../data/shared-dir/zypper/credentials/credentials_file'
             )
-            mock_open.assert_called_once_with(
-                '../data/shared-dir/zypper/credentials/credentials_file', 'w'
-            )
+            assert mock_open.call_args_list == [
+                call('../data/shared-dir/zypper/credentials/credentials_file', 'w'),
+                call('../data/shared-dir/zypper/repos/foo.repo', 'w')
+            ]
             assert file_handle.write.call_args_list == [
                 call('username=user\n'),
                 call('password=secret\n')

--- a/test/unit/storage/loop_device_test.py
+++ b/test/unit/storage/loop_device_test.py
@@ -24,7 +24,7 @@ class TestLoopDevice:
             LoopDevice('loop-file-does-not-exist-and-no-size-given')
 
     def test_get_device(self):
-        assert self.loop.get_device() is None
+        assert self.loop.get_device() == ''
 
     def test_is_loop(self):
         assert self.loop.is_loop() is True

--- a/test/unit/storage/subformat/vagrant_base_test.py
+++ b/test/unit/storage/subformat/vagrant_base_test.py
@@ -43,7 +43,7 @@ class TestDiskFormatVagrantBase:
             self.xml_state, 'root_dir', 'target_dir',
             {'vagrantconfig': self.vagrantconfig}
         )
-        assert self.disk_format.image_format is None
+        assert self.disk_format.image_format == ''
         assert self.disk_format.provider is None
 
     def test_create_box_img_not_implemented(self):

--- a/test/unit/system/profile_test.py
+++ b/test/unit/system/profile_test.py
@@ -79,7 +79,6 @@ class TestProfile:
             'kiwi_oemsilentverify': None,
             'kiwi_oemskipverify': 'true',
             'kiwi_oemswapMB': None,
-            'kiwi_oemswap': None,
             'kiwi_oemtitle': 'schäfer',
             'kiwi_oemunattended_id': None,
             'kiwi_oemunattended': None,

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -1001,19 +1001,19 @@ class TestSystemSetup:
     def test_export_package_list_unknown_packager(
         self, mock_get_default_packager_tool
     ):
-        assert self.setup.export_package_list('target_dir') is None
+        assert self.setup.export_package_list('target_dir') == ''
 
     @patch('kiwi.defaults.Defaults.get_default_packager_tool')
     def test_export_package_changes_unknown_packager(
         self, mock_get_default_packager_tool
     ):
-        assert self.setup.export_package_changes('target_dir') is None
+        assert self.setup.export_package_changes('target_dir') == ''
 
     @patch('kiwi.defaults.Defaults.get_default_packager_tool')
     def test_export_package_verification_unknown_packager(
         self, mock_get_default_packager_tool
     ):
-        assert self.setup.export_package_verification('target_dir') is None
+        assert self.setup.export_package_verification('target_dir') == ''
 
     @patch('kiwi.system.setup.Command.run')
     @patch('kiwi.system.setup.RpmDataBase')

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,7 @@ deps = {[testenv]deps}
 changedir=test/unit
 commands =
     bash -c 'cd ../../ && ./setup.py develop'
+    bash -c 'cd ../../ && mypy kiwi'
     pytest --no-cov-on-fail --cov=kiwi \
         --cov-report=term-missing \
         --cov-fail-under=100 --cov-config .coveragerc {posargs}
@@ -76,6 +77,7 @@ deps = {[testenv]deps}
 changedir=test/unit
 commands =
     bash -c 'cd ../../ && ./setup.py develop'
+    bash -c 'cd ../../ && mypy kiwi'
     pytest --doctest-modules --no-cov-on-fail --cov=kiwi \
         --cov-report=term-missing --cov-fail-under=100 \
         --cov-config .coveragerc {posargs}


### PR DESCRIPTION
**Complete strong typing for API methods**
    
Added required code changes to let mypy pass when running from the toplevel kiwi namespace. This now finally
Fixes #1644

**Added mypy call to tox target**
    
For the tox unit_pyX targets, mypy static type checking is now called prior tests.

**Decommission obsolete code reaching EOL**
    
Use the @decommissioned decorator to raise for API methods  that a over the obsoletion period
