### PR TITLE
Added openssl to the core requires

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -113,6 +113,7 @@ Requires:       kiwi-tools
 Requires:       mtools
 Requires:       rsync
 Requires:       tar >= 1.2.7
+Requires:       openssl
 
 %description -n kiwi-systemdeps-core
 This metapackage installs the necessary system dependencies


### PR DESCRIPTION
openssl is used in kiwi to construct a password hash
if the plaintext password feature for user settings
is used. This Fixes bsc#1184128


