### PR TITLE
Added option to set the image target architecture

### DIFF
--- a/doc/source/commands/kiwi.rst
+++ b/doc/source/commands/kiwi.rst
@@ -24,6 +24,7 @@ SYNOPSIS
        result <command> [<args>...]
    kiwi-ng [--profile=<name>...]
            [--shared-cache-dir=<directory>]
+           [--target-arch=<name>]
            [--type=<build_type>]
            [--logfile=<filename>]
            [--debug]
@@ -113,6 +114,16 @@ GLOBAL OPTIONS
   root system and contains information about package repositories
   and their cache and meta data. The default location is set
   to /var/cache/kiwi
+
+--target-arch=<name>
+
+  Specify the image architecture. By default the host architecture is
+  used as the image architecture. If the specified architecture name
+  does not match the host architecture and is therefore requesting
+  a cross architecture image build, it's important to understand that
+  for this process to work a preparatory step to support the image
+  architecture and binary format on the building host is required
+  and not a responsibility of {kiwi}.
 
 --type=<build_type>
 

--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -30,6 +30,7 @@ usage: kiwi-ng -h | --help
            result <command> [<args>...]
        kiwi-ng [--profile=<name>...]
                [--shared-cache-dir=<directory>]
+               [--target-arch=<name>]
                [--type=<build_type>]
                [--logfile=<filename>]
                [--debug]
@@ -71,6 +72,16 @@ global options for services: image, system
     --type=<build_type>
         image build type. If not set the default XML specified
         build type will be used
+
+global options for services: system
+    --target-arch=<name>
+        set the image architecture. By default the host architecture is
+        used as the image architecture. If the specified architecture name
+        does not match the host architecture and is therefore requesting
+        a cross architecture image build, it's important to understand that
+        for this process to work a preparatory step to support the image
+        architecture and binary format on the building host is required
+        and not a responsibility of kiwi.
 """
 import logging
 import sys
@@ -218,6 +229,8 @@ class Cli:
                     value = os.sep + Defaults.get_shared_cache_location()
                 if arg == '--shared-cache-dir' and value:
                     Defaults.set_shared_cache_location(value)
+                if arg == '--target-arch' and value:
+                    Defaults.set_platform_name(value)
                 if arg == '--config' and value:
                     Defaults.set_custom_runtime_config_file(value)
                 result[arg] = value

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -41,6 +41,7 @@ IMAGE_METADATA_DIR = 'image'
 ROOT_VOLUME_NAME = 'LVRoot'
 SHARED_CACHE_DIR = '/var/cache/kiwi'
 CUSTOM_RUNTIME_CONFIG_FILE = None
+PLATFORM_MACHINE = platform.machine()
 
 
 class Defaults:
@@ -108,10 +109,31 @@ class Defaults:
 
     @staticmethod
     def get_platform_name():
-        arch = platform.machine()
+        """
+        Provides the machine architecture name as used by KIWI
+
+        This is the architecture name as it is returned by 'uname -m'
+        with one exception for the 32bit x86 architecture which is
+        handled as 'ix86' in general
+
+        :return: architecture name
+
+        :rtype: str
+        """
+        arch = PLATFORM_MACHINE
         if arch == 'i686' or arch == 'i586':
             arch = 'ix86'
         return arch
+
+    @staticmethod
+    def set_platform_name(name: str):
+        """
+        Sets the platform architecture once
+
+        :param str name: an architecture name
+        """
+        global PLATFORM_MACHINE
+        PLATFORM_MACHINE = name
 
     @staticmethod
     def is_x86_arch(arch):

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -21,6 +21,8 @@ from tempfile import NamedTemporaryFile
 from typing import List, Dict
 
 # project
+import kiwi.defaults as defaults
+
 from kiwi.defaults import Defaults
 from kiwi.command import Command
 from kiwi.repository.base import RepositoryBase
@@ -130,6 +132,9 @@ class RepositoryZypper(RepositoryBase):
         self.runtime_zypp_config.set(
             'main', 'credentials.global.dir',
             self.shared_zypper_dir['credentials-dir']
+        )
+        self.runtime_zypp_config.set(
+            'main', 'arch', defaults.PLATFORM_MACHINE
         )
         if self.exclude_docs:
             self.runtime_zypp_config.set(

--- a/kiwi/solver/repository/base.py
+++ b/kiwi/solver/repository/base.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-import platform
 from base64 import b64encode
 from urllib.request import urlopen
 from urllib.request import Request
@@ -27,6 +26,8 @@ import glob
 import os
 
 # project
+import kiwi.defaults as defaults
+
 from kiwi.exceptions import KiwiUriOpenError
 from kiwi.path import Path
 from kiwi.command import Command
@@ -172,7 +173,7 @@ class SolverRepositoryBase:
         """
         dir_listing_download = NamedTemporaryFile()
         self.download_from_repository(
-            platform.machine(), dir_listing_download.name
+            defaults.PLATFORM_MACHINE, dir_listing_download.name
         )
         if os.path.isfile(dir_listing_download.name):
             with open(dir_listing_download.name) as listing:

--- a/kiwi/solver/sat.py
+++ b/kiwi/solver/sat.py
@@ -17,12 +17,13 @@
 #
 import importlib
 import logging
-import platform
 from collections import namedtuple
 from xml.etree import ElementTree
 from xml.dom import minidom
 
 # project
+import kiwi.defaults as defaults
+
 from kiwi.exceptions import (
     KiwiSatSolverPluginError,
     KiwiSatSolverJobError,
@@ -59,7 +60,7 @@ class Sat:
 
     def set_dist_type(self, dist, arch=None):
         if not arch:
-            arch = platform.machine()
+            arch = defaults.PLATFORM_MACHINE
         dist_types = {
             'deb-x86_64': {
                 'pool_dist': self.solv.Pool.DISTTYPE_DEB,

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -21,7 +21,6 @@ from typing import (
 import re
 import logging
 import copy
-import platform
 from textwrap import dedent
 
 # project
@@ -90,7 +89,7 @@ class XMLState:
     ):
         self.root_partition_uuid: Optional[str] = None
         self.root_filesystem_uuid: Optional[str] = None
-        self.host_architecture = platform.machine()
+        self.host_architecture = defaults.PLATFORM_MACHINE
         self.xml_data = xml_data
         self.profiles = self._used_profiles(profiles)
         self.build_type = self._build_type_section(

--- a/test/unit/boot/image/base_test.py
+++ b/test/unit/boot/image/base_test.py
@@ -5,6 +5,9 @@ from mock import (
 )
 from pytest import raises
 
+from kiwi.boot.image.base import BootImageBase
+from kiwi.defaults import Defaults
+
 from kiwi.exceptions import (
     KiwiTargetDirectoryNotFound,
     KiwiBootImageDumpError,
@@ -12,14 +15,11 @@ from kiwi.exceptions import (
     KiwiDiskBootImageError
 )
 
-from kiwi.boot.image.base import BootImageBase
-
 
 class TestBootImageBase:
     @patch('kiwi.boot.image.base.os.path.exists')
-    @patch('platform.machine')
-    def setup(self, mock_machine, mock_exists):
-        mock_machine.return_value = 'x86_64'
+    def setup(self, mock_exists):
+        Defaults.set_platform_name('x86_64')
         self.boot_names_type = namedtuple(
             'boot_names_type', ['kernel_name', 'initrd_name']
         )

--- a/test/unit/boot/image/builtin_kiwi_test.py
+++ b/test/unit/boot/image/builtin_kiwi_test.py
@@ -8,18 +8,19 @@ import kiwi
 
 from ...test_helper import argv_kiwi_tests
 
+from kiwi.defaults import Defaults
 from kiwi.boot.image.builtin_kiwi import BootImageKiwi
 from kiwi.xml_description import XMLDescription
 from kiwi.xml_state import XMLState
+
 from kiwi.exceptions import KiwiConfigFileNotFound
 
 
 class TestBootImageKiwi:
     @patch('kiwi.boot.image.builtin_kiwi.mkdtemp')
     @patch('kiwi.boot.image.builtin_kiwi.os.path.exists')
-    @patch('platform.machine')
-    def setup(self, mock_machine, mock_exists, mock_mkdtemp):
-        mock_machine.return_value = 'x86_64'
+    def setup(self, mock_exists, mock_mkdtemp):
+        Defaults.set_platform_name('x86_64')
         mock_exists.return_value = True
         description = XMLDescription('../data/example_config.xml')
         self.xml_state = XMLState(

--- a/test/unit/boot/image/dracut_test.py
+++ b/test/unit/boot/image/dracut_test.py
@@ -3,6 +3,7 @@ from mock import (
 )
 from collections import namedtuple
 
+from kiwi.defaults import Defaults
 from kiwi.boot.image.dracut import BootImageDracut
 from kiwi.xml_description import XMLDescription
 from kiwi.xml_state import XMLState
@@ -11,9 +12,8 @@ from kiwi.xml_state import XMLState
 class TestBootImageKiwi:
     @patch('kiwi.boot.image.dracut.Command.run')
     @patch('kiwi.boot.image.base.os.path.exists')
-    @patch('platform.machine')
-    def setup(self, mock_machine, mock_exists, mock_cmd):
-        mock_machine.return_value = 'x86_64'
+    def setup(self, mock_exists, mock_cmd):
+        Defaults.set_platform_name('x86_64')
         mock_exists.return_value = True
         command_type = namedtuple('command', ['output'])
         mock_cmd.return_value = command_type(

--- a/test/unit/bootloader/config/base_test.py
+++ b/test/unit/bootloader/config/base_test.py
@@ -6,6 +6,7 @@ from pytest import (
     raises, fixture
 )
 
+from kiwi.defaults import Defaults
 from kiwi.xml_state import XMLState
 from kiwi.xml_description import XMLDescription
 from kiwi.exceptions import KiwiBootLoaderTargetError
@@ -17,9 +18,8 @@ class TestBootLoaderConfigBase:
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
-    @patch('platform.machine')
-    def setup(self, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
         description = XMLDescription(
             '../data/example_config.xml'
         )

--- a/test/unit/bootloader/config/isolinux_test.py
+++ b/test/unit/bootloader/config/isolinux_test.py
@@ -6,6 +6,7 @@ from mock import (
 from pytest import (
     raises, fixture
 )
+from kiwi.defaults import Defaults
 from kiwi.bootloader.config.isolinux import BootLoaderConfigIsoLinux
 
 from kiwi.exceptions import KiwiTemplateError
@@ -17,9 +18,8 @@ class TestBootLoaderConfigIsoLinux:
         self._caplog = caplog
 
     @patch('os.path.exists')
-    @patch('platform.machine')
-    def setup(self, mock_machine, mock_exists):
-        mock_machine.return_value = 'x86_64'
+    def setup(self, mock_exists):
+        Defaults.set_platform_name('x86_64')
         mock_exists.return_value = True
         self.state = mock.Mock()
         self.state.get_build_type_bootloader_console = mock.Mock(
@@ -93,19 +93,17 @@ class TestBootLoaderConfigIsoLinux:
             self.state, 'root_dir'
         )
 
-    @patch('platform.machine')
-    def test_post_init_ix86_platform(self, mock_machine):
-        mock_machine.return_value = 'i686'
+    def test_post_init_ix86_platform(self):
+        Defaults.set_platform_name('i686')
         bootloader = BootLoaderConfigIsoLinux(self.state, 'root_dir')
         assert bootloader.arch == 'ix86'
 
     @patch('os.path.exists')
-    @patch('platform.machine')
-    def test_post_init_dom0(self, mock_machine, mock_exists):
+    def test_post_init_dom0(self, mock_exists):
+        Defaults.set_platform_name('x86_64')
         self.state.is_xen_server = mock.Mock(
             return_value=True
         )
-        mock_machine.return_value = 'x86_64'
         mock_exists.return_value = True
         self.bootloader.post_init(None)
         assert self.bootloader.multiboot is True

--- a/test/unit/bootloader/install/grub2_test.py
+++ b/test/unit/bootloader/install/grub2_test.py
@@ -15,9 +15,8 @@ from kiwi.exceptions import (
 
 
 class TestBootLoaderInstallGrub2:
-    @patch('platform.machine')
-    def setup(self, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
 
         self.firmware = mock.Mock()
         self.firmware.efi_mode = mock.Mock(

--- a/test/unit/builder/archive_test.py
+++ b/test/unit/builder/archive_test.py
@@ -6,14 +6,15 @@ import kiwi
 
 from ..test_helper import argv_kiwi_tests
 
-from kiwi.exceptions import KiwiArchiveSetupError
+from kiwi.defaults import Defaults
 from kiwi.builder.archive import ArchiveBuilder
+
+from kiwi.exceptions import KiwiArchiveSetupError
 
 
 class TestArchiveBuilder:
-    @patch('platform.machine')
-    def setup(self, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
         self.xml_state = mock.Mock()
         self.xml_state.get_image_version = mock.Mock(
             return_value='1.2.3'
@@ -50,9 +51,8 @@ class TestArchiveBuilder:
             archive.create()
 
     @patch('kiwi.builder.archive.ArchiveTar')
-    @patch('platform.machine')
-    def test_create(self, mock_machine, mock_tar):
-        mock_machine.return_value = 'x86_64'
+    def test_create(self, mock_tar):
+        Defaults.set_platform_name('x86_64')
         archive = mock.Mock()
         mock_tar.return_value = archive
         self.archive.create()

--- a/test/unit/builder/container_test.py
+++ b/test/unit/builder/container_test.py
@@ -5,14 +5,15 @@ from pytest import raises
 import mock
 import kiwi
 
+from kiwi.defaults import Defaults
 from kiwi.builder.container import ContainerBuilder
 from kiwi.exceptions import KiwiContainerBuilderError
 
 
 class TestContainerBuilder:
-    @patch('platform.machine')
     @patch('os.path.exists')
-    def setup(self, mock_exists, mock_machine):
+    def setup(self, mock_exists):
+        Defaults.set_platform_name('x86_64')
         self.runtime_config = mock.Mock()
         self.runtime_config.get_max_size_constraint = mock.Mock(
             return_value=None
@@ -20,7 +21,6 @@ class TestContainerBuilder:
         kiwi.builder.container.RuntimeConfig = mock.Mock(
             return_value=self.runtime_config
         )
-        mock_machine.return_value = 'x86_64'
         self.xml_state = mock.Mock()
         self.xml_state.get_derived_from_image_uri.return_value = mock.Mock()
         self.container_config = {

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -11,6 +11,7 @@ from collections import OrderedDict
 from collections import namedtuple
 from builtins import bytes
 
+from kiwi.defaults import Defaults
 from kiwi.xml_description import XMLDescription
 from kiwi.xml_state import XMLState
 from kiwi.builder.disk import DiskBuilder
@@ -25,9 +26,8 @@ from kiwi.exceptions import (
 
 class TestDiskBuilder:
     @patch('os.path.exists')
-    @patch('platform.machine')
-    def setup(self, mock_machine, mock_exists):
-        mock_machine.return_value = 'x86_64'
+    def setup(self, mock_exists):
+        Defaults.set_platform_name('x86_64')
 
         def side_effect(filename):
             if filename.endswith('.config/kiwi/config.yml'):
@@ -195,9 +195,8 @@ class TestDiskBuilder:
     def teardown(self):
         sys.argv = argv_kiwi_tests
 
-    @patch('platform.machine')
-    def test_setup_ix86(self, mock_machine):
-        mock_machine.return_value = 'i686'
+    def test_setup_ix86(self):
+        Defaults.set_platform_name('i686')
         description = XMLDescription(
             '../data/example_disk_config.xml'
         )

--- a/test/unit/builder/filesystem_test.py
+++ b/test/unit/builder/filesystem_test.py
@@ -8,15 +8,15 @@ from ..test_helper import argv_kiwi_tests
 
 import kiwi
 
+from kiwi.defaults import Defaults
 from kiwi.exceptions import KiwiFileSystemSetupError
 from kiwi.builder.filesystem import FileSystemBuilder
 
 
 class TestFileSystemBuilder:
     @patch('kiwi.builder.filesystem.FileSystemSetup')
-    @patch('platform.machine')
-    def setup(self, mock_machine, mock_fs_setup):
-        mock_machine.return_value = 'x86_64'
+    def setup(self, mock_fs_setup):
+        Defaults.set_platform_name('x86_64')
         self.loop_provider = Mock()
         self.loop_provider.get_device = Mock(
             return_value='/dev/loop1'
@@ -90,11 +90,10 @@ class TestFileSystemBuilder:
     @patch('kiwi.builder.filesystem.LoopDevice')
     @patch('kiwi.builder.filesystem.FileSystem.new')
     @patch('kiwi.builder.filesystem.FileSystemSetup')
-    @patch('platform.machine')
     def test_create_on_loop(
-        self, mock_machine, mock_fs_setup, mock_fs, mock_loop
+        self, mock_fs_setup, mock_fs, mock_loop
     ):
-        mock_machine.return_value = 'x86_64'
+        Defaults.set_platform_name('x86_64')
         mock_fs_setup.return_value = self.fs_setup
         mock_fs.return_value = self.filesystem
         mock_loop.return_value = self.loop_provider
@@ -126,11 +125,10 @@ class TestFileSystemBuilder:
 
     @patch('kiwi.builder.filesystem.FileSystem.new')
     @patch('kiwi.builder.filesystem.DeviceProvider')
-    @patch('platform.machine')
     def test_create_on_file(
-        self, mock_machine, mock_provider, mock_fs
+        self, mock_provider, mock_fs
     ):
-        mock_machine.return_value = 'x86_64'
+        Defaults.set_platform_name('x86_64')
         provider = Mock()
         mock_provider.return_value = provider
         mock_fs.return_value = self.filesystem

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -7,17 +7,17 @@ import kiwi
 
 from collections import namedtuple
 
+from kiwi.defaults import Defaults
 from kiwi.builder.install import InstallImageBuilder
 from kiwi.exceptions import KiwiInstallBootImageError
 
 
 class TestInstallImageBuilder:
-    @patch('platform.machine')
-    def setup(self, mock_machine):
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
         boot_names_type = namedtuple(
             'boot_names_type', ['kernel_name', 'initrd_name']
         )
-        mock_machine.return_value = 'x86_64'
         self.setup = mock.Mock()
         kiwi.builder.install.SystemSetup = mock.Mock(
             return_value=self.setup
@@ -92,9 +92,8 @@ class TestInstallImageBuilder:
             self.xml_state, 'root_dir', 'target_dir', self.boot_image_task
         )
 
-    @patch('platform.machine')
-    def test_setup_ix86(self, mock_machine):
-        mock_machine.return_value = 'i686'
+    def test_setup_ix86(self):
+        Defaults.set_platform_name('i686')
         xml_state = mock.Mock()
         xml_state.xml_data.get_name = mock.Mock(
             return_value='result-image'

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -8,14 +8,14 @@ import kiwi
 
 from ..test_helper import argv_kiwi_tests
 
+from kiwi.defaults import Defaults
 from kiwi.builder.live import LiveImageBuilder
 from kiwi.exceptions import KiwiLiveBootImageError
 
 
 class TestLiveImageBuilder:
-    @patch('platform.machine')
-    def setup(self, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
 
         self.firmware = mock.Mock()
         self.firmware.efi_mode = mock.Mock(
@@ -114,8 +114,8 @@ class TestLiveImageBuilder:
     def teardown(self):
         sys.argv = argv_kiwi_tests
 
-    @patch('platform.machine')
-    def test_init_for_ix86_platform(self, mock_machine):
+    def test_init_for_ix86_platform(self):
+        Defaults.set_platform_name('i686')
         xml_state = mock.Mock()
         xml_state.xml_data.get_name = mock.Mock(
             return_value='some-image'
@@ -123,7 +123,6 @@ class TestLiveImageBuilder:
         xml_state.get_image_version = mock.Mock(
             return_value='1.2.3'
         )
-        mock_machine.return_value = 'i686'
         live_image = LiveImageBuilder(
             xml_state, 'target_dir', 'root_dir'
         )

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -8,6 +8,8 @@ from pytest import (
 from .test_helper import argv_kiwi_tests
 
 from kiwi.cli import Cli
+from kiwi.defaults import Defaults
+
 from kiwi.exceptions import (
     KiwiCompatError,
     KiwiLoadCommandUndefined,
@@ -38,6 +40,7 @@ class TestCli:
             'result': False,
             '--profile': [],
             '--shared-cache-dir': '/var/cache/kiwi',
+            '--target-arch': None,
             '--help': False,
             '--config': 'config-file'
         }
@@ -114,6 +117,17 @@ class TestCli:
             cli.get_global_args()
             assert 'vmx type is now a subset of oem, --type set to oem' in \
                 self._caplog.text
+
+    def test_set_target_arch(self):
+        sys.argv = [
+            sys.argv[0],
+            '--target-arch', 'artificial', 'system', 'build',
+            '--description', 'description',
+            '--target-dir', 'directory'
+        ]
+        cli = Cli()
+        cli.get_global_args()
+        assert Defaults.get_platform_name() == 'artificial'
 
     def test_get_servicename_image(self):
         sys.argv = [

--- a/test/unit/container/setup/appx_test.py
+++ b/test/unit/container/setup/appx_test.py
@@ -5,6 +5,8 @@ from mock import (
 )
 
 from kiwi.container.setup.appx import ContainerSetupAppx
+from kiwi.defaults import Defaults
+
 from kiwi.exceptions import KiwiContainerSetupError
 
 
@@ -42,9 +44,8 @@ class TestContainerSetupAppx:
         with raises(KiwiContainerSetupError):
             self.appx.setup()
 
-    @patch('platform.machine')
-    def test_setup(self, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def test_setup(self):
+        Defaults.set_platform_name('x86_64')
         with patch('builtins.open', create=True) as mock_open:
             mock_open.return_value = MagicMock(spec=io.IOBase)
             file_handle = mock_open.return_value.__enter__.return_value

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -36,7 +36,8 @@ class TestDefaults:
         )
 
     def test_get_preparer(self):
-        assert Defaults.get_preparer() == 'KIWI - https://github.com/OSInside/kiwi'
+        assert Defaults.get_preparer() == \
+            'KIWI - https://github.com/OSInside/kiwi'
 
     def test_get_publisher(self):
         assert Defaults.get_publisher() == 'SUSE LINUX GmbH'
@@ -63,11 +64,10 @@ class TestDefaults:
         assert Defaults.get_live_dracut_modules_from_flag('dmsquash') == \
             ['dmsquash-live', 'livenet']
 
-    @patch('platform.machine')
-    def test_get_iso_boot_path(self, mock_machine):
-        mock_machine.return_value = 'i686'
+    def test_get_iso_boot_path(self):
+        Defaults.set_platform_name('i686')
         assert Defaults.get_iso_boot_path() == 'boot/ix86'
-        mock_machine.return_value = 'x86_64'
+        Defaults.set_platform_name('x86_64')
         assert Defaults.get_iso_boot_path() == 'boot/x86_64'
 
     @patch('kiwi.defaults.glob.iglob')

--- a/test/unit/filesystem/squashfs_test.py
+++ b/test/unit/filesystem/squashfs_test.py
@@ -2,6 +2,7 @@ from mock import patch
 
 import mock
 
+from kiwi.defaults import Defaults
 from kiwi.filesystem.squashfs import FileSystemSquashFs
 
 
@@ -11,10 +12,9 @@ class TestFileSystemSquashfs:
         mock_exists.return_value = True
         self.squashfs = FileSystemSquashFs(mock.Mock(), 'root_dir')
 
-    @patch('platform.machine')
     @patch('kiwi.filesystem.squashfs.Command.run')
-    def test_create_on_file(self, mock_command, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def test_create_on_file(self, mock_command):
+        Defaults.set_platform_name('x86_64')
         self.squashfs.create_on_file('myimage', 'label')
         mock_command.assert_called_once_with(
             [
@@ -23,10 +23,9 @@ class TestFileSystemSquashfs:
             ]
         )
 
-    @patch('platform.machine')
     @patch('kiwi.filesystem.squashfs.Command.run')
-    def test_create_on_file_exclude_data(self, mock_command, mock_machine):
-        mock_machine.return_value = 'ppc64le'
+    def test_create_on_file_exclude_data(self, mock_command):
+        Defaults.set_platform_name('ppc64le')
         self.squashfs.create_on_file('myimage', 'label', ['foo'])
         mock_command.assert_called_once_with(
             [
@@ -35,10 +34,9 @@ class TestFileSystemSquashfs:
             ]
         )
 
-    @patch('platform.machine')
     @patch('kiwi.filesystem.squashfs.Command.run')
-    def test_create_on_file_unkown_arch(self, mock_command, mock_machine):
-        mock_machine.return_value = 'aarch64'
+    def test_create_on_file_unkown_arch(self, mock_command):
+        Defaults.set_platform_name('aarch64')
         self.squashfs.create_on_file('myimage', 'label')
         mock_command.assert_called_once_with(
             [

--- a/test/unit/firmware_test.py
+++ b/test/unit/firmware_test.py
@@ -1,16 +1,15 @@
-from mock import patch
 from pytest import raises
 import mock
 
 from kiwi.firmware import FirmWare
+from kiwi.defaults import Defaults
 
 from kiwi.exceptions import KiwiNotImplementedError
 
 
 class TestFirmWare:
-    @patch('platform.machine')
-    def setup(self, mock_platform):
-        mock_platform.return_value = 'x86_64'
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
         xml_state = mock.Mock()
         xml_state.build_type.get_firmware = mock.Mock()
         xml_state.build_type.get_firmware.return_value = 'bios'
@@ -32,7 +31,7 @@ class TestFirmWare:
         xml_state.build_type.get_firmware.return_value = 'ec2'
         self.firmware_ec2 = FirmWare(xml_state)
 
-        mock_platform.return_value = 's390x'
+        Defaults.set_platform_name('s390x')
         xml_state.build_type.get_firmware.return_value = None
         xml_state.get_build_type_bootloader_targettype = mock.Mock()
 
@@ -42,14 +41,14 @@ class TestFirmWare:
         xml_state.get_build_type_bootloader_targettype.return_value = 'SCSI'
         self.firmware_s390_scsi = FirmWare(xml_state)
 
-        mock_platform.return_value = 'ppc64le'
+        Defaults.set_platform_name('ppc64le')
         xml_state.build_type.get_firmware.return_value = 'ofw'
         self.firmware_ofw = FirmWare(xml_state)
 
         xml_state.build_type.get_firmware.return_value = 'opal'
         self.firmware_opal = FirmWare(xml_state)
 
-        mock_platform.return_value = 'arm64'
+        Defaults.set_platform_name('x86_64')
 
     def test_firmware_unsupported(self):
         xml_state = mock.Mock()

--- a/test/unit/iso_tools/base_test.py
+++ b/test/unit/iso_tools/base_test.py
@@ -3,13 +3,13 @@ from mock import (
 )
 from pytest import raises
 
+from kiwi.defaults import Defaults
 from kiwi.iso_tools.base import IsoToolsBase
 
 
 class TestIsoToolsBase:
-    @patch('platform.machine')
-    def setup(self, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
         self.iso_tool = IsoToolsBase('source-dir')
 
     def test_create_iso(self):

--- a/test/unit/iso_tools/cdrtools_test.py
+++ b/test/unit/iso_tools/cdrtools_test.py
@@ -4,15 +4,15 @@ from mock import (
 from pytest import raises
 from collections import namedtuple
 
+from kiwi.defaults import Defaults
 from kiwi.iso_tools.cdrtools import IsoToolsCdrTools
 
 from kiwi.exceptions import KiwiIsoToolError
 
 
 class TestIsoToolsCdrTools:
-    @patch('platform.machine')
-    def setup(self, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
         self.iso_tool = IsoToolsCdrTools('source-dir')
 
     @patch('kiwi.iso_tools.cdrtools.Path.which')

--- a/test/unit/iso_tools/iso_test.py
+++ b/test/unit/iso_tools/iso_test.py
@@ -8,7 +8,7 @@ import struct
 import pytest
 import sys
 
-
+from kiwi.defaults import Defaults
 from kiwi.iso_tools.iso import Iso
 from kiwi.path import Path
 from tempfile import NamedTemporaryFile
@@ -21,9 +21,8 @@ from kiwi.exceptions import (
 
 
 class TestIso:
-    @patch('platform.machine')
-    def setup(self, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
         self.iso = Iso('source-dir')
 
     def test_create_header_end_marker(self):

--- a/test/unit/iso_tools/xorriso_test.py
+++ b/test/unit/iso_tools/xorriso_test.py
@@ -1,15 +1,15 @@
 from mock import patch
 from pytest import raises
 
+from kiwi.defaults import Defaults
 from kiwi.iso_tools.xorriso import IsoToolsXorrIso
 
 from kiwi.exceptions import KiwiIsoToolError
 
 
 class TestIsoToolsXorrIso:
-    @patch('platform.machine')
-    def setup(self, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
         self.iso_tool = IsoToolsXorrIso('source-dir')
 
     @patch('kiwi.iso_tools.xorriso.Path.which')

--- a/test/unit/repository/zypper_test.py
+++ b/test/unit/repository/zypper_test.py
@@ -6,6 +6,7 @@ import io
 import mock
 import os
 
+from kiwi.defaults import Defaults
 from kiwi.repository.zypper import RepositoryZypper
 from kiwi.exceptions import KiwiCommandError
 
@@ -47,6 +48,7 @@ class TestRepositoryZypper:
     def test_custom_args_init_check_signatures(
         self, mock_config, mock_temp, mock_command
     ):
+        Defaults.set_platform_name('x86_64')
         runtime_zypp_config = mock.Mock()
         mock_config.return_value = runtime_zypp_config
         with patch('builtins.open', create=True):
@@ -58,6 +60,7 @@ class TestRepositoryZypper:
                     'credentials.global.dir',
                     '../data/shared-dir/zypper/credentials'
                 ),
+                call('main', 'arch', 'x86_64'),
                 call('main', 'gpgcheck', '1'),
             ]
 

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -8,6 +8,7 @@ from .test_helper import argv_kiwi_tests
 
 import kiwi
 
+from kiwi.defaults import Defaults
 from kiwi.xml_state import XMLState
 from kiwi.xml_description import XMLDescription
 from kiwi.runtime_checker import RuntimeChecker
@@ -227,13 +228,12 @@ class TestRuntimeChecker:
         with raises(KiwiRuntimeError):
             runtime_checker.check_container_tool_chain_installed()
 
-    @patch('platform.machine')
     @patch('kiwi.runtime_checker.Defaults.get_boot_image_description_path')
     def test_check_consistent_kernel_in_boot_and_system_image(
-        self, mock_boot_path, mock_machine
+        self, mock_boot_path
     ):
+        Defaults.set_platform_name('x86_64')
         mock_boot_path.return_value = '../data'
-        mock_machine.return_value = 'x86_64'
         xml_state = XMLState(
             self.description.load(), ['vmxFlavour'], 'oem'
         )
@@ -372,11 +372,8 @@ class TestRuntimeChecker:
         with raises(KiwiRuntimeError):
             runtime_checker.check_image_version_provided()
 
-    @patch('platform.machine')
-    def test_check_architecture_supports_iso_firmware_setup(
-        self, mock_machine
-    ):
-        mock_machine.return_value = 'aarch64'
+    def test_check_architecture_supports_iso_firmware_setup(self):
+        Defaults.set_platform_name('aarch64')
         xml_state = XMLState(
             self.description.load(), ['vmxFlavour'], 'iso'
         )
@@ -390,13 +387,12 @@ class TestRuntimeChecker:
         with raises(KiwiRuntimeError):
             runtime_checker.check_architecture_supports_iso_firmware_setup()
 
-    @patch('platform.machine')
     @patch('kiwi.runtime_checker.Path.which')
     def test_check_syslinux_installed_if_isolinux_is_used(
-        self, mock_Path_which, mock_machine
+        self, mock_Path_which
     ):
+        Defaults.set_platform_name('x86_64')
         mock_Path_which.return_value = None
-        mock_machine.return_value = 'x86_64'
         xml_state = XMLState(
             self.description.load(), ['vmxFlavour'], 'iso'
         )

--- a/test/unit/solver/repository/base_test.py
+++ b/test/unit/solver/repository/base_test.py
@@ -8,6 +8,7 @@ import mock
 
 from lxml import etree
 
+from kiwi.defaults import Defaults
 from kiwi.solver.repository.base import SolverRepositoryBase
 
 from kiwi.exceptions import KiwiUriOpenError
@@ -67,13 +68,12 @@ class TestSolverRepositoryBase:
 
     @patch('kiwi.solver.repository.base.NamedTemporaryFile')
     @patch.object(SolverRepositoryBase, 'download_from_repository')
-    @patch('platform.machine')
     @patch('os.path.isfile')
     def test__get_pacman_packages(
-        self, mock_os_isfile, mock_machine, mock_download, mock_tmpfile
+        self, mock_os_isfile, mock_download, mock_tmpfile
     ):
+        Defaults.set_platform_name('x86_64')
         mock_os_isfile.return_value = True
-        mock_machine.return_value = 'x86_64'
         tmpfile = mock.Mock()
         tmpfile.name = 'tmpfile'
         mock_tmpfile.return_value = tmpfile

--- a/test/unit/solver/sat_test.py
+++ b/test/unit/solver/sat_test.py
@@ -6,6 +6,7 @@ from pytest import (
     raises, fixture
 )
 
+from kiwi.defaults import Defaults
 from kiwi.solver.sat import Sat
 
 from kiwi.exceptions import (
@@ -49,16 +50,14 @@ class TestSat:
         with raises(KiwiSatSolverPluginError):
             Sat()
 
-    @patch('platform.machine')
-    def test_set_dist_type_raises(self, mock_platform_machine):
-        mock_platform_machine.return_value = 'x86_64'
+    def test_set_dist_type_raises(self):
+        Defaults.set_platform_name('x86_64')
         self.sat.pool.setdisttype.return_value = -1
         with raises(KiwiSatSolverPluginError):
             self.sat.set_dist_type('deb')
 
-    @patch('platform.machine')
-    def test_set_dist_type_deb(self, mock_platform_machine):
-        mock_platform_machine.return_value = 'x86_64'
+    def test_set_dist_type_deb(self):
+        Defaults.set_platform_name('x86_64')
         self.sat.pool.setdisttype.return_value = 0
         self.sat.set_dist_type('deb')
         self.sat.pool.setdisttype.assert_called_once_with(

--- a/test/unit/storage/setup_test.py
+++ b/test/unit/storage/setup_test.py
@@ -16,9 +16,8 @@ class TestDiskSetup:
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
-    @patch('platform.machine')
-    def setup(self, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
         self.size = mock.Mock()
         self.size.customize = mock.Mock(
             return_value=42
@@ -65,7 +64,7 @@ class TestDiskSetup:
             XMLState(description.load()), 'root_dir'
         )
 
-        mock_machine.return_value = 'ppc64'
+        Defaults.set_platform_name('ppc64')
         description = XMLDescription(
             '../data/example_ppc_disk_size_config.xml'
         )
@@ -73,7 +72,7 @@ class TestDiskSetup:
             XMLState(description.load()), 'root_dir'
         )
 
-        mock_machine.return_value = 'arm64'
+        Defaults.set_platform_name('arm64')
         description = XMLDescription(
             '../data/example_arm_disk_size_config.xml'
         )

--- a/test/unit/storage/subformat/base_test.py
+++ b/test/unit/storage/subformat/base_test.py
@@ -3,6 +3,7 @@ from mock import (
 )
 from pytest import raises
 
+from kiwi.defaults import Defaults
 from kiwi.storage.subformat.base import DiskFormatBase
 
 import kiwi
@@ -14,10 +15,9 @@ from kiwi.exceptions import (
 
 
 class TestDiskFormatBase:
-    @patch('platform.machine')
     @patch('kiwi.storage.subformat.base.DiskFormatBase.post_init')
-    def setup(self, mock_post_init, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def setup(self, mock_post_init):
+        Defaults.set_platform_name('x86_64')
         xml_data = Mock()
         xml_data.get_name = Mock(
             return_value='some-disk-image'

--- a/test/unit/storage/subformat/ova_test.py
+++ b/test/unit/storage/subformat/ova_test.py
@@ -3,6 +3,7 @@ from mock import (
 )
 from pytest import raises
 
+from kiwi.defaults import Defaults
 from kiwi.storage.subformat.ova import DiskFormatOva
 
 import kiwi
@@ -14,8 +15,8 @@ from kiwi.exceptions import (
 
 
 class TestDiskFormatOva:
-    @patch('platform.machine')
-    def setup(self, mock_machine):
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
         self.context_manager_mock = Mock()
         self.file_mock = Mock()
         self.enter_mock = Mock()
@@ -23,7 +24,6 @@ class TestDiskFormatOva:
         self.enter_mock.return_value = self.file_mock
         setattr(self.context_manager_mock, '__enter__', self.enter_mock)
         setattr(self.context_manager_mock, '__exit__', self.exit_mock)
-        mock_machine.return_value = 'x86_64'
         xml_data = Mock()
         xml_data.get_name = Mock(
             return_value='some-disk-image'

--- a/test/unit/storage/subformat/qcow2_test.py
+++ b/test/unit/storage/subformat/qcow2_test.py
@@ -4,13 +4,13 @@ from mock import (
 
 import kiwi
 
+from kiwi.defaults import Defaults
 from kiwi.storage.subformat.qcow2 import DiskFormatQcow2
 
 
 class TestDiskFormatQcow2:
-    @patch('platform.machine')
-    def setup(self, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
         xml_data = Mock()
         xml_data.get_name = Mock(
             return_value='some-disk-image'

--- a/test/unit/storage/subformat/vdi_test.py
+++ b/test/unit/storage/subformat/vdi_test.py
@@ -3,13 +3,13 @@ from mock import patch
 from mock import Mock
 import kiwi
 
+from kiwi.defaults import Defaults
 from kiwi.storage.subformat.vdi import DiskFormatVdi
 
 
 class TestDiskFormatVdi:
-    @patch('platform.machine')
-    def setup(self, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
         xml_data = Mock()
         xml_data.get_name = Mock(
             return_value='some-disk-image'

--- a/test/unit/storage/subformat/vhd_test.py
+++ b/test/unit/storage/subformat/vhd_test.py
@@ -4,13 +4,13 @@ from mock import (
 
 import kiwi
 
+from kiwi.defaults import Defaults
 from kiwi.storage.subformat.vhd import DiskFormatVhd
 
 
 class TestDiskFormatVhd:
-    @patch('platform.machine')
-    def setup(self, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
         xml_data = Mock()
         xml_data.get_name = Mock(
             return_value='some-disk-image'

--- a/test/unit/storage/subformat/vhdfixed_test.py
+++ b/test/unit/storage/subformat/vhdfixed_test.py
@@ -7,15 +7,15 @@ from pytest import raises
 
 import kiwi
 
+from kiwi.defaults import Defaults
 from kiwi.storage.subformat.vhdfixed import DiskFormatVhdFixed
 
 from kiwi.exceptions import KiwiVhdTagError
 
 
 class TestDiskFormatVhdFixed:
-    @patch('platform.machine')
-    def setup(self, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
         xml_data = Mock()
         xml_data.get_name = Mock(
             return_value='some-disk-image'

--- a/test/unit/storage/subformat/vhdx_test.py
+++ b/test/unit/storage/subformat/vhdx_test.py
@@ -4,13 +4,13 @@ from mock import (
 
 import kiwi
 
+from kiwi.defaults import Defaults
 from kiwi.storage.subformat.vhdx import DiskFormatVhdx
 
 
 class TestDiskFormatVhdx:
-    @patch('platform.machine')
-    def setup(self, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
         xml_data = Mock()
         xml_data.get_name = Mock(
             return_value='some-disk-image'

--- a/test/unit/storage/subformat/vmdk_test.py
+++ b/test/unit/storage/subformat/vmdk_test.py
@@ -6,14 +6,15 @@ from pytest import raises
 
 import kiwi
 
+from kiwi.defaults import Defaults
 from kiwi.storage.subformat.vmdk import DiskFormatVmdk
 
 from kiwi.exceptions import KiwiTemplateError
 
 
 class TestDiskFormatVmdk:
-    @patch('platform.machine')
-    def setup(self, mock_machine):
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
         self.context_manager_mock = Mock()
         self.file_mock = Mock()
         self.enter_mock = Mock()
@@ -21,7 +22,6 @@ class TestDiskFormatVmdk:
         self.enter_mock.return_value = self.file_mock
         setattr(self.context_manager_mock, '__enter__', self.enter_mock)
         setattr(self.context_manager_mock, '__exit__', self.exit_mock)
-        mock_machine.return_value = 'x86_64'
         xml_data = Mock()
         xml_data.get_name = Mock(
             return_value='some-disk-image'

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -28,15 +28,14 @@ class TestSystemSetup:
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
-    @patch('platform.machine')
     @patch('kiwi.system.setup.RuntimeConfig')
-    def setup(self, mock_RuntimeConfig, mock_machine):
+    def setup(self, mock_RuntimeConfig):
+        Defaults.set_platform_name('x86_64')
         self.runtime_config = Mock()
         self.runtime_config.get_package_changes = Mock(
             return_value=True
         )
         mock_RuntimeConfig.return_value = self.runtime_config
-        mock_machine.return_value = 'x86_64'
         self.xml_state = MagicMock()
         self.xml_state.get_package_manager = Mock(
             return_value='zypper'
@@ -74,9 +73,8 @@ class TestSystemSetup:
     def teardown(self):
         sys.argv = argv_kiwi_tests
 
-    @patch('platform.machine')
-    def test_setup_ix86(self, mock_machine):
-        mock_machine.return_value = 'i686'
+    def test_setup_ix86(self):
+        Defaults.set_platform_name('i686')
         setup = SystemSetup(
             MagicMock(), 'root_dir'
         )

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -7,6 +7,7 @@ from pytest import (
     raises, fixture
 )
 
+from kiwi.defaults import Defaults
 from kiwi.xml_state import XMLState
 from kiwi.xml_description import XMLDescription
 
@@ -22,9 +23,8 @@ class TestXMLState:
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
-    @patch('platform.machine')
-    def setup(self, mock_machine):
-        mock_machine.return_value = 'x86_64'
+    def setup(self):
+        Defaults.set_platform_name('x86_64')
         self.description = XMLDescription(
             '../data/example_config.xml'
         )
@@ -58,13 +58,13 @@ class TestXMLState:
         assert description.specification == \
             'Testing various configuration states'
 
-    @patch('platform.machine')
-    def test_get_preferences_by_architecture(self, mock_machine):
-        mock_machine.return_value = 'aarch64'
+    def test_get_preferences_by_architecture(self):
+        Defaults.set_platform_name('aarch64')
         state = XMLState(
             self.description.load()
         )
         preferences = state.get_preferences_sections()
+        Defaults.set_platform_name('x86_64')
         assert len(preferences) == 3
         assert preferences[2].get_arch() == 'aarch64'
         assert state.get_build_type_name() == 'iso'
@@ -128,9 +128,8 @@ class TestXMLState:
             'vim'
         ]
 
-    @patch('platform.machine')
-    def test_get_system_packages_some_arch(self, mock_machine):
-        mock_machine.return_value = 's390'
+    def test_get_system_packages_some_arch(self):
+        Defaults.set_platform_name('s390')
         state = XMLState(
             self.description.load()
         )
@@ -145,6 +144,7 @@ class TestXMLState:
             'plymouth-branding-openSUSE',
             'vim'
         ]
+        Defaults.set_platform_name('x86_64')
 
     def test_get_system_collections(self):
         assert self.state.get_system_collections() == [
@@ -892,19 +892,17 @@ class TestXMLState:
     def test_is_xen_guest_no_xen_guest_setup(self):
         assert self.boot_state.is_xen_guest() is False
 
-    @patch('platform.machine')
-    def test_is_xen_guest_by_firmware_setup(self, mock_platform_machine):
-        mock_platform_machine.return_value = 'x86_64'
+    def test_is_xen_guest_by_firmware_setup(self):
         xml_data = self.description.load()
         state = XMLState(xml_data, ['ec2Flavour'], 'oem')
         assert state.is_xen_guest() is True
 
-    @patch('platform.machine')
-    def test_is_xen_guest_by_architecture(self, mock_platform_machine):
-        mock_platform_machine.return_value = 'unsupported'
+    def test_is_xen_guest_by_architecture(self):
+        Defaults.set_platform_name('unsupported')
         xml_data = self.description.load()
         state = XMLState(xml_data, ['ec2Flavour'], 'oem')
         assert state.is_xen_guest() is False
+        Defaults.set_platform_name('x86_64')
 
     def test_get_initrd_system(self):
         xml_data = self.description.load()


### PR DESCRIPTION
The option --target-arch allows to set the architecture
used to build the image. By default this is the host
architecture. Please note, if the specified architecture
name does not match the host architecture and is therefore
requesting a cross architecture image build, it's important
to understand that for this process to work a preparatory
step to support the image architecture and binary format
on the building host is required and is not considered a
responsibility of kiwi. There will be a followup effort
on providing a plugin for kiwi which should be used to
manage the needed binfmt settings for cross arch image
builds

