### PR TITLE
Update zypp.conf architecture setting

### DIFF
--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -21,6 +21,8 @@ from tempfile import NamedTemporaryFile
 from typing import List, Dict
 
 # project
+import kiwi.defaults as defaults
+
 from kiwi.defaults import Defaults
 from kiwi.command import Command
 from kiwi.repository.base import RepositoryBase
@@ -130,6 +132,9 @@ class RepositoryZypper(RepositoryBase):
         self.runtime_zypp_config.set(
             'main', 'credentials.global.dir',
             self.shared_zypper_dir['credentials-dir']
+        )
+        self.runtime_zypp_config.set(
+            'main', 'arch', defaults.PLATFORM_MACHINE
         )
         if self.exclude_docs:
             self.runtime_zypp_config.set(

--- a/test/unit/repository/zypper_test.py
+++ b/test/unit/repository/zypper_test.py
@@ -6,6 +6,7 @@ import io
 import mock
 import os
 
+from kiwi.defaults import Defaults
 from kiwi.repository.zypper import RepositoryZypper
 from kiwi.exceptions import KiwiCommandError
 
@@ -47,6 +48,7 @@ class TestRepositoryZypper:
     def test_custom_args_init_check_signatures(
         self, mock_config, mock_temp, mock_command
     ):
+        Defaults.set_platform_name('x86_64')
         runtime_zypp_config = mock.Mock()
         mock_config.return_value = runtime_zypp_config
         with patch('builtins.open', create=True):
@@ -58,6 +60,7 @@ class TestRepositoryZypper:
                     'credentials.global.dir',
                     '../data/shared-dir/zypper/credentials'
                 ),
+                call('main', 'arch', 'x86_64'),
                 call('main', 'gpgcheck', '1'),
             ]
 


### PR DESCRIPTION
Make sure the architecture is set as parameter in the
zypp.conf file used for building the image. This is needed
to allow differentiation between host arch and image arch
for cross image build environments

