### PR TITLE
Add support for a custom exclude file

### DIFF
--- a/kiwi/builder/archive.py
+++ b/kiwi/builder/archive.py
@@ -88,7 +88,9 @@ class ArchiveBuilder:
             )
             archive.create_xz_compressed(
                 self.root_dir, xz_options=self.xz_options,
-                exclude=Defaults.get_exclude_list_for_root_data_sync()
+                exclude=Defaults.
+                get_exclude_list_for_root_data_sync() + Defaults.
+                get_exclude_list_from_custom_exclude_files(self.root_dir)
             )
             Result.verify_image_size(
                 self.runtime_config.get_max_size_constraint(),

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -622,7 +622,9 @@ class DiskBuilder:
         )
 
     def _get_exclude_list_for_root_data_sync(self, device_map: Dict) -> list:
-        exclude_list = Defaults.get_exclude_list_for_root_data_sync()
+        exclude_list = Defaults.\
+            get_exclude_list_for_root_data_sync() + Defaults.\
+            get_exclude_list_from_custom_exclude_files(self.root_dir)
         if 'spare' in device_map and self.spare_part_mountpoint:
             exclude_list.append(
                 '{0}/*'.format(self.spare_part_mountpoint.lstrip(os.sep))

--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -181,7 +181,9 @@ class FileSystemBuilder:
             f'--> Syncing data to filesystem on {loop_provider.get_device()}'
         )
         filesystem.sync_data(
-            Defaults.get_exclude_list_for_root_data_sync()
+            Defaults.
+            get_exclude_list_for_root_data_sync() + Defaults.
+            get_exclude_list_from_custom_exclude_files(self.root_dir)
         )
 
     def _operate_on_file(self) -> None:

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -243,7 +243,9 @@ class LiveImageBuilder:
             '--> Syncing data to {0} root image'.format(root_filesystem)
         )
         live_filesystem.sync_data(
-            Defaults.get_exclude_list_for_root_data_sync()
+            Defaults.
+            get_exclude_list_for_root_data_sync() + Defaults.
+            get_exclude_list_from_custom_exclude_files(self.root_dir)
         )
         live_filesystem.umount()
 

--- a/kiwi/container/appx.py
+++ b/kiwi/container/appx.py
@@ -75,7 +75,9 @@ class ContainerImageAppx:
         :param string filename: archive file name
         :param string base_image: not-supported
         """
-        exclude_list = Defaults.get_exclude_list_for_root_data_sync()
+        exclude_list = Defaults.\
+            get_exclude_list_for_root_data_sync() + Defaults.\
+            get_exclude_list_from_custom_exclude_files(self.root_dir)
         exclude_list.append('boot')
         exclude_list.append('dev')
         exclude_list.append('sys')

--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -113,7 +113,9 @@ class ContainerImageOCI:
         :param string filename: archive file name
         :param string base_image: archive used as a base image
         """
-        exclude_list = Defaults.get_exclude_list_for_root_data_sync()
+        exclude_list = Defaults.\
+            get_exclude_list_for_root_data_sync() + Defaults.\
+            get_exclude_list_from_custom_exclude_files(self.root_dir)
         exclude_list.append('dev/*')
         exclude_list.append('sys/*')
         exclude_list.append('proc/*')

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -15,11 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import logging
 import os
 import glob
 from collections import namedtuple
 import platform
+import yaml
 from pkg_resources import resource_filename
+from typing import List
 
 # project
 from kiwi.path import Path
@@ -42,6 +45,8 @@ ROOT_VOLUME_NAME = 'LVRoot'
 SHARED_CACHE_DIR = '/var/cache/kiwi'
 CUSTOM_RUNTIME_CONFIG_FILE = None
 PLATFORM_MACHINE = platform.machine()
+
+log = logging.getLogger('kiwi')
 
 
 class Defaults:
@@ -284,6 +289,37 @@ class Defaults:
             Defaults.get_buildservice_env_name(),
             Defaults.get_shared_cache_location()
         ]
+        return exclude_list
+
+    @staticmethod
+    def get_exclude_list_from_custom_exclude_files(root_dir: str) -> List:
+        """
+        Provides the list of folders that are excluded by the
+        optional metadata file image/exclude_files.yaml
+
+        :return: list of file and directory names
+
+        :param string root_dir: image root directory
+
+        :rtype: list
+        """
+        exclude_file = os.sep.join(
+            [root_dir, 'image', 'exclude_files.yaml']
+        )
+        exclude_list = []
+        if os.path.isfile(exclude_file):
+            with open(exclude_file) as exclude:
+                exclude_dict = yaml.safe_load(exclude)
+                exclude_data = exclude_dict.get('exclude')
+                if exclude_data and isinstance(exclude_data, list):
+                    for exclude_file in exclude_data:
+                        exclude_list.append(
+                            exclude_file.lstrip(os.sep)
+                        )
+                else:
+                    log.warning(
+                        f'invalid yaml structure in {exclude_file}, ignored'
+                    )
         return exclude_list
 
     @staticmethod

--- a/test/data/root-dir/image/exclude_files.yaml
+++ b/test/data/root-dir/image/exclude_files.yaml
@@ -1,0 +1,4 @@
+exclude:
+- /usr/bin/qemu-binfmt
+- /usr/bin/qemu-x86_64-binfmt
+- /usr/bin/qemu-x86_64

--- a/test/unit/container/appx_test.py
+++ b/test/unit/container/appx_test.py
@@ -36,11 +36,13 @@ class TestContainerImageAppx:
     @patch('kiwi.container.appx.ArchiveTar')
     @patch('kiwi.container.appx.Compress')
     @patch('kiwi.container.appx.Defaults.get_exclude_list_for_root_data_sync')
+    @patch('kiwi.container.appx.Defaults.get_exclude_list_from_custom_exclude_files')
     @patch('kiwi.container.appx.NamedTemporaryFile')
     @patch('kiwi.container.appx.Command.run')
     @patch('os.walk')
     def test_create(
         self, mock_os_walk, mock_Command_run, mock_NamedTemporaryFile,
+        mock_get_exclude_list_from_custom_exclude_files,
         mock_get_exclude_list_for_root_data_sync,
         mock_Compress, mock_ArchiveTar
     ):
@@ -67,7 +69,9 @@ class TestContainerImageAppx:
         mock_ArchiveTar.assert_called_once_with('meta/data/install.tar')
         archive.create.assert_called_once_with(
             'root_dir',
-            exclude=mock_get_exclude_list_for_root_data_sync.return_value
+            exclude=mock_get_exclude_list_for_root_data_sync.
+            return_value + mock_get_exclude_list_from_custom_exclude_files.
+            return_value
         )
         mock_Compress.assert_called_once_with(
             archive.create.return_value


### PR DESCRIPTION
The new optional metadata file image/exclude_files.yaml can
be placed inside of the local image root tree. At creation time of
the image binary the file contents are used to extend the default
exclude list with additional information. The structure of the
file must be as follows:

```yaml
exclude:
  - exclude-name-used-in-rsync
```


