### PR TITLE
Do not apply default subcommand for derivate containers

### DIFF
--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -95,11 +95,6 @@ class ContainerImageOCI:
             self.oci_config['container_tag'] = \
                 Defaults.get_default_container_tag()
 
-        if 'entry_command' not in self.oci_config and \
-                'entry_subcommand' not in self.oci_config:
-            self.oci_config['entry_subcommand'] = \
-                Defaults.get_default_container_subcommand()
-
         if 'history' not in self.oci_config:
             self.oci_config['history'] = {}
         if 'created_by' not in self.oci_config['history']:
@@ -128,6 +123,11 @@ class ContainerImageOCI:
                 )
             )
         else:
+            # Apply default subcommand only for base images
+            if 'entry_command' not in self.oci_config and \
+                    'entry_subcommand' not in self.oci_config:
+                self.oci_config['entry_subcommand'] = \
+                    Defaults.get_default_container_subcommand()
             oci.init_container()
 
         image_ref = '{0}:{1}'.format(

--- a/test/unit/container/oci_test.py
+++ b/test/unit/container/oci_test.py
@@ -63,7 +63,6 @@ class TestContainerImageOCI:
         assert container.oci_config == {
             'container_name': 'kiwi-container',
             'container_tag': 'latest',
-            'entry_subcommand': ['/bin/bash'],
             'history': {'created_by': 'KIWI {0}'.format(__version__)}
         }
 
@@ -188,14 +187,12 @@ class TestContainerImageOCI:
             'container_name': 'foo/bar',
             'additional_tags': ['current', 'foobar'],
             'container_tag': 'latest',
-            'entry_subcommand': ['/bin/bash'],
             'history': {'created_by': 'KIWI {0}'.format(__version__)}
         })
         mock_oci.set_config.assert_called_once_with({
             'container_name': 'foo/bar',
             'additional_tags': ['current', 'foobar'],
             'container_tag': 'latest',
-            'entry_subcommand': ['/bin/bash'],
             'history': {'created_by': 'KIWI {0}'.format(__version__)}
         })
         mock_oci.post_process.assert_called_once_with()


### PR DESCRIPTION
This commit does not apply the default subcommand for derivate
containers.

Fixes bsc#1184823
