### PR TITLE
Change zypper download mode to in-advance

### DIFF
--- a/kiwi/package_manager/zypper.py
+++ b/kiwi/package_manager/zypper.py
@@ -113,7 +113,8 @@ class PackageManagerZypper(PackageManagerBase):
         """
         command = ['zypper'] + self.zypper_args + [
             '--root', self.root_dir,
-            'install', '--auto-agree-with-licenses'
+            'install', '--download', 'in-advance',
+            '--auto-agree-with-licenses'
         ] + self.custom_args + ['--'] + self._install_items()
         return Command.call(
             command, self.command_env
@@ -144,7 +145,8 @@ class PackageManagerZypper(PackageManagerBase):
                 )
         return Command.call(
             ['chroot', self.root_dir, 'zypper'] + self.chroot_zypper_args + [
-                'install', '--auto-agree-with-licenses'
+                'install', '--download', 'in-advance',
+                '--auto-agree-with-licenses'
             ] + self.custom_args + ['--'] + self._install_items(),
             self.chroot_command_env
         )
@@ -201,7 +203,8 @@ class PackageManagerZypper(PackageManagerBase):
         """
         return Command.call(
             ['chroot', self.root_dir, 'zypper'] + self.chroot_zypper_args + [
-                'update', '--auto-agree-with-licenses'
+                'update', '--download', 'in-advance',
+                '--auto-agree-with-licenses'
             ] + self.custom_args,
             self.chroot_command_env
         )

--- a/test/unit/package_manager/zypper_test.py
+++ b/test/unit/package_manager/zypper_test.py
@@ -56,7 +56,8 @@ class TestPackageManagerZypper:
             [
                 'zypper', '--reposd-dir', 'root-dir/my/repos',
                 '--root', 'root-dir',
-                'install', '--auto-agree-with-licenses'
+                'install', '--download', 'in-advance',
+                '--auto-agree-with-licenses'
             ] + self.manager.custom_args + ['--', 'vim'], self.command_env
         )
 
@@ -79,7 +80,8 @@ class TestPackageManagerZypper:
         )
         mock_call.assert_called_once_with(
             ['chroot', 'root-dir', 'zypper'] + self.chroot_zypper_args + [
-                'install', '--auto-agree-with-licenses'
+                'install', '--download', 'in-advance',
+                '--auto-agree-with-licenses'
             ] + self.manager.custom_args + ['--', 'vim'], self.chroot_command_env
         )
 
@@ -122,7 +124,8 @@ class TestPackageManagerZypper:
         self.manager.update()
         mock_call.assert_called_once_with(
             ['chroot', 'root-dir', 'zypper'] + self.chroot_zypper_args + [
-                'update', '--auto-agree-with-licenses'
+                'update', '--download', 'in-advance',
+                '--auto-agree-with-licenses'
             ] + self.manager.custom_args, self.chroot_command_env
         )
 


### PR DESCRIPTION
In relation to upcoming zypper changes e.g to make use of librpm on
single transaction operations there is the possibility that file
triggers start being used. To ensure zypper behaves consistently
DownloadInAdvance mode should be used, this way the transaction
happens as a whole and with the upcoming zypper changes zypper
will still be capable to handle the file triggers.
This Fixes #1789


