### PR TITLE
Fixed spec file on Debian tool settings

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -83,15 +83,19 @@ Obsoletes:      kiwi-image-tbz-requires < %{version}-%{release}
 %if "%{_vendor}" != "debbuild"
 Provides:       kiwi-image:tbz
 %endif
-# tools used by kiwi
+# tools conditionally used by kiwi
 %if 0%{?fedora} || 0%{?rhel} >= 8
 Recommends:     gnupg2
+Recommends:     debootstrap
+Recommends:     dpkg
 %endif
 %if 0%{?suse_version}
-# If it's available, let's pull it in
-Recommends:     dnf
 Recommends:     gpg2
+Recommends:     dnf
+Recommends:     debootstrap
+Recommends:     dpkg
 %endif
+# package managers required by distro
 %if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?suse_version} >= 1550
 Provides:       kiwi-packagemanager:microdnf
 Requires:       microdnf
@@ -107,8 +111,10 @@ Provides:       kiwi-packagemanager:zypper
 %endif
 %if 0%{?debian} || 0%{?ubuntu}
 Requires:       debootstrap
+Requires:       dpkg
 Requires:       gnupg
 %endif
+# tools required by kiwi
 Requires:       kiwi-tools
 Requires:       mtools
 Requires:       rsync


### PR DESCRIPTION
debootstrap should always come with dpkg because we don't
want to handle the architecture names used on Debian when
dpkg knows them better than we do. since debootstrap itself
considers the possibility of being called without dpkg on
the system we generate the dependency by a spec change
here. This Fixes #1778

