### PR TITLE
Add uefi support on ubuntu

### DIFF
--- a/build-tests/x86/debian/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/debian/test-image-live-disk/appliance.kiwi
@@ -30,7 +30,7 @@
         </type>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="efi" format="qcow2">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="uefi" format="qcow2">
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
@@ -84,6 +84,10 @@
         <package name="netbase"/>
         <package name="bsdmainutils"/>
         <package name="usrmerge"/>
+    </packages>
+    <packages type="image" profiles="Virtual">
+        <package name="shim-signed"/>
+        <package name="grub-efi-amd64-signed"/>
     </packages>
     <packages type="image" profiles="Live">
         <package name="dracut-kiwi-live"/>

--- a/build-tests/x86/ubuntu/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/ubuntu/test-image-live-disk/appliance.kiwi
@@ -30,7 +30,7 @@
         </type>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="efi" format="qcow2">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="uefi" format="qcow2">
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
@@ -89,6 +89,10 @@
             however this is installed by debootstrap
         -->
         <package name="mawk"/>
+    </packages>
+    <packages type="image" profiles="Virtual">
+        <package name="shim"/>
+        <package name="shim-signed"/>
     </packages>
     <packages type="image" profiles="Live">
         <package name="dracut-kiwi-live"/>

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -16,6 +16,7 @@ from kiwi.exceptions import (
     KiwiPackagesDeletePhaseFailed
 )
 
+from kiwi.defaults import Defaults
 from kiwi.system.prepare import SystemPrepare
 from kiwi.xml_description import XMLDescription
 from kiwi.xml_state import XMLState
@@ -30,6 +31,7 @@ class TestSystemPrepare:
     @patch('kiwi.system.prepare.RootBind')
     @patch('kiwi.logger.Logger.get_logfile')
     def setup(self, mock_get_logfile, mock_root_bind, mock_root_init):
+        Defaults.set_platform_name('x86_64')
         mock_get_logfile.return_value = None
         description = XMLDescription(
             description='../data/example_config.xml',

--- a/test/unit/tasks/base_test.py
+++ b/test/unit/tasks/base_test.py
@@ -10,6 +10,7 @@ from ..test_helper import argv_kiwi_tests
 import kiwi.xml_parse
 from kiwi.tasks.base import CliTask
 
+from kiwi.defaults import Defaults
 from kiwi.exceptions import KiwiConfigFileNotFound
 
 
@@ -31,6 +32,7 @@ class TestCliTask:
         mock_load_command, mock_help_check, mock_color,
         mock_setlog, mock_setlevel
     ):
+        Defaults.set_platform_name('x86_64')
         mock_global_args.return_value = {
             '--debug': True,
             '--logfile': 'log',


### PR DESCRIPTION
Added support for UEFI on Ubuntu
    
The Ubuntu folks have a different system to support EFI secure boot. In order to make use of it kiwi needs some adaptions done in this pull request. This Fixes #1743