### PR TITLE
Fix WSL appx filemap relative paths not preserved

### DIFF
--- a/kiwi/container/appx.py
+++ b/kiwi/container/appx.py
@@ -105,12 +105,13 @@ class ContainerImageAppx:
                 for entry in sorted(dirs + files):
                     if entry in files:
                         mapfile = os.sep.join([topdir, entry])
+                        mapfile_relative = os.path.relpath(mapfile, start=self.meta_data_path)
                         log.info(
-                            'Adding {0} to Appx filemap'.format(mapfile)
+                            'Adding {0} to Appx filemap as relative path {1}'.format(mapfile, mapfile_relative)
                         )
                         filemap.write(
                             '"{0}" "{1}"{2}'.format(
-                                mapfile, os.path.basename(mapfile), os.linesep
+                                mapfile, mapfile_relative, os.linesep
                             )
                         )
 


### PR DESCRIPTION
During WSL appx image type creation step the file hierarchy under metadata_path
is written to a temporary file for eventual use as argument to utility appx.
The file hierarchy information is dropped resulting in all filemap entries
appearing to be at the metadata_path root. The resulting image will side load
and run but without icon and other resources. Stricter checks at Windows Store
submission will fail due to mismatch between image manifest and contents.

Fix by preserving relative path of filemap entries relative to metadata_path.
Add log output showing both input absolute path and output relative path.

Fixes #1804 .

Changes proposed in this pull request:
* Preserve relative path of filemap entries relative to metadata_path
* Add log output showing both input absolute path and output relative path
