### PR TITLE
Make installation media unattended

### DIFF
--- a/build-tests/x86/centos/test-image-live-disk-v7/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-live-disk-v7/appliance.kiwi
@@ -41,6 +41,7 @@
             <bootloader name="grub2" console="serial"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
+                <oem-unattended>true</oem-unattended>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>200</oem-swapsize>
                 <oem-multipath-scan>false</oem-multipath-scan>

--- a/build-tests/x86/centos/test-image-live-disk-v8/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-live-disk-v8/appliance.kiwi
@@ -41,6 +41,7 @@
             <bootloader name="grub2" console="serial"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
+                <oem-unattended>true</oem-unattended>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>200</oem-swapsize>
                 <oem-multipath-scan>false</oem-multipath-scan>

--- a/build-tests/x86/debian/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/debian/test-image-live-disk/appliance.kiwi
@@ -42,6 +42,7 @@
             <bootloader name="grub2" console="serial"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>
+                <oem-unattended>true</oem-unattended>
                 <oem-device-filter>/dev/ram</oem-device-filter>
                 <oem-multipath-scan>false</oem-multipath-scan>
             </oemconfig>

--- a/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
@@ -42,6 +42,7 @@
             <bootloader name="grub2" console="serial"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
+                <oem-unattended>true</oem-unattended>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>200</oem-swapsize>
                 <oem-multipath-scan>false</oem-multipath-scan>

--- a/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
@@ -42,6 +42,7 @@
             <bootloader name="grub2" console="serial"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
+                <oem-unattended>true</oem-unattended>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>200</oem-swapsize>
                 <oem-multipath-scan>false</oem-multipath-scan>

--- a/build-tests/x86/ubuntu/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/ubuntu/test-image-live-disk/appliance.kiwi
@@ -42,6 +42,7 @@
             <bootloader name="grub2" console="serial"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>
+                <oem-unattended>true</oem-unattended>
                 <oem-device-filter>/dev/ram</oem-device-filter>
                 <oem-multipath-scan>false</oem-multipath-scan>
             </oemconfig>

--- a/test/unit/container/appx_test.py
+++ b/test/unit/container/appx_test.py
@@ -64,7 +64,7 @@ class TestContainerImageAppx:
             self.appx.create('target_dir/image.appx')
             assert file_handle.write.call_args_list == [
                 call('[Files]\n'),
-                call('"source/baz/baz_file" "baz_file"\n')
+                call('"source/baz/baz_file" "../../source/baz/baz_file"\n')
             ]
         mock_ArchiveTar.assert_called_once_with('meta/data/install.tar')
         archive.create.assert_called_once_with(


### PR DESCRIPTION
This commit configures install media of several tests to run unattended
installation. This is done to facilitate the logic of functional tests.