### PR TITLE
Fixed setup of repository architecture

### DIFF
--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -45,9 +45,11 @@ class BootImageBase:
     :param string target_dir: target dir to store the initrd
     :param string root_dir: system image root directory
     :param list signing_keys: list of package signing keys
+    :param str target_arch: target architecture
     """
     def __init__(
-        self, xml_state, target_dir, root_dir=None, signing_keys=None
+        self, xml_state, target_dir, root_dir=None,
+        signing_keys=None, target_arch=None
     ):
         self.xml_state = xml_state
         self.target_dir = target_dir
@@ -55,6 +57,7 @@ class BootImageBase:
         self.boot_xml_state = None
         self.setup = None
         self.signing_keys = signing_keys
+        self.target_arch = target_arch
         self.boot_root_directory = root_dir
 
         if not os.path.exists(target_dir):

--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -77,7 +77,9 @@ class BootImageKiwi(BootImageBase):
             root_dir=self.boot_root_directory,
             allow_existing=True
         )
-        manager = system.setup_repositories(signing_keys=self.signing_keys)
+        manager = system.setup_repositories(
+            signing_keys=self.signing_keys, target_arch=self.target_arch
+        )
         system.install_bootstrap(
             manager
         )

--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -351,7 +351,10 @@ class RepositoryDnf(RepositoryBase):
             )
         if self.target_arch:
             self.runtime_dnf_config.set(
-                'main', 'basearch', self.target_arch
+                'main', 'arch', self.target_arch
+            )
+            self.runtime_dnf_config.set(
+                'main', 'ignorearch', '1'
             )
 
     def _create_runtime_plugin_config_parser(self) -> None:

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -18,7 +18,7 @@
 import os
 import logging
 from typing import (
-    List, Any
+    List, Any, Optional
 )
 from textwrap import dedent
 
@@ -101,7 +101,8 @@ class SystemPrepare:
         self.uri_list: List[Uri] = []
 
     def setup_repositories(
-        self, clear_cache: bool = False, signing_keys: List[str] = None
+        self, clear_cache: bool = False,
+        signing_keys: List[str] = None, target_arch: Optional[str] = None
     ) -> PackageManagerBase:
         """
         Set up repositories for software installation and return a
@@ -111,6 +112,8 @@ class SystemPrepare:
             Flag the clear cache before configure anything
         :param list signing_keys:
             Keys imported to the package manager
+        :param str target_arch:
+            Target architecture name
 
         :return: instance of :class:`PackageManager` subclass
 
@@ -128,6 +131,10 @@ class SystemPrepare:
         if rpm_locale_list:
             repository_options.append(
                 '_install_langs%{0}'.format(':'.join(rpm_locale_list))
+            )
+        if target_arch:
+            repository_options.append(
+                f'_target_arch%{target_arch}'
             )
         repo = Repository.new(
             self.root_bind, package_manager, repository_options

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -196,7 +196,8 @@ class SystemBuildTask(CliTask):
         )
         manager = system.setup_repositories(
             self.command_args['--clear-cache'],
-            self.command_args['--signing-key']
+            self.command_args['--signing-key'],
+            self.global_args['--target-arch']
         )
         system.install_bootstrap(
             manager, self.command_args['--add-bootstrap-package']

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -180,7 +180,8 @@ class SystemPrepareTask(CliTask):
         )
         manager = system.setup_repositories(
             self.command_args['--clear-cache'],
-            self.command_args['--signing-key']
+            self.command_args['--signing-key'],
+            self.global_args['--target-arch']
         )
         system.install_bootstrap(
             manager, self.command_args['--add-bootstrap-package']

--- a/kiwi/tasks/system_update.py
+++ b/kiwi/tasks/system_update.py
@@ -89,7 +89,9 @@ class SystemUpdateTask(CliTask):
             abs_root_path,
             allow_existing=True
         )
-        manager = self.system.setup_repositories()
+        manager = self.system.setup_repositories(
+            target_arch=self.global_args['--target-arch']
+        )
 
         if not package_requests:
             self.system.update_system(manager)

--- a/test/unit/boot/image/builtin_kiwi_test.py
+++ b/test/unit/boot/image/builtin_kiwi_test.py
@@ -60,7 +60,7 @@ class TestBootImageKiwi:
         mock_boot_path.return_value = '../data'
         self.boot_image.prepare()
         self.system_prepare.setup_repositories.assert_called_once_with(
-            signing_keys=None
+            signing_keys=None, target_arch=None
         )
         self.system_prepare.install_bootstrap.assert_called_once_with(
             self.manager

--- a/test/unit/repository/dnf_test.py
+++ b/test/unit/repository/dnf_test.py
@@ -45,7 +45,8 @@ class TestRepositoryDnf:
             call('main', 'plugins', '1'),
             call('main', 'gpgcheck', '0'),
             call('main', 'tsflags', 'nodocs'),
-            call('main', 'basearch', 'x86_64'),
+            call('main', 'arch', 'x86_64'),
+            call('main', 'ignorearch', '1'),
             call('main', 'enabled', '1')
         ]
 
@@ -93,7 +94,8 @@ class TestRepositoryDnf:
             call('main', 'plugins', '1'),
             call('main', 'gpgcheck', '0'),
             call('main', 'tsflags', 'nodocs'),
-            call('main', 'basearch', 'x86_64'),
+            call('main', 'arch', 'x86_64'),
+            call('main', 'ignorearch', '1'),
             call('main', 'enabled', '1')
         ]
 

--- a/test/unit/repository/dnf_test.py
+++ b/test/unit/repository/dnf_test.py
@@ -27,7 +27,10 @@ class TestRepositoryDnf:
 
         with patch('builtins.open', create=True):
             self.repo = RepositoryDnf(
-                root_bind, ['exclude_docs', '_install_langs%en_US:de_DE']
+                root_bind, [
+                    'exclude_docs', '_install_langs%en_US:de_DE',
+                    '_target_arch%x86_64'
+                ]
             )
 
         assert runtime_dnf_config.set.call_args_list == [
@@ -42,6 +45,7 @@ class TestRepositoryDnf:
             call('main', 'plugins', '1'),
             call('main', 'gpgcheck', '0'),
             call('main', 'tsflags', 'nodocs'),
+            call('main', 'basearch', 'x86_64'),
             call('main', 'enabled', '1')
         ]
 
@@ -89,6 +93,7 @@ class TestRepositoryDnf:
             call('main', 'plugins', '1'),
             call('main', 'gpgcheck', '0'),
             call('main', 'tsflags', 'nodocs'),
+            call('main', 'basearch', 'x86_64'),
             call('main', 'enabled', '1')
         ]
 

--- a/test/unit/repository/zypper_test.py
+++ b/test/unit/repository/zypper_test.py
@@ -52,7 +52,9 @@ class TestRepositoryZypper:
         runtime_zypp_config = mock.Mock()
         mock_config.return_value = runtime_zypp_config
         with patch('builtins.open', create=True):
-            repo = RepositoryZypper(self.root_bind, ['check_signatures'])
+            repo = RepositoryZypper(
+                self.root_bind, ['check_signatures', '_target_arch%x86_64']
+            )
             assert repo.custom_args == []
             assert runtime_zypp_config.set.call_args_list == [
                 call(

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -197,13 +197,15 @@ class TestSystemPrepare:
 
         self.system.setup_repositories(
             clear_cache=True,
-            signing_keys=['key-file-a.asc', 'key-file-b.asc']
+            signing_keys=['key-file-a.asc', 'key-file-b.asc'],
+            target_arch='x86_64'
         )
 
         mock_repo.assert_called_once_with(
             self.system.root_bind, 'package-manager-name', [
                 'check_signatures', 'exclude_docs',
-                '_install_langs%POSIX:C:C.UTF-8:en_US:de_DE'
+                '_install_langs%POSIX:C:C.UTF-8:en_US:de_DE',
+                '_target_arch%x86_64'
             ]
         )
         # mock local repos will be translated and bind mounted

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -156,7 +156,7 @@ class TestSystemBuildTask:
             check_architecture_supports_iso_firmware_setup.\
             assert_called_once_with()
         self.system_prepare.setup_repositories.assert_called_once_with(
-            False, None
+            False, None, None
         )
         self.system_prepare.install_bootstrap.assert_called_once_with(
             self.manager, []
@@ -198,7 +198,7 @@ class TestSystemBuildTask:
         self.task.command_args['--add-package'] = ['vim']
         self.task.process()
         self.system_prepare.setup_repositories.assert_called_once_with(
-            False, None
+            False, None, None
         )
         self.system_prepare.install_packages.assert_called_once_with(
             self.manager, ['vim']
@@ -210,7 +210,7 @@ class TestSystemBuildTask:
         self.task.command_args['--delete-package'] = ['vim']
         self.task.process()
         self.system_prepare.setup_repositories.assert_called_once_with(
-            False, None
+            False, None, None
         )
         self.system_prepare.delete_packages.assert_called_once_with(
             self.manager, ['vim']

--- a/test/unit/tasks/system_prepare_test.py
+++ b/test/unit/tasks/system_prepare_test.py
@@ -141,7 +141,7 @@ class TestSystemPrepareTask:
             check_architecture_supports_iso_firmware_setup.\
             assert_called_once_with()
         self.system_prepare.setup_repositories.assert_called_once_with(
-            True, None
+            True, None, None
         )
         self.system_prepare.install_bootstrap.assert_called_once_with(
             self.manager, []
@@ -177,7 +177,7 @@ class TestSystemPrepareTask:
         self.task.command_args['--add-package'] = ['vim']
         self.task.process()
         self.system_prepare.setup_repositories.assert_called_once_with(
-            False, None
+            False, None, None
         )
         self.system_prepare.install_packages.assert_called_once_with(
             self.manager, ['vim']
@@ -188,7 +188,7 @@ class TestSystemPrepareTask:
         self.task.command_args['--delete-package'] = ['vim']
         self.task.process()
         self.system_prepare.setup_repositories.assert_called_once_with(
-            False, None
+            False, None, None
         )
         self.system_prepare.delete_packages.assert_called_once_with(
             self.manager, ['vim']

--- a/test/unit/tasks/system_update_test.py
+++ b/test/unit/tasks/system_update_test.py
@@ -43,7 +43,9 @@ class TestSystemUpdateTask:
         self._init_command_args()
         self.task.command_args['update'] = True
         self.task.process()
-        self.task.system.setup_repositories.assert_called_once_with()
+        self.task.system.setup_repositories.assert_called_once_with(
+            target_arch=None
+        )
         self.task.system.update_system.assert_called_once_with(self.manager)
 
     def test_process_system_update_add_package(self):
@@ -51,7 +53,9 @@ class TestSystemUpdateTask:
         self.task.command_args['update'] = True
         self.task.command_args['--add-package'] = ['vim']
         self.task.process()
-        self.task.system.setup_repositories.assert_called_once_with()
+        self.task.system.setup_repositories.assert_called_once_with(
+            target_arch=None
+        )
         self.task.system.install_packages.assert_called_once_with(
             self.manager, ['vim']
         )
@@ -61,7 +65,9 @@ class TestSystemUpdateTask:
         self.task.command_args['update'] = True
         self.task.command_args['--delete-package'] = ['vim']
         self.task.process()
-        self.task.system.setup_repositories.assert_called_once_with()
+        self.task.system.setup_repositories.assert_called_once_with(
+            target_arch=None
+        )
         self.task.system.delete_packages.assert_called_once_with(
             self.manager, ['vim']
         )


### PR DESCRIPTION
Unfortunately the architecture reported by uname is not
necessarily the same name as used in the repository metadata.
For example on armv7l the repo arch is armv7hl when using
zypper. Therefore it's required to allow for a translation
map. This commit implements it for use with zypper on arm
and Fixes bsc#1185287


