### PR TITLE
Fixed live network setup to be generic

### DIFF
--- a/dracut/modules.d/90kiwi-live/kiwi-live-genrules.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-genrules.sh
@@ -15,7 +15,11 @@ case "${root}" in
         wait_for_dev -n "${root#live:}"
         ;;
     live:aoe:/dev/*)
-        /sbin/initqueue \
-            --settled --onetime --unique /sbin/kiwi-live-root "${root}"
+        {
+        printf 'KERNEL=="%s", RUN+="/sbin/initqueue %s %s %s"\n' \
+            "${root#live:aoe:/dev/}" "--settled --onetime --unique" \
+            "/sbin/kiwi-live-root" "${root#live:aoe:}"
+        } >> /etc/udev/rules.d/99-live-aoe-kiwi.rules
+        wait_for_dev -n "${root#live:aoe:}"
         ;;
 esac

--- a/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
@@ -70,19 +70,7 @@ function initGlobalDevices {
     if [ -z "$1" ]; then
         die "No root device for operation given"
     fi
-    if getargbool 0 rd.kiwi.live.pxe; then
-        local bootdev
-        read -r bootdev < /tmp/net.bootdev 2>/dev/null
-        if [ -n "${bootdev}" ] && [ -e /tmp/net."${bootdev}".did-setup ]; then
-            : # already set up
-        elif ! ifup lan0 &>/tmp/net.info;then
-            die "Network setup failed, see /tmp/net.info"
-        fi
-        modprobe aoe
-        isodev="${1#live:aoe:}"
-    else
-        isodev="$1"
-    fi
+    isodev="$1"
     local isodisk
     isodisk=$(lookupIsoDiskDevice "${isodev}")
     isodiskdev=$(echo "${isodisk}" | cut -f1 -d%)

--- a/dracut/modules.d/90kiwi-live/kiwi-live-root.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-root.sh
@@ -11,14 +11,14 @@ setupDebugMode
 # initialize profile environment
 initialize
 
+# load required kernel modules
+loadKernelModules
+
 # device nodes and types
 initGlobalDevices "$1"
 
 # live options and their default values
 initGlobalOptions
-
-# load required kernel modules
-loadKernelModules
 
 # mount ISO device
 iso_mount_point=$(mountIso)

--- a/dracut/modules.d/90kiwi-live/parse-kiwi-live.sh
+++ b/dracut/modules.d/90kiwi-live/parse-kiwi-live.sh
@@ -14,6 +14,11 @@ fi
 
 modprobe -q loop
 
+need_network=0
+if getargbool 0 rd.kiwi.live.pxe; then
+    need_network=1
+fi
+
 case "${liveroot}" in
     live:CDLABEL=*|CDLABEL=*) \
         root="${root#live:}"
@@ -21,15 +26,25 @@ case "${liveroot}" in
         root="live:/dev/disk/by-label/${root#CDLABEL=}"
         rootok=1 ;;
     live:AOEINTERFACE=*|AOEINTERFACE=*) \
+        modprobe -q aoe
         root="${root#live:}"
         root="${root//\//\\x2f}"
         root="live:aoe:/dev/etherd/${root#AOEINTERFACE=}"
+        need_network=1
         rootok=1 ;;
 esac
 
 [ "$rootok" = "1" ] || return 1
 
 info "root was ${liveroot}, is now ${root}"
+
+# create network setup if needed
+if [ "${need_network}" = "1" ];then
+    echo "rd.neednet=1" > /etc/cmdline.d/kiwi-generated.conf
+    if ! getarg "ip="; then
+        echo "ip=dhcp" >> /etc/cmdline.d/kiwi-generated.conf
+    fi
+fi
 
 # make sure that init doesn't complain
 [ -z "${root}" ] && root="live"


### PR DESCRIPTION
In dracut the network setup comes with different models
providing a different set of functions. The ifup method as
used in the live iso dracut module is only available with the
network-legacy mode and fails with network-wicked. This commit
uses a dracut conf file in /etc/cmdline.d which uses the dracut
network interface parameters instead of calling module specific
methods. This Fixes #1802

