### PR TITLE
Fix shim path on fedora

### DIFF
--- a/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
@@ -53,10 +53,10 @@
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
     <repository type="rpm-md" alias="kiwi-next-generation" priority="1">
-        <source path="obs://Virtualization:Appliances:Staging/Fedora_33"/>
+        <source path="obs://Virtualization:Appliances:Staging/Fedora_34"/>
     </repository>
-    <repository type="rpm-md" alias="Fedora_33">
-        <source path="obs://Fedora:33/standard"/>
+    <repository type="rpm-md" alias="Fedora_34">
+        <source path="obs://Fedora:34/standard"/>
     </repository>
     <repository type="rpm-md" alias="Fedora_EPEL">
         <source path="obs://Fedora:EPEL:8/standard"/>

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -699,7 +699,7 @@ class Defaults:
         shim_file_patterns = [
             '/usr/share/efi/*/shim.efi',
             '/usr/lib64/efi/shim.efi',
-            '/boot/efi/EFI/*/shim.efi',
+            '/boot/efi/EFI/*/shim*.efi',
             '/usr/lib/shim/shim*.efi'
         ]
         for shim_file_pattern in shim_file_patterns:


### PR DESCRIPTION
Update shim path lookup
    
Distributions like Fedora has changed the EFI binaries location
to be shim<efiarch>.efi in /boot/efi/EFI/<vendor> in order to
support multiarch setup for UEFI. This change requires the
lookup in KIWI to be more global matching. This Fixes #1806
