### PR TITLE
Update kiwi installation documentation

### DIFF
--- a/doc/source/building_images/build_expandable_disk.rst
+++ b/doc/source/building_images/build_expandable_disk.rst
@@ -99,7 +99,7 @@ The following steps shows how to do it:
 
    .. code:: bash
 
-       $ qemu -hda target_disk -m 4096 -serial stdio
+       $ sudo qemu -hda target_disk -m 4096 -serial stdio
 
 
    At first boot of the target_disk the system is expanded to the
@@ -124,7 +124,8 @@ The following steps shows how to do it:
 
    .. code:: bash
 
-       $ qemu -cdrom {exc_image_base_name_disk}.x86_64-{exc_image_version}.install.iso -hda target_disk \
+       $ sudo qemu -cdrom \
+             {exc_image_base_name_disk}.x86_64-{exc_image_version}.install.iso -hda target_disk \
              -boot d -m 4096 -serial stdio
 
    .. note:: USB Stick Deployment
@@ -270,7 +271,7 @@ target system:
 
    .. code:: bash
 
-      $ qemu -boot n -hda target_disk -m 4096
+      $ sudo qemu -boot n -hda target_disk -m 4096
 
    .. note:: QEMU bridged networking
 

--- a/doc/source/building_images/build_live_iso.rst
+++ b/doc/source/building_images/build_live_iso.rst
@@ -65,7 +65,8 @@ be tested with QEMU:
 
 .. code:: bash
 
-   $ qemu -cdrom {exc_image_base_name_live}.x86_64-{exc_image_version}.iso \
+   $ sudo qemu -cdrom \
+         {exc_image_base_name_live}.x86_64-{exc_image_version}.iso \
          -m 4096 -serial stdio
 
 The image is now complete and ready to use. See :ref:`iso_to_usb_stick` and

--- a/doc/source/building_images/build_simple_disk.rst
+++ b/doc/source/building_images/build_simple_disk.rst
@@ -81,7 +81,7 @@ The live image can then be tested with QEMU:
 
 .. code:: bash
 
-   $ qemu \
+   $ sudo qemu \
        -drive file={exc_image_base_name_disk_simple}.x86_64-{exc_image_version}.raw,format=raw,if=virtio \
        -m 4096
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -5,9 +5,15 @@ Installation
 
 .. note::
 
-   This document describes how to install {kiwi}. Apart from the preferred
-   method to install {kiwi} via rpm, it is also available on `pypi
-   <https://pypi.org/project/kiwi/>`__ and can be installed via pip.
+   This document describes how to install {kiwi}.
+
+Apart from the preferred method to install {kiwi} via a distribution
+package manager, it is also available on `pypi <https://pypi.org/project/kiwi/>`__
+and can be installed using Python's package manager pip as follows:
+
+.. code:: shell-session
+
+    $ sudo pip install kiwi
 
 .. _installation-from-obs:
 
@@ -33,90 +39,60 @@ To install {kiwi}, follow these steps:
 
    .. code:: shell-session
 
-       $ sudo zypper addrepo http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/<DIST> appliance-builder
+       $ sudo zypper addrepo \
+             http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/<DIST> \
+             kiwi-appliance-builder
+
+4. Install {kiwi}:
+
+   .. code:: shell-session
+
+       $ sudo zypper --gpg-auto-import-keys install python3-kiwi
+
+
+.. note:: Other Distributions
 
    If your distribution is not using :command:`zypper`, please use your
-   package manager's appropriate command instead. For :command:`dnf` that
-   is:
+   package manager's appropriate command instead. For :command:`dnf`,
+   as an example, that is:
 
    .. code:: shell-session
 
-      $ sudo dnf config-manager --add-repo https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/<DIST>/Virtualization:Appliances:Builder.repo
+      $ sudo dnf config-manager \
+            --add-repo https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/<DIST>/Virtualization:Appliances:Builder.repo
 
-4. Add the repositories' signing-key to your package manager's
-   database. For rpm run:
-
-   .. code:: shell-session
-
-      $ sudo rpm --import https://build.opensuse.org/projects/Virtualization:Appliances:Builder/public_key
-
-   And verify that you got the correct key:
-
-   .. code:: shell-session
-
-      $ rpm -qi gpg-pubkey-74cbe823-* | gpg2
-      gpg: WARNING: no command supplied.  Trying to guess what you mean ...
-      pub   dsa1024 2009-05-04 [SC] [expires: 2020-10-09]
-            F7E82012C74FD0B85F5334DC994B195474CBE823
-      uid           Virtualization:Appliances OBS Project <Virtualization:Appliances@build.opensuse.org>
-
-.. note::
-
-   :command:`rpm` requires network utilities in order to download and
-   import remote keys. Make sure :command:`curl` is installed before
-   trying to import remote keys using :command:`rpm`. 
-   
-   Alternatively, the package manager, if not executed in non-interactive mode,
-   will ask you to trust or not the public key of the new repository when
-   refreshing repositories or installing new packages. If trusted the package
-   manager will automatically import it.
-
-5. Install {kiwi}:
-
-   .. code:: shell-session
-
-       $ sudo zypper in python3-kiwi
+      $ sudo dnf install python3-kiwi
 
 
-Installation from your distribution's repositories
---------------------------------------------------
-
-.. note::
-
-   There are many packages that contain the name {kiwi} in their name, some
-   of these are even python packages. Please double check the packages'
-   description whether it is actually the {kiwi} Appliance builder before
-   installing it.
-
+Installation from Distribution Repositories
+-------------------------------------------
 
 Some Linux distributions ship {kiwi} in their official repositories. These
-include openSUSE Tumbleweed, openSUSE Leap, and Fedora since
-version 28. Note, these packages tend to not be as up to date as the
-packages from OBS, so some features described here might not exist yet.
+include **openSUSE** and **Fedora** since version 28. Note, these packages tend to
+not be as up to date as the packages from OBS, so some features described
+here might not exist yet.
 
-To install {kiwi} on openSUSE, run the following command:
+.. note::
 
-.. code:: shell-session
+   There are many packages that contain the name *kiwi* in their name, some
+   of these are not even python packages. Please double check the packages'
+   description whether it is actually the {kiwi} Appliance builder before
+   installing it. Please also note, depending on how the responsible
+   packager has integrated {kiwi} into the distribution, the install
+   name can be different from the instructions provided in:
+   :ref:`installation-from-obs`
 
-   $ sudo zypper install python3-kiwi
+To install {kiwi} for the desired distribution, run the following command:
 
-On Fedora, use the following command instead:
+Leap/Tumbleweed:
+  .. code:: shell-session
 
-.. code:: shell-session
+     $ sudo zypper install python3-kiwi
 
-   $ sudo dnf install kiwi-cli
+Fedora/Rawhide:
+  .. code:: shell-session
 
-
-Installation from PyPI
-----------------------
-
-{kiwi} can be obtained from the Python Package Index (PyPi) via Python's
-package manager pip:
-
-.. code:: shell-session
-
-   $ pip install kiwi
-
+     $ sudo dnf install kiwi-cli
 
 .. _example-descriptions:
 

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -17,7 +17,7 @@ Before you start
 
    .. code:: bash
 
-      $ pip install kiwi
+      $ sudo pip install kiwi
 
 2. Clone the {kiwi} repository containing example appliances (see
    :ref:`example-descriptions`):
@@ -71,7 +71,7 @@ QEMU and boot it as follows:
 
 .. code:: bash
 
-    $ qemu -boot c \
+    $ sudo qemu -boot c \
         -drive file={exc_image_base_name_disk}.x86_64-{exc_image_version}.raw,format=raw,if=virtio \
         -m 4096 -serial stdio
 

--- a/doc/source/working_with_images/disk_ramdisk_deployment.rst
+++ b/doc/source/working_with_images/disk_ramdisk_deployment.rst
@@ -51,7 +51,8 @@ follows:
 
 .. code:: bash
 
-    $ qemu -cdrom {exc_image_base_name}.x86_64-{exc_image_version}.install.iso \
+    $ sudo qemu -cdrom \
+          {exc_image_base_name}.x86_64-{exc_image_version}.install.iso \
           -serial stdio
 
 .. note:: Enough Main Memory

--- a/doc/source/working_with_images/legacy_netboot_root_filesystem.rst
+++ b/doc/source/working_with_images/legacy_netboot_root_filesystem.rst
@@ -136,7 +136,7 @@ system. As diskless client, a QEMU virtual machine is used.
 
    .. code:: bash
 
-       $ qemu -boot n -m 4096
+       $ sudo qemu -boot n -m 4096
 
 .. _pxe_legacy_client_config:
 

--- a/doc/source/working_with_images/network_live_iso_boot.rst
+++ b/doc/source/working_with_images/network_live_iso_boot.rst
@@ -115,4 +115,4 @@ the network:
 
    .. code:: bash
 
-      $ qemu -boot n
+      $ sudo qemu -boot n

--- a/doc/source/working_with_images/network_overlay_boot.rst
+++ b/doc/source/working_with_images/network_overlay_boot.rst
@@ -151,4 +151,4 @@ from the network:
 
    .. code:: bash
 
-      $ qemu -boot n
+      $ sudo qemu -boot n


### PR DESCRIPTION
The installation chapter contained information about the manual
install of package keys. That information is suspect to be always
outdated because these keys changes. Instead of describing the
manual install of the package key the docs moved to use the
auto-import feature of the package manager. As the instructions
were also rpm specific but we also support install via other
package mangers the complete chapter was a bit reworked and
should be more straight forward now. This Fixes #1799

