### PR TITLE
Update integration tests to be non interactive

### DIFF
--- a/build-tests/arm/fedora/test-image-live/appliance.kiwi
+++ b/build-tests/arm/fedora/test-image-live/appliance.kiwi
@@ -18,7 +18,7 @@
     </preferences>
     <preferences>
         <type image="iso" flags="overlay" firmware="uefi" hybridpersistent_filesystem="ext4" hybridpersistent="true" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/arm/fedora/test-image-live/appliance.kiwi
+++ b/build-tests/arm/fedora/test-image-live/appliance.kiwi
@@ -18,7 +18,7 @@
     </preferences>
     <preferences>
         <type image="iso" flags="overlay" firmware="uefi" hybridpersistent_filesystem="ext4" hybridpersistent="true" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/arm/rawhide/test-image-live-disk/appliance.kiwi
+++ b/build-tests/arm/rawhide/test-image-live-disk/appliance.kiwi
@@ -28,9 +28,10 @@
         </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" firmware="uefi" kernelcmdline="console=ttyS0" installiso="true" filesystem="ext4">
-            <bootloader name="grub2" console="serial"/>
+        <type image="oem" firmware="uefi" kernelcmdline="console=ttyS0" installiso="true" installboot="install" filesystem="ext4">
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <oemconfig>
+                <oem-unattended>true</oem-unattended>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>200</oem-swapsize>
             </oemconfig>

--- a/build-tests/arm/rawhide/test-image-live-disk/appliance.kiwi
+++ b/build-tests/arm/rawhide/test-image-live-disk/appliance.kiwi
@@ -29,7 +29,7 @@
     </preferences>
     <preferences profiles="Disk">
         <type image="oem" firmware="uefi" kernelcmdline="console=ttyS0" installiso="true" installboot="install" filesystem="ext4">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-unattended>true</oem-unattended>
                 <oem-swap>true</oem-swap>

--- a/build-tests/arm/tumbleweed/test-image-live-disk/appliance.kiwi
+++ b/build-tests/arm/tumbleweed/test-image-live-disk/appliance.kiwi
@@ -27,9 +27,10 @@
         <type image="iso" flags="overlay" firmware="uefi" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="ext4" hybridpersistent="true"/>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" firmware="uefi" kernelcmdline="console=ttyS0" installiso="true" filesystem="ext4">
-            <bootloader name="grub2" console="serial"/>
+        <type image="oem" firmware="uefi" kernelcmdline="console=ttyS0" installiso="true" installboot="install" filesystem="ext4">
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <oemconfig>
+                <oem-unattended>true</oem-unattended>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>200</oem-swapsize>
             </oemconfig>

--- a/build-tests/arm/tumbleweed/test-image-live-disk/appliance.kiwi
+++ b/build-tests/arm/tumbleweed/test-image-live-disk/appliance.kiwi
@@ -28,7 +28,7 @@
     </preferences>
     <preferences profiles="Disk">
         <type image="oem" firmware="uefi" kernelcmdline="console=ttyS0" installiso="true" installboot="install" filesystem="ext4">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-unattended>true</oem-unattended>
                 <oem-swap>true</oem-swap>

--- a/build-tests/arm/tumbleweed/test-image-rpi-overlay/appliance.kiwi
+++ b/build-tests/arm/tumbleweed/test-image-rpi-overlay/appliance.kiwi
@@ -14,7 +14,7 @@
         <timezone>UTC</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <type image="oem" filesystem="xfs" firmware="efi" kernelcmdline="loglevel=3 splash=silent plymouth.enable=0 console=tty0 rd.root.overlay.readonly" efipartsize="64" efiparttable="msdos" editbootinstall="uboot-image-raspberrypi4-install" overlayroot="true">
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <oemconfig>
                 <oem-swap>false</oem-swap>
                 <oem-resize>false</oem-resize>

--- a/build-tests/arm/tumbleweed/test-image-rpi-overlay/appliance.kiwi
+++ b/build-tests/arm/tumbleweed/test-image-rpi-overlay/appliance.kiwi
@@ -14,7 +14,7 @@
         <timezone>UTC</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <type image="oem" filesystem="xfs" firmware="efi" kernelcmdline="loglevel=3 splash=silent plymouth.enable=0 console=tty0 rd.root.overlay.readonly" efipartsize="64" efiparttable="msdos" editbootinstall="uboot-image-raspberrypi4-install" overlayroot="true">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-swap>false</oem-swap>
                 <oem-resize>false</oem-resize>

--- a/build-tests/arm/tumbleweed/test-image-rpi/appliance.kiwi
+++ b/build-tests/arm/tumbleweed/test-image-rpi/appliance.kiwi
@@ -16,7 +16,7 @@
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <type image="oem" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 swiotlb=512 cma=64M console=ttyS0" bootpartition="false" devicepersistency="by-label" btrfs_root_is_snapshot="true" efipartsize="16" editbootinstall="editbootinstall_rpi.sh">
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <systemdisk name="RaspberryPi">
                 <volume name="home"/>
                 <volume name="root"/>

--- a/build-tests/arm/tumbleweed/test-image-rpi/appliance.kiwi
+++ b/build-tests/arm/tumbleweed/test-image-rpi/appliance.kiwi
@@ -16,7 +16,7 @@
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <type image="oem" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 swiotlb=512 cma=64M console=ttyS0" bootpartition="false" devicepersistency="by-label" btrfs_root_is_snapshot="true" efipartsize="16" editbootinstall="editbootinstall_rpi.sh">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <systemdisk name="RaspberryPi">
                 <volume name="home"/>
                 <volume name="root"/>

--- a/build-tests/ppc/fedora/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/ppc/fedora/test-image-disk-simple/appliance.kiwi
@@ -17,7 +17,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/ppc/fedora/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/ppc/fedora/test-image-disk-simple/appliance.kiwi
@@ -17,7 +17,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/ppc/sle15/test-image-disk/appliance.kiwi
+++ b/build-tests/ppc/sle15/test-image-disk/appliance.kiwi
@@ -27,17 +27,23 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <preferences profiles="PhysicalBSZ_4096">
         <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install" target_blocksize="4096">
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
+            <oemconfig>
+                <oem-unattended>true</oem-unattended>
+            </oemconfig>
         </type>
     </preferences>
     <preferences profiles="PhysicalBSZ_512">
         <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install">
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
+            <oemconfig>
+                <oem-unattended>true</oem-unattended>
+            </oemconfig>
         </type>
     </preferences>
     <users>

--- a/build-tests/ppc/sle15/test-image-disk/appliance.kiwi
+++ b/build-tests/ppc/sle15/test-image-disk/appliance.kiwi
@@ -27,12 +27,12 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <preferences profiles="PhysicalBSZ_4096">
         <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install" target_blocksize="4096">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-unattended>true</oem-unattended>
             </oemconfig>
@@ -40,7 +40,7 @@
     </preferences>
     <preferences profiles="PhysicalBSZ_512">
         <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-unattended>true</oem-unattended>
             </oemconfig>

--- a/build-tests/ppc/tumbleweed/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/ppc/tumbleweed/test-image-disk-simple/appliance.kiwi
@@ -18,7 +18,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/ppc/tumbleweed/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/ppc/tumbleweed/test-image-disk-simple/appliance.kiwi
@@ -18,7 +18,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/ppc/tumbleweed/test-image-disk/appliance.kiwi
+++ b/build-tests/ppc/tumbleweed/test-image-disk/appliance.kiwi
@@ -23,7 +23,7 @@
     </preferences>
     <preferences profiles="PhysicalBSZ_4096">
         <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install" target_blocksize="4096">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-unattended>true</oem-unattended>
             </oemconfig>
@@ -31,7 +31,7 @@
     </preferences>
     <preferences profiles="PhysicalBSZ_512">
         <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-unattended>true</oem-unattended>
             </oemconfig>

--- a/build-tests/ppc/tumbleweed/test-image-disk/appliance.kiwi
+++ b/build-tests/ppc/tumbleweed/test-image-disk/appliance.kiwi
@@ -23,12 +23,18 @@
     </preferences>
     <preferences profiles="PhysicalBSZ_4096">
         <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install" target_blocksize="4096">
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
+            <oemconfig>
+                <oem-unattended>true</oem-unattended>
+            </oemconfig>
         </type>
     </preferences>
     <preferences profiles="PhysicalBSZ_512">
         <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="ofw" installiso="true" installboot="install">
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
+            <oemconfig>
+                <oem-unattended>true</oem-unattended>
+            </oemconfig>
         </type>
     </preferences>
     <users>

--- a/build-tests/s390/sle15/test-image-disk/appliance.kiwi
+++ b/build-tests/s390/sle15/test-image-disk/appliance.kiwi
@@ -27,12 +27,12 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2_s390x_emu" console="serial" timeout="2"/>
+            <bootloader name="grub2_s390x_emu" console="serial" timeout="10"/>
         </type>
     </preferences>
     <preferences profiles="Physical_DASD">
         <type image="oem" filesystem="xfs" kernelcmdline="console=ttyS0 dasd_mod.dasd=ipldev" bootpartition="true" bootfilesystem="ext3" target_blocksize="4096">
-            <bootloader name="grub2_s390x_emu" console="serial" targettype="CDL" timeout="2"/>
+            <bootloader name="grub2_s390x_emu" console="serial" targettype="CDL" timeout="10"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>512</oem-swapsize>
@@ -41,7 +41,7 @@
     </preferences>
     <preferences profiles="Physical_FBA">
         <type image="oem" filesystem="xfs" kernelcmdline="console=ttyS0" bootpartition="true" bootfilesystem="ext3">
-            <bootloader name="grub2_s390x_emu" console="serial" targettype="FBA" timeout="2"/>
+            <bootloader name="grub2_s390x_emu" console="serial" targettype="FBA" timeout="10"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>512</oem-swapsize>

--- a/build-tests/s390/sle15/test-image-disk/appliance.kiwi
+++ b/build-tests/s390/sle15/test-image-disk/appliance.kiwi
@@ -27,12 +27,12 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2_s390x_emu" console="serial"/>
+            <bootloader name="grub2_s390x_emu" console="serial" timeout="2"/>
         </type>
     </preferences>
     <preferences profiles="Physical_DASD">
         <type image="oem" filesystem="xfs" kernelcmdline="console=ttyS0 dasd_mod.dasd=ipldev" bootpartition="true" bootfilesystem="ext3" target_blocksize="4096">
-            <bootloader name="grub2_s390x_emu" console="serial" targettype="CDL"/>
+            <bootloader name="grub2_s390x_emu" console="serial" targettype="CDL" timeout="2"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>512</oem-swapsize>
@@ -41,7 +41,7 @@
     </preferences>
     <preferences profiles="Physical_FBA">
         <type image="oem" filesystem="xfs" kernelcmdline="console=ttyS0" bootpartition="true" bootfilesystem="ext3">
-            <bootloader name="grub2_s390x_emu" console="serial" targettype="FBA"/>
+            <bootloader name="grub2_s390x_emu" console="serial" targettype="FBA" timeout="2"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>512</oem-swapsize>

--- a/build-tests/s390/tumbleweed/test-image-disk/appliance.kiwi
+++ b/build-tests/s390/tumbleweed/test-image-disk/appliance.kiwi
@@ -26,12 +26,12 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2_s390x_emu" console="serial"/>
+            <bootloader name="grub2_s390x_emu" console="serial" timeout="2"/>
         </type>
     </preferences>
     <preferences profiles="Physical">
         <type image="oem" filesystem="xfs" kernelcmdline="console=ttyS0 dasd_mod.dasd=ipldev" bootpartition="true" bootfilesystem="ext3" target_blocksize="4096">
-            <bootloader name="grub2_s390x_emu" console="serial" targettype="CDL"/>
+            <bootloader name="grub2_s390x_emu" console="serial" targettype="CDL" timeout="2"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>512</oem-swapsize>

--- a/build-tests/s390/tumbleweed/test-image-disk/appliance.kiwi
+++ b/build-tests/s390/tumbleweed/test-image-disk/appliance.kiwi
@@ -26,12 +26,12 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2_s390x_emu" console="serial" timeout="2"/>
+            <bootloader name="grub2_s390x_emu" console="serial" timeout="10"/>
         </type>
     </preferences>
     <preferences profiles="Physical">
         <type image="oem" filesystem="xfs" kernelcmdline="console=ttyS0 dasd_mod.dasd=ipldev" bootpartition="true" bootfilesystem="ext3" target_blocksize="4096">
-            <bootloader name="grub2_s390x_emu" console="serial" targettype="CDL" timeout="2"/>
+            <bootloader name="grub2_s390x_emu" console="serial" targettype="CDL" timeout="10"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>512</oem-swapsize>

--- a/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
+++ b/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
@@ -50,8 +50,11 @@
              grub.cfg file. This hotpatch only applies for disk images
              therefore the installation ISO does not support EFI
         -->
-        <type image="oem" filesystem="ext4" installiso="true" kernelcmdline="console=ttyS0" editbootinstall="editbootinstall_arch.sh" firmware="efi">
-            <bootloader name="grub2" console="serial"/>
+        <type image="oem" filesystem="ext4" installiso="true" installboot="install" kernelcmdline="console=ttyS0" editbootinstall="editbootinstall_arch.sh" firmware="efi">
+            <bootloader name="grub2" console="serial" timeout="2"/>
+            <oemconfig>
+                <oem-unattended>true</oem-unattended>
+            </oemconfig>
         </type>
     </preferences>
     <preferences profiles="KIS">

--- a/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
+++ b/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
@@ -51,7 +51,7 @@
              therefore the installation ISO does not support EFI
         -->
         <type image="oem" filesystem="ext4" installiso="true" installboot="install" kernelcmdline="console=ttyS0" editbootinstall="editbootinstall_arch.sh" firmware="efi">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-unattended>true</oem-unattended>
             </oemconfig>

--- a/build-tests/x86/centos/test-image-live-disk-v7/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-live-disk-v7/appliance.kiwi
@@ -37,8 +37,8 @@
         </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" filesystem="ext4" installiso="true" firmware="uefi" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial"/>
+        <type image="oem" filesystem="ext4" installiso="true" installboot="install" firmware="uefi" kernelcmdline="console=ttyS0">
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/centos/test-image-live-disk-v7/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-live-disk-v7/appliance.kiwi
@@ -38,7 +38,7 @@
     </preferences>
     <preferences profiles="Disk">
         <type image="oem" filesystem="ext4" installiso="true" installboot="install" firmware="uefi" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/centos/test-image-live-disk-v8/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-live-disk-v8/appliance.kiwi
@@ -37,8 +37,8 @@
         </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" filesystem="ext4" installiso="true" firmware="uefi" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial"/>
+        <type image="oem" filesystem="ext4" installiso="true" installboot="install" firmware="uefi" kernelcmdline="console=ttyS0">
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/centos/test-image-live-disk-v8/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-live-disk-v8/appliance.kiwi
@@ -38,7 +38,7 @@
     </preferences>
     <preferences profiles="Disk">
         <type image="oem" filesystem="ext4" installiso="true" installboot="install" firmware="uefi" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/debian/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/debian/test-image-live-disk/appliance.kiwi
@@ -26,7 +26,7 @@
     </preferences>
     <preferences profiles="Live">
         <type image="iso" flags="overlay" hybridpersistent_filesystem="ext4" hybridpersistent="true" firmware="efi" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <preferences profiles="Virtual">
@@ -34,12 +34,12 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <preferences profiles="Disk">
         <type image="oem" filesystem="ext4" firmware="efi" installiso="true" installboot="install" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/debian/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/debian/test-image-live-disk/appliance.kiwi
@@ -26,7 +26,7 @@
     </preferences>
     <preferences profiles="Live">
         <type image="iso" flags="overlay" hybridpersistent_filesystem="ext4" hybridpersistent="true" firmware="efi" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <preferences profiles="Virtual">
@@ -34,12 +34,12 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" filesystem="ext4" firmware="efi" installiso="true" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial"/>
+        <type image="oem" filesystem="ext4" firmware="efi" installiso="true" installboot="install" kernelcmdline="console=ttyS0">
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
@@ -26,7 +26,7 @@
     </preferences>
     <preferences profiles="Live">
         <type image="iso" flags="overlay" firmware="uefi" hybridpersistent_filesystem="ext4" hybridpersistent="true" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <preferences profiles="Virtual">
@@ -34,12 +34,12 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" filesystem="ext4" installiso="true" firmware="uefi" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial"/>
+        <type image="oem" filesystem="ext4" installiso="true" installboot="install" firmware="uefi" kernelcmdline="console=ttyS0">
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
@@ -26,7 +26,7 @@
     </preferences>
     <preferences profiles="Live">
         <type image="iso" flags="overlay" firmware="uefi" hybridpersistent_filesystem="ext4" hybridpersistent="true" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <preferences profiles="Virtual">
@@ -34,12 +34,12 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <preferences profiles="Disk">
         <type image="oem" filesystem="ext4" installiso="true" installboot="install" firmware="uefi" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/fedora/test-image-microdnf/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-microdnf/appliance.kiwi
@@ -21,7 +21,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/fedora/test-image-microdnf/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-microdnf/appliance.kiwi
@@ -21,7 +21,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/leap/test-image-custom-partitions/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-custom-partitions/appliance.kiwi
@@ -25,7 +25,7 @@
                 <oem-swapsize>512</oem-swapsize>
                 <oem-device-filter>/dev/ram</oem-device-filter>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/leap/test-image-custom-partitions/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-custom-partitions/appliance.kiwi
@@ -18,13 +18,14 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext4" firmware="uefi" spare_part="500M" editbootconfig="custom_partitions_create.sh" editbootinstall="custom_partitions_setup.sh" installiso="true" kernelcmdline="console=ttyS0">
+        <type image="oem" filesystem="ext4" firmware="uefi" spare_part="500M" editbootconfig="custom_partitions_create.sh" editbootinstall="custom_partitions_setup.sh" installiso="true" installboot="install" kernelcmdline="console=ttyS0">
             <oemconfig>
+                <oem-unattended>true</oem-unattended>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>512</oem-swapsize>
                 <oem-device-filter>/dev/ram</oem-device-filter>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/leap/test-image-disk-ramdisk/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-disk-ramdisk/appliance.kiwi
@@ -18,7 +18,7 @@
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" filesystem="ext4" firmware="uefi" installiso="true" installboot="install" kernelcmdline="rd.kiwi.ramdisk ramdisk_size=2192000 console=ttyS0">
             <size unit="G">2</size>
-            <bootloader name="grub2" console="serial" timeout="1"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <oemconfig>
                 <oem-skip-verify>true</oem-skip-verify>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/leap/test-image-disk-ramdisk/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-disk-ramdisk/appliance.kiwi
@@ -18,7 +18,7 @@
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" filesystem="ext4" firmware="uefi" installiso="true" installboot="install" kernelcmdline="rd.kiwi.ramdisk ramdisk_size=2192000 console=ttyS0">
             <size unit="G">2</size>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-skip-verify>true</oem-skip-verify>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/leap/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-disk-simple/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/leap/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-disk-simple/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/leap/test-image-disk/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-disk/appliance.kiwi
@@ -17,7 +17,7 @@
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" filesystem="btrfs" kernelcmdline="console=ttyS0" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true" installboot="install">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-unattended>true</oem-unattended>
                 <oem-swapsize>1024</oem-swapsize>

--- a/build-tests/x86/leap/test-image-disk/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-disk/appliance.kiwi
@@ -17,7 +17,7 @@
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" filesystem="btrfs" kernelcmdline="console=ttyS0" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true" installboot="install">
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <oemconfig>
                 <oem-unattended>true</oem-unattended>
                 <oem-swapsize>1024</oem-swapsize>

--- a/build-tests/x86/leap/test-image-live/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-live/appliance.kiwi
@@ -17,7 +17,7 @@
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="iso" flags="overlay" firmware="efi" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="true">
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/leap/test-image-live/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-live/appliance.kiwi
@@ -17,7 +17,7 @@
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="iso" flags="overlay" firmware="efi" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="true">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/leap/test-image-luks/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-luks/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/leap/test-image-luks/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-luks/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/leap/test-image-lvm/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-lvm/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <systemdisk>
                 <volume name="home"/>
             </systemdisk>

--- a/build-tests/x86/leap/test-image-lvm/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-lvm/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <systemdisk>
                 <volume name="home"/>
             </systemdisk>

--- a/build-tests/x86/leap/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-overlayroot/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <size unit="G">4</size>
         </type>
     </preferences>

--- a/build-tests/x86/leap/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-overlayroot/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <size unit="G">4</size>
         </type>
     </preferences>

--- a/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
@@ -26,7 +26,7 @@
     </preferences>
     <preferences profiles="Live">
         <type image="iso" flags="overlay" firmware="uefi" hybridpersistent_filesystem="ext4" hybridpersistent="true" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <preferences profiles="Virtual">
@@ -34,12 +34,12 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" filesystem="ext4" installiso="true" firmware="uefi" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial"/>
+        <type image="oem" filesystem="ext4" installiso="true" installboot="install" firmware="uefi" kernelcmdline="console=ttyS0">
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
@@ -26,7 +26,7 @@
     </preferences>
     <preferences profiles="Live">
         <type image="iso" flags="overlay" firmware="uefi" hybridpersistent_filesystem="ext4" hybridpersistent="true" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <preferences profiles="Virtual">
@@ -34,12 +34,12 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <preferences profiles="Disk">
         <type image="oem" filesystem="ext4" installiso="true" installboot="install" firmware="uefi" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/rawhide/test-image-microdnf/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-microdnf/appliance.kiwi
@@ -21,7 +21,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/rawhide/test-image-microdnf/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-microdnf/appliance.kiwi
@@ -21,7 +21,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/tumbleweed/test-image-MicroOS/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-MicroOS/appliance.kiwi
@@ -12,11 +12,12 @@
         <bootloader-theme>openSUSE</bootloader-theme>
         <rpm-excludedocs>true</rpm-excludedocs>
         <locale>en_US</locale>
-        <type image="oem" filesystem="btrfs" firmware="uefi" installiso="true" kernelcmdline="quiet systemd.show_status=yes console=ttyS0,115200 console=tty0 net.ifnames=0 \$ignition_firstboot ignition.platform.id=qemu" bootpartition="false" bootkernel="custom" devicepersistency="by-uuid" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true" btrfs_quota_groups="true" format="qcow2" spare_part="5G" spare_part_mountpoint="/var" spare_part_fs="btrfs" spare_part_is_last="true" spare_part_fs_attributes="no-copy-on-write">
+        <type image="oem" filesystem="btrfs" firmware="uefi" installiso="true" installboot="install" kernelcmdline="quiet systemd.show_status=yes console=ttyS0,115200 console=tty0 net.ifnames=0 \$ignition_firstboot ignition.platform.id=qemu" bootpartition="false" bootkernel="custom" devicepersistency="by-uuid" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true" btrfs_quota_groups="true" format="qcow2" spare_part="5G" spare_part_mountpoint="/var" spare_part_fs="btrfs" spare_part_is_last="true" spare_part_fs_attributes="no-copy-on-write">
             <oemconfig>
+                <oem-unattended>true</oem-unattended>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <systemdisk>
                 <volume name="home"/>
                 <volume name="root"/>

--- a/build-tests/x86/tumbleweed/test-image-MicroOS/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-MicroOS/appliance.kiwi
@@ -17,7 +17,7 @@
                 <oem-unattended>true</oem-unattended>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <systemdisk>
                 <volume name="home"/>
                 <volume name="root"/>

--- a/build-tests/x86/tumbleweed/test-image-azure/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-azure/appliance.kiwi
@@ -11,7 +11,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <size unit="M">30720</size>
         </type>
         <version>1.0.5</version>

--- a/build-tests/x86/tumbleweed/test-image-azure/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-azure/appliance.kiwi
@@ -11,7 +11,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <size unit="M">30720</size>
         </type>
         <version>1.0.5</version>

--- a/build-tests/x86/tumbleweed/test-image-custom-partitions/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-custom-partitions/appliance.kiwi
@@ -25,7 +25,7 @@
                 <oem-swapsize>512</oem-swapsize>
                 <oem-device-filter>/dev/ram</oem-device-filter>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/tumbleweed/test-image-custom-partitions/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-custom-partitions/appliance.kiwi
@@ -18,13 +18,14 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext4" firmware="uefi" spare_part="500M" editbootconfig="custom_partitions_create.sh" editbootinstall="custom_partitions_setup.sh" installiso="true" kernelcmdline="console=ttyS0">
+        <type image="oem" filesystem="ext4" firmware="uefi" spare_part="500M" editbootconfig="custom_partitions_create.sh" editbootinstall="custom_partitions_setup.sh" installiso="true" installboot="install" kernelcmdline="console=ttyS0">
             <oemconfig>
+                <oem-unattended>true</oem-unattended>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>512</oem-swapsize>
                 <oem-device-filter>/dev/ram</oem-device-filter>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/tumbleweed/test-image-disk-legacy/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-legacy/appliance.kiwi
@@ -17,8 +17,9 @@
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" filesystem="btrfs" initrd_system="kiwi" boot="oemboot/suse-tumbleweed" kernelcmdline="console=ttyS0" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true" installboot="install">
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <oemconfig>
+                <oem-unattended>true</oem-unattended>
                 <oem-swapsize>1024</oem-swapsize>
                 <oem-multipath-scan>false</oem-multipath-scan>
             </oemconfig>

--- a/build-tests/x86/tumbleweed/test-image-disk-legacy/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-legacy/appliance.kiwi
@@ -17,7 +17,7 @@
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" filesystem="btrfs" initrd_system="kiwi" boot="oemboot/suse-tumbleweed" kernelcmdline="console=ttyS0" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true" installboot="install">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-unattended>true</oem-unattended>
                 <oem-swapsize>1024</oem-swapsize>

--- a/build-tests/x86/tumbleweed/test-image-disk-ramdisk/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-ramdisk/appliance.kiwi
@@ -18,7 +18,7 @@
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" filesystem="ext4" firmware="uefi" installiso="true" installboot="install" kernelcmdline="rd.kiwi.ramdisk ramdisk_size=2192000 console=ttyS0">
             <size unit="G">2</size>
-            <bootloader name="grub2" console="serial" timeout="1"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <oemconfig>
                 <oem-skip-verify>true</oem-skip-verify>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/tumbleweed/test-image-disk-ramdisk/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-ramdisk/appliance.kiwi
@@ -18,7 +18,7 @@
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" filesystem="ext4" firmware="uefi" installiso="true" installboot="install" kernelcmdline="rd.kiwi.ramdisk ramdisk_size=2192000 console=ttyS0">
             <size unit="G">2</size>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-skip-verify>true</oem-skip-verify>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/tumbleweed/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-simple/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/tumbleweed/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-simple/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/tumbleweed/test-image-disk/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk/appliance.kiwi
@@ -17,7 +17,7 @@
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" filesystem="btrfs" kernelcmdline="console=ttyS0" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true" installboot="install">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-unattended>true</oem-unattended>
                 <oem-swapsize>1024</oem-swapsize>

--- a/build-tests/x86/tumbleweed/test-image-disk/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk/appliance.kiwi
@@ -17,7 +17,7 @@
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" filesystem="btrfs" kernelcmdline="console=ttyS0" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true" installboot="install">
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <oemconfig>
                 <oem-unattended>true</oem-unattended>
                 <oem-swapsize>1024</oem-swapsize>

--- a/build-tests/x86/tumbleweed/test-image-ec2/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-ec2/appliance.kiwi
@@ -11,7 +11,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" timeout="1" console="serial"/>
+            <bootloader name="grub2" timeout="2" console="serial"/>
             <size unit="M">10240</size>
             <machine xen_loader="pvgrub"/>
         </type>

--- a/build-tests/x86/tumbleweed/test-image-ec2/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-ec2/appliance.kiwi
@@ -11,7 +11,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" timeout="2" console="serial"/>
+            <bootloader name="grub2" timeout="10" console="serial"/>
             <size unit="M">10240</size>
             <machine xen_loader="pvgrub"/>
         </type>

--- a/build-tests/x86/tumbleweed/test-image-gce/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-gce/appliance.kiwi
@@ -11,7 +11,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" timeout="2" console="serial"/>
+            <bootloader name="grub2" timeout="10" console="serial"/>
             <size unit="M">10240</size>
         </type>
         <version>1.0.17</version>

--- a/build-tests/x86/tumbleweed/test-image-gce/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-gce/appliance.kiwi
@@ -11,7 +11,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" timeout="1" console="serial"/>
+            <bootloader name="grub2" timeout="2" console="serial"/>
             <size unit="M">10240</size>
         </type>
         <version>1.0.17</version>

--- a/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
@@ -17,7 +17,7 @@
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="iso" flags="overlay" firmware="efi" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="true">
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
@@ -17,7 +17,7 @@
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="iso" flags="overlay" firmware="efi" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="true">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/tumbleweed/test-image-lvm/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-lvm/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <systemdisk>
                 <volume name="home"/>
             </systemdisk>

--- a/build-tests/x86/tumbleweed/test-image-lvm/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-lvm/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <systemdisk>
                 <volume name="home"/>
             </systemdisk>

--- a/build-tests/x86/tumbleweed/test-image-orthos/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-orthos/appliance.kiwi
@@ -14,7 +14,7 @@
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <type image="oem" filesystem="btrfs" kernelcmdline="console=ttyS0" firmware="efi" installpxe="true">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-skip-verify>true</oem-skip-verify>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/tumbleweed/test-image-orthos/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-orthos/appliance.kiwi
@@ -14,7 +14,7 @@
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <type image="oem" filesystem="btrfs" kernelcmdline="console=ttyS0" firmware="efi" installpxe="true">
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <oemconfig>
                 <oem-skip-verify>true</oem-skip-verify>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <size unit="G">4</size>
         </type>
     </preferences>

--- a/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <size unit="G">4</size>
         </type>
     </preferences>

--- a/build-tests/x86/tumbleweed/test-image-qcow-openstack/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-qcow-openstack/appliance.kiwi
@@ -11,7 +11,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" timeout="1" console="serial gfxterm"/>
+            <bootloader name="grub2" timeout="2" console="serial gfxterm"/>
             <size unit="M">10240</size>
         </type>
         <version>0.3.10</version>

--- a/build-tests/x86/tumbleweed/test-image-qcow-openstack/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-qcow-openstack/appliance.kiwi
@@ -11,7 +11,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" timeout="2" console="serial gfxterm"/>
+            <bootloader name="grub2" timeout="10" console="serial gfxterm"/>
             <size unit="M">10240</size>
         </type>
         <version>0.3.10</version>

--- a/build-tests/x86/tumbleweed/test-image-suse-on-dnf/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-suse-on-dnf/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/tumbleweed/test-image-suse-on-dnf/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-suse-on-dnf/appliance.kiwi
@@ -20,7 +20,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <users>

--- a/build-tests/x86/ubuntu/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/ubuntu/test-image-live-disk/appliance.kiwi
@@ -26,7 +26,7 @@
     </preferences>
     <preferences profiles="Live">
         <type image="iso" flags="overlay" hybridpersistent_filesystem="ext4" hybridpersistent="true" firmware="efi" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <preferences profiles="Virtual">
@@ -34,12 +34,12 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <preferences profiles="Disk">
         <type image="oem" filesystem="ext4" installiso="true" installboot="install" firmware="efi" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial" timeout="2"/>
+            <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-unattended>true</oem-unattended>

--- a/build-tests/x86/ubuntu/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/ubuntu/test-image-live-disk/appliance.kiwi
@@ -26,7 +26,7 @@
     </preferences>
     <preferences profiles="Live">
         <type image="iso" flags="overlay" hybridpersistent_filesystem="ext4" hybridpersistent="true" firmware="efi" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <preferences profiles="Virtual">
@@ -34,12 +34,12 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial"/>
+            <bootloader name="grub2" console="serial" timeout="2"/>
         </type>
     </preferences>
     <preferences profiles="Disk">
-        <type image="oem" filesystem="ext4" installiso="true" firmware="efi" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial"/>
+        <type image="oem" filesystem="ext4" installiso="true" installboot="install" firmware="efi" kernelcmdline="console=ttyS0">
+            <bootloader name="grub2" console="serial" timeout="2"/>
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-unattended>true</oem-unattended>


### PR DESCRIPTION
Some integration tests allows for interactive dialogs on the
bootloader menu or in the installation process. As we plan to
use these tests for automated functional testing there should
be no interaction whenever possible. This Fixes #1811

