### PR TITLE
Fix blocking of verification dialog

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
@@ -34,6 +34,7 @@ function run_progress_dialog {
     # Run the gauge dialog via systemd reading progress
     # status information from stdin
     # """
+    stop_plymouth
     declare fifo=${current_progress_fifo}
     local title=$1
     local backtitle=$2


### PR DESCRIPTION
Fixed blocking of progress dialog
    
When starting a progress dialog it must be sure that the fifo
has data to read PRIOR the progress dialog to start, otherwise
there is a blocking condition which still stop the deployment
and never succeeds

Skip verification process for CentOS8
    
On this distribution we run into a console blocking issue
which I have no good explanation for and only seen on
CentOS8. If the console ist not set to ttyS0 or the
multiple consoles (ttyS0, tty0) are configured the issue
is gone. But with only the serial console enabled the
verification fails because the dialog cannot be displayed
for still unknown reasons.

