### PR TITLE
Make dracut version check more robust

### DIFF
--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -101,9 +101,8 @@ class RuntimeChecker:
                         message.format(repo_source)
                     )
 
-    def check_target_directory_not_in_shared_cache(
-        self, target_dir: str
-    ) -> None:
+    @staticmethod
+    def check_target_directory_not_in_shared_cache(target_dir: str) -> None:
         """
         The target directory must be outside of the kiwi shared cache
         directory in order to avoid busy mounts because kiwi bind mounts


### PR DESCRIPTION
The ```check_dracut_module_versions_compatible_to_kiwi()``` runtime check calls the package manager from the host and reads the package database from the image root. Doing this requires the package database in the image to be compatible with the package manager on the host.

However this cannot be guaranteed and it is more robust to chroot into the image root and call the package manager from there. However, this change also comes with the cost that it's required to have a package manager available in the image root tree. 

Therefore along with the chroot based call, eventual exceptions from the call are now catched and leads to a debug message in the log file but will not lead the runtime check to fail. I consider the cases without a package database inside of the image to be less critical than the incompatibility issue between the host tooling and the package database in the image.

This Fixes bsc#1185937

