### PR TITLE
Add log information on grub search

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -643,6 +643,7 @@ class Defaults:
 
         :rtype: str
         """
+        log.debug(f'Searching grub file: {filename}')
         install_dirs = [
             'usr/share', 'usr/lib'
         ]
@@ -652,7 +653,9 @@ class Defaults:
                 grub_path = os.path.join(
                     root_path, install_dir, grub_name, filename
                 )
+                log.debug(f'--> {grub_path}')
                 if os.path.exists(grub_path):
+                    log.debug(f'--> Found in: {grub_path}')
                     return grub_path
                 lookup_list.append(grub_path)
         if raise_on_error:


### PR DESCRIPTION
There is a method in kiwi which searches for grub files.
As grub is packaged differently within the distributions
a dynamic lookup is needed. However, the result and where
kiwi looked it up was not part of the log file. In terms
of issues like the one from Issue #1754 it would be very
handy to know about this information. Thus this commit
adds debug information to the log file regarding what
grub files are searched and where and if found

