### PR TITLE
Do not return default stdout if it is no raising on failure

### DIFF
--- a/kiwi/command.py
+++ b/kiwi/command.py
@@ -120,11 +120,11 @@ class Command:
                 '%s: %s: %s' % (command[0], type(e).__name__, format(e))
             )
         output, error = process.communicate()
-        if process.returncode != 0 and not error:
-            error = bytes(b'(no output on stderr)')
-        if process.returncode != 0 and not output:
-            output = bytes(b'(no output on stdout)')
         if process.returncode != 0 and raise_on_error:
+            if not error:
+                error = bytes(b'(no output on stderr)')
+            if not output:
+                output = bytes(b'(no output on stdout)')
             log.debug(
                 'EXEC: Failed with stderr: {0}, stdout: {1}'.format(
                     Codec.decode(error), Codec.decode(output)

--- a/test/unit/command_test.py
+++ b/test/unit/command_test.py
@@ -19,7 +19,7 @@ class TestCommand:
         mock_which.return_value = 'command'
         mock_process = mock.Mock()
         mock_process.communicate = mock.Mock(
-            return_value=[str.encode('stdout'), str.encode('stderr')]
+            return_value=[str.encode(''), str.encode('')]
         )
         mock_process.returncode = 1
         mock_popen.return_value = mock_process
@@ -49,7 +49,7 @@ class TestCommand:
         mock_process.returncode = 1
         mock_popen.return_value = mock_process
         result = Command.run(['command', 'args'], os.environ, False)
-        assert result.error == '(no output on stderr)'
+        assert result.error == ''
         assert result.output == 'stdout'
 
     @patch('kiwi.path.Path.which')


### PR DESCRIPTION
This commit prevents the use of a default stdout and stderr in case
return code reports errors and it is not raising an exception.

If we are not raising an exception there is no specific need to
artificially append some stdout and stderr default message, we just
behave as if there was no error.
