### PR TITLE
Fix installation of man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ install:
 	${MAKE} -C tools buildroot=${buildroot} install
 	# manual pages
 	install -d -m 755 ${buildroot}usr/share/man/man8
-	for man in doc/build/man/8/*.8; do \
+	for man in doc/build/man/*.8; do \
 		install -m 644 $$man ${buildroot}usr/share/man/man8 ;\
 	done
 	# completion


### PR DESCRIPTION
The generated source archive on PyPI has the man page files
in `./doc/build/man` instead of `./doc/build/man/8`.

Adjust the Makefile to use the correct path to install the
man pages.