### PR TITLE
config/functions.sh: Avoid non-zero exit status

### DIFF
--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -345,7 +345,7 @@ function baseStripDocs {
     "
     for dir in ${directories}; do
         docfiles=$(find "${dir}" -type f |\
-            grep -iv "copying\|license\|copyright")
+            grep -iv "copying\|license\|copyright" || :)
         rm -f "${docfiles}"
     done
     rm -rf /usr/share/info
@@ -714,7 +714,7 @@ function baseStripFirmware {
     mkdir -p /lib/firmware-required
     find "${base}" \( -name "*.ko" -o -name "*.ko.xz" \) -print0 | \
     while IFS= read -r -d $'\0' kernel_module; do
-        firmware=$(modinfo "${kernel_module}" | grep ^firmware)
+        firmware=$(modinfo "${kernel_module}" | grep ^firmware || :)
         if [ -z "${firmware}" ];then
             continue
         fi


### PR DESCRIPTION
Changes proposed in this pull request:

* In baseStripDocs and baseStripFirmware avoid non-zero exit status of grep. This allows the functions to be used in a script that sets the exit-on-error flag.
