### PR TITLE
Added support for skipping initrd creation

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -557,8 +557,12 @@ hybridpersistent_filesystem="ext4|xfs":
   writing if a hybrid image is used as disk on e.g a USB Stick.
   By default the ext4 filesystem is used.
 
-initrd_system="kiwi|dracut":
-  Specify which initrd builder to use, default is set to `dracut`
+initrd_system="kiwi|dracut|none":
+  Specify which initrd builder to use, default is set to `dracut`.
+  If set to `none` the image is build without an initrd. Depending
+  on the image type this can lead to a non bootable system as its
+  now a kernel responsibility if the given root device can be
+  mounted or not.
 
 metadata_path="dir_path":
   Specifies a path to additional metadata required for the selected

--- a/kiwi/boot/image/__init__.py
+++ b/kiwi/boot/image/__init__.py
@@ -44,7 +44,7 @@ class BootImage(metaclass=ABCMeta):
     @staticmethod
     def new(
         xml_state: XMLState, target_dir: str,
-        root_dir: str=None, signing_keys: List=None  # noqa: E252
+        root_dir: str = None, signing_keys: List = None
     ):
         initrd_system = xml_state.get_initrd_system()
         name_map = {

--- a/kiwi/boot/image/__init__.py
+++ b/kiwi/boot/image/__init__.py
@@ -49,7 +49,8 @@ class BootImage(metaclass=ABCMeta):
         initrd_system = xml_state.get_initrd_system()
         name_map = {
             'kiwi': {'builtin_kiwi': 'BootImageKiwi'},
-            'dracut': {'dracut': 'BootImageDracut'}
+            'dracut': {'dracut': 'BootImageDracut'},
+            'none': {'base': 'BootImageBase'}
         }
         try:
             (boot_image_namespace, boot_image_name) = \

--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -83,6 +83,15 @@ class BootImageBase:
         """
         pass
 
+    def has_initrd_support(self) -> bool:
+        """
+        Indicates if this instance supports actual creation of an initrd
+
+        The method needs to be overwritten by the subclass
+        implementing preparation and creation of an initrd
+        """
+        return False
+
     def include_file(self, filename, install_media=False):
         """
         Include file to boot image

--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -103,7 +103,8 @@ class BootImageBase:
         """
         pass
 
-    def has_initrd_support(self) -> bool:
+    @staticmethod
+    def has_initrd_support() -> bool:
         """
         Indicates if this instance supports actual creation of an initrd
 

--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -45,7 +45,8 @@ class BootImageKiwi(BootImageBase):
     to control the first boot an appliance. The kiwi initrd replaces
     itself after first boot by the result of dracut.
     """
-    def has_initrd_support(self) -> bool:
+    @staticmethod
+    def has_initrd_support() -> bool:
         """
         This instance supports initrd preparation and creation
         """

--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -41,6 +41,12 @@ class BootImageKiwi(BootImageBase):
     to control the first boot an appliance. The kiwi initrd replaces
     itself after first boot by the result of dracut.
     """
+    def has_initrd_support(self) -> bool:
+        """
+        This instance supports initrd preparation and creation
+        """
+        return True
+
     def post_init(self):
         """
         Post initialization method

--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -37,7 +37,8 @@ class BootImageDracut(BootImageBase):
     """
     **Implements creation of dracut boot(initrd) images.**
     """
-    def has_initrd_support(self) -> bool:
+    @staticmethod
+    def has_initrd_support() -> bool:
         """
         This instance supports initrd preparation and creation
         """

--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -33,6 +33,12 @@ class BootImageDracut(BootImageBase):
     """
     **Implements creation of dracut boot(initrd) images.**
     """
+    def has_initrd_support(self) -> bool:
+        """
+        This instance supports initrd preparation and creation
+        """
+        return True
+
     def post_init(self):
         """
         Post initialization method

--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -17,6 +17,9 @@
 #
 import os
 import logging
+from typing import (
+    List, Optional, Dict
+)
 
 # project
 from kiwi.command import Command
@@ -25,6 +28,7 @@ from kiwi.boot.image.base import BootImageBase
 from kiwi.defaults import Defaults
 from kiwi.system.profile import Profile
 from kiwi.system.setup import SystemSetup
+from kiwi.system.identifier import SystemIdentifier
 
 log = logging.getLogger('kiwi')
 
@@ -39,7 +43,7 @@ class BootImageDracut(BootImageBase):
         """
         return True
 
-    def post_init(self):
+    def post_init(self) -> None:
         """
         Post initialization method
 
@@ -52,28 +56,28 @@ class BootImageDracut(BootImageBase):
         self.signing_keys = None
 
         # Initialize empty list of dracut caller options
-        self.dracut_options = []
-        self.included_files = []
-        self.modules = []
-        self.add_modules = []
-        self.omit_modules = []
+        self.dracut_options: List[str] = []
+        self.included_files: List[str] = []
+        self.modules: List[str] = []
+        self.add_modules: List[str] = []
+        self.omit_modules: List[str] = []
         self.available_modules = self._get_modules()
 
-    def include_file(self, filename, install_media=False):
+    def include_file(self, filename: str, install_media: bool = False) -> None:
         """
         Include file to dracut boot image
 
-        :param string filename: file path name
+        :param str filename: file path name
         :param bool install_media: unused
         """
         self.included_files.append('--install')
         self.included_files.append(filename)
 
-    def include_module(self, module, install_media=False):
+    def include_module(self, module: str, install_media: bool = False) -> None:
         """
         Include module to dracut boot image
 
-        :param string module: module to include
+        :param str module: module to include
         :param bool install_media: unused
         """
         warn_msg = 'module "{0}" not included in initrd'.format(module)
@@ -83,17 +87,19 @@ class BootImageDracut(BootImageBase):
         else:
             log.warning(warn_msg)
 
-    def omit_module(self, module, install_media=False):
+    def omit_module(self, module: str, install_media: bool = False) -> None:
         """
         Omit module to dracut boot image
 
-        :param string module: module to omit
+        :param str module: module to omit
         :param bool install_media: unused
         """
         if module not in self.omit_modules:
             self.omit_modules.append(module)
 
-    def set_static_modules(self, modules, install_media=False):
+    def set_static_modules(
+        self, modules: List[str], install_media: bool = False
+    ) -> None:
         """
         Set static dracut modules list for boot image
 
@@ -102,12 +108,14 @@ class BootImageDracut(BootImageBase):
         """
         self.modules = modules
 
-    def write_system_config_file(self, config, config_file=None):
+    def write_system_config_file(
+        self, config: Dict, config_file: Optional[str] = None
+    ) -> None:
         """
         Writes modules configuration into a dracut configuration file.
 
         :param dict config: a dictionary containing the modules to add and omit
-        :param string conf_file: configuration file to write
+        :param str conf_file: configuration file to write
         """
         dracut_config = []
         if not config_file:
@@ -134,11 +142,11 @@ class BootImageDracut(BootImageBase):
                     ' '.join(config['install_items'])
                 )
             )
-        if dracut_config:
-            with open(config_file, 'w') as config:
-                config.writelines(dracut_config)
+        if dracut_config and config_file:
+            with open(config_file, 'w') as config_handle:
+                config_handle.writelines(dracut_config)
 
-    def prepare(self):
+    def prepare(self) -> None:
         """
         Prepare dracut caller environment
 
@@ -151,14 +159,17 @@ class BootImageDracut(BootImageBase):
         self.dracut_options.append('--install')
         self.dracut_options.append('/.profile')
 
-    def create_initrd(self, mbrid=None, basename=None, install_initrd=False):
+    def create_initrd(
+        self, mbrid: Optional[SystemIdentifier] = None,
+        basename: Optional[str] = None, install_initrd: bool = False
+    ) -> None:
         """
         Create kiwi .profile environment to be included in dracut initrd.
         Call dracut as chroot operation to create the initrd and move
         the result into the image build target directory
 
-        :param object mbrid: unused
-        :param string basename: base initrd file name
+        :param SystemIdentifier mbrid: unused
+        :param str basename: base initrd file name
         :param bool install_initrd: unused
         """
         if self.is_prepared():
@@ -182,19 +193,20 @@ class BootImageDracut(BootImageBase):
             ] if self.omit_modules else []
             dracut_initrd_basename += '.xz'
             options = self.dracut_options + modules_args + included_files
-            dracut_call = Command.run(
-                [
-                    'chroot', self.boot_root_directory,
-                    'dracut', '--verbose',
-                    '--no-hostonly',
-                    '--no-hostonly-cmdline',
-                    '--xz'
-                ] + options + [
-                    dracut_initrd_basename,
-                    kernel_details.version
-                ],
-                stderr_to_stdout=True
-            )
+            if kernel_details:
+                dracut_call = Command.run(
+                    [
+                        'chroot', self.boot_root_directory,
+                        'dracut', '--verbose',
+                        '--no-hostonly',
+                        '--no-hostonly-cmdline',
+                        '--xz'
+                    ] + options + [
+                        dracut_initrd_basename,
+                        kernel_details.version
+                    ],
+                    stderr_to_stdout=True
+                )
             log.debug(dracut_call.output)
             Command.run(
                 [
@@ -209,7 +221,7 @@ class BootImageDracut(BootImageBase):
                 [self.target_dir, dracut_initrd_basename]
             )
 
-    def _get_modules(self):
+    def _get_modules(self) -> List[str]:
         cmd = Command.run(
             [
                 'chroot', self.boot_root_directory,
@@ -218,14 +230,14 @@ class BootImageDracut(BootImageBase):
         )
         return cmd.output.splitlines()
 
-    def _module_available(self, module):
+    def _module_available(self, module: str) -> bool:
         warn_msg = 'dracut module "{0}" not found in the root tree'
         if module in self.available_modules:
             return True
         log.warning(warn_msg.format(module))
         return False
 
-    def _create_profile_environment(self):
+    def _create_profile_environment(self) -> None:
         profile = Profile(self.xml_state)
         defaults = Defaults()
         defaults.to_profile(profile)

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1594,15 +1594,14 @@ div {
             sch:param [ name = "types" value = "oem" ]
         ]
     k.type.initrd_system.attribute =
-        ## specify which initrd builder to use, default is kiwi's
-        ## builtin architecture. Be aware that the dracut initrd
-        ## system does not support all features of the kiwi initrd
+        ## specify which initrd builder to use, default is dracut
+        ## initrd architecture.
         attribute initrd_system {
-            "kiwi" | "dracut"
+            "kiwi" | "dracut" | "none"
         }
         >> sch:pattern [ id = "initrd_system" is-a = "image_type"
             sch:param [ name = "attr" value = "initrd_system" ]
-            sch:param [ name = "types" value = "oem pxe" ]
+            sch:param [ name = "types" value = "oem pxe kis" ]
         ]
     k.type.image.attribute =
         ## Specifies the image type

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2332,17 +2332,17 @@ create a hybrid GPT/MBR partition table</a:documentation>
     </define>
     <define name="k.type.initrd_system.attribute">
       <attribute name="initrd_system">
-        <a:documentation>specify which initrd builder to use, default is kiwi's
-builtin architecture. Be aware that the dracut initrd
-system does not support all features of the kiwi initrd</a:documentation>
+        <a:documentation>specify which initrd builder to use, default is dracut
+initrd architecture.</a:documentation>
         <choice>
           <value>kiwi</value>
           <value>dracut</value>
+          <value>none</value>
         </choice>
       </attribute>
       <sch:pattern id="initrd_system" is-a="image_type">
         <sch:param name="attr" value="initrd_system"/>
-        <sch:param name="types" value="oem pxe"/>
+        <sch:param name="types" value="oem pxe kis"/>
       </sch:pattern>
     </define>
     <define name="k.type.image.attribute">

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -174,24 +174,28 @@ class XMLState:
 
         Depending on the image type a specific initrd system is
         either pre selected or free of choice according to the
-        XML type setup
+        XML type setup.
 
-        :return: dracut, kiwi or None
+        :return: 'dracut', 'kiwi' or 'none'
 
         :rtype: str
         """
-        if self.get_build_type_name() in ['vmx', 'iso', 'kis']:
-            # vmx, iso and kis image types always use dracut as initrd system
-            initrd_system = 'dracut'
-        elif self.get_build_type_name() == 'pxe':
-            # pxe image type defaults to kiwi if unset
-            initrd_system = self.build_type.get_initrd_system() or 'kiwi'
-        elif self.get_build_type_name() == 'oem':
-            # oem image type defaults to dracut if unset
-            initrd_system = self.build_type.get_initrd_system() or 'dracut'
-        else:
-            initrd_system = self.build_type.get_initrd_system()
-        return initrd_system
+        pre_selection_map = {
+            'vmx': 'dracut',
+            'oem': 'dracut',
+            'iso': 'dracut',
+            'kis': 'dracut',
+            'pxe': 'kiwi',
+        }
+        build_type = self.get_build_type_name()
+        default_initrd_system = pre_selection_map.get(build_type) or 'none'
+
+        if build_type == 'iso':
+            # iso type always use dracut as initrd system
+            return default_initrd_system
+
+        # Allow to choose for any other build type
+        return self.build_type.get_initrd_system() or default_initrd_system
 
     def get_locale(self) -> Optional[List]:
         """

--- a/test/unit/boot/image/base_test.py
+++ b/test/unit/boot/image/base_test.py
@@ -171,3 +171,6 @@ class TestBootImageBase:
         self.boot_image.set_static_modules(['module'])
         self.boot_image.write_system_config_file({'config_key': 'value'})
         self.boot_image.cleanup()
+
+    def test_has_initrd_support(self):
+        assert self.boot_image.has_initrd_support() is False

--- a/test/unit/boot/image/builtin_kiwi_test.py
+++ b/test/unit/boot/image/builtin_kiwi_test.py
@@ -178,5 +178,8 @@ class TestBootImageKiwi:
         self.boot_image.cleanup()
         mock_wipe.assert_called_once_with('boot-root-directory')
 
+    def test_has_initrd_support(self):
+        assert self.boot_image.has_initrd_support() is True
+
     def teardown(self):
         sys.argv = argv_kiwi_tests

--- a/test/unit/boot/image/builtin_kiwi_test.py
+++ b/test/unit/boot/image/builtin_kiwi_test.py
@@ -1,7 +1,7 @@
 import sys
-import mock
-from mock import patch
-from mock import call
+from mock import (
+    patch, call, Mock
+)
 from pytest import raises
 
 import kiwi
@@ -27,27 +27,28 @@ class TestBootImageKiwi:
             description.load()
         )
 
-        self.manager = mock.Mock()
-        self.system_prepare = mock.Mock()
-        self.setup = mock.Mock()
-        self.profile = mock.Mock()
+        self.manager = Mock()
+        self.system_prepare = Mock()
+        self.setup = Mock()
+        self.profile = Mock()
         self.profile.dot_profile = dict()
-        self.system_prepare.setup_repositories = mock.Mock(
+        self.system_prepare.setup_repositories = Mock(
             return_value=self.manager
         )
-        kiwi.boot.image.builtin_kiwi.SystemPrepare = mock.Mock(
+        kiwi.boot.image.builtin_kiwi.SystemPrepare = Mock(
             return_value=self.system_prepare
         )
-        kiwi.boot.image.builtin_kiwi.SystemSetup = mock.Mock(
+        kiwi.boot.image.builtin_kiwi.SystemSetup = Mock(
             return_value=self.setup
         )
-        kiwi.boot.image.builtin_kiwi.Profile = mock.Mock(
+        kiwi.boot.image.builtin_kiwi.Profile = Mock(
             return_value=self.profile
         )
         mock_mkdtemp.return_value = 'boot-root-directory'
         self.boot_image = BootImageKiwi(
             self.xml_state, 'some-target-dir'
         )
+        self.boot_image.boot_xml_state = Mock()
 
     def test_include_file(self):
         # is a nop for builtin kiwi initrd and does nothing
@@ -106,15 +107,15 @@ class TestBootImageKiwi:
         self, mock_os_chmod, mock_mkdtemp, mock_prepared, mock_sync,
         mock_wipe, mock_create, mock_compress, mock_cpio
     ):
-        data = mock.Mock()
+        data = Mock()
         mock_sync.return_value = data
         mock_mkdtemp.return_value = 'temp-boot-directory'
         mock_prepared.return_value = True
         self.boot_image.boot_root_directory = 'boot-root-directory'
-        mbrid = mock.Mock()
-        mbrid.write = mock.Mock()
-        cpio = mock.Mock()
-        compress = mock.Mock()
+        mbrid = Mock()
+        mbrid.write = Mock()
+        cpio = Mock()
+        compress = Mock()
         mock_cpio.return_value = cpio
         mock_compress.return_value = compress
         self.boot_image.create_initrd(mbrid)

--- a/test/unit/boot/image/dracut_test.py
+++ b/test/unit/boot/image/dracut_test.py
@@ -157,3 +157,6 @@ class TestBootImageKiwi:
                 'some-target-dir'
             ])
         ]
+
+    def test_has_initrd_support(self):
+        assert self.boot_image.has_initrd_support() is True

--- a/test/unit/builder/kis_test.py
+++ b/test/unit/builder/kis_test.py
@@ -1,3 +1,4 @@
+import logging
 from collections import namedtuple
 from mock import (
     patch, Mock, MagicMock, mock_open
@@ -74,6 +75,17 @@ class TestKisBuilder:
         )
         self.kis.image_name = 'myimage'
         self.kis.compressed = True
+
+    @patch('kiwi.builder.kis.FileSystemBuilder')
+    @patch('kiwi.builder.kis.BootImage')
+    def test_setup_warn_no_initrd_support(self, mock_boot, mock_filesystem):
+        boot_image_task = MagicMock()
+        boot_image_task.has_initrd_support = Mock(
+            return_value=False
+        )
+        mock_boot.new.return_value = boot_image_task
+        with self._caplog.at_level(logging.WARNING):
+            KisBuilder(self.xml_state, 'target_dir', 'root_dir')
 
     @patch('kiwi.builder.kis.Checksum')
     @patch('kiwi.builder.kis.Compress')

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -911,7 +911,7 @@ class TestXMLState:
         state = XMLState(xml_data, ['vmxSimpleFlavour'], 'iso')
         assert state.get_initrd_system() == 'dracut'
         state = XMLState(xml_data, ['containerFlavour'], 'docker')
-        assert state.get_initrd_system() is None
+        assert state.get_initrd_system() == 'none'
         state = XMLState(xml_data, [], 'oem')
         assert state.get_initrd_system() == 'dracut'
 


### PR DESCRIPTION
This change is two fold:

**Added support for skipping initrd creation**
    
Embedded systems and other customer use cases sometimes doesn't require an initrd. So far the initrd creation was
a mandatory step in the process. With this commit it's  possible to configure

```xml
<type ... initrd_system="none"/>
```

and therefore skip the creation and setup of an initrd.  Using this feature comes with a price. Without an initrd the task of mounting the specified root=DEVICE_SPEC now  becomes a task of the kernel. If the kernel doesn't have the required filesystem driver compiled in or the mount process of the device is not just a simple mount  action, the boot of such an appliance will fail

**Add strong typing for the following API methods**
    
- [x]  kiwi/boot/image/base.py
- [x]  kiwi/boot/image/builtin_kiwi.py
- [x]  kiwi/boot/image/dracut.py
    
This references issue #1644


