### PR TITLE
Fixed creating grub bios module

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -931,12 +931,16 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                     self._get_grub2_mkimage_tool()
                 ) or 'grub2-mkimage',
                 '-O', Defaults.get_bios_module_directory_name(),
-                '-o', self._get_bios_image_name(os.sep),
+                '-o', self._get_bios_image_name(self.root_dir).replace(
+                    self.root_dir, ''
+                ),
                 '-c', early_boot_script.replace(self.boot_dir, ''),
                 '-p', os.sep.join(
                     [self.get_boot_path(), self.boot_directory_name]
                 ),
-                '-d', self._get_bios_modules_path(os.sep)
+                '-d', self._get_bios_modules_path(self.root_dir).replace(
+                    self.root_dir, ''
+                )
             ] + Defaults.get_grub_bios_modules(multiboot=self.xen_guest)
         )
         log.debug(mkimage_call.output)


### PR DESCRIPTION
If no prebuilt grub bios module was found, kiwi creates one.
In this case kiwi searches for the grub modules and runs
the grub mkimage tool. The search for the modules for the
bios module used the host system (/) grub and that fails if
the host has packaged grub differently than the image target.
This fix moves the lookup into the image root directory
which is the correct place to lookup the grub data



