### PR TITLE
Fixed cleanup of temporary directory

### DIFF
--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -17,6 +17,7 @@
 #
 import os
 import logging
+from tempfile import TemporaryDirectory
 from tempfile import mkdtemp
 from typing import (
     Optional, List
@@ -151,13 +152,11 @@ class BootImageKiwi(BootImageBase):
                 kiwi_initrd_basename = basename
             else:
                 kiwi_initrd_basename = self.initrd_base_name
-            temp_boot_root_directory = mkdtemp(
+            temp_boot_root = TemporaryDirectory(
                 prefix='kiwi_boot_root_copy.'
             )
+            temp_boot_root_directory = temp_boot_root.name
             os.chmod(temp_boot_root_directory, 0o755)
-            self.temp_directories.append(
-                temp_boot_root_directory
-            )
             data = DataSync(
                 self.boot_root_directory + '/',
                 temp_boot_root_directory

--- a/test/unit/boot/image/builtin_kiwi_test.py
+++ b/test/unit/boot/image/builtin_kiwi_test.py
@@ -104,13 +104,18 @@ class TestBootImageKiwi:
     @patch('kiwi.boot.image.base.BootImageBase.is_prepared')
     @patch('kiwi.boot.image.builtin_kiwi.mkdtemp')
     @patch('kiwi.boot.image.builtin_kiwi.os.chmod')
+    @patch('kiwi.boot.image.builtin_kiwi.TemporaryDirectory')
     def test_create_initrd(
-        self, mock_os_chmod, mock_mkdtemp, mock_prepared, mock_sync,
+        self, mock_TemporaryDirectory, mock_os_chmod,
+        mock_mkdtemp, mock_prepared, mock_sync,
         mock_wipe, mock_create, mock_compress, mock_cpio
     ):
         data = Mock()
         mock_sync.return_value = data
         mock_mkdtemp.return_value = 'temp-boot-directory'
+        temporary_directory = Mock()
+        temporary_directory.name = 'temp-boot-directory'
+        mock_TemporaryDirectory.return_value = temporary_directory
         mock_prepared.return_value = True
         self.boot_image.boot_root_directory = 'boot-root-directory'
         mbrid = Mock()


### PR DESCRIPTION
In the custom kiwi initrd build process a temporary directory
holding a copy of the initrd root tree is created. That data
got never cleaned up. This commit uses a TemporaryDirectory
object from the tempfile module to make sure it gets deleted
once the execution scope is done. This Fixes #1837

