### PR TITLE
Allow creation of LUKS system with empty key

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -686,7 +686,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                     grub_default_entries['GRUB_USE_INITRDEFI'] = 'true'
         if self.xml_state.build_type.get_btrfs_root_is_snapshot():
             grub_default_entries['SUSE_BTRFS_SNAPSHOT_BOOTING'] = 'true'
-        if self.custom_args.get('boot_is_crypto'):
+        if self.custom_args.get('crypto_disk'):
             grub_default_entries['GRUB_ENABLE_CRYPTODISK'] = 'y'
 
         enable_blscfg_implemented = Command.run(

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -110,6 +110,7 @@ class TestBootLoaderConfigGrub2:
             self.state, 'root_dir', None, {
                 'grub_directory_name': 'grub2',
                 'boot_is_crypto': True,
+                'crypto_disk': True,
                 'targetbase': 'rootdev'
             }
         )


### PR DESCRIPTION
To support cloud platforms better we should allow the
creation of an initial(insecure) LUKS encrypted image
with an empty passphrase/keyfile


