### PR TITLE
Allow the ISO to be booted from grub directly

### DIFF
--- a/doc/source/working_with_images.rst
+++ b/doc/source/working_with_images.rst
@@ -12,6 +12,7 @@ Working with Images
 
    working_with_images/iso_to_usb_stick_deployment
    working_with_images/iso_to_usb_stick_file_based_deployment
+   working_with_images/iso_to_usb_stick_grub2_boot_from_iso
 
    working_with_images/disk_setup_for_ec2
    working_with_images/disk_setup_for_azure

--- a/doc/source/working_with_images/iso_to_usb_stick_grub2_boot_from_iso.rst
+++ b/doc/source/working_with_images/iso_to_usb_stick_grub2_boot_from_iso.rst
@@ -1,0 +1,66 @@
+.. _grub_boot_from_iso:
+
+Booting a Live ISO Images from Grub2
+====================================
+
+.. sidebar:: Abstract
+
+   This page provides further information for handling
+   ISO images built with {kiwi} and references the following
+   articles:
+
+   * :ref:`hybrid_iso`
+
+In {kiwi}, all generated ISO images are created to be hybrid. This means,
+the image can be used as a CD/DVD or as a disk. This works because
+the ISO image also has a partition table embedded. With more and more
+computers delivered without a CD/DVD drive this becomes important.
+The deployment of such an image onto a disk like an USB stick normally 
+destroys all existing data on this device. It is also not possible to use 
+USB stick as a data storage device. Most USB sticks are pre-formatted 
+with a FAT32 or exFAT Windows File System and to keep the existing data 
+on the stick untouched a different deployment needs to be used.
+
+Fortunately Grub2 supports booting directly from ISO files. It does not matter 
+whether it is installed on your computer's hard drive or on a USB stick.
+The following deployment process copies the ISO image as an additional file 
+to the USB stick or hard drive. The ability to boot from the disk is configured 
+through a Grub2 feature which allows to loopback mount an ISO file and boot the
+kernel and initrd directly from the ISO file.
+
+The initrd loaded in this process must also be able to loopback
+mount the ISO file to access the root filesystem and boot the
+live system. Almost every Linux distribution supports fat32, 
+and more and more of them also support exFAT. For hard drives, 
+Linux filesystems are also supported.
+
+The dracut initrd system used by {kiwi} provides this
+feature upstream called as "iso-scan/filename". Therefore all {kiwi} generated
+live ISO images supports this deployment mode.
+
+The following procedure shows how to setup Grub2 on your hard drive:
+
+1. Copy the ISO image to a folder of your choice on your hard drive.
+
+2. Add the following code to the "grub.cfg" file:
+
+   Be sure to set the path to the ISO image, you can set your own menu name.
+   The drive identification for Grub2 can be checked at boot time 
+   by pressing the 'c' key and typing 'ls'.
+
+   .. code:: bash
+
+      menuentry "Boot from openSUSE ISO" {
+   	   iso_path="(hd0,gpt2)/path/to/openSUSE.iso"
+   	   export iso_path
+	   loopback loop "$iso_path"
+	   root=(loop)
+	   configfile /boot/grub2/loopback.cfg
+	   loopback --delete loop
+      }
+
+3. Restart your computer and select the added menu.
+
+For USB sticks, the procedure is identical. You would then install 
+Grub2 on the USB drive and follow the steps above. 
+The use of scripts such as "MultiOS-USB" is strongly recommended.

--- a/doc/source/working_with_images/iso_to_usb_stick_grub2_boot_from_iso.rst
+++ b/doc/source/working_with_images/iso_to_usb_stick_grub2_boot_from_iso.rst
@@ -51,8 +51,8 @@ The following procedure shows how to setup Grub2 on your hard drive:
    .. code:: bash
 
       menuentry "Boot from openSUSE ISO" {
-   	   iso_path="(hd0,gpt2)/path/to/openSUSE.iso"
-   	   export iso_path
+	   iso_path="(hd0,gpt2)/path/to/openSUSE.iso"
+	   export iso_path
 	   loopback loop "$iso_path"
 	   root=(loop)
 	   configfile /boot/grub2/loopback.cfg

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -439,6 +439,12 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 lookup_path=lookup_path, mbrid=mbrid
             )
 
+        log.info('--> Creating loopback config')
+        loopback_file = self.boot_dir + '/' + self.get_boot_path() + '/' + self.boot_directory_name + '/loopback.cfg'
+        self._create_loopback_config(
+            loopback_file
+        )
+
     def setup_live_boot_images(self, mbrid, lookup_path=None):
         """
         Create/Provide grub2 boot images and metadata
@@ -1397,4 +1403,12 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         except Exception:
             raise KiwiDiskGeometryError(
                 'unknown format for disk geometry: %s' % fdasd_output
+            )
+
+    def _create_loopback_config(self, filename):
+        with open(filename, 'w') as loopback_cfg:
+            loopback_cfg.write(
+                'source /boot/{0}/grub.cfg{1}'.format(
+                    self.boot_directory_name, os.linesep
+                )
             )

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -440,7 +440,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
 
         log.info('--> Creating loopback config')
-        loopback_file = self.boot_dir + '/' + self.get_boot_path() + '/' + self.boot_directory_name + '/loopback.cfg'
+        loopback_file = os.path.join(
+            self.boot_dir, self.get_boot_path(), self.boot_directory_name, '/loopback.cfg'
+        )
         self._create_loopback_config(
             loopback_file
         )

--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -36,6 +36,9 @@ class BootLoaderTemplateGrub2:
                 menuentry "If OK, run snapper rollback and reboot." { true; }
               }
             fi
+            if [ -n "$${iso_path}" ]; then
+              isoboot="iso-scan/filename=$${iso_path}"
+            fi
         ''').strip() + os.linesep
 
         self.timeout = dedent('''
@@ -143,7 +146,7 @@ class BootLoaderTemplateGrub2:
             menuentry "${title}" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                $$linux ($$root)${bootpath}/${kernel_file} $${extra_cmdline} ${boot_options}
+                $$linux ($$root)${bootpath}/${kernel_file} $${extra_cmdline} $${isoboot} ${boot_options}
                 echo Loading initrd...
                 $$initrd ($$root)${bootpath}/${initrd_file}
             }
@@ -165,7 +168,7 @@ class BootLoaderTemplateGrub2:
             menuentry "${title}" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                linux ($$root)${bootpath}/${kernel_file} $${extra_cmdline} ${boot_options}
+                linux ($$root)${bootpath}/${kernel_file} $${extra_cmdline} $${isoboot} ${boot_options}
                 echo Loading initrd...
                 initrd ($$root)${bootpath}/${initrd_file}
             }
@@ -175,7 +178,7 @@ class BootLoaderTemplateGrub2:
             menuentry "Failsafe -- ${title}" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                $$linux ($$root)${bootpath}/${kernel_file} $${extra_cmdline} ${failsafe_boot_options}
+                $$linux ($$root)${bootpath}/${kernel_file} $${extra_cmdline} $${isoboot} ${failsafe_boot_options}
                 echo Loading initrd...
                 $$initrd ($$root)${bootpath}/${initrd_file}
             }
@@ -197,7 +200,7 @@ class BootLoaderTemplateGrub2:
             menuentry "Failsafe -- ${title}" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                linux ($$root)${bootpath}/${kernel_file} $${extra_cmdline} ${failsafe_boot_options}
+                linux ($$root)${bootpath}/${kernel_file} $${extra_cmdline} $${isoboot} ${failsafe_boot_options}
                 echo Loading initrd...
                 initrd ($$root)${bootpath}/${initrd_file}
             }
@@ -207,7 +210,7 @@ class BootLoaderTemplateGrub2:
             menuentry "Install ${title}" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                $$linux ($$root)${bootpath}/${kernel_file} cdinst=1 ${boot_options}
+                $$linux ($$root)${bootpath}/${kernel_file} cdinst=1 $${isoboot} ${boot_options}
                 echo Loading initrd...
                 $$initrd ($$root)${bootpath}/${initrd_file}
             }
@@ -229,7 +232,7 @@ class BootLoaderTemplateGrub2:
             menuentry "Install ${title}" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                linux ($$root)${bootpath}/${kernel_file} cdinst=1 ${boot_options}
+                linux ($$root)${bootpath}/${kernel_file} cdinst=1 $${isoboot} ${boot_options}
                 echo Loading initrd...
                 initrd ($$root)${bootpath}/${initrd_file}
             }
@@ -239,7 +242,7 @@ class BootLoaderTemplateGrub2:
             menuentry "Mediacheck" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                $$linux ($$root)${bootpath}/${kernel_file} mediacheck=1 plymouth.enable=0 ${boot_options}
+                $$linux ($$root)${bootpath}/${kernel_file} mediacheck=1 plymouth.enable=0 $${isoboot} ${boot_options}
                 echo Loading initrd...
                 $$initrd ($$root)${bootpath}/${initrd_file}
             }
@@ -261,7 +264,7 @@ class BootLoaderTemplateGrub2:
             menuentry "Mediacheck" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                linux ($$root)${bootpath}/${kernel_file} mediacheck=1 plymouth.enable=0 ${boot_options}
+                linux ($$root)${bootpath}/${kernel_file} mediacheck=1 plymouth.enable=0 $${isoboot} ${boot_options}
                 echo Loading initrd...
                 initrd ($$root)${bootpath}/${initrd_file}
             }
@@ -271,7 +274,7 @@ class BootLoaderTemplateGrub2:
             menuentry "Failsafe -- Install ${title}" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                $$linux ($$root)${bootpath}/${kernel_file} cdinst=1 ${failsafe_boot_options}
+                $$linux ($$root)${bootpath}/${kernel_file} cdinst=1 $${isoboot} ${failsafe_boot_options}
                 echo Loading initrd...
                 $$initrd ($$root)${bootpath}/${initrd_file}
             }
@@ -293,7 +296,7 @@ class BootLoaderTemplateGrub2:
             menuentry "Failsafe -- Install ${title}" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                linux ($$root)${bootpath}/${kernel_file} cdinst=1 ${failsafe_boot_options}
+                linux ($$root)${bootpath}/${kernel_file} cdinst=1 $${isoboot} ${failsafe_boot_options}
                 echo Loading initrd...
                 initrd ($$root)${bootpath}/${initrd_file}
             }

--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -210,7 +210,7 @@ class BootLoaderTemplateGrub2:
             menuentry "Install ${title}" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                $$linux ($$root)${bootpath}/${kernel_file} cdinst=1 $${isoboot} ${boot_options}
+                $$linux ($$root)${bootpath}/${kernel_file} cdinst=1 ${boot_options}
                 echo Loading initrd...
                 $$initrd ($$root)${bootpath}/${initrd_file}
             }
@@ -232,7 +232,7 @@ class BootLoaderTemplateGrub2:
             menuentry "Install ${title}" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                linux ($$root)${bootpath}/${kernel_file} cdinst=1 $${isoboot} ${boot_options}
+                linux ($$root)${bootpath}/${kernel_file} cdinst=1 ${boot_options}
                 echo Loading initrd...
                 initrd ($$root)${bootpath}/${initrd_file}
             }
@@ -274,7 +274,7 @@ class BootLoaderTemplateGrub2:
             menuentry "Failsafe -- Install ${title}" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                $$linux ($$root)${bootpath}/${kernel_file} cdinst=1 $${isoboot} ${failsafe_boot_options}
+                $$linux ($$root)${bootpath}/${kernel_file} cdinst=1 ${failsafe_boot_options}
                 echo Loading initrd...
                 $$initrd ($$root)${bootpath}/${initrd_file}
             }
@@ -296,7 +296,7 @@ class BootLoaderTemplateGrub2:
             menuentry "Failsafe -- Install ${title}" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                linux ($$root)${bootpath}/${kernel_file} cdinst=1 $${isoboot} ${failsafe_boot_options}
+                linux ($$root)${bootpath}/${kernel_file} cdinst=1 ${failsafe_boot_options}
                 echo Loading initrd...
                 initrd ($$root)${bootpath}/${initrd_file}
             }

--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -37,7 +37,7 @@ class BootLoaderTemplateGrub2:
               }
             fi
             if [ -n "$${iso_path}" ]; then
-              isoboot="iso-scan/filename=$${iso_path}"
+                isoboot="iso-scan/filename=$${iso_path}"
             fi
         ''').strip() + os.linesep
 


### PR DESCRIPTION
This PR adds the ability to run an ISO image directly from grub.
This can be done using a simple menu, e.g:  [link](https://github.com/Mexit/MultiOS-USB/blob/master/config/grub_loopback/loopback.cfg).
Loopback compatible ISO images on your USB, HDD, SSD drive are automatically detected and you can boot from the selected ISO image. There is no need to burn an ISO image to disk. This allows you to have many different versions on one disk.