### PR TITLE
Updates to functions integration tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,17 @@ unit_py38:
     paths:
       - .tox/3.8
 
+scripts:
+  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
+  stage: test
+  <<: *only-default
+  script:
+    - tox -e scripts
+  cache:
+    key: "$CI_JOB_NAME"
+    paths:
+      - .tox/3
+
 build_doc:
   image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$TUMBLEWEED_BUILD
   stage: documentation

--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -50,3 +50,7 @@ python-dateutil
 
 # for release
 twine
+
+# for scripts testing
+pytest-testinfra
+dataclasses ; python_version < "3.7"

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -129,6 +129,14 @@ To resume your work, :command:`cd` into your local Git repository and call:
     $ source .tox/3/bin/activate
 
 
+Alternatively, you can launch single commands inside the virtualenv without
+sourcing it directly:
+
+.. code:: shell-session
+
+   $ tox -e devel -- kiwi-ng --version
+
+
 Running the Unit Tests
 ----------------------
 

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -181,6 +181,95 @@ example runs the test cases for the Python 3.6 interpreter only:
 
     $ tox -e unit_py3_6
 
+
+Write Integration Tests for the Scripts
+---------------------------------------
+
+Kiwi ships a set of helper functions that can be used in :file:`config.sh` (see
+also: :ref:`working-with-kiwi-user-defined-scripts`:). These utilize containers
+to run the individual functions and verify that they resulted in the desired
+state.
+
+Ensure that you have either :command:`podman` or :command:`docker` installed and
+configured on your system. The integration tests will use :command:`podman` in
+**rootless mode** by default, if it is installed on your system. You can select
+:command:``docker` instead by setting the environment variable
+``CONTAINER_RUNTIME`` to ``docker``. Then you can run the integration tests via
+tox:
+
+.. code:: shell-session
+
+    $ tox -e scripts -- -n NUMBER_OF_THREADS
+
+
+It is recommended to leverage `testinfra https://testinfra.readthedocs.io/`__
+and the `shared_container` and `container_per_test` fixtures for writing these
+integration tests. The fixtures give your test functions a connection to a
+running container (by default that will be `opensuse/tumbleweed` with python3
+installed in it) :file:`functions.sh` copied to :file:`/bin/functions.sh` inside
+the container. You can then use the connection to perform some setup, tear down
+and the actual tests as follows:
+
+.. code:: python
+
+    def test_RmWorks(shared_container):
+        # create the file /root/foobar
+        shared_container.run_expect([0], "touch /root/foobar")
+        assert shared_container.file("/root/foobar").exists
+
+        # source the functions and execute our function under test
+        shared_container.run_expect([0], ". /bin/functions.sh && Rm /root/foobar")
+
+        # verify the result
+        assert not shared_container.file("/root/foobar").exists
+
+
+In this example we used the `shared_container` fixture: it creates a podman
+container at the start of the test session and gives each function using this
+fixture the same connection. Therefore you must only use it for tests where you
+do not perform any mutation of the container that you are not undoing
+afterwards! If you need to perform extensive mutation that you cannot or do not
+want to undo yourself, then resort to the `container_per_test` fixture. It will
+give you a fresh container for each test function. While this makes writing
+tests simpler, it also increases the runtime significantly, thus only use it
+when necessary.
+
+
+Running Tests for multiple container images
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is important to test certain functions on multiple operating systems &
+versions, to e.g. ensure that older tools behave the same way that you expect
+them to.
+
+This can be achieved by leveraging pytest's `fixture parametrization
+https://docs.pytest.org/en/stable/parametrize.html`__ as follows:
+
+.. code:: python
+
+    @pytest.mark.parametrize(
+        "shared_container",
+        (
+            None,  # None means default (-> tumbleweed)
+            "Leap-15.2",
+        ),
+        indirect=True,
+    )
+    def test_something(shared_container):
+        pass
+
+
+Where we pass multiple image names to the container images to the
+`shared_container` fixture. Pytest will then look for the image with the given
+name in the predefined list of containers in :file:`conftest.py`.
+
+To add a new container, simply add a new `Container` class to the `CONTAINERS`
+list and give it appropriate values for `name`, `url` and optionally for
+`install_command`. The later will be inserted into a :file:`Dockerfile` to build
+a container image for the actual tests. It can be used to include additional
+packages that are not available in the base image.
+
+
 Create a Branch for each Feature or Bugfix
 ------------------------------------------
 

--- a/test/scripts/conftest.py
+++ b/test/scripts/conftest.py
@@ -1,0 +1,170 @@
+import subprocess
+from dataclasses import dataclass
+from os import getenv, path
+from typing import Any, List, Optional, Tuple
+
+import pytest
+import testinfra
+
+
+CONTAINER_URL = "registry.opensuse.org/opensuse/tumbleweed:latest"
+SELECTED_CONTAINER_RUNTIME: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class Container:
+    name: str
+    url: str
+
+    def launch_and_prepare_container(
+        self, runner_binary: str
+    ) -> Tuple[Any, str]:
+        container_id = (
+            subprocess.check_output(
+                [runner_binary, "run", "-d", "-it", self.url, "/bin/sh"]
+            )
+            .decode()
+            .strip()
+        )
+        subprocess.check_call(
+            [
+                runner_binary,
+                "cp",
+                path.abspath(
+                    path.join(
+                        path.dirname(__file__),
+                        "..",
+                        "..",
+                        "kiwi",
+                        "config",
+                        "functions.sh",
+                    )
+                ),
+                container_id + ":" + "/bin/functions.sh",
+            ],
+        )
+
+        return (
+            testinfra.get_host(f"{runner_binary}://{container_id}"),
+            container_id,
+        )
+
+    @staticmethod
+    def cleanup_container(runner_binary: str, container_id: str) -> None:
+        subprocess.check_call([runner_binary, "rm", "-f", container_id])
+
+
+TUMBLEWEED_CONTAINER = Container(
+    name="Tumbleweed",
+    url="registry.opensuse.org/opensuse/tumbleweed:latest",
+)
+
+CONTAINERS = [
+    Container(
+        name="Leap-15.3", url="registry.opensuse.org/opensuse/leap:15.3"
+    ),
+    Container(
+        name="Leap-15.2", url="registry.opensuse.org/opensuse/leap:15.2"
+    ),
+    TUMBLEWEED_CONTAINER,
+    Container(name="SLE-15-SP3", url="registry.suse.com/suse/sle15:15.3"),
+    Container(name="SLE-15-SP2", url="registry.suse.com/suse/sle15:15.2"),
+    Container(name="SLE-15-SP1", url="registry.suse.com/suse/sle15:15.1"),
+    Container(
+        name="SLE-12-SP5", url="registry.suse.com/suse/sles12sp5:latest"
+    ),
+]
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _check_container_runtimes():
+    """Fixture that checks whether the podman & docker runtimes work and
+    selects one (either the only one that works or the one from the environment
+    variable `CONTAINER_RUNTIME`).
+    """
+    localhost = testinfra.host.get_host("local://")
+
+    runtimes = ["podman", "docker"]
+    working_container_runtimes: List[str] = []
+
+    for runtime in runtimes:
+        if not localhost.exists(runtime):
+            continue
+        try:
+            con, con_id = TUMBLEWEED_CONTAINER.launch_and_prepare_container(
+                runtime
+            )
+            assert con.file("/etc/os-release").exists
+            Container.cleanup_container(runtime, con_id)
+
+            working_container_runtimes.append(runtime)
+        except Exception:
+            pass
+
+    if len(working_container_runtimes) == 0:
+        raise ValueError("No working container runtime found")
+    elif len(working_container_runtimes) == 1:
+        global SELECTED_CONTAINER_RUNTIME
+        SELECTED_CONTAINER_RUNTIME = working_container_runtimes[0]
+    else:
+        assert len(working_container_runtimes) == 2
+
+        runtime_choice = getenv("CONTAINER_RUNTIME", "podman").lower()
+        if runtime_choice not in runtimes:
+            raise ValueError(f"Invalid CONTAINER_RUNTIME {runtime_choice}")
+
+        SELECTED_CONTAINER_RUNTIME = runtime_choice
+
+
+def get_container_by_name(container_name: str = "Tumbleweed") -> Container:
+    match = [c for c in CONTAINERS if c.name == container_name]
+    assert len(match) == 1, "found {0} containers with the name {1}".format(
+        len(match), container_name
+    )
+
+    return match[0]
+
+
+def get_container_name(request) -> str:
+    return getattr(request, "param", "Tumbleweed")
+
+
+@pytest.fixture(scope="function")
+def container_per_test(request, _check_container_runtimes):
+    """Fixture that requests a new container for each function.
+
+    By default the Tumbleweed container is used if no parameter is passed to
+    this fixture.
+
+    This fixture is pretty expensive, as it will launch and destroy a new
+    container for **every** test function. Thus only use it for tests that
+    perform extensive mutation, which you do not feel comfortable to undo
+    quickly in the test.
+    """
+    assert SELECTED_CONTAINER_RUNTIME is not None
+    container = get_container_by_name(get_container_name(request))
+    con, container_id = container.launch_and_prepare_container(
+        SELECTED_CONTAINER_RUNTIME
+    )
+    yield con
+    Container.cleanup_container(SELECTED_CONTAINER_RUNTIME, container_id)
+
+
+@pytest.fixture(scope="session")
+def shared_container(request, _check_container_runtimes):
+    """Fixture that requests a new container for the whole test session.
+
+    By default the Tumbleweed container is used if no parameter is passed to
+    this fixture.
+
+    **Caution:** The container will be shared by all tests that request this
+    fixture. You **must** ensure that you do not mutate the container in your
+    test, as later tests could then fail due to your changes.
+    """
+    assert SELECTED_CONTAINER_RUNTIME is not None
+    container = get_container_by_name(get_container_name(request))
+    con, container_id = container.launch_and_prepare_container(
+        SELECTED_CONTAINER_RUNTIME
+    )
+    yield con
+    Container.cleanup_container(SELECTED_CONTAINER_RUNTIME, container_id)

--- a/test/scripts/conftest.py
+++ b/test/scripts/conftest.py
@@ -1,4 +1,5 @@
 import subprocess
+import logging
 from dataclasses import dataclass
 from os import getenv, path
 from typing import Any, List, Optional, Tuple
@@ -98,8 +99,8 @@ def _check_container_runtimes():
             Container.cleanup_container(runtime, con_id)
 
             working_container_runtimes.append(runtime)
-        except Exception:
-            pass
+        except Exception as issue:
+            logging.debug(issue)
 
     if len(working_container_runtimes) == 0:
         raise ValueError("No working container runtime found")

--- a/test/scripts/test_suseSetupProduct.py
+++ b/test/scripts/test_suseSetupProduct.py
@@ -1,0 +1,81 @@
+import pytest
+
+
+def test_does_nothing_when_product_correct(shared_container):
+    previous_contents = shared_container.file("/etc/products.d").listdir()
+    shared_container.run_expect([0], ". /bin/functions.sh && suseSetupProduct")
+    assert (
+        shared_container.file("/etc/products.d").listdir() == previous_contents
+    )
+
+
+@pytest.mark.parametrize(
+    "shared_container,product_name",
+    (
+        ("Tumbleweed", "openSUSE.prod"),
+        ("Leap-15.2", "openSUSE.prod"),
+        ("Leap-15.3", "Leap.prod"),
+        ("SLE-15-SP3", "SLES.prod"),
+        ("SLE-15-SP2", "SLES.prod"),
+        ("SLE-15-SP1", "SLES.prod"),
+        ("SLE-12-SP5", "SLES.prod"),
+    ),
+    indirect=["shared_container"],
+)
+def test_sets_baseproduct_from_etc_os_relesae(shared_container, product_name):
+    assert not shared_container.file("/etc/SuSE-brand").exists
+
+    shared_container.run_expect([0], "rm /etc/products.d/baseproduct")
+    shared_container.run_expect([0], ". /bin/functions.sh && suseSetupProduct")
+
+    assert shared_container.file("/etc/products.d/baseproduct").exists
+    assert shared_container.file("/etc/products.d/baseproduct").is_symlink
+    assert (
+        shared_container.file("/etc/products.d/baseproduct").linked_to
+        == "/etc/products.d/" + product_name
+    )
+
+
+def test_sets_baseproduct_with_weird_os_release(container_per_test):
+    assert not container_per_test.file("/etc/SuSE-brand").exists
+    container_per_test.run_expect([0], "rm /etc/products.d/baseproduct")
+    container_per_test.run_expect(
+        [0],
+        """cat <<EOF > /etc/os-release
+NAME=openSUSE Tumbleweed
+ID="opensuse-tumbleweed"
+ID_LIKE="opensuse suse"
+EOF
+""",
+    )
+
+    container_per_test.run_expect(
+        [0], ". /bin/functions.sh && suseSetupProduct"
+    )
+    assert container_per_test.file("/etc/products.d/baseproduct").exists
+    assert container_per_test.file("/etc/products.d/baseproduct").is_symlink
+    assert (
+        container_per_test.file("/etc/products.d/baseproduct").linked_to
+        == "/etc/products.d/openSUSE.prod"
+    )
+
+
+def test_sets_baseproduct_from_prod_files(container_per_test):
+    container_per_test.run_expect(
+        [0],
+        """rm /etc/products.d/baseproduct
+rm /etc/products.d/openSUSE.prod
+touch /etc/products.d/10.prod
+touch /etc/products.d/20.prod
+""",
+    )
+
+    container_per_test.run_expect(
+        [0], ". /bin/functions.sh && suseSetupProduct"
+    )
+    assert container_per_test.file("/etc/products.d/baseproduct").exists
+    assert container_per_test.file("/etc/products.d/baseproduct").is_symlink
+    assert (
+        container_per_test.file("/etc/products.d/baseproduct").linked_to
+        == "/etc/products.d/20.prod"
+    )

--- a/test/scripts/test_suseSetupProduct.py
+++ b/test/scripts/test_suseSetupProduct.py
@@ -31,8 +31,9 @@ def test_sets_baseproduct_from_etc_os_relesae(shared_container, product_name):
     assert shared_container.file("/etc/products.d/baseproduct").exists
     assert shared_container.file("/etc/products.d/baseproduct").is_symlink
     assert (
-        shared_container.file("/etc/products.d/baseproduct").linked_to
-        == "/etc/products.d/" + product_name
+        shared_container.file(
+            "/etc/products.d/baseproduct"
+        ).linked_to == "/etc/products.d/" + product_name
     )
 
 
@@ -55,8 +56,9 @@ EOF
     assert container_per_test.file("/etc/products.d/baseproduct").exists
     assert container_per_test.file("/etc/products.d/baseproduct").is_symlink
     assert (
-        container_per_test.file("/etc/products.d/baseproduct").linked_to
-        == "/etc/products.d/openSUSE.prod"
+        container_per_test.file(
+            "/etc/products.d/baseproduct"
+        ).linked_to == "/etc/products.d/openSUSE.prod"
     )
 
 
@@ -76,6 +78,7 @@ touch /etc/products.d/20.prod
     assert container_per_test.file("/etc/products.d/baseproduct").exists
     assert container_per_test.file("/etc/products.d/baseproduct").is_symlink
     assert (
-        container_per_test.file("/etc/products.d/baseproduct").linked_to
-        == "/etc/products.d/20.prod"
+        container_per_test.file(
+            "/etc/products.d/baseproduct"
+        ).linked_to == "/etc/products.d/20.prod"
     )

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,8 @@ envlist =
     check,
     unit_py3_8,
     unit_py3_6,
-    packagedoc
+    packagedoc,
+    scripts,
 
 
 [testenv]
@@ -27,12 +28,12 @@ description =
     devel: Test KIWI
 whitelist_externals = *
 basepython =
-    {check,devel,packagedoc,doc,doc_gh_pages,doc_suse,doc_man}: python3
+    {check,devel,packagedoc,doc,doc_gh_pages,doc_suse,doc_man,scripts,}: python3
     unit_py3_8: python3.8
     unit_py3_6: python3.6
     release: python3.6
 envdir =
-    {check,devel,packagedoc,doc,doc_gh_pages,doc_suse,doc_man}: {toxworkdir}/3
+    {check,devel,packagedoc,doc,doc_gh_pages,doc_suse,doc_man,scripts,}: {toxworkdir}/3
     unit_py3_8: {toxworkdir}/3.8
     unit_py3_6: {toxworkdir}/3.6
     release: {toxworkdir}/3.6
@@ -198,3 +199,13 @@ usedevelop = True
 commands =
     python setup.py sdist
     twine upload --skip-existing --non-interactive --config-file ./.pypirc dist/*
+
+[testenv:scripts]
+description = Integration tests of the builtin shell scripts
+deps =
+     {[testenv]deps}
+     pytest-testinfra
+     dataclasses ; python_version < "3.7"
+changedir=test/scripts
+commands =
+    pytest -vv {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -209,3 +209,7 @@ deps =
 changedir=test/scripts
 commands =
     pytest -vv {posargs}
+
+[testenv:devel]
+passenv = *
+commands = {posargs} []

--- a/tox.ini
+++ b/tox.ini
@@ -187,6 +187,7 @@ usedevelop = True
 commands =
     flake8 --statistics -j auto --count {toxinidir}/kiwi
     flake8 --statistics -j auto --count {toxinidir}/test/unit
+    flake8 --statistics -j auto --count {toxinidir}/test/scripts
     bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174,SC1117 {toxinidir}/dracut/modules.d/*/* -s bash'
     bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174,SC1117 {toxinidir}/kiwi/config/functions.sh -s bash'
 
@@ -204,8 +205,6 @@ commands =
 description = Integration tests of the builtin shell scripts
 deps =
      {[testenv]deps}
-     pytest-testinfra
-     dataclasses ; python_version < "3.7"
 changedir=test/scripts
 commands =
     pytest -vv {posargs}


### PR DESCRIPTION
Update for functions integration tests
    
* Move dependencies from tox into the .virtualenv.dev-requirements.txt
   This allows to re-use tox environments for other tasks
* Add debug logging information to conftest.py
* Integrate scripts to linter checks
* Fixup code smells
