### PR TITLE
Raise XML related error on syntax error

### DIFF
--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -194,6 +194,13 @@ class KiwiConfigFileFormatNotSupported(KiwiError):
     """
 
 
+
+class KiwiConfigSyntaxError(KiwiError):
+    """
+    Exception raised if kiwi description is in XML but cannot be parsed.
+    """
+
+
 class KiwiContainerSetupError(KiwiError):
     """
     Exception raised if an error in the creation of the

--- a/kiwi/markup/base.py
+++ b/kiwi/markup/base.py
@@ -20,7 +20,10 @@ from lxml import etree
 
 # project
 from kiwi.defaults import Defaults
-from kiwi.exceptions import KiwiConfigFileFormatNotSupported
+from kiwi.exceptions import (
+    KiwiConfigFileFormatNotSupported,
+    KiwiConfigSyntaxError
+)
 
 
 class MarkupBase:
@@ -55,6 +58,12 @@ class MarkupBase:
         try:
             parsed_description = etree.parse(description)
         except etree.XMLSyntaxError:
+            with open(description) as image_description:
+                content = image_description.readlines()
+                if content[0].startswith('<?xml '):
+                    raise KiwiConfigSyntaxError(
+                        'The configuration file contains an XML syntax error '
+                        'and the file could not be parsed.')
             raise KiwiConfigFileFormatNotSupported(
                 'Support for non-XML formatted config files requires '
                 'the Python anymarkup module.')

--- a/test/data/example_no_xml_config.xml
+++ b/test/data/example_no_xml_config.xml
@@ -1,0 +1,45 @@
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>ms@suse.com</contact>
+        <specification>
+            openSUSE 13.2 JeOS, is a small text based image
+        </specification>
+    </description>
+    <preferences>
+        <version>1.13.2</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>false</rpm-check-signatures>
+        <bootsplash-theme>openSUSE</bootsplash-theme>
+        <bootloader-theme>openSUSE</bootloader-theme>
+        <type image="oem" filesystem="btrfs" installiso="true" kernelcmdline="splash" firmware="efi">
+            <systemdisk/>
+            <oemconfig>
+                <oem-systemsize>2048</oem-systemsize>
+                <oem-swap>true</oem-swap>
+            </oemconfig>
+            <machine memory="512" guestOS="suse" HWversion="4">
+                <vmdisk id="0" controller="ide"/>
+                <vmnic driver="e1000" interface="0" mode="bridged"/>
+            </machine>
+        </type>
+    </preferences>
+    <users>
+        <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+    </users>
+    <repository>
+        <source path="obs://13.2/repo/oss"/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-openSUSE-base"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+    </packages>
+</image>

--- a/test/data/example_syntaxerror_config.xml
+++ b/test/data/example_syntaxerror_config.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>ms@suse.com</contact>
+        <specification>
+            openSUSE 13.2 JeOS, is a small text based image
+        </specification>
+    </description>
+    <preferences>
+        <version>1.13.2</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>false</rpm-check-signatures>
+        <bootsplash-theme>openSUSE</bootsplash-theme>
+        <bootloader-theme>openSUSE</bootloader-theme>
+        <type image="oem" filesystem="btrfs installiso="true" kernelcmdline="splash" firmware="efi">
+            <systemdisk/>
+            <oemconfig>
+                <oem-systemsize>2048</oem-systemsize>
+                <oem-swap>true</oem-swap>
+            </oemconfig>
+            <machine memory="512" guestOS="suse" HWversion="4">
+                <vmdisk id="0" controller="ide"/>
+                <vmnic driver="e1000" interface="0" mode="bridged"/>
+            </machine>
+        </type>
+    </preferences>
+    <users>
+        <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+    </users>
+    <repository>
+        <source path="obs://13.2/repo/oss"/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-openSUSE-base"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+    </packages>
+</image>

--- a/test/unit/markup/base_test.py
+++ b/test/unit/markup/base_test.py
@@ -4,7 +4,10 @@ from pytest import raises
 
 from kiwi.markup.base import MarkupBase
 
-from kiwi.exceptions import KiwiConfigFileFormatNotSupported
+from kiwi.exceptions import (
+    KiwiConfigFileFormatNotSupported,
+    KiwiConfigSyntaxError
+)
 
 
 class TestMarkupBase:
@@ -29,5 +32,13 @@ class TestMarkupBase:
         mock_parse.side_effect = etree.XMLSyntaxError('not-XML', '<', 1, 1)
         with raises(KiwiConfigFileFormatNotSupported):
             self.markup.apply_xslt_stylesheets(
-                'artificial_and_invalid_XML_markup'
+                '../data/example_no_xml_config.xml'
+            )
+
+    @patch('kiwi.markup.base.etree.parse')
+    def test_apply_xslt_stylesheets_syntax_error(self, mock_parse):
+        mock_parse.side_effect = etree.XMLSyntaxError('not-XML', '<', 1, 1)
+        with raises(KiwiConfigSyntaxError):
+            self.markup.apply_xslt_stylesheets(
+                '../data/xample_syntaxerror_config.xml'
             )


### PR DESCRIPTION
At present kiwi raises a KiwiConfigFileFormatNotSupported error when
an XML file is used that contains a syntax error. The message about
needing Python anymarkup is confusing. If the file failing to be
parsed is indeed XML as indicated by <?xml at the beginning of the file
we now raise a syntax error.