### PR TITLE
Prevent calling pacman through a shell

### DIFF
--- a/kiwi/package_manager/pacman.py
+++ b/kiwi/package_manager/pacman.py
@@ -114,7 +114,7 @@ class PackageManagerPacman(PackageManagerBase):
                 '--root', self.root_dir, '-Sy'
             ]
         )
-        bash_command = [
+        pacman_command = [
             'pacman'
         ] + self.pacman_args + [
             '--root', self.root_dir
@@ -124,7 +124,7 @@ class PackageManagerPacman(PackageManagerBase):
         ] + self.package_requests
         self.cleanup_requests()
         return Command.call(
-            ['bash', '-c', ' '.join(bash_command)], self.command_env
+            pacman_command, self.command_env
         )
 
     def process_install_requests(self) -> command_call_type:
@@ -136,14 +136,14 @@ class PackageManagerPacman(PackageManagerBase):
         :rtype: namedtuple
         """
         chroot_pacman_args = Path.move_to_root(self.root_dir, self.pacman_args)
-        bash_command = [
+        pacman_command = [
             'chroot', self.root_dir, 'pacman'
         ] + chroot_pacman_args + self.custom_args + [
             '-S', '--needed'
         ] + self.package_requests
         self.cleanup_requests()
         return Command.call(
-            ['bash', '-c', ' '.join(bash_command)], self.command_env
+            pacman_command, self.command_env
         )
 
     def process_delete_requests(self, force: bool = False) -> command_call_type:

--- a/test/unit/package_manager/pacman_test.py
+++ b/test/unit/package_manager/pacman_test.py
@@ -54,10 +54,10 @@ class TestPackageManagerPacman:
         ]
         mock_call.assert_called_once_with(
             [
-                'bash', '-c',
-                'pacman --config /root-dir/pacman.conf -y --noconfirm '
-                '--root /root-dir -S --needed --overwrite /root-dir/var/run '
-                'vim collection'
+                'pacman', '--config', '/root-dir/pacman.conf',
+                '-y', '--noconfirm', '--root', '/root-dir', '-S',
+                '--needed', '--overwrite', '/root-dir/var/run',
+                'vim', 'collection'
             ], ['env']
         )
 
@@ -69,9 +69,9 @@ class TestPackageManagerPacman:
         self.manager.process_install_requests()
         mock_call.assert_called_once_with(
             [
-                'bash', '-c',
-                'chroot /root-dir pacman --config /pacman.conf -y '
-                '--noconfirm -S --needed vim collection'
+                'chroot', '/root-dir', 'pacman', '--config',
+                '/pacman.conf', '-y', '--noconfirm', '-S',
+                '--needed', 'vim', 'collection'
             ], ['env']
         )
 


### PR DESCRIPTION
There is no reason to shell out for calling pacman.
In fact it can be counter productive if the shell
evaluates eventually existing package name/instruction
patterns. This is related to Issue #1856


