### PR TITLE
Do not shell out for calling microdnf.

### DIFF
--- a/kiwi/package_manager/microdnf.py
+++ b/kiwi/package_manager/microdnf.py
@@ -107,7 +107,7 @@ class PackageManagerMicroDnf(PackageManagerBase):
 
         :rtype: namedtuple
         """
-        bash_command = [
+        microdnf_command = [
             'microdnf'
         ] + ['--refresh'] + self.dnf_args + [
             '--installroot', self.root_dir,
@@ -124,7 +124,7 @@ class PackageManagerMicroDnf(PackageManagerBase):
         ] + self.custom_args + ['install'] + self.package_requests
         self.cleanup_requests()
         return Command.call(
-            ['bash', '-c', ' '.join(bash_command)], self.command_env
+            microdnf_command, self.command_env
         )
 
     def process_install_requests(self) -> command_call_type:
@@ -146,14 +146,14 @@ class PackageManagerMicroDnf(PackageManagerBase):
         chroot_dnf_args = Path.move_to_root(
             self.root_dir, self.dnf_args
         )
-        bash_command = [
+        microdnf_command = [
             'chroot', self.root_dir, 'microdnf'
         ] + chroot_dnf_args + self.custom_args + exclude_args + [
             'install'
         ] + self.package_requests
         self.cleanup_requests()
         return Command.call(
-            ['bash', '-c', ' '.join(bash_command)], self.command_env
+            microdnf_command, self.command_env
         )
 
     def process_delete_requests(self, force: bool = False) -> command_call_type:

--- a/test/unit/package_manager/microdnf_test.py
+++ b/test/unit/package_manager/microdnf_test.py
@@ -50,13 +50,12 @@ class TestPackageManagerMicroDnf:
         self.manager.process_install_requests_bootstrap()
         mock_call.assert_called_once_with(
             [
-                'bash', '-c',
-                'microdnf --refresh --config /root-dir/dnf.conf -y '
-                '--installroot /root-dir --releasever=0 --noplugins '
-                '--setopt=cachedir=cache '
-                '--setopt=reposdir=repos '
-                '--setopt=varsdir=vars '
-                'install vim'
+                'microdnf', '--refresh', '--config', '/root-dir/dnf.conf',
+                '-y', '--installroot', '/root-dir', '--releasever=0',
+                '--noplugins', '--setopt=cachedir=cache',
+                '--setopt=reposdir=repos',
+                '--setopt=varsdir=vars',
+                'install', 'vim'
             ], ['env']
         )
 
@@ -68,9 +67,8 @@ class TestPackageManagerMicroDnf:
         self.manager.process_install_requests()
         mock_call.assert_called_once_with(
             [
-                'bash', '-c',
-                'chroot /root-dir microdnf --config /dnf.conf -y '
-                '--exclude=skipme install vim'
+                'chroot', '/root-dir', 'microdnf', '--config', '/dnf.conf',
+                '-y', '--exclude=skipme', 'install', 'vim'
             ], ['env']
         )
 


### PR DESCRIPTION
In fact it can be counter productive if the shell
evaluates eventually existing package name/instruction
patterns. This is related to Issue #1856

