### PR TITLE
Add missing util-linux-systemd dependency to dracut-kiwi-overlay

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -530,6 +530,10 @@ BuildRequires:  dracut
 %endif
 Requires:       dracut-kiwi-lib = %{version}-%{release}
 Requires:       util-linux
+# lsblk is part of util-linux-systemd on openSUSE
+%if 0%{?suse_version}
+Requires:       util-linux-systemd
+%endif
 Requires:       dracut
 License:        GPL-3.0-or-later
 Group:          %{sysgroup}


### PR DESCRIPTION
The script kiwi-overlay-root.sh requires lsblk which is provided by
util-linux-systemd. If that package is missing in the final image, then booting
an overlayroot image hangs with:
```
dracut-pre-mount[480]: //lib/dracut/hooks/pre-mount/30-kiwi-overlay-root.sh: line 46: lsblk: command not found
```
