### PR TITLE
Use latest stylesheet for branding update

### DIFF
--- a/doc/DC-kiwi
+++ b/doc/DC-kiwi
@@ -4,5 +4,5 @@
 MAIN=xml/book.xml
 ADOC_POST=yes
 ADOC_TYPE=book
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
 DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"


### PR DESCRIPTION
Changes proposed in this pull request:

* Use "suse2021-ns" instead of "suse2013-ns" due to new branding (one-liner)

There is no explict issue for this. I hope this is sync'ed to `OSInside/kiwi-suse-doc`.