### PR TITLE
Use namespaced files in /var/tmp for temporary files

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -742,7 +742,7 @@ class DiskBuilder:
 
         if self.root_filesystem_is_overlay:
             log.info('--> creating readonly root partition')
-            squashed_root_file = NamedTemporaryFile()
+            squashed_root_file = NamedTemporaryFile(dir='/var/tmp', prefix='kiwi-')
             squashed_root = FileSystemSquashFs(
                 device_provider=DeviceProvider(), root_dir=self.root_dir,
                 custom_args={
@@ -1052,7 +1052,7 @@ class DiskBuilder:
 
         log.info('--> Syncing root filesystem data')
         if self.root_filesystem_is_overlay:
-            squashed_root_file = NamedTemporaryFile()
+            squashed_root_file = NamedTemporaryFile(dir='/var/tmp', prefix='kiwi-')
             squashed_root = FileSystemSquashFs(
                 device_provider=DeviceProvider(), root_dir=self.root_dir,
                 custom_args={

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -225,7 +225,7 @@ class LiveImageBuilder:
         filesystem_setup = FileSystemSetup(
             self.xml_state, self.root_dir
         )
-        root_image = NamedTemporaryFile()
+        root_image = NamedTemporaryFile(dir='/var/tmp', prefix='kiwi-')
         loop_provider = LoopDevice(
             root_image.name,
             filesystem_setup.get_size_mbytes(root_filesystem),
@@ -266,7 +266,7 @@ class LiveImageBuilder:
                     self.xml_state.build_type.get_squashfscompression()
             }
         )
-        container_image = NamedTemporaryFile()
+        container_image = NamedTemporaryFile(dir='/var/tmp', prefix='kiwi-')
         live_container_image.create_on_file(
             container_image.name
         )

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -559,7 +559,7 @@ class TestDiskBuilder:
         mock_squashfs.return_value = squashfs
         mock_getsize.return_value = 1048576
         tempfile = Mock()
-        tempfile.name = 'tempname'
+        tempfile.name = 'kiwi-tempname'
         mock_temp.return_value = tempfile
         mock_exists.return_value = True
         self.disk_builder.initrd_system = 'dracut'
@@ -580,16 +580,16 @@ class TestDiskBuilder:
             )
         ]
         assert squashfs.create_on_file.call_args_list == [
-            call(exclude=['var/cache/kiwi'], filename='tempname'),
+            call(exclude=['var/cache/kiwi'], filename='kiwi-tempname'),
             call(exclude=[
                 'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
                 '.buildenv', 'var/cache/kiwi',
                 'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
-            ], filename='tempname')
+            ], filename='kiwi-tempname')
         ]
         self.disk.create_root_readonly_partition.assert_called_once_with(11)
         assert mock_command.call_args_list[2] == call(
-            ['dd', 'if=tempname', 'of=/dev/readonly-root-device']
+            ['dd', 'if=kiwi-tempname', 'of=/dev/readonly-root-device']
         )
         assert m_open.return_value.write.call_args_list == [
             call('kiwi_BootPart="1"\n'),

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -145,7 +145,7 @@ class TestLiveImageBuilder:
         mock_setup_media_loader_directory, mock_DeviceProvider
     ):
         tempfile = mock.Mock()
-        tempfile.name = 'tmpfile'
+        tempfile.name = 'kiwi-tmpfile'
         mock_tmpfile.return_value = tempfile
         mock_exists.return_value = True
         mock_grub_dir.return_value = 'grub2'
@@ -200,11 +200,11 @@ class TestLiveImageBuilder:
             'image', '.profile', '.kconfig',
             'run/*', 'tmp/*', '.buildenv', 'var/cache/kiwi'
         ])
-        filesystem.create_on_file.assert_called_once_with('tmpfile')
+        filesystem.create_on_file.assert_called_once_with('kiwi-tmpfile')
 
         assert mock_shutil.copy.call_args_list == [
-            call('tmpfile', 'temp-squashfs/LiveOS/rootfs.img'),
-            call('tmpfile', 'temp_media_dir/LiveOS/squashfs.img')
+            call('kiwi-tmpfile', 'temp-squashfs/LiveOS/rootfs.img'),
+            call('kiwi-tmpfile', 'temp_media_dir/LiveOS/squashfs.img')
         ]
 
         self.setup.call_edit_boot_config_script.assert_called_once_with(


### PR DESCRIPTION
Previously, kiwi created the squashfs as a plain temporary file
in /tmp, which causes issues on operating systems where /tmp is tmpfs.
Notably, image builds would fail with "no space left on the device"
because the tmpfs was not big enough for everything to exist there.

To fix this, we change to use /var/tmp, and additionally add a prefix
for our temporary files so that the user knows which ones kiwi created.

Fixes #1866.