### PR TITLE
Fixed fedora integration test builds

### DIFF
--- a/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
@@ -52,14 +52,8 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" alias="kiwi-next-generation" priority="1">
-        <source path="obs://Virtualization:Appliances:Staging/Fedora_34"/>
-    </repository>
-    <repository type="rpm-md" alias="Fedora_34">
-        <source path="obs://Fedora:34/standard"/>
-    </repository>
-    <repository type="rpm-md" alias="Fedora_EPEL">
-        <source path="obs://Fedora:EPEL:8/standard"/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="grub2"/>

--- a/build-tests/x86/fedora/test-image-microdnf/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-microdnf/appliance.kiwi
@@ -27,14 +27,8 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" alias="kiwi-next-generation" priority="1">
-        <source path="obs://Virtualization:Appliances:Staging/Fedora_33"/>
-    </repository>
-    <repository type="rpm-md" alias="Fedora_33">
-        <source path="obs://Fedora:33/standard"/>
-    </repository>
-    <repository type="rpm-md" alias="Fedora_EPEL">
-        <source path="obs://Fedora:EPEL:8/standard"/>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
         <package name="grub2"/>


### PR DESCRIPTION
Maintain the repos in the obs prj config which prevents
the weird "nothing provides kernel-obs-build" error


