### PR TITLE
Fixed grub cmdline setup with custom root

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -641,7 +641,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             'GRUB_TERMINAL': '"{0}"'.format(self.terminal)
         }
         grub_final_cmdline = re.sub(
-            r'root=.* |root=.*$', '', self.cmdline
+            r'(^root=[^\s]+)|( root=[^\s]+)', '', self.cmdline
         ).strip()
         if self.persistency_type != 'by-uuid':
             grub_default_entries['GRUB_DISABLE_LINUX_UUID'] = 'true'


### PR DESCRIPTION
If the kiwi kernelcmdline attribute contains root=... information
it is extracted from being written to GRUB_CMDLINE_LINUX_DEFAULT.
However, the regexp to extract the root=... information was broken
and deleted more elements of the cmdline information than just
the root device information. This commit fixes the regexp to only
delete the root=... information taking into account that every
kernel parameter is delimited by '\s'
This Fixes #1875


