### PR TITLE
Fixed secure boot fallback setup

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -750,6 +750,11 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                     os.sep.join([self.efi_boot_path, grub_image.binaryname])
                 ]
             )
+            mok_manager = Defaults.get_mok_manager(lookup_path)
+            if mok_manager:
+                Command.run(
+                    ['cp', mok_manager, self.efi_boot_path]
+                )
         else:
             # Without shim a self signed grub image is used that
             # gets loaded by the firmware

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -710,6 +710,31 @@ class Defaults:
                 return shim_file
 
     @staticmethod
+    def get_mok_manager(root_path: str) -> Optional[str]:
+        """
+        Provides Mok Manager file path
+
+        Searches distribution specific locations to find
+        the Mok Manager EFI binary
+
+        :param str root_path: image root path
+
+        :return: file path or None
+
+        :rtype: str
+        """
+        mok_manager_file_patterns = [
+            '/usr/share/efi/*/MokManager.efi',
+            '/usr/lib64/efi/MokManager.efi',
+            '/boot/efi/EFI/*/mm*.efi',
+            '/usr/lib/shim/mm*.efi'
+        ]
+        for mok_manager_file_pattern in mok_manager_file_patterns:
+            for mm_file in glob.iglob(root_path + mok_manager_file_pattern):
+                return mm_file
+        return None
+
+    @staticmethod
     def get_grub_efi_font_directory(root_path):
         """
         Provides distribution specific EFI font directory used with grub.

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -62,6 +62,7 @@ class TestBootLoaderConfigGrub2:
             'root_dir/boot/efi/': True
         }
         self.glob_iglob = [
+            ['root_dir/usr/lib64/efi/MokManager.efi'],
             ['root_dir/usr/lib64/efi/shim.efi'],
             ['root_dir/usr/lib64/efi/grub.efi'],
             ['root_dir/boot/efi/EFI/DIST/fonts']
@@ -1358,9 +1359,16 @@ class TestBootLoaderConfigGrub2:
                             'cp', 'root_dir/usr/lib64/efi/grub.efi',
                             'root_dir/boot/efi/EFI/BOOT/grub.efi'
                         ]
+                    ),
+                    call(
+                        [
+                            'cp', 'root_dir/usr/lib64/efi/MokManager.efi',
+                            'root_dir/boot/efi/EFI/BOOT'
+                        ]
                     )
                 ]
 
+    @patch('kiwi.bootloader.config.grub2.Defaults.get_shim_loader')
     @patch('kiwi.bootloader.config.base.BootLoaderConfigBase.get_boot_path')
     @patch('kiwi.bootloader.config.grub2.Path.which')
     @patch('kiwi.bootloader.config.grub2.Command.run')
@@ -1370,11 +1378,12 @@ class TestBootLoaderConfigGrub2:
     @patch('os.stat')
     def test_setup_disk_boot_images_bios_plus_efi_secure_boot_no_shim_at_all(
         self, mock_stat, mock_chmod, mock_glob,
-        mock_exists, mock_command, mock_which, mock_get_boot_path
+        mock_exists, mock_command, mock_which, mock_get_boot_path,
+        mock_get_shim_loader
     ):
         # we expect the copy of grub.efi from the fallback
         # code if no shim was found at all
-        self.glob_iglob[0] = [None]
+        mock_get_shim_loader.return_value = None
 
         Defaults.set_platform_name('x86_64')
         mock_get_boot_path.return_value = '/boot'
@@ -1721,6 +1730,12 @@ class TestBootLoaderConfigGrub2:
                         [
                             'cp', 'root_dir/usr/lib64/efi/grub.efi',
                             'root_dir/EFI/BOOT/grub.efi'
+                        ]
+                    ),
+                    call(
+                        [
+                            'cp', 'root_dir/usr/lib64/efi/MokManager.efi',
+                            'root_dir/EFI/BOOT'
                         ]
                     )
                 ]

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -147,3 +147,19 @@ class TestDefaults:
             '/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed',
             binaryname='grubx64.efi'
         )
+
+    @patch('glob.iglob')
+    def test_get_mok_manager(self, mock_iglob):
+        mock_iglob.return_value = []
+        assert Defaults.get_mok_manager('root_path') is None
+
+        mock_iglob.return_value = ['some_glob_result']
+        assert Defaults.get_mok_manager('root_path') == 'some_glob_result'
+
+    @patch('glob.iglob')
+    def test_get_shim_loader(self, mock_iglob):
+        mock_iglob.return_value = []
+        assert Defaults.get_shim_loader('root_path') is None
+
+        mock_iglob.return_value = ['some_glob_result']
+        assert Defaults.get_shim_loader('root_path') == 'some_glob_result'


### PR DESCRIPTION
Make sure MokManager gets copied. This Fixes bsc#1187515


