### PR TITLE
Fixed LUKS keyfile permission bits

### DIFF
--- a/kiwi/storage/luks_device.py
+++ b/kiwi/storage/luks_device.py
@@ -200,6 +200,7 @@ class LuksDevice(DeviceProvider):
         """
         with open(filename, 'wb') as keyfile:
             keyfile.write(os.urandom(Defaults.get_luks_key_length()))
+        os.chmod(filename, 0o600)
 
     def __del__(self):
         if self.luks_device:

--- a/test/unit/storage/luks_device_test.py
+++ b/test/unit/storage/luks_device_test.py
@@ -43,7 +43,10 @@ class TestLuksDevice:
         assert self.luks.get_device() is None
 
     @patch('kiwi.storage.luks_device.Command.run')
-    def test_create_crypto_luks_empty_passphrase(self, mock_command):
+    @patch('os.chmod')
+    def test_create_crypto_luks_empty_passphrase(
+        self, mock_os_chmod, mock_command
+    ):
         with patch('builtins.open', create=True):
             self.luks.create_crypto_luks(
                 passphrase='', os='sle12', keyfile='some-keyfile'
@@ -83,7 +86,10 @@ class TestLuksDevice:
 
     @patch('kiwi.storage.luks_device.Command.run')
     @patch('kiwi.storage.luks_device.NamedTemporaryFile')
-    def test_create_crypto_luks(self, mock_tmpfile, mock_command):
+    @patch('os.chmod')
+    def test_create_crypto_luks(
+        self, mock_os_chmod, mock_tmpfile, mock_command
+    ):
         tmpfile = Mock()
         tmpfile.name = 'tmpfile'
         mock_tmpfile.return_value = tmpfile
@@ -143,7 +149,8 @@ class TestLuksDevice:
             self.luks.luks_device = None
 
     @patch('os.urandom')
-    def test_create_random_keyfile(self, mock_os_urandom):
+    @patch('os.chmod')
+    def test_create_random_keyfile(self, mock_os_chmod, mock_os_urandom):
         secret = b'secret'
         mock_os_urandom.return_value = secret
         with patch('builtins.open', create=True) as mock_open:
@@ -151,6 +158,7 @@ class TestLuksDevice:
             file_handle = mock_open.return_value.__enter__.return_value
             LuksDevice.create_random_keyfile('some-file')
             file_handle.write.assert_called_once_with(secret)
+            mock_os_chmod.assert_called_once_with('some-file', 0o600)
 
     def test_is_loop(self):
         assert self.luks.is_loop() is True


### PR DESCRIPTION
LUKS keyfile should use 0600 file permission flags

