### PR TITLE
Fix vagrant usr etc split

### DIFF
--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -545,6 +545,7 @@ function baseVagrantSetup {
     # insert the default insecure ssh key from here:
     # https://github.com/hashicorp/vagrant/blob/master/keys/vagrant.pub
     mkdir -p /home/vagrant/.ssh/
+    chmod 0700 /home/vagrant/.ssh/
     echo "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key" > /home/vagrant/.ssh/authorized_keys
     chmod 0600 /home/vagrant/.ssh/authorized_keys
     chown -R vagrant:vagrant /home/vagrant/

--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -549,9 +549,15 @@ function baseVagrantSetup {
     chmod 0600 /home/vagrant/.ssh/authorized_keys
     chown -R vagrant:vagrant /home/vagrant/
 
-    # recommended ssh settings for vagrant boxes
-    echo "UseDNS no" >> /etc/ssh/sshd_config
-    echo "GSSAPIAuthentication no" >> /etc/ssh/sshd_config
+    # apply recommended ssh settings for vagrant boxes
+    SSHD_CONFIG=/etc/ssh/sshd_config.d/99-vagrant.conf
+    if [[ ! -d "$(dirname ${SSHD_CONFIG})" ]]; then
+        SSHD_CONFIG=/etc/ssh/sshd_config
+        # prepend the settings, so that they take precedence
+        echo -e "UseDNS no\nGSSAPIAuthentication no\n$(cat ${SSHD_CONFIG})" > ${SSHD_CONFIG}
+    else
+        echo -e "UseDNS no\nGSSAPIAuthentication no" > ${SSHD_CONFIG}
+    fi
 
     # vagrant assumes that it can sudo without a password
     # => add the vagrant user to the sudoers list

--- a/test/scripts/conftest.py
+++ b/test/scripts/conftest.py
@@ -74,6 +74,7 @@ CONTAINERS = [
     Container(
         name="SLE-12-SP5", url="registry.suse.com/suse/sles12sp5:latest"
     ),
+    Container(name="centos:stream8", url="quay.io/centos/centos:stream8"),
 ]
 
 

--- a/test/scripts/test_baseVagrantSetup.py
+++ b/test/scripts/test_baseVagrantSetup.py
@@ -1,0 +1,83 @@
+import pytest
+
+
+ZYPPER_IN_CMD = "zypper -n in openssh sudo && /usr/sbin/sshd-gen-keys-start"
+
+
+@pytest.mark.parametrize(
+    "container_per_test,install_cmd",
+    (
+        ("Tumbleweed", ZYPPER_IN_CMD),
+        ("Leap-15.2", ZYPPER_IN_CMD),
+        ("Leap-15.3", ZYPPER_IN_CMD),
+        ("centos:stream8", "yum -y install openssh-server sudo && /usr/libexec/openssh/sshd-keygen ed25519")
+    ),
+    indirect=["container_per_test"],
+)
+def test_configures_system_for_vagrant(container_per_test, install_cmd):
+    # unfortunately we have to do a bit of setup for vagrant
+    container_per_test.run_expect([0], install_cmd)
+    container_per_test.run_expect(
+        [0], "groupadd vagrant && useradd -g vagrant vagrant"
+    )
+
+    container_per_test.run_expect(
+        [0],
+        r"""cat <<EOF > /usr/bin/systemctl
+#!/bin/bash
+printf "%s " "\$@" >> /systemctl_params
+echo >> /systemctl_params
+EOF
+chmod +x /usr/bin/systemctl
+""",
+    )
+
+    container_per_test.run_expect(
+        [0], ". /bin/functions.sh && baseVagrantSetup"
+    )
+
+    # check vagrant user's ssh config
+    dot_ssh = container_per_test.file("/home/vagrant/.ssh")
+    assert dot_ssh.is_directory
+    assert dot_ssh.group == "vagrant"
+    assert dot_ssh.user == "vagrant"
+    assert dot_ssh.mode == 0o700
+
+    authorized_keys = container_per_test.file(
+        "/home/vagrant/.ssh/authorized_keys"
+    )
+    assert authorized_keys.is_file
+    assert authorized_keys.group == "vagrant"
+    assert authorized_keys.user == "vagrant"
+    assert authorized_keys.mode == 0o600
+    assert "vagrant insecure public key" in authorized_keys.content_string
+
+    # check the sshd config
+    sshd_config = container_per_test.run_expect([0], "sshd -T")
+    assert "UseDNS no".lower() in sshd_config.stdout
+    assert "GSSAPIAuthentication no".lower() in sshd_config.stdout
+
+    # check that the shared /vagrant folder is present and has the correct permissions
+    vagrant_shared_dir = container_per_test.file("/vagrant")
+    assert vagrant_shared_dir.is_directory
+    assert vagrant_shared_dir.group == "vagrant"
+    assert vagrant_shared_dir.user == "vagrant"
+
+    vagrant_sudoers = container_per_test.file("/etc/sudoers.d/vagrant")
+    if vagrant_sudoers.exists and vagrant_sudoers.is_file:
+        assert (
+            vagrant_sudoers.content_string.strip() == "vagrant ALL=(ALL) NOPASSWD: ALL"
+        )
+        assert vagrant_sudoers.mode == 0o440
+        assert vagrant_sudoers.user == "root"
+        assert vagrant_sudoers.group == "root"
+    else:
+        sudoers = container_per_test.file("/etc/sudoers")
+        assert sudoers.exists and sudoers.is_file
+        assert "vagrant ALL=(ALL) NOPASSWD: ALL" in sudoers.content_string
+
+    # check that systemctl was called enabling sshd
+    assert (
+        "enable sshd"
+        in container_per_test.file("/systemctl_params").content_string
+    )


### PR DESCRIPTION
In Tumbleweed we switched from shipping sshd's config file in /etc to /usr/etc, but `baseVagrantSetup` was not respecting that.

Now we try to do "the right thing" depending on where the sshd config file exists. Also, this PR adds test coverage for that function.

