### PR TITLE
Increase size of efi fat image

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -824,7 +824,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             [self.boot_dir + '/boot/', self.arch, '/efi']
         )
         Command.run(
-            ['qemu-img', 'create', efi_fat_image, '15M']
+            ['qemu-img', 'create', efi_fat_image, '20M']
         )
         Command.run(
             ['mkdosfs', '-n', 'BOOT', efi_fat_image]

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -300,7 +300,7 @@ class TestBootLoaderConfigGrub2:
         assert mock_command.call_args_list == [
             call(
                 [
-                    'qemu-img', 'create', 'root_dir/boot/x86_64/efi', '15M'
+                    'qemu-img', 'create', 'root_dir/boot/x86_64/efi', '20M'
                 ]
             ),
             call(


### PR DESCRIPTION
For ISO images an embedded efi fat image is needed to boot.
As consequence of adding the mok manager it can happen that
the size of the efi fat image is too small. With this commit
the size is increased to prevent an out of space issue


