### PR TITLE
Handle decoding errors more graceful

### DIFF
--- a/kiwi/utils/codec.py
+++ b/kiwi/utils/codec.py
@@ -28,14 +28,16 @@ class Codec:
     **Performs conversions of literal byte sequences to strings**
     """
     @staticmethod
-    def decode(literal):
+    def decode(literal: bytes) -> str:
         """
-        Decodes the given literal with the default charset. In case of
-        failure attemps to decode using utf-8 charset.
+        Decodes the given literal with the default encoding. In
+        case of failure attemps to decode using utf-8 charset with
+        the 'replace' error strategy.
 
         :param bytes literal: literal to decode
 
-        :return: decoded string
+        :return: decoded str
+
         :rtype: str
         """
         if literal is None:
@@ -45,16 +47,22 @@ class Codec:
         except Exception:
             log.warning("Failed decoding literal. Forcing UTF-8 decoding")
             try:
-                return Codec._wrapped_decode(literal, 'utf_8')
+                return Codec._wrapped_decode(
+                    literal, encoding='utf_8', error_handling_schema='replace'
+                )
             except Exception:
                 raise KiwiDecodingError(
                     'Locale setup is not utf-8 compatible'
                 )
 
     @staticmethod
-    def _wrapped_decode(literal, charset=None):
+    def _wrapped_decode(
+        literal: bytes, encoding: str = '', error_handling_schema: str = ''
+    ) -> str:
         # This decode wrapper is only implemented to facilitate unit testing
-        if charset:
-            return literal.decode(charset)
+        if encoding:
+            return literal.decode(
+                encoding=encoding, errors=error_handling_schema
+            )
         else:
             return literal.decode()

--- a/test/unit/utils/codec_test.py
+++ b/test/unit/utils/codec_test.py
@@ -21,8 +21,8 @@ class TestCodec:
     def test_decode_ascii_failure(self, mock_decode):
         msg = 'utf-8 compatible string'
 
-        def mocked_decode(literal, charset):
-            if charset:
+        def mocked_decode(literal, encoding, error_handling_schema):
+            if encoding:
                 return msg
             else:
                 raise KiwiDecodingError('ascii decoding failure')
@@ -42,8 +42,8 @@ class TestCodec:
 
     @patch('kiwi.utils.codec.Codec._wrapped_decode')
     def test_decode_utf8_failure(self, mock_decode):
-        def mocked_decode(literal, charset):
-            if charset:
+        def mocked_decode(literal, encoding, error_handling_schema):
+            if encoding:
                 raise KiwiDecodingError('utf-8 decoding failure')
             else:
                 raise KiwiDecodingError('ascii decoding failure')


### PR DESCRIPTION
If the Codec.decode() method cannot encode the given data to
utf-8 an Encoding exception is raised which causes kiwi to
raise a KiwiDecodingError. That way to handle the error causes
an image build to fail. However, this sort of error for example
happens if the .changes file of a package contains invalid
characters. From a user perspective this cannot be fixed and
you cannot build the image because of a stupid character
error in a .changes file outside your control. Thus this
commit handles the error more graceful and logs the relevant
data as debug message plus prints a warning to the user
and uses whatever format(literal) gives us back even though
this data will be a binary blob


