### PR TITLE
Moving temp data handling to its own namespace

### DIFF
--- a/doc/source/commands/kiwi.rst
+++ b/doc/source/commands/kiwi.rst
@@ -12,6 +12,7 @@ SYNOPSIS
 
    kiwi-ng -h | --help
    kiwi-ng [--profile=<name>...]
+           [--temp-dir=<directory>]
            [--type=<build_type>]
            [--logfile=<filename>]
            [--debug]
@@ -24,6 +25,7 @@ SYNOPSIS
        result <command> [<args>...]
    kiwi-ng [--profile=<name>...]
            [--shared-cache-dir=<directory>]
+           [--temp-dir=<directory>]
            [--target-arch=<name>]
            [--type=<build_type>]
            [--logfile=<filename>]
@@ -105,7 +107,7 @@ GLOBAL OPTIONS
 
   Select profile to use. The specified profile must be part of the
   XML description. The option can be specified multiple times to
-  allow using a combination of profiles
+  allow using a combination of profiles.
 
 --shared-cache-dir=<directory>
 
@@ -113,7 +115,13 @@ GLOBAL OPTIONS
   is shared via bind mount between the build host and image
   root system and contains information about package repositories
   and their cache and meta data. The default location is set
-  to /var/cache/kiwi
+  to `/var/cache/kiwi`.
+
+--temp-dir=<directory>
+
+  Specify an alternative base temporary directory. The
+  provided path is used as base directory to store temporary
+  files and directories. By default `/var/tmp` is used.
 
 --target-arch=<name>
 

--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -17,8 +17,7 @@
 #
 import os
 import logging
-from tempfile import TemporaryDirectory
-from tempfile import mkdtemp
+from kiwi.utils.temporary import Temporary
 from typing import (
     Optional, List
 )
@@ -74,9 +73,10 @@ class BootImageKiwi(BootImageBase):
         Prepare new root system suitable to create a kiwi initrd from it
         """
         if self.boot_xml_state:
-            self.boot_root_directory = mkdtemp(
+            self.boot_root_directory_temporary = Temporary(
                 prefix='kiwi_boot_root.', dir=self.target_dir
-            )
+            ).new_dir()
+            self.boot_root_directory = self.boot_root_directory_temporary.name
             self.temp_directories.append(
                 self.boot_root_directory
             )
@@ -152,9 +152,9 @@ class BootImageKiwi(BootImageBase):
                 kiwi_initrd_basename = basename
             else:
                 kiwi_initrd_basename = self.initrd_base_name
-            temp_boot_root = TemporaryDirectory(
+            temp_boot_root = Temporary(
                 prefix='kiwi_boot_root_copy.'
-            )
+            ).new_dir()
             temp_boot_root_directory = temp_boot_root.name
             os.chmod(temp_boot_root_directory, 0o755)
             data = DataSync(

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -17,7 +17,6 @@
 #
 import os
 import logging
-from tempfile import NamedTemporaryFile
 from typing import (
     Dict, List, Optional, Tuple, Any
 )
@@ -25,6 +24,7 @@ from typing import (
 # project
 import kiwi.defaults as defaults
 
+from kiwi.utils.temporary import Temporary
 from kiwi.defaults import Defaults
 from kiwi.filesystem.base import FileSystemBase
 from kiwi.bootloader.config import BootLoaderConfig
@@ -742,7 +742,7 @@ class DiskBuilder:
 
         if self.root_filesystem_is_overlay:
             log.info('--> creating readonly root partition')
-            squashed_root_file = NamedTemporaryFile(dir='/var/tmp', prefix='kiwi-')
+            squashed_root_file = Temporary().new_file()
             squashed_root = FileSystemSquashFs(
                 device_provider=DeviceProvider(), root_dir=self.root_dir,
                 custom_args={
@@ -1052,7 +1052,7 @@ class DiskBuilder:
 
         log.info('--> Syncing root filesystem data')
         if self.root_filesystem_is_overlay:
-            squashed_root_file = NamedTemporaryFile(dir='/var/tmp', prefix='kiwi-')
+            squashed_root_file = Temporary().new_file()
             squashed_root = FileSystemSquashFs(
                 device_provider=DeviceProvider(), root_dir=self.root_dir,
                 custom_args={

--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -18,6 +18,7 @@
 """
 usage: kiwi-ng -h | --help
        kiwi-ng [--profile=<name>...]
+               [--temp-dir=<directory>]
                [--type=<build_type>]
                [--logfile=<filename>]
                [--debug]
@@ -30,6 +31,7 @@ usage: kiwi-ng -h | --help
            result <command> [<args>...]
        kiwi-ng [--profile=<name>...]
                [--shared-cache-dir=<directory>]
+               [--temp-dir=<directory>]
                [--target-arch=<name>]
                [--type=<build_type>]
                [--logfile=<filename>]
@@ -69,6 +71,10 @@ global options for services: image, system
         is shared via bind mount between the build host and image
         root system and contains information about package repositories
         and their cache and meta data.
+    --temp-dir=<directory>
+        specify an alternative base temporary directory. The
+        provided path is used as base directory to store temporary
+        files and directories. By default /var/tmp is used.
     --type=<build_type>
         image build type. If not set the default XML specified
         build type will be used
@@ -229,6 +235,10 @@ class Cli:
                     value = os.sep + Defaults.get_shared_cache_location()
                 if arg == '--shared-cache-dir' and value:
                     Defaults.set_shared_cache_location(value)
+                if arg == '--temp-dir' and not value:
+                    value = Defaults.get_temp_location()
+                if arg == '--temp-dir' and value:
+                    Defaults.set_temp_location(value)
                 if arg == '--target-arch' and value:
                     Defaults.set_platform_name(value)
                 if arg == '--config' and value:

--- a/kiwi/container/appx.py
+++ b/kiwi/container/appx.py
@@ -17,9 +17,9 @@
 #
 import os
 import logging
-from tempfile import NamedTemporaryFile
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.archive.tar import ArchiveTar
 from kiwi.defaults import Defaults
 from kiwi.utils.compress import Compress
@@ -98,7 +98,7 @@ class ContainerImageAppx:
         compressor = Compress(archive_file_name)
         archive_file_name = compressor.gzip()
 
-        filemap_file = NamedTemporaryFile()
+        filemap_file = Temporary().new_file()
         with open(filemap_file.name, 'w') as filemap:
             filemap.write('[Files]{0}'.format(os.linesep))
             for topdir, dirs, files in sorted(os.walk(self.meta_data_path)):

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -45,6 +45,7 @@ EDIT_BOOT_INSTALL_SCRIPT = 'edit_boot_install.sh'
 IMAGE_METADATA_DIR = 'image'
 ROOT_VOLUME_NAME = 'LVRoot'
 SHARED_CACHE_DIR = '/var/cache/kiwi'
+TEMP_DIR = '/var/tmp'
 CUSTOM_RUNTIME_CONFIG_FILE = None
 PLATFORM_MACHINE = platform.machine()
 
@@ -253,6 +254,16 @@ class Defaults:
         CUSTOM_RUNTIME_CONFIG_FILE = filename
 
     @staticmethod
+    def set_temp_location(location):
+        """
+        Sets the temp directory location once
+
+        :param str location: a location path
+        """
+        global TEMP_DIR
+        TEMP_DIR = location
+
+    @staticmethod
     def get_shared_cache_location():
         """
         Provides the shared cache location
@@ -270,6 +281,22 @@ class Defaults:
         return os.path.abspath(os.path.normpath(
             SHARED_CACHE_DIR
         )).lstrip(os.sep)
+
+    @staticmethod
+    def get_temp_location():
+        """
+        Provides the base temp directory location
+
+        This is the directory used to store any temporary files
+        and directories created by kiwi during runtime
+
+        :return: directory path
+
+        :rtype: str
+        """
+        return os.path.abspath(
+            os.path.normpath(TEMP_DIR)
+        )
 
     @staticmethod
     def get_sync_options():

--- a/kiwi/iso_tools/cdrtools.py
+++ b/kiwi/iso_tools/cdrtools.py
@@ -17,13 +17,13 @@
 #
 import os
 import re
-from tempfile import NamedTemporaryFile
 from collections import (
     namedtuple,
     OrderedDict
 )
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.defaults import Defaults
 from kiwi.iso_tools.base import IsoToolsBase
 from kiwi.utils.command_capabilities import CommandCapabilities
@@ -250,7 +250,7 @@ class IsoToolsCdrTools(IsoToolsBase):
 
         :rtype: str
         """
-        self.iso_sortfile = NamedTemporaryFile()
+        self.iso_sortfile = Temporary().new_file()
         catalog_file = \
             self.source_dir + '/' + self.boot_path + '/boot.catalog'
         loader_file = \

--- a/kiwi/markup/any.py
+++ b/kiwi/markup/any.py
@@ -17,9 +17,9 @@
 #
 from typing import Any
 import importlib
-from tempfile import NamedTemporaryFile
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.markup.base import MarkupBase
 
 from kiwi.exceptions import (
@@ -44,7 +44,7 @@ class MarkupAny(MarkupBase):
         except Exception as issue:
             raise KiwiAnyMarkupPluginError(issue)
         try:
-            self.description_markup_processed = NamedTemporaryFile()
+            self.description_markup_processed = Temporary().new_file()
             markup = self.anymarkup.parse_file(
                 self.description, force_types=None
             )

--- a/kiwi/markup/base.py
+++ b/kiwi/markup/base.py
@@ -15,10 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-from tempfile import NamedTemporaryFile
 from lxml import etree
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.defaults import Defaults
 from kiwi.exceptions import KiwiConfigFileFormatNotSupported
 
@@ -64,7 +64,7 @@ class MarkupBase:
         xslt_transform = etree.XSLT(
             etree.parse(Defaults.get_xsl_stylesheet_file())
         )
-        self.description_xslt_processed = NamedTemporaryFile(prefix='xslt-')
+        self.description_xslt_processed = Temporary(prefix='xslt-').new_file()
         with open(self.description_xslt_processed.name, "wb") as xsltout:
             xsltout.write(
                 etree.tostring(xslt_transform(parsed_description))

--- a/kiwi/mount_manager.py
+++ b/kiwi/mount_manager.py
@@ -17,11 +17,10 @@
 #
 import time
 import logging
-from tempfile import mkdtemp
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.command import Command
-from kiwi.path import Path
 
 log = logging.getLogger('kiwi')
 
@@ -40,10 +39,11 @@ class MountManager:
     """
     def __init__(self, device, mountpoint=None):
         self.device = device
-        self.mountpoint_created_by_mount_manager = False
         if not mountpoint:
-            self.mountpoint = mkdtemp(prefix='kiwi_mount_manager.')
-            self.mountpoint_created_by_mount_manager = True
+            self.mountpoint_tempdir = Temporary(
+                prefix='kiwi_mount_manager.'
+            ).new_dir()
+            self.mountpoint = self.mountpoint_tempdir.name
         else:
             self.mountpoint = mountpoint
 
@@ -129,7 +129,3 @@ class MountManager:
             return True
         else:
             return False
-
-    def __del__(self):
-        if self.mountpoint_created_by_mount_manager and not self.is_mounted():
-            Path.wipe(self.mountpoint)

--- a/kiwi/oci_tools/umoci.py
+++ b/kiwi/oci_tools/umoci.py
@@ -15,10 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-from tempfile import mkdtemp
 import os
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.oci_tools.base import OCIBase
 from kiwi.command import Command
 from kiwi.path import Path
@@ -34,7 +34,8 @@ class OCIUmoci(OCIBase):
         """
         Initializes some umoci parameters and options
         """
-        self.oci_dir = mkdtemp(prefix='kiwi_oci_dir.')
+        self.oci_dir_tempfile = Temporary(prefix='kiwi_oci_dir.').new_dir()
+        self.oci_dir = self.oci_dir_tempfile.name
         self.container_dir = os.sep.join(
             [self.oci_dir, 'oci_layout']
         )
@@ -102,7 +103,10 @@ class OCIUmoci(OCIBase):
         """
         Unpack current container root data
         """
-        self.oci_root_dir = mkdtemp(prefix='kiwi_oci_root_dir.')
+        self.oci_root_dir_tempdir = Temporary(
+            prefix='kiwi_oci_root_dir.'
+        ).new_dir()
+        self.oci_root_dir = self.oci_root_dir_tempdir.name
         Command.run([
             'umoci', 'unpack', '--image',
             self.working_image, self.oci_root_dir
@@ -259,9 +263,3 @@ class OCIUmoci(OCIBase):
         Command.run(
             ['umoci', 'gc', '--layout', self.container_dir]
         )
-
-    def __del__(self):
-        if self.oci_root_dir:
-            Path.wipe(self.oci_root_dir)
-        if self.oci_dir:
-            Path.wipe(self.oci_dir)

--- a/kiwi/partitioner/dasd.py
+++ b/kiwi/partitioner/dasd.py
@@ -15,10 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-from tempfile import NamedTemporaryFile
 import logging
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.command import Command
 from kiwi.partitioner.base import PartitionerBase
 
@@ -55,7 +55,7 @@ class PartitionerDasd(PartitionerBase):
         :param list flags: unused
         """
         self.partition_id += 1
-        fdasd_input = NamedTemporaryFile()
+        fdasd_input = Temporary().new_file()
         with open(fdasd_input.name, 'w') as partition:
             log.debug(
                 '%s: fdasd: n p cur_position +%sM w q',

--- a/kiwi/partitioner/msdos.py
+++ b/kiwi/partitioner/msdos.py
@@ -15,10 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-from tempfile import NamedTemporaryFile
 import logging
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.command import Command
 from kiwi.partitioner.base import PartitionerBase
 
@@ -60,7 +60,7 @@ class PartitionerMsDos(PartitionerBase):
         :param list flags: additional flags
         """
         self.partition_id += 1
-        fdisk_input = NamedTemporaryFile()
+        fdisk_input = Temporary().new_file()
         if self.partition_id > 1:
             # Undefined start sector value skips this for fdisk and
             # use its default value

--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -17,11 +17,11 @@
 #
 import os
 import logging
-from tempfile import NamedTemporaryFile
 from urllib.parse import urlparse
 from typing import List, Dict
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.repository.template.apt import PackageManagerTemplateAptGet
 from kiwi.repository.base import RepositoryBase
 from kiwi.path import Path
@@ -86,9 +86,9 @@ class RepositoryApt(RepositoryBase):
         }
         self.keyring = '{}/trusted.gpg'.format(self.manager_base)
 
-        self.runtime_apt_get_config_file = NamedTemporaryFile(
+        self.runtime_apt_get_config_file = Temporary(
             dir=self.root_dir
-        )
+        ).new_file()
 
         self.apt_get_args = [
             '-q', '-c', self.runtime_apt_get_config_file.name, '-y'

--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -18,10 +18,10 @@
 import os
 import glob
 from configparser import ConfigParser
-from tempfile import NamedTemporaryFile
 from typing import List, Dict
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.defaults import Defaults
 from kiwi.command import Command
 from kiwi.repository.base import RepositoryBase
@@ -92,9 +92,9 @@ class RepositoryDnf(RepositoryBase):
             'vars-dir': manager_base + '/vars'
         }
 
-        self.runtime_dnf_config_file = NamedTemporaryFile(
+        self.runtime_dnf_config_file = Temporary(
             dir=self.root_dir
-        )
+        ).new_file()
 
         self.dnf_args = [
             '--config', self.runtime_dnf_config_file.name, '-y'

--- a/kiwi/repository/pacman.py
+++ b/kiwi/repository/pacman.py
@@ -17,12 +17,12 @@
 #
 import os
 from configparser import ConfigParser
-from tempfile import NamedTemporaryFile
 from typing import (
     List, Dict
 )
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.repository.base import RepositoryBase
 from kiwi.path import Path
 from kiwi.command import Command
@@ -52,9 +52,9 @@ class RepositoryPacman(RepositoryBase):
         self.check_signatures = False
         self.repo_names: List = []
 
-        self.runtime_pacman_config_file = NamedTemporaryFile(
+        self.runtime_pacman_config_file = Temporary(
             dir=self.root_dir
-        )
+        ).new_file()
 
         if 'check_signatures' in self.custom_args:
             self.custom_args.remove('check_signatures')

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -17,10 +17,10 @@
 #
 import os
 from configparser import ConfigParser
-from tempfile import NamedTemporaryFile
 from typing import List, Dict
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.defaults import Defaults
 from kiwi.command import Command
 from kiwi.repository.base import RepositoryBase
@@ -108,12 +108,12 @@ class RepositoryZypper(RepositoryBase):
             )
         }
 
-        self.runtime_zypper_config_file = NamedTemporaryFile(
+        self.runtime_zypper_config_file = Temporary(
             dir=self.root_dir
-        )
-        self.runtime_zypp_config_file = NamedTemporaryFile(
+        ).new_file()
+        self.runtime_zypp_config_file = Temporary(
             dir=self.root_dir
-        )
+        ).new_file()
 
         self.zypper_args = [
             '--non-interactive',

--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -19,9 +19,9 @@ import os
 import logging
 from collections import OrderedDict
 from typing import Dict
-from tempfile import NamedTemporaryFile
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.command import Command
 from kiwi.storage.device_provider import DeviceProvider
 from kiwi.storage.mapped_device import MappedDevice
@@ -259,7 +259,7 @@ class Disk(DeviceProvider):
         """
         if 'dasd' in self.table_type:
             log.debug('Initialize DASD disk with new VTOC table')
-            fdasd_input = NamedTemporaryFile()
+            fdasd_input = Temporary().new_file()
             with open(fdasd_input.name, 'w') as vtoc:
                 vtoc.write('y\n\nw\nq\n')
             bash_command = ' '.join(

--- a/kiwi/storage/luks_device.py
+++ b/kiwi/storage/luks_device.py
@@ -17,10 +17,10 @@
 #
 import os
 import logging
-from tempfile import NamedTemporaryFile
 from typing import Optional
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.command import Command
 from kiwi.defaults import Defaults
 from kiwi.storage.device_provider import DeviceProvider
@@ -119,7 +119,7 @@ class LuksDevice(DeviceProvider):
         log.info('--> Creating LUKS map')
 
         if passphrase:
-            passphrase_file_tmp = NamedTemporaryFile()
+            passphrase_file_tmp = Temporary().new_file()
             with open(passphrase_file_tmp.name, 'w') as credentials:
                 credentials.write(passphrase)
             passphrase_file = passphrase_file_tmp.name

--- a/kiwi/storage/subformat/gce.py
+++ b/kiwi/storage/subformat/gce.py
@@ -17,9 +17,9 @@
 #
 import os
 from collections import OrderedDict
-from tempfile import mkdtemp
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.command import Command
 from kiwi.storage.subformat.base import DiskFormatBase
 from kiwi.archive.tar import ArchiveTar
@@ -56,9 +56,9 @@ class DiskFormatGce(DiskFormatBase):
         Create GCE disk format and manifest
         """
         gce_tar_ball_file_list = []
-        self.temp_image_dir = mkdtemp(
+        temp_image_dir = Temporary(
             prefix='kiwi_gce_subformat.', dir=self.target_dir
-        )
+        ).new_dir()
         diskname = ''.join(
             [
                 self.target_dir, '/',
@@ -69,12 +69,12 @@ class DiskFormatGce(DiskFormatBase):
             ]
         )
         if self.tag:
-            with open(self.temp_image_dir + '/manifest.json', 'w') as manifest:
+            with open(temp_image_dir.name + '/manifest.json', 'w') as manifest:
                 manifest.write('{"licenses": ["%s"]}' % self.tag)
             gce_tar_ball_file_list.append('manifest.json')
 
         Command.run(
-            ['cp', diskname, self.temp_image_dir + '/disk.raw']
+            ['cp', diskname, temp_image_dir.name + '/disk.raw']
         )
         gce_tar_ball_file_list.append('disk.raw')
 
@@ -91,7 +91,7 @@ class DiskFormatGce(DiskFormatBase):
             file_list=gce_tar_ball_file_list
         )
         archive.create_gnu_gzip_compressed(
-            self.temp_image_dir
+            temp_image_dir.name
         )
 
     def store_to_result(self, result: Result) -> None:

--- a/kiwi/storage/subformat/qcow2.py
+++ b/kiwi/storage/subformat/qcow2.py
@@ -14,9 +14,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
-from tempfile import NamedTemporaryFile
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.storage.subformat.base import DiskFormatBase
 from kiwi.command import Command
 from kiwi.system.result import Result
@@ -41,7 +41,7 @@ class DiskFormatQcow2(DiskFormatBase):
         """
         Create qcow2 disk format
         """
-        intermediate = NamedTemporaryFile()
+        intermediate = Temporary().new_file()
         Command.run(
             [
                 'qemu-img', 'convert', '-f', 'raw', self.diskname,

--- a/kiwi/storage/subformat/vagrant_base.py
+++ b/kiwi/storage/subformat/vagrant_base.py
@@ -18,7 +18,7 @@
 import json
 import os.path
 
-from tempfile import mkdtemp
+from kiwi.utils.temporary import Temporary
 from typing import (
     Dict, Optional, List
 )
@@ -131,15 +131,15 @@ class DiskFormatVagrantBase(DiskFormatBase):
                 'vagrant_post_init: Missing provider and/or box name setup'
             )
 
-        self.temp_image_dir = mkdtemp(prefix='kiwi_vagrant_box.')
+        temp_image_dir = Temporary(prefix='kiwi_vagrant_box.').new_dir()
 
-        box_img_files = self.create_box_img(self.temp_image_dir)
+        box_img_files = self.create_box_img(temp_image_dir.name)
 
-        metadata_json = os.path.join(self.temp_image_dir, 'metadata.json')
+        metadata_json = os.path.join(temp_image_dir.name, 'metadata.json')
         with open(metadata_json, 'w') as meta:
             meta.write(self._create_box_metadata())
 
-        vagrantfile = os.path.join(self.temp_image_dir, 'Vagrantfile')
+        vagrantfile = os.path.join(temp_image_dir.name, 'Vagrantfile')
         with open(vagrantfile, 'w') as vagrant:
             # autogenerate a Vagrantfile:
             if not self.vagrantconfig.get_embedded_vagrantfile():
@@ -157,7 +157,7 @@ class DiskFormatVagrantBase(DiskFormatBase):
 
         Command.run(
             [
-                'tar', '-C', self.temp_image_dir,
+                'tar', '-C', temp_image_dir.name,
                 '-czf', self.get_target_file_path_for_format(
                     self.image_format
                 ),

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -19,9 +19,9 @@ import os
 import logging
 import collections
 from typing import Dict
-from tempfile import NamedTemporaryFile
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.xml_state import XMLState
 from kiwi.system.shell import Shell
 from kiwi.defaults import Defaults
@@ -82,7 +82,7 @@ class Profile:
         :param str filename: file path name
         """
         sorted_profile = self.get_settings()
-        temp_profile = NamedTemporaryFile()
+        temp_profile = Temporary().new_file()
         with open(temp_profile.name, 'w') as profile:
             for key, value in list(sorted_profile.items()):
                 profile.write(

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -21,12 +21,12 @@ import logging
 import copy
 from collections import OrderedDict
 from collections import namedtuple
-from tempfile import NamedTemporaryFile
 from typing import Any
 
 # project
 import kiwi.defaults as defaults
 
+from kiwi.utils.temporary import Temporary
 from kiwi.utils.fstab import Fstab
 from kiwi.xml_state import XMLState
 from kiwi.runtime_config import RuntimeConfig
@@ -738,9 +738,7 @@ class SystemSetup:
             'partition_filesystem':
                 self.root_dir + '/recovery.tar.filesystem'
         }
-        recovery_archive = NamedTemporaryFile(
-            delete=False
-        )
+        recovery_archive = Temporary(delete=False).new_file()
         archive = ArchiveTar(
             filename=recovery_archive.name,
             create_from_file_list=False

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -19,6 +19,7 @@ import glob
 import os
 import logging
 import copy
+import pathlib
 from collections import OrderedDict
 from collections import namedtuple
 from typing import Any
@@ -26,7 +27,6 @@ from typing import Any
 # project
 import kiwi.defaults as defaults
 
-from kiwi.utils.temporary import Temporary
 from kiwi.utils.fstab import Fstab
 from kiwi.xml_state import XMLState
 from kiwi.runtime_config import RuntimeConfig
@@ -738,9 +738,9 @@ class SystemSetup:
             'partition_filesystem':
                 self.root_dir + '/recovery.tar.filesystem'
         }
-        recovery_archive = Temporary(delete=False).new_file()
+        pathlib.Path(metadata['archive_name']).touch()
         archive = ArchiveTar(
-            filename=recovery_archive.name,
+            filename=metadata['archive_name'],
             create_from_file_list=False
         )
         archive.create(
@@ -751,9 +751,6 @@ class SystemSetup:
                 '--hard-dereference',
                 '--preserve-permissions'
             ]
-        )
-        Command.run(
-            ['mv', recovery_archive.name, metadata['archive_name']]
         )
         # recovery.tar.filesystem
         recovery_filesystem = self.xml_state.build_type.get_filesystem()

--- a/kiwi/system/shell.py
+++ b/kiwi/system/shell.py
@@ -15,11 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-from tempfile import NamedTemporaryFile
 from typing import Optional, Any, List
 from collections.abc import Iterable
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.command import Command
 from kiwi.defaults import Defaults
 
@@ -63,7 +63,7 @@ class Shell:
 
         :rtype: List[str]
         """
-        temp_copy = NamedTemporaryFile()
+        temp_copy = Temporary().new_file()
         Command.run(['cp', filename, temp_copy.name])
         Shell.run_common_function('baseQuoteFile', [temp_copy.name])
         with open(temp_copy.name) as quoted:

--- a/kiwi/utils/compress.py
+++ b/kiwi/utils/compress.py
@@ -17,9 +17,9 @@
 #
 import os
 import logging
-from tempfile import NamedTemporaryFile
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.command import Command
 from kiwi.defaults import Defaults
 
@@ -107,7 +107,7 @@ class Compress:
             Command.run([zipper, '-d', self.source_filename])
             self.uncompressed_filename = self.source_filename
         else:
-            self.temp_file = NamedTemporaryFile()
+            self.temp_file = Temporary().new_file()
             bash_command = [
                 zipper, '-c', '-d', self.source_filename,
                 '>', self.temp_file.name

--- a/kiwi/utils/output.py
+++ b/kiwi/utils/output.py
@@ -18,9 +18,9 @@
 import json
 import os
 import logging
-from tempfile import NamedTemporaryFile
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.path import Path
 
 log = logging.getLogger('kiwi')
@@ -87,7 +87,7 @@ class DataOutput:
         """
         Show data in json output format with nice color highlighting
         """
-        out_file = NamedTemporaryFile()
+        out_file = Temporary().new_file()
         out_file.write(json.dumps(self.data, sort_keys=True).encode())
         out_file.flush()
         pjson_cmd = ''.join(

--- a/kiwi/utils/temporary.py
+++ b/kiwi/utils/temporary.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2021 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+from typing import IO
+
+from tempfile import (
+    NamedTemporaryFile,
+    TemporaryDirectory
+)
+
+# project
+import kiwi.defaults as defaults
+
+
+class Temporary:
+    """
+    **Provides namespace to handle temporary files and directories**
+    """
+    def __init__(
+        self, dir: str = defaults.TEMP_DIR, prefix: str = '',
+        delete: bool = True
+    ):
+        self.prefix = f'kiwi_{prefix}' if prefix else 'kiwi_'
+        self.delete = delete
+        self.dir = dir
+
+    def new_file(self) -> IO[bytes]:
+        return NamedTemporaryFile(
+            dir=self.dir, prefix=self.prefix, delete=self.delete
+        )
+
+    def new_dir(self) -> TemporaryDirectory:
+        return TemporaryDirectory(
+            dir=self.dir, prefix=self.prefix
+        )

--- a/kiwi/utils/temporary.py
+++ b/kiwi/utils/temporary.py
@@ -31,16 +31,14 @@ class Temporary:
     **Provides namespace to handle temporary files and directories**
     """
     def __init__(
-        self, dir: str = defaults.TEMP_DIR, prefix: str = '',
-        delete: bool = True
+        self, dir: str = defaults.TEMP_DIR, prefix: str = ''
     ):
         self.prefix = f'kiwi_{prefix}' if prefix else 'kiwi_'
-        self.delete = delete
         self.dir = dir
 
     def new_file(self) -> IO[bytes]:
         return NamedTemporaryFile(
-            dir=self.dir, prefix=self.prefix, delete=self.delete
+            dir=self.dir, prefix=self.prefix
         )
 
     def new_dir(self) -> TemporaryDirectory:

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -16,11 +16,11 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 from collections import namedtuple
-from tempfile import mkdtemp
 import logging
 import os
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.command import Command
 from kiwi.storage.device_provider import DeviceProvider
 from kiwi.mount_manager import MountManager
@@ -358,9 +358,6 @@ class VolumeManagerBase(DeviceProvider):
         Implements creation of a master directory holding
         the mounts of all volumes
         """
-        self.mountpoint = mkdtemp(prefix='kiwi_volumes.')
-        self.temp_directories.append(self.mountpoint)
-
-    def _cleanup_tempdirs(self):
-        for directory in self.temp_directories:
-            Path.wipe(directory)
+        self.mountpoint_tempdir = Temporary(prefix='kiwi_volumes.').new_dir()
+        self.mountpoint = self.mountpoint_tempdir.name
+        self.temp_directories.append(self.mountpoint_tempdir)

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -454,4 +454,3 @@ class VolumeManagerBtrfs(VolumeManagerBase):
                 log.warning('Subvolumes still busy')
                 return
             Path.wipe(self.mountpoint)
-        self._cleanup_tempdirs()

--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -399,4 +399,3 @@ class VolumeManagerLVM(VolumeManagerBase):
                         'volume group %s still busy', self.volume_group
                     )
                     return
-        self._cleanup_tempdirs()

--- a/kiwi/xml_description.py
+++ b/kiwi/xml_description.py
@@ -25,9 +25,9 @@ from lxml import (
     etree,
     isoschematron
 )
-from tempfile import NamedTemporaryFile
 
 # project
+from kiwi.utils.temporary import Temporary
 from kiwi.markup import Markup
 from kiwi.defaults import Defaults
 from kiwi import xml_parse
@@ -164,7 +164,7 @@ class XMLDescription:
                         xml_data_domtree = minidom.parseString(
                             xml_data_unformatted
                         )
-                        extension_file = NamedTemporaryFile()
+                        extension_file = Temporary().new_file()
                         with open(extension_file.name, 'w') as xml_data:
                             xml_data.write(xml_data_domtree.toprettyxml())
                         XMLDescription._get_relaxng_validation_details(

--- a/test/unit/boot/image/builtin_kiwi_test.py
+++ b/test/unit/boot/image/builtin_kiwi_test.py
@@ -17,10 +17,12 @@ from kiwi.exceptions import KiwiConfigFileNotFound
 
 
 class TestBootImageKiwi:
-    @patch('kiwi.boot.image.builtin_kiwi.mkdtemp')
+    @patch('kiwi.boot.image.builtin_kiwi.Temporary')
     @patch('kiwi.boot.image.builtin_kiwi.os.path.exists')
     @patch('kiwi.defaults.Defaults.get_boot_image_description_path')
-    def setup(self, mock_boot_path, mock_exists, mock_mkdtemp):
+    def setup(self, mock_boot_path, mock_exists, mock_Temporary):
+        mock_Temporary.return_value.new_dir.return_value.name = \
+            'boot-root-directory'
         mock_boot_path.return_value = '../data'
         Defaults.set_platform_name('x86_64')
         mock_exists.return_value = True
@@ -46,7 +48,6 @@ class TestBootImageKiwi:
         kiwi.boot.image.builtin_kiwi.Profile = Mock(
             return_value=self.profile
         )
-        mock_mkdtemp.return_value = 'boot-root-directory'
         self.boot_image = BootImageKiwi(
             self.xml_state, 'some-target-dir'
         )
@@ -56,9 +57,10 @@ class TestBootImageKiwi:
         self.boot_image.include_file('/root/a')
 
     @patch('kiwi.defaults.Defaults.get_boot_image_description_path')
-    @patch('kiwi.boot.image.builtin_kiwi.mkdtemp')
-    def test_prepare(self, mock_mkdtemp, mock_boot_path):
-        mock_mkdtemp.return_value = 'boot-root-directory'
+    @patch('kiwi.boot.image.builtin_kiwi.Temporary')
+    def test_prepare(self, mock_Temporary, mock_boot_path):
+        mock_Temporary.return_value.new_dir.return_value.name = \
+            'boot-root-directory'
         mock_boot_path.return_value = '../data'
         self.boot_image.prepare()
         self.system_prepare.setup_repositories.assert_called_once_with(
@@ -87,11 +89,12 @@ class TestBootImageKiwi:
         self.setup.call_image_script.assert_called_once_with()
 
     @patch('os.path.exists')
-    @patch('kiwi.boot.image.builtin_kiwi.mkdtemp')
+    @patch('kiwi.boot.image.builtin_kiwi.Temporary')
     def test_prepare_no_boot_description_found(
-        self, mock_mkdtemp, mock_os_path
+        self, mock_Temporary, mock_os_path
     ):
-        mock_mkdtemp.return_value = 'boot-root-directory'
+        mock_Temporary.return_value.new_dir.return_value.name = \
+            'boot-root-directory'
         mock_os_path.return_value = False
         with raises(KiwiConfigFileNotFound):
             self.boot_image.post_init()
@@ -102,20 +105,17 @@ class TestBootImageKiwi:
     @patch('kiwi.boot.image.builtin_kiwi.Path.wipe')
     @patch('kiwi.boot.image.builtin_kiwi.DataSync')
     @patch('kiwi.boot.image.base.BootImageBase.is_prepared')
-    @patch('kiwi.boot.image.builtin_kiwi.mkdtemp')
     @patch('kiwi.boot.image.builtin_kiwi.os.chmod')
-    @patch('kiwi.boot.image.builtin_kiwi.TemporaryDirectory')
+    @patch('kiwi.boot.image.builtin_kiwi.Temporary')
     def test_create_initrd(
-        self, mock_TemporaryDirectory, mock_os_chmod,
-        mock_mkdtemp, mock_prepared, mock_sync,
-        mock_wipe, mock_create, mock_compress, mock_cpio
+        self, mock_Temporary, mock_os_chmod,
+        mock_prepared, mock_sync, mock_wipe, mock_create,
+        mock_compress, mock_cpio
     ):
         data = Mock()
         mock_sync.return_value = data
-        mock_mkdtemp.return_value = 'temp-boot-directory'
-        temporary_directory = Mock()
-        temporary_directory.name = 'temp-boot-directory'
-        mock_TemporaryDirectory.return_value = temporary_directory
+        mock_Temporary.return_value.new_dir.return_value.name = \
+            'temp-boot-directory'
         mock_prepared.return_value = True
         self.boot_image.boot_root_directory = 'boot-root-directory'
         mbrid = Mock()

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -545,7 +545,7 @@ class TestDiskBuilder:
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     @patch('os.path.exists')
     @patch('os.path.getsize')
-    @patch('kiwi.builder.disk.NamedTemporaryFile')
+    @patch('kiwi.builder.disk.Temporary.new_file')
     @patch('random.randrange')
     def test_create_disk_standard_root_is_overlay(
         self, mock_rand, mock_temp, mock_getsize, mock_exists,

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -1,5 +1,5 @@
 from mock import (
-    patch, call, mock_open, ANY
+    patch, call, mock_open, ANY, Mock
 )
 from pytest import raises
 import mock
@@ -125,22 +125,28 @@ class TestInstallImageBuilder:
     @patch('kiwi.builder.install.BootLoaderConfig.new')
     @patch('kiwi.builder.install.IsoToolsBase.setup_media_loader_directory')
     @patch('kiwi.builder.install.shutil.copy')
-    @patch('kiwi.builder.install.mkdtemp')
+    @patch('kiwi.builder.install.Temporary')
     @patch('kiwi.builder.install.Command.run')
     @patch('kiwi.builder.install.Defaults.get_grub_boot_directory_name')
     def test_create_install_iso(
-        self, mock_grub_dir, mock_command, mock_dtemp, mock_copy,
+        self, mock_grub_dir, mock_command, mock_Temporary, mock_copy,
         mock_setup_media_loader_directory, mock_BootLoaderConfig,
         mock_DeviceProvider
     ):
-        tmpdir_name = ['temp-squashfs', 'temp_media_dir']
+        temp_squashfs = Mock()
+        temp_squashfs.new_dir.return_value.name = 'temp-squashfs'
+
+        temp_media_dir = Mock()
+        temp_media_dir.new_dir.return_value.name = 'temp_media_dir'
+
+        tmpdir_name = [temp_squashfs, temp_media_dir]
 
         def side_effect(prefix, dir):
             return tmpdir_name.pop()
 
         bootloader_config = mock.Mock()
         mock_BootLoaderConfig.return_value = bootloader_config
-        mock_dtemp.side_effect = side_effect
+        mock_Temporary.side_effect = side_effect
 
         m_open = mock_open()
         with patch('builtins.open', m_open, create=True):
@@ -216,7 +222,7 @@ class TestInstallImageBuilder:
             'target_dir/result-image.x86_64-1.2.3.install.iso'
         )
 
-        tmpdir_name = ['temp-squashfs', 'temp_media_dir']
+        tmpdir_name = [temp_squashfs, temp_media_dir]
         self.install_image.initrd_system = 'dracut'
 
         m_open.reset_mock()
@@ -243,7 +249,7 @@ class TestInstallImageBuilder:
         ]
 
         mock_BootLoaderConfig.reset_mock()
-        tmpdir_name = ['temp-squashfs', 'temp_media_dir']
+        tmpdir_name = [temp_squashfs, temp_media_dir]
         self.firmware.efi_mode.return_value = None
 
         with patch('builtins.open', m_open, create=True):
@@ -255,10 +261,10 @@ class TestInstallImageBuilder:
         )
 
     @patch('kiwi.builder.install.IsoToolsBase.setup_media_loader_directory')
-    @patch('kiwi.builder.install.mkdtemp')
+    @patch('kiwi.builder.install.Temporary')
     @patch('kiwi.builder.install.Command.run')
     def test_create_install_iso_no_kernel_found(
-        self, mock_command, mock_dtemp, mock_setup_media_loader_directory
+        self, mock_command, mock_Temporary, mock_setup_media_loader_directory
     ):
         self.kernel.get_kernel.return_value = False
         with patch('builtins.open'):
@@ -266,44 +272,45 @@ class TestInstallImageBuilder:
                 self.install_image.create_install_iso()
 
     @patch('kiwi.builder.install.IsoToolsBase.setup_media_loader_directory')
-    @patch('kiwi.builder.install.mkdtemp')
+    @patch('kiwi.builder.install.Temporary')
     @patch('kiwi.builder.install.Command.run')
     def test_create_install_iso_no_hypervisor_found(
-        self, mock_command, mock_dtemp, mock_setup_media_loader_directory
+        self, mock_command, mock_Temporary, mock_setup_media_loader_directory
     ):
         self.kernel.get_xen_hypervisor.return_value = False
         with patch('builtins.open'):
             with raises(KiwiInstallBootImageError):
                 self.install_image.create_install_iso()
 
-    @patch('kiwi.builder.install.mkdtemp')
+    @patch('kiwi.builder.install.Temporary')
     @patch('kiwi.builder.install.Command.run')
     @patch('kiwi.builder.install.Checksum')
     @patch('kiwi.builder.install.Compress')
     def test_create_install_pxe_no_kernel_found(
-        self, mock_compress, mock_md5, mock_command, mock_dtemp
+        self, mock_compress, mock_md5, mock_command, mock_Temporary
     ):
-        mock_dtemp.return_value = 'tmpdir'
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         self.kernel.get_kernel.return_value = False
         with patch('builtins.open'):
             with raises(KiwiInstallBootImageError):
                 self.install_image.create_install_pxe_archive()
 
-    @patch('kiwi.builder.install.mkdtemp')
+    @patch('kiwi.builder.install.Temporary')
     @patch('kiwi.builder.install.Command.run')
     @patch('kiwi.builder.install.Checksum')
     @patch('kiwi.builder.install.Compress')
     @patch('kiwi.builder.install.os.symlink')
     def test_create_install_pxe_no_hypervisor_found(
-        self, mock_symlink, mock_compress, mock_md5, mock_command, mock_dtemp
+        self, mock_symlink, mock_compress, mock_md5, mock_command,
+        mock_Temporary
     ):
-        mock_dtemp.return_value = 'tmpdir'
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         self.kernel.get_xen_hypervisor.return_value = False
         with patch('builtins.open'):
             with raises(KiwiInstallBootImageError):
                 self.install_image.create_install_pxe_archive()
 
-    @patch('kiwi.builder.install.mkdtemp')
+    @patch('kiwi.builder.install.Temporary')
     @patch('kiwi.builder.install.Command.run')
     @patch('kiwi.builder.install.ArchiveTar')
     @patch('kiwi.builder.install.Checksum')
@@ -313,9 +320,9 @@ class TestInstallImageBuilder:
     @patch('kiwi.builder.install.os.chmod')
     def test_create_install_pxe_archive(
         self, mock_chmod, mock_symlink, mock_copy, mock_compress,
-        mock_md5, mock_archive, mock_command, mock_dtemp
+        mock_md5, mock_archive, mock_command, mock_Temporary
     ):
-        mock_dtemp.return_value = 'tmpdir'
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
 
         archive = mock.Mock()
         mock_archive.return_value = archive
@@ -425,19 +432,3 @@ class TestInstallImageBuilder:
         self.boot_image_task.set_static_modules.assert_called_once_with(
             ['module1', 'module2']
         )
-
-    @patch('kiwi.builder.install.Path.wipe')
-    @patch('os.path.exists')
-    def test_destructor(self, mock_exists, mock_wipe):
-        mock_exists.return_value = True
-        self.install_image.initrd_system = 'dracut'
-        self.install_image.pxe_dir = 'pxe-dir'
-        self.install_image.media_dir = 'media-dir'
-        self.install_image.squashed_contents = 'squashed-dir'
-        self.install_image.__del__()
-        assert mock_wipe.call_args_list == [
-            call('media-dir'), call('pxe-dir'), call('squashed-dir')
-        ]
-        self.install_image.pxe_dir = None
-        self.install_image.media_dir = None
-        self.install_image.squashed_contents = None

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -1,8 +1,7 @@
 from mock import (
-    patch, call
+    patch, call, Mock
 )
 from pytest import raises
-import mock
 import sys
 import kiwi
 
@@ -17,89 +16,89 @@ class TestLiveImageBuilder:
     def setup(self):
         Defaults.set_platform_name('x86_64')
 
-        self.firmware = mock.Mock()
-        self.firmware.efi_mode = mock.Mock(
+        self.firmware = Mock()
+        self.firmware.efi_mode = Mock(
             return_value='uefi'
         )
-        kiwi.builder.live.FirmWare = mock.Mock(
+        kiwi.builder.live.FirmWare = Mock(
             return_value=self.firmware
         )
 
-        self.setup = mock.Mock()
-        kiwi.builder.live.SystemSetup = mock.Mock(
+        self.setup = Mock()
+        kiwi.builder.live.SystemSetup = Mock(
             return_value=self.setup
         )
 
-        self.filesystem_setup = mock.Mock()
-        kiwi.builder.live.FileSystemSetup = mock.Mock(
+        self.filesystem_setup = Mock()
+        kiwi.builder.live.FileSystemSetup = Mock(
             return_value=self.filesystem_setup
         )
 
-        self.loop = mock.Mock()
-        kiwi.builder.live.LoopDevice = mock.Mock(
+        self.loop = Mock()
+        kiwi.builder.live.LoopDevice = Mock(
             return_value=self.loop
         )
 
-        self.bootloader = mock.Mock()
-        kiwi.builder.live.BootLoaderConfig.new = mock.Mock(
+        self.bootloader = Mock()
+        kiwi.builder.live.BootLoaderConfig.new = Mock(
             return_value=self.bootloader
         )
 
-        self.boot_image_task = mock.Mock()
+        self.boot_image_task = Mock()
         self.boot_image_task.boot_root_directory = 'initrd_dir'
         self.boot_image_task.initrd_filename = 'initrd'
-        kiwi.builder.live.BootImageDracut = mock.Mock(
+        kiwi.builder.live.BootImageDracut = Mock(
             return_value=self.boot_image_task
         )
 
-        self.mbrid = mock.Mock()
-        self.mbrid.get_id = mock.Mock(
+        self.mbrid = Mock()
+        self.mbrid.get_id = Mock(
             return_value='0xffffffff'
         )
-        kiwi.builder.live.SystemIdentifier = mock.Mock(
+        kiwi.builder.live.SystemIdentifier = Mock(
             return_value=self.mbrid
         )
 
-        kiwi.builder.live.Path = mock.Mock()
+        kiwi.builder.live.Path = Mock()
 
-        self.kernel = mock.Mock()
-        self.kernel.get_kernel = mock.Mock()
-        self.kernel.get_xen_hypervisor = mock.Mock()
-        self.kernel.copy_kernel = mock.Mock()
-        self.kernel.copy_xen_hypervisor = mock.Mock()
-        kiwi.builder.live.Kernel = mock.Mock(
+        self.kernel = Mock()
+        self.kernel.get_kernel = Mock()
+        self.kernel.get_xen_hypervisor = Mock()
+        self.kernel.copy_kernel = Mock()
+        self.kernel.copy_xen_hypervisor = Mock()
+        kiwi.builder.live.Kernel = Mock(
             return_value=self.kernel
         )
 
-        self.xml_state = mock.Mock()
-        self.xml_state.get_fs_mount_option_list = mock.Mock(
+        self.xml_state = Mock()
+        self.xml_state.get_fs_mount_option_list = Mock(
             return_value=['async']
         )
-        self.xml_state.get_fs_create_option_list = mock.Mock(
+        self.xml_state.get_fs_create_option_list = Mock(
             return_value=['-O', 'option']
         )
-        self.xml_state.build_type.get_flags = mock.Mock(
+        self.xml_state.build_type.get_flags = Mock(
             return_value=None
         )
-        self.xml_state.build_type.get_squashfscompression = mock.Mock(
+        self.xml_state.build_type.get_squashfscompression = Mock(
             return_value='lzo'
         )
-        self.xml_state.get_image_version = mock.Mock(
+        self.xml_state.get_image_version = Mock(
             return_value='1.2.3'
         )
-        self.xml_state.xml_data.get_name = mock.Mock(
+        self.xml_state.xml_data.get_name = Mock(
             return_value='result-image'
         )
-        self.xml_state.build_type.get_volid = mock.Mock(
+        self.xml_state.build_type.get_volid = Mock(
             return_value='volid'
         )
-        self.xml_state.build_type.get_kernelcmdline = mock.Mock(
+        self.xml_state.build_type.get_kernelcmdline = Mock(
             return_value='custom_cmdline'
         )
-        self.xml_state.build_type.get_mediacheck = mock.Mock(
+        self.xml_state.build_type.get_mediacheck = Mock(
             return_value=True
         )
-        self.xml_state.build_type.get_publisher = mock.Mock(
+        self.xml_state.build_type.get_publisher = Mock(
             return_value='Custom publisher'
         )
 
@@ -108,7 +107,7 @@ class TestLiveImageBuilder:
             custom_args={'signing_keys': ['key_file_a', 'key_file_b']}
         )
 
-        self.result = mock.Mock()
+        self.result = Mock()
         self.live_image.result = self.result
 
     def teardown(self):
@@ -116,11 +115,11 @@ class TestLiveImageBuilder:
 
     def test_init_for_ix86_platform(self):
         Defaults.set_platform_name('i686')
-        xml_state = mock.Mock()
-        xml_state.xml_data.get_name = mock.Mock(
+        xml_state = Mock()
+        xml_state.xml_data.get_name = Mock(
             return_value='some-image'
         )
-        xml_state.get_image_version = mock.Mock(
+        xml_state.get_image_version = Mock(
             return_value='1.2.3'
         )
         live_image = LiveImageBuilder(
@@ -130,8 +129,7 @@ class TestLiveImageBuilder:
 
     @patch('kiwi.builder.live.DeviceProvider')
     @patch('kiwi.builder.live.IsoToolsBase.setup_media_loader_directory')
-    @patch('kiwi.builder.live.mkdtemp')
-    @patch('kiwi.builder.live.NamedTemporaryFile')
+    @patch('kiwi.builder.live.Temporary')
     @patch('kiwi.builder.live.shutil')
     @patch('kiwi.builder.live.Iso.set_media_tag')
     @patch('kiwi.builder.live.FileSystemIsoFs')
@@ -141,31 +139,37 @@ class TestLiveImageBuilder:
     @patch('os.path.exists')
     def test_create_overlay_structure(
         self, mock_exists, mock_grub_dir, mock_size, mock_filesystem,
-        mock_isofs, mock_tag, mock_shutil, mock_tmpfile, mock_dtemp,
+        mock_isofs, mock_tag, mock_shutil, mock_Temporary,
         mock_setup_media_loader_directory, mock_DeviceProvider
     ):
-        tempfile = mock.Mock()
-        tempfile.name = 'kiwi-tmpfile'
-        mock_tmpfile.return_value = tempfile
         mock_exists.return_value = True
         mock_grub_dir.return_value = 'grub2'
-        tmpdir_name = ['temp-squashfs', 'temp_media_dir']
-        filesystem = mock.Mock()
+
+        temp_squashfs = Mock()
+        temp_squashfs.name = 'temp-squashfs'
+
+        temp_media_dir = Mock()
+        temp_media_dir.name = 'temp_media_dir'
+
+        tmpdir_name = [temp_squashfs, temp_media_dir]
+
+        filesystem = Mock()
         mock_filesystem.return_value = filesystem
 
-        def side_effect(prefix, dir):
+        def side_effect():
             return tmpdir_name.pop()
 
-        mock_dtemp.side_effect = side_effect
+        mock_Temporary.return_value.new_dir.side_effect = side_effect
+        mock_Temporary.return_value.new_file.return_value.name = 'kiwi-tmpfile'
 
         self.live_image.live_type = 'overlay'
 
-        iso_image = mock.Mock()
+        iso_image = Mock()
         iso_image.create_on_file.return_value = 'offset'
         mock_isofs.return_value = iso_image
 
-        rootsize = mock.Mock()
-        rootsize.accumulate_mbyte_file_sizes = mock.Mock(
+        rootsize = Mock()
+        rootsize.accumulate_mbyte_file_sizes = Mock(
             return_value=8192
         )
         mock_size.return_value = rootsize
@@ -315,7 +319,7 @@ class TestLiveImageBuilder:
         )
 
         self.firmware.efi_mode.return_value = None
-        tmpdir_name = ['temp-squashfs', 'temp_media_dir']
+        tmpdir_name = [temp_squashfs, temp_media_dir]
         kiwi.builder.live.BootLoaderConfig.new.reset_mock()
         self.live_image.create()
         kiwi.builder.live.BootLoaderConfig.new.assert_called_once_with(
@@ -324,50 +328,38 @@ class TestLiveImageBuilder:
         )
 
     @patch('kiwi.builder.live.IsoToolsBase.setup_media_loader_directory')
-    @patch('kiwi.builder.live.mkdtemp')
+    @patch('kiwi.builder.live.Temporary')
     @patch('kiwi.builder.live.shutil')
     def test_create_no_kernel_found(
-        self, mock_shutil, mock_dtemp,
+        self, mock_shutil, mock_Temporary,
         mock_setup_media_loader_directory
     ):
-        mock_dtemp.return_value = 'tmpdir'
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         self.kernel.get_kernel.return_value = False
         with raises(KiwiLiveBootImageError):
             self.live_image.create()
 
     @patch('kiwi.builder.live.IsoToolsBase.setup_media_loader_directory')
-    @patch('kiwi.builder.live.mkdtemp')
+    @patch('kiwi.builder.live.Temporary')
     @patch('kiwi.builder.live.shutil')
     def test_create_no_hypervisor_found(
-        self, mock_shutil, mock_dtemp,
+        self, mock_shutil, mock_Temporary,
         mock_setup_media_loader_directory
     ):
-        mock_dtemp.return_value = 'tmpdir'
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         self.kernel.get_xen_hypervisor.return_value = False
         with raises(KiwiLiveBootImageError):
             self.live_image.create()
 
     @patch('kiwi.builder.live.IsoToolsBase.setup_media_loader_directory')
-    @patch('kiwi.builder.live.mkdtemp')
+    @patch('kiwi.builder.live.Temporary')
     @patch('kiwi.builder.live.shutil')
     @patch('os.path.exists')
     def test_create_no_initrd_found(
-        self, mock_exists, mock_shutil, mock_dtemp,
+        self, mock_exists, mock_shutil, mock_Temporary,
         mock_setup_media_loader_directory
     ):
-        mock_dtemp.return_value = 'tmpdir'
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         mock_exists.return_value = False
         with raises(KiwiLiveBootImageError):
             self.live_image.create()
-
-    @patch('kiwi.builder.live.Path.wipe')
-    def test_destructor(self, mock_wipe):
-        self.live_image.media_dir = 'media-dir'
-        self.live_image.live_container_dir = 'container-dir'
-        self.live_image.__del__()
-        assert mock_wipe.call_args_list == [
-            call('media-dir'),
-            call('container-dir')
-        ]
-        self.live_image.media_dir = None
-        self.live_image.live_container_dir = None

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -40,6 +40,7 @@ class TestCli:
             'result': False,
             '--profile': [],
             '--shared-cache-dir': '/var/cache/kiwi',
+            '--temp-dir': '/var/tmp',
             '--target-arch': None,
             '--help': False,
             '--config': 'config-file'

--- a/test/unit/container/appx_test.py
+++ b/test/unit/container/appx_test.py
@@ -37,11 +37,11 @@ class TestContainerImageAppx:
     @patch('kiwi.container.appx.Compress')
     @patch('kiwi.container.appx.Defaults.get_exclude_list_for_root_data_sync')
     @patch('kiwi.container.appx.Defaults.get_exclude_list_from_custom_exclude_files')
-    @patch('kiwi.container.appx.NamedTemporaryFile')
+    @patch('kiwi.container.appx.Temporary.new_file')
     @patch('kiwi.container.appx.Command.run')
     @patch('os.walk')
     def test_create(
-        self, mock_os_walk, mock_Command_run, mock_NamedTemporaryFile,
+        self, mock_os_walk, mock_Command_run, mock_Temporary_new_file,
         mock_get_exclude_list_from_custom_exclude_files,
         mock_get_exclude_list_for_root_data_sync,
         mock_Compress, mock_ArchiveTar
@@ -53,7 +53,7 @@ class TestContainerImageAppx:
         ]
         tempfile = Mock()
         tempfile.name = 'tempfile'
-        mock_NamedTemporaryFile.return_value = tempfile
+        mock_Temporary_new_file.return_value = tempfile
         archive = Mock()
         mock_ArchiveTar.return_value = archive
         compress = Mock()

--- a/test/unit/filesystem/clicfs_test.py
+++ b/test/unit/filesystem/clicfs_test.py
@@ -12,14 +12,13 @@ class TestFileSystemClicFs:
         self.clicfs = FileSystemClicFs(mock.Mock(), 'root_dir')
 
     @patch('kiwi.filesystem.clicfs.Command.run')
-    @patch('kiwi.filesystem.clicfs.mkdtemp')
+    @patch('kiwi.filesystem.clicfs.Temporary')
     @patch('kiwi.filesystem.clicfs.LoopDevice')
     @patch('kiwi.filesystem.clicfs.FileSystemExt4')
     @patch('kiwi.filesystem.clicfs.SystemSize')
-    @patch('kiwi.filesystem.clicfs.Path.wipe')
     def test_create_on_file(
-        self, mock_wipe, mock_size, mock_ext4, mock_loop,
-        mock_dtemp, mock_command
+        self, mock_size, mock_ext4, mock_loop,
+        mock_Temporary, mock_command
     ):
         size = mock.Mock()
         size.customize = mock.Mock(
@@ -33,7 +32,7 @@ class TestFileSystemClicFs:
         mock_ext4.return_value = filesystem
         loop_provider = mock.Mock()
         mock_loop.return_value = loop_provider
-        mock_dtemp.return_value = 'tmpdir'
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
 
         self.clicfs.create_on_file('myimage', 'label')
 
@@ -55,9 +54,3 @@ class TestFileSystemClicFs:
                 ['mkclicfs', 'tmpdir/fsdata.ext4', 'myimage']
             )
         ]
-
-    @patch('kiwi.filesystem.clicfs.Path.wipe')
-    def test_destructor(self, mock_wipe):
-        self.clicfs.container_dir = 'tmpdir'
-        self.clicfs.__del__()
-        mock_wipe.assert_called_once_with('tmpdir')

--- a/test/unit/iso_tools/cdrtools_test.py
+++ b/test/unit/iso_tools/cdrtools_test.py
@@ -35,7 +35,7 @@ class TestIsoToolsCdrTools:
             self.iso_tool.get_tool_name()
 
     @patch('os.walk')
-    @patch('kiwi.iso_tools.cdrtools.NamedTemporaryFile')
+    @patch('kiwi.iso_tools.cdrtools.Temporary.new_file')
     def test_init_iso_creation_parameters(
         self, mock_tempfile, mock_walk
     ):

--- a/test/unit/iso_tools/iso_test.py
+++ b/test/unit/iso_tools/iso_test.py
@@ -11,7 +11,7 @@ import sys
 from kiwi.defaults import Defaults
 from kiwi.iso_tools.iso import Iso
 from kiwi.path import Path
-from tempfile import NamedTemporaryFile
+from kiwi.utils.temporary import Temporary
 
 from kiwi.exceptions import (
     KiwiIsoLoaderError,
@@ -76,7 +76,7 @@ class TestIso:
         Path.which('isoinfo') is None, reason='requires cdrtools'
     )
     def test_create_header_end_block_on_test_iso(self):
-        temp_file = NamedTemporaryFile()
+        temp_file = Temporary().new_file()
         self.iso.header_end_file = temp_file.name
         assert self.iso.create_header_end_block(
             '../data/iso_with_marker.iso'
@@ -101,7 +101,7 @@ class TestIso:
         Path.which('isoinfo') is None, reason='requires cdrtools'
     )
     def test_create_header_end_block_raises_on_test_iso(self):
-        temp_file = NamedTemporaryFile()
+        temp_file = Temporary().new_file()
         self.iso.header_end_file = temp_file.name
         with raises(KiwiIsoLoaderError):
             self.iso.create_header_end_block(

--- a/test/unit/partitioner/dasd_test.py
+++ b/test/unit/partitioner/dasd_test.py
@@ -15,7 +15,7 @@ class TestPartitionerDasd:
         self._caplog = caplog
 
     @patch('kiwi.partitioner.dasd.Command.run')
-    @patch('kiwi.partitioner.dasd.NamedTemporaryFile')
+    @patch('kiwi.partitioner.dasd.Temporary.new_file')
     def setup(self, mock_temp, mock_command):
         self.tempfile = mock.Mock()
         self.tempfile.name = 'tempfile'
@@ -30,7 +30,7 @@ class TestPartitionerDasd:
         self.partitioner = PartitionerDasd(disk_provider)
 
     @patch('kiwi.partitioner.dasd.Command.run')
-    @patch('kiwi.partitioner.dasd.NamedTemporaryFile')
+    @patch('kiwi.partitioner.dasd.Temporary.new_file')
     def test_create(self, mock_temp, mock_command):
         mock_command.side_effect = Exception
         mock_temp.return_value = self.tempfile
@@ -48,7 +48,7 @@ class TestPartitionerDasd:
         )
 
     @patch('kiwi.partitioner.dasd.Command.run')
-    @patch('kiwi.partitioner.dasd.NamedTemporaryFile')
+    @patch('kiwi.partitioner.dasd.Temporary.new_file')
     def test_create_all_free(self, mock_temp, mock_command):
         mock_temp.return_value = self.tempfile
 

--- a/test/unit/partitioner/msdos_test.py
+++ b/test/unit/partitioner/msdos_test.py
@@ -26,7 +26,7 @@ class TestPartitionerMsDos:
 
     @patch('kiwi.partitioner.msdos.Command.run')
     @patch('kiwi.partitioner.msdos.PartitionerMsDos.set_flag')
-    @patch('kiwi.partitioner.msdos.NamedTemporaryFile')
+    @patch('kiwi.partitioner.msdos.Temporary.new_file')
     def test_create(self, mock_temp, mock_flag, mock_command):
         mock_command.side_effect = Exception
         temp_type = namedtuple(
@@ -55,7 +55,7 @@ class TestPartitionerMsDos:
 
     @patch('kiwi.partitioner.msdos.Command.run')
     @patch('kiwi.partitioner.msdos.PartitionerMsDos.set_flag')
-    @patch('kiwi.partitioner.msdos.NamedTemporaryFile')
+    @patch('kiwi.partitioner.msdos.Temporary.new_file')
     def test_create_custom_start_sector(
         self, mock_temp, mock_flag, mock_command
     ):
@@ -93,7 +93,7 @@ class TestPartitionerMsDos:
 
     @patch('kiwi.partitioner.msdos.Command.run')
     @patch('kiwi.partitioner.msdos.PartitionerMsDos.set_flag')
-    @patch('kiwi.partitioner.msdos.NamedTemporaryFile')
+    @patch('kiwi.partitioner.msdos.Temporary.new_file')
     def test_create_all_free(
         self, mock_temp, mock_flag, mock_command
     ):

--- a/test/unit/repository/apt_test.py
+++ b/test/unit/repository/apt_test.py
@@ -8,7 +8,7 @@ from kiwi.repository.apt import RepositoryApt
 
 
 class TestRepositoryApt:
-    @patch('kiwi.repository.apt.NamedTemporaryFile')
+    @patch('kiwi.repository.apt.Temporary.new_file')
     @patch('kiwi.repository.apt.PackageManagerTemplateAptGet')
     @patch('kiwi.repository.apt.Path.create')
     def setup(self, mock_path, mock_template, mock_temp):
@@ -54,7 +54,8 @@ class TestRepositoryApt:
         template = mock.Mock()
         template.substitute.return_value = 'template-data'
         self.apt_conf.get_image_template.return_value = template
-        self.repo.use_default_location()
+        with patch('builtins.open', create=True):
+            self.repo.use_default_location()
         assert self.repo.shared_apt_get_dir['sources-dir'] == \
             '../data/etc/apt/sources.list.d'
         assert self.repo.shared_apt_get_dir['preferences-dir'] == \

--- a/test/unit/repository/dnf_test.py
+++ b/test/unit/repository/dnf_test.py
@@ -12,7 +12,7 @@ class TestRepositoryDnf:
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
-    @patch('kiwi.repository.dnf.NamedTemporaryFile')
+    @patch('kiwi.repository.dnf.Temporary.new_file')
     @patch('kiwi.repository.dnf.ConfigParser')
     @patch('kiwi.repository.dnf.Path.create')
     def setup(self, mock_path, mock_config, mock_temp):
@@ -50,14 +50,14 @@ class TestRepositoryDnf:
             call('main', 'enabled', '1')
         ]
 
-    @patch('kiwi.repository.dnf.NamedTemporaryFile')
+    @patch('kiwi.repository.dnf.Temporary.new_file')
     @patch('kiwi.repository.dnf.Path.create')
     def test_post_init_no_custom_args(self, mock_path, mock_temp):
         with patch('builtins.open', create=True):
             self.repo.post_init()
         assert self.repo.custom_args == []
 
-    @patch('kiwi.repository.dnf.NamedTemporaryFile')
+    @patch('kiwi.repository.dnf.Temporary.new_file')
     @patch('kiwi.repository.dnf.Path.create')
     @patch('os.path.exists')
     def test_post_init_with_custom_args(

--- a/test/unit/repository/pacman_test.py
+++ b/test/unit/repository/pacman_test.py
@@ -9,7 +9,7 @@ from kiwi.repository.pacman import RepositoryPacman
 
 
 class TestRepositorPacman(object):
-    @patch('kiwi.repository.pacman.NamedTemporaryFile')
+    @patch('kiwi.repository.pacman.Temporary.new_file')
     @patch('kiwi.repository.pacman.ConfigParser')
     @patch('kiwi.repository.pacman.Path.create')
     def setup(self, mock_path, mock_config, mock_temp):

--- a/test/unit/repository/zypper_test.py
+++ b/test/unit/repository/zypper_test.py
@@ -13,7 +13,7 @@ from kiwi.exceptions import KiwiCommandError
 
 class TestRepositoryZypper:
     @patch('kiwi.command.Command.run')
-    @patch('kiwi.repository.zypper.NamedTemporaryFile')
+    @patch('kiwi.repository.zypper.Temporary.new_file')
     def setup(self, mock_temp, mock_command):
 
         self.context_manager_mock = mock.Mock()
@@ -36,14 +36,14 @@ class TestRepositoryZypper:
             )
 
     @patch('kiwi.command.Command.run')
-    @patch('kiwi.repository.zypper.NamedTemporaryFile')
+    @patch('kiwi.repository.zypper.Temporary.new_file')
     def test_custom_args_init_excludedocs(self, mock_temp, mock_command):
         with patch('builtins.open', create=True):
             repo = RepositoryZypper(self.root_bind)
             assert repo.custom_args == []
 
     @patch('kiwi.command.Command.run')
-    @patch('kiwi.repository.zypper.NamedTemporaryFile')
+    @patch('kiwi.repository.zypper.Temporary.new_file')
     @patch('kiwi.repository.zypper.ConfigParser')
     def test_custom_args_init_check_signatures(
         self, mock_config, mock_temp, mock_command

--- a/test/unit/storage/disk_test.py
+++ b/test/unit/storage/disk_test.py
@@ -195,7 +195,7 @@ class TestDisk:
         )
 
     @patch('kiwi.storage.disk.Command.run')
-    @patch('kiwi.storage.disk.NamedTemporaryFile')
+    @patch('kiwi.storage.disk.Temporary.new_file')
     def test_wipe_dasd(self, mock_temp, mock_command):
         mock_command.side_effect = Exception
         self.disk.table_type = 'dasd'

--- a/test/unit/storage/luks_device_test.py
+++ b/test/unit/storage/luks_device_test.py
@@ -85,7 +85,7 @@ class TestLuksDevice:
             self.luks.luks_device = None
 
     @patch('kiwi.storage.luks_device.Command.run')
-    @patch('kiwi.storage.luks_device.NamedTemporaryFile')
+    @patch('kiwi.storage.luks_device.Temporary.new_file')
     @patch('os.chmod')
     def test_create_crypto_luks(
         self, mock_os_chmod, mock_tmpfile, mock_command

--- a/test/unit/storage/subformat/gce_test.py
+++ b/test/unit/storage/subformat/gce_test.py
@@ -44,11 +44,11 @@ class TestDiskFormatGce:
 
     @patch('kiwi.storage.subformat.gce.Command.run')
     @patch('kiwi.storage.subformat.gce.ArchiveTar')
-    @patch('kiwi.storage.subformat.gce.mkdtemp')
+    @patch('kiwi.storage.subformat.gce.Temporary')
     def test_create_image_format(
-        self, mock_mkdtemp, mock_archive, mock_command
+        self, mock_Temporary, mock_archive, mock_command
     ):
-        mock_mkdtemp.return_value = 'tmpdir'
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         archive = mock.Mock()
         mock_archive.return_value = archive
         self.disk_format.tag = 'gce-license'

--- a/test/unit/storage/subformat/qcow2_test.py
+++ b/test/unit/storage/subformat/qcow2_test.py
@@ -34,11 +34,11 @@ class TestDiskFormatQcow2:
         assert self.disk_format.options == ['-o', 'option=value']
 
     @patch('kiwi.storage.subformat.qcow2.Command.run')
-    @patch('kiwi.storage.subformat.qcow2.NamedTemporaryFile')
-    def test_create_image_format(self, mock_NamedTemporaryFile, mock_command):
+    @patch('kiwi.storage.subformat.qcow2.Temporary.new_file')
+    def test_create_image_format(self, mock_Temporary_new_file, mock_command):
         tmpfile = Mock()
         tmpfile.name = 'tmpfile'
-        mock_NamedTemporaryFile.return_value = tmpfile
+        mock_Temporary_new_file.return_value = tmpfile
         self.disk_format.create_image_format()
         assert mock_command.call_args_list == [
             call(

--- a/test/unit/storage/subformat/vagrant_base_test.py
+++ b/test/unit/storage/subformat/vagrant_base_test.py
@@ -69,10 +69,10 @@ class TestDiskFormatVagrantBase:
             self.disk_format.store_to_result(Mock())
 
     @patch('kiwi.storage.subformat.vagrant_base.Command.run')
-    @patch('kiwi.storage.subformat.vagrant_base.mkdtemp')
+    @patch('kiwi.storage.subformat.vagrant_base.Temporary')
     @patch.object(DiskFormatVagrantBase, 'create_box_img')
     def test_create_image_format(
-        self, mock_create_box_img, mock_mkdtemp, mock_command
+        self, mock_create_box_img, mock_Temporary, mock_command
     ):
         # select an example provider
         self.disk_format.image_format = 'vagrant.libvirt.box'
@@ -89,7 +89,7 @@ class TestDiskFormatVagrantBase:
             end
         ''').strip()
 
-        mock_mkdtemp.return_value = 'tmpdir'
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
 
         with patch('builtins.open', create=True) as mock_file:
             mock_file.return_value = MagicMock(spec=io.IOBase)
@@ -114,17 +114,17 @@ class TestDiskFormatVagrantBase:
         )
 
     @patch('kiwi.storage.subformat.vagrant_base.Command.run')
-    @patch('kiwi.storage.subformat.vagrant_base.mkdtemp')
+    @patch('kiwi.storage.subformat.vagrant_base.Temporary')
     @patch.object(DiskFormatVagrantBase, 'create_box_img')
     def test_user_provided_vagrantfile(
-        self, mock_create_box_img, mock_mkdtemp, mock_cmd_run
+        self, mock_create_box_img, mock_Temporary, mock_cmd_run
     ):
         # select an example provider
         self.disk_format.image_format = 'vagrant.virtualbox.box'
         self.disk_format.provider = 'virtualbox'
 
         # deterministic tempdir:
-        mock_mkdtemp.return_value = 'tmpdir'
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
 
         self.vagrantconfig.get_embedded_vagrantfile = Mock(
             return_value='example_Vagrantfile'

--- a/test/unit/storage/subformat/vagrant_libvirt_test.py
+++ b/test/unit/storage/subformat/vagrant_libvirt_test.py
@@ -74,12 +74,12 @@ class TestDiskFormatVagrantLibVirt:
             ''').strip()
 
     @patch('kiwi.storage.subformat.vagrant_base.Command.run')
-    @patch('kiwi.storage.subformat.vagrant_base.mkdtemp')
+    @patch('kiwi.storage.subformat.vagrant_base.Temporary')
     @patch.object(DiskFormatVagrantLibVirt, 'create_box_img')
     def test_create_image_format(
-        self, mock_create_box_img, mock_mkdtemp, mock_command
+        self, mock_create_box_img, mock_Temporary, mock_command
     ):
-        mock_mkdtemp.return_value = 'tmpdir'
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         mock_create_box_img.return_value = ['arbitrary']
 
         m_open = mock_open()

--- a/test/unit/storage/subformat/vagrant_virtualbox_test.py
+++ b/test/unit/storage/subformat/vagrant_virtualbox_test.py
@@ -94,14 +94,14 @@ class TestDiskFormatVagrantVirtualBox:
             expected_res
 
     @patch('kiwi.storage.subformat.vagrant_base.Command.run')
-    @patch('kiwi.storage.subformat.vagrant_base.mkdtemp')
+    @patch('kiwi.storage.subformat.vagrant_base.Temporary')
     @patch('kiwi.storage.subformat.vagrant_virtualbox.random.randrange')
     @patch.object(DiskFormatVagrantVirtualBox, 'create_box_img')
     def test_create_image_format_with_and_without_guest_additions(
         self, mock_create_box_img, mock_rand,
-        mock_mkdtemp, mock_command
+        mock_Temporary, mock_command
     ):
-        mock_mkdtemp.return_value = 'tmpdir'
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         mock_create_box_img.return_value = ['arbitrary']
 
         # without guest additions

--- a/test/unit/system/profile_test.py
+++ b/test/unit/system/profile_test.py
@@ -1,7 +1,6 @@
 # vim: set fileencoding=utf-8
 from mock import patch
 
-import mock
 import os
 
 from kiwi.system.profile import Profile
@@ -11,21 +10,16 @@ from kiwi.xml_description import XMLDescription
 
 class TestProfile:
     def setup(self):
-        self.tmpfile = mock.Mock()
-        self.tmpfile.name = 'tmpfile'
         self.profile_file = 'tmpfile.profile'
         description = XMLDescription('../data/example_dot_profile_config.xml')
         self.profile = Profile(
             XMLState(description.load())
         )
 
-    @patch('kiwi.system.profile.NamedTemporaryFile')
     @patch('kiwi.path.Path.which')
-    def test_create(self, mock_which, mock_temp):
+    def test_create(self, mock_which):
         mock_which.return_value = 'cp'
-        mock_temp.return_value = self.tmpfile
         self.profile.create(self.profile_file)
-        os.remove(self.tmpfile.name)
         os.remove(self.profile_file)
         assert self.profile.dot_profile == {
             'kiwi_Volume_1': 'usr_lib|size:1024|usr/lib',
@@ -104,32 +98,26 @@ class TestProfile:
             'kiwi_rootpartuuid': None
         }
 
-    @patch('kiwi.system.profile.NamedTemporaryFile')
     @patch('kiwi.path.Path.which')
-    def test_create_displayname_is_image_name(self, mock_which, mock_temp):
+    def test_create_displayname_is_image_name(self, mock_which):
         mock_which.return_value = 'cp'
-        mock_temp.return_value = self.tmpfile
         description = XMLDescription('../data/example_pxe_config.xml')
         profile = Profile(
             XMLState(description.load())
         )
         profile.create(self.profile_file)
-        os.remove(self.tmpfile.name)
         os.remove(self.profile_file)
         assert profile.dot_profile['kiwi_displayname'] == \
             'LimeJeOS-openSUSE-13.2'
 
-    @patch('kiwi.system.profile.NamedTemporaryFile')
     @patch('kiwi.path.Path.which')
-    def test_create_cpio(self, mock_which, mock_temp):
+    def test_create_cpio(self, mock_which):
         mock_which.return_value = 'cp'
-        mock_temp.return_value = self.tmpfile
         description = XMLDescription('../data/example_dot_profile_config.xml')
         profile = Profile(
             XMLState(description.load(), None, 'cpio')
         )
         profile.create(self.profile_file)
-        os.remove(self.tmpfile.name)
         os.remove(self.profile_file)
         assert profile.dot_profile['kiwi_cpio_name'] == \
             'LimeJeOS-openSUSE-13.2'

--- a/test/unit/system/root_init_test.py
+++ b/test/unit/system/root_init_test.py
@@ -25,16 +25,15 @@ class TestRootInit:
     @patch('os.makedirs')
     @patch('os.chown')
     @patch('os.symlink')
-    @patch('shutil.rmtree')
     @patch('kiwi.system.root_init.DataSync')
-    @patch('kiwi.system.root_init.mkdtemp')
+    @patch('kiwi.system.root_init.Temporary')
     @patch('kiwi.system.root_init.Path.create')
     def test_create_raises_error(
-        self, mock_Path_create, mock_temp, mock_data_sync, mock_rmtree,
+        self, mock_Path_create, mock_Temporary, mock_data_sync,
         mock_symlink, mock_chwon, mock_makedirs, mock_path
     ):
         mock_path.return_value = False
-        mock_temp.return_value = 'tmpdir'
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         mock_data_sync.side_effect = Exception
         root = RootInit('root_dir')
         with raises(KiwiRootInitCreationError):
@@ -47,13 +46,12 @@ class TestRootInit:
     @patch('os.makedev')
     @patch('kiwi.path.Path.create')
     @patch('kiwi.system.root_init.copy')
-    @patch('kiwi.system.root_init.rmtree')
     @patch('kiwi.system.root_init.DataSync')
-    @patch('kiwi.system.root_init.mkdtemp')
+    @patch('kiwi.system.root_init.Temporary')
     @patch('kiwi.system.root_init.Path.create')
     def test_create(
-        self, mock_Path_create, mock_temp, mock_data_sync,
-        mock_rmtree, mock_copy, mock_create, mock_makedev,
+        self, mock_Path_create, mock_Temporary, mock_data_sync,
+        mock_copy, mock_create, mock_makedev,
         mock_symlink, mock_chwon, mock_makedirs,
         mock_path
     ):
@@ -71,7 +69,7 @@ class TestRootInit:
         mock_path.side_effect = path_exists
 
         mock_path.return_value = False
-        mock_temp.return_value = 'tmpdir'
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         root = RootInit('root_dir', True)
         assert root.create() is None
         assert mock_makedirs.call_args_list == [
@@ -103,9 +101,6 @@ class TestRootInit:
         )
         data_sync.sync_data.assert_called_once_with(
             options=['-a', '--ignore-existing']
-        )
-        mock_rmtree.assert_called_once_with(
-            'tmpdir', ignore_errors=True
         )
 
         mock_copy.assert_called_once_with(

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -901,7 +901,7 @@ class TestSystemSetup:
         ]
 
     @patch('kiwi.command.Command.run')
-    @patch('kiwi.system.setup.NamedTemporaryFile')
+    @patch('kiwi.system.setup.Temporary.new_file')
     @patch('kiwi.system.setup.ArchiveTar')
     @patch('kiwi.system.setup.Compress')
     @patch('os.path.getsize')

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -901,23 +901,20 @@ class TestSystemSetup:
         ]
 
     @patch('kiwi.command.Command.run')
-    @patch('kiwi.system.setup.Temporary.new_file')
+    @patch('pathlib.Path.touch')
     @patch('kiwi.system.setup.ArchiveTar')
     @patch('kiwi.system.setup.Compress')
     @patch('os.path.getsize')
     @patch('kiwi.system.setup.Path.wipe')
     def test_create_recovery_archive(
         self, mock_wipe, mock_getsize, mock_compress,
-        mock_archive, mock_temp, mock_command
+        mock_archive, mock_pathlib_Path_touch, mock_command
     ):
         mock_getsize.return_value = 42
         compress = Mock()
         mock_compress.return_value = compress
         archive = Mock()
         mock_archive.return_value = archive
-        tmpdir = Mock()
-        tmpdir.name = 'tmpdir'
-        mock_temp.return_value = tmpdir
         self.setup.oemconfig['recovery'] = True
         self.setup.oemconfig['recovery_inplace'] = True
 
@@ -929,7 +926,7 @@ class TestSystemSetup:
             ['bash', '-c', 'rm -f root_dir/recovery.*']
         )
         mock_archive.assert_called_once_with(
-            create_from_file_list=False, filename='tmpdir'
+            create_from_file_list=False, filename='root_dir/recovery.tar'
         )
         archive.create.assert_called_once_with(
             exclude=['dev', 'proc', 'sys'],
@@ -940,14 +937,12 @@ class TestSystemSetup:
             ],
             source_dir='root_dir'
         )
-        assert mock_command.call_args_list[1] == call(
-            ['mv', 'tmpdir', 'root_dir/recovery.tar']
-        )
         assert m_open.call_args_list[0] == call(
             'root_dir/recovery.tar.filesystem', 'w'
         )
         assert m_open.return_value.write.call_args_list[0] == call('ext3')
-        assert mock_command.call_args_list[2] == call(
+
+        assert mock_command.call_args_list[1] == call(
             ['bash', '-c', 'tar -tf root_dir/recovery.tar | wc -l']
         )
         assert m_open.call_args_list[1] == call(

--- a/test/unit/tasks/image_info_test.py
+++ b/test/unit/tasks/image_info_test.py
@@ -183,7 +183,7 @@ class TestImageInfoTask:
         self.task.command_args['--print-xml'] = True
         self.task.process()
         tmpfile, message = mock_out.display_file.call_args.args
-        assert tmpfile.startswith('/tmp/xslt-')
+        assert tmpfile.startswith('/var/tmp/kiwi_xslt-')
         assert message == 'Description(XML):'
 
     @patch('kiwi.tasks.image_info.DataOutput')
@@ -192,5 +192,5 @@ class TestImageInfoTask:
         self.task.command_args['--print-yaml'] = True
         self.task.process()
         tmpfile, message = mock_out.display_file.call_args.args
-        assert tmpfile.startswith('/tmp/xslt-')
+        assert tmpfile.startswith('/var/tmp/kiwi_xslt-')
         assert message == 'Description(YAML):'

--- a/test/unit/utils/compress_test.py
+++ b/test/unit/utils/compress_test.py
@@ -59,7 +59,7 @@ class TestCompress:
         assert self.compress.compressed_filename == 'some-file.gz'
 
     @patch('kiwi.command.Command.run')
-    @patch('kiwi.utils.compress.NamedTemporaryFile')
+    @patch('kiwi.utils.compress.Temporary.new_file')
     @patch('kiwi.utils.compress.Compress.get_format')
     def test_uncompress(self, mock_format, mock_temp, mock_command):
         mock_format.return_value = 'xz'
@@ -70,7 +70,7 @@ class TestCompress:
         assert self.compress.uncompressed_filename == 'some-file'
 
     @patch('kiwi.command.Command.run')
-    @patch('kiwi.utils.compress.NamedTemporaryFile')
+    @patch('kiwi.utils.compress.Temporary.new_file')
     @patch('kiwi.utils.compress.Compress.get_format')
     def test_uncompress_temporary(self, mock_format, mock_temp, mock_command):
         tempfile = Mock()

--- a/test/unit/utils/output_test.py
+++ b/test/unit/utils/output_test.py
@@ -35,7 +35,7 @@ class TestDataOutput:
 
     @patch('sys.stdout')
     @patch('os.system')
-    @patch('kiwi.utils.output.NamedTemporaryFile')
+    @patch('kiwi.utils.output.Temporary.new_file')
     def test_display_color(self, mock_temp, mock_system, mock_stdout):
         out_file = mock.Mock()
         out_file.name = 'tmpfile'

--- a/test/unit/utils/temporary_test.py
+++ b/test/unit/utils/temporary_test.py
@@ -11,7 +11,7 @@ class TestTemporary:
     def test_new_file(self, mock_NamedTemporaryFile):
         self.temporary.new_file()
         mock_NamedTemporaryFile.assert_called_once_with(
-            dir='/var/tmp', prefix='kiwi_', delete=True
+            dir='/var/tmp', prefix='kiwi_'
         )
 
     @patch('kiwi.utils.temporary.TemporaryDirectory')

--- a/test/unit/utils/temporary_test.py
+++ b/test/unit/utils/temporary_test.py
@@ -1,0 +1,22 @@
+from mock import patch
+
+from kiwi.utils.temporary import Temporary
+
+
+class TestTemporary:
+    def setup(self):
+        self.temporary = Temporary()
+
+    @patch('kiwi.utils.temporary.NamedTemporaryFile')
+    def test_new_file(self, mock_NamedTemporaryFile):
+        self.temporary.new_file()
+        mock_NamedTemporaryFile.assert_called_once_with(
+            dir='/var/tmp', prefix='kiwi_', delete=True
+        )
+
+    @patch('kiwi.utils.temporary.TemporaryDirectory')
+    def test_new_dir(self, mock_TemporaryDirectory):
+        self.temporary.new_dir()
+        mock_TemporaryDirectory.assert_called_once_with(
+            dir='/var/tmp', prefix='kiwi_'
+        )

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -236,9 +236,9 @@ class TestVolumeManagerBase:
         )
         assert self.volume_manager.get_mountpoint() == 'mountpoint'
 
-    @patch('kiwi.volume_manager.base.mkdtemp')
-    def test_setup_mountpoint(self, mock_mkdtemp):
-        mock_mkdtemp.return_value = 'tmpdir'
+    @patch('kiwi.volume_manager.base.Temporary')
+    def test_setup_mountpoint(self, mock_Temporary):
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         self.volume_manager.setup_mountpoint()
         assert self.volume_manager.mountpoint == 'tmpdir'
 
@@ -259,9 +259,3 @@ class TestVolumeManagerBase:
         mock_command.assert_called_once_with(
             ['chattr', '+C', 'toplevel/etc']
         )
-
-    @patch('kiwi.volume_manager.base.Path.wipe')
-    def test_cleanup_tempdirs(self, mock_Path_wipe):
-        self.volume_manager.temp_directories = ['tmpdir']
-        self.volume_manager._cleanup_tempdirs()
-        mock_Path_wipe.assert_called_once_with('tmpdir')

--- a/test/unit/volume_manager/btrfs_test.py
+++ b/test/unit/volume_manager/btrfs_test.py
@@ -70,12 +70,12 @@ class TestVolumeManagerBtrfs:
     @patch('kiwi.volume_manager.btrfs.FileSystem.new')
     @patch('kiwi.volume_manager.btrfs.MappedDevice')
     @patch('kiwi.volume_manager.btrfs.MountManager')
-    @patch('kiwi.volume_manager.base.mkdtemp')
+    @patch('kiwi.volume_manager.base.Temporary')
     def test_setup_no_snapshot(
-        self, mock_mkdtemp, mock_mount, mock_mapped_device, mock_fs,
+        self, mock_Temporary, mock_mount, mock_mapped_device, mock_fs,
         mock_command, mock_os_exists
     ):
-        mock_mkdtemp.return_value = 'tmpdir'
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         toplevel_mount = Mock()
         mock_mount.return_value = toplevel_mount
         command_call = Mock()
@@ -101,12 +101,12 @@ class TestVolumeManagerBtrfs:
     @patch('kiwi.volume_manager.btrfs.FileSystem.new')
     @patch('kiwi.volume_manager.btrfs.MappedDevice')
     @patch('kiwi.volume_manager.btrfs.MountManager')
-    @patch('kiwi.volume_manager.base.mkdtemp')
+    @patch('kiwi.volume_manager.base.Temporary')
     def test_setup_with_snapshot(
-        self, mock_mkdtemp, mock_mount, mock_mapped_device, mock_fs,
+        self, mock_Temporary, mock_mount, mock_mapped_device, mock_fs,
         mock_command, mock_os_exists
     ):
-        mock_mkdtemp.return_value = 'tmpdir'
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         toplevel_mount = Mock()
         mock_mount.return_value = toplevel_mount
         command_call = Mock()
@@ -143,9 +143,9 @@ class TestVolumeManagerBtrfs:
     @patch('kiwi.volume_manager.btrfs.FileSystem.new')
     @patch('kiwi.volume_manager.btrfs.MappedDevice')
     @patch('kiwi.volume_manager.btrfs.MountManager')
-    @patch('kiwi.volume_manager.base.mkdtemp')
+    @patch('kiwi.volume_manager.base.Temporary')
     def test_setup_volume_id_not_detected(
-        self, mock_mkdtemp, mock_mount, mock_mapped_device, mock_fs,
+        self, mock_Temporary, mock_mount, mock_mapped_device, mock_fs,
         mock_command, mock_os_exists
     ):
         command_call = Mock()
@@ -299,12 +299,13 @@ class TestVolumeManagerBtrfs:
     @patch('kiwi.volume_manager.btrfs.FileSystem.new')
     @patch('kiwi.volume_manager.btrfs.MappedDevice')
     @patch('kiwi.volume_manager.btrfs.MountManager')
-    @patch('kiwi.volume_manager.base.mkdtemp')
+    @patch('kiwi.volume_manager.base.Temporary')
     def test_remount_volumes(
-        self, mock_mkdtemp, mock_mount, mock_mapped_device, mock_fs,
+        self, mock_Temporary, mock_mount, mock_mapped_device, mock_fs,
         mock_command, mock_os_exists
     ):
-        mock_mkdtemp.return_value = '/tmp/kiwi_volumes.xx'
+        mock_Temporary.return_value.new_dir.return_value.name = \
+            '/tmp/kiwi_volumes.xx'
         toplevel_mount = Mock()
         toplevel_mount.is_mounted = Mock(
             return_value=False

--- a/test/unit/volume_manager/lvm_test.py
+++ b/test/unit/volume_manager/lvm_test.py
@@ -93,9 +93,9 @@ class TestVolumeManagerLVM:
             '/dev/lvswap'
 
     @patch('kiwi.volume_manager.lvm.Command.run')
-    @patch('kiwi.volume_manager.base.mkdtemp')
-    def test_setup(self, mock_mkdtemp, mock_command):
-        mock_mkdtemp.return_value = 'tmpdir'
+    @patch('kiwi.volume_manager.base.Temporary')
+    def test_setup(self, mock_Temporary, mock_command):
+        mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         command = Mock()
         # no output for commands to mock empty information for
         # vgs command, indicating the volume group is not in use
@@ -128,8 +128,10 @@ class TestVolumeManagerLVM:
         self.volume_manager.volume_group = None
 
     @patch('kiwi.volume_manager.lvm.Command.run')
-    @patch('kiwi.volume_manager.base.mkdtemp')
-    def test_setup_volume_group_host_conflict(self, mock_mkdtemp, mock_command):
+    @patch('kiwi.volume_manager.base.Temporary')
+    def test_setup_volume_group_host_conflict(
+        self, mock_Temporary, mock_command
+    ):
         command = Mock()
         command.output = 'some_data_about_volume_group'
         mock_command.return_value = command

--- a/test/unit/xml_description_test.py
+++ b/test/unit/xml_description_test.py
@@ -4,7 +4,7 @@ from builtins import bytes
 from lxml import etree
 from pytest import raises
 from collections import namedtuple
-from tempfile import NamedTemporaryFile
+from kiwi.utils.temporary import Temporary
 
 from kiwi.xml_description import XMLDescription
 
@@ -118,26 +118,26 @@ class TestSchema:
         self.description_from_file = XMLDescription(
             description='../data/example_config.xml'
         )
-        test_xml_file = NamedTemporaryFile()
+        test_xml_file = Temporary().new_file()
         with open(test_xml_file.name, 'wb') as description:
             description.write(test_xml)
         self.description_from_data = XMLDescription(test_xml_file.name)
 
-        test_xml_extension_file = NamedTemporaryFile()
+        test_xml_extension_file = Temporary().new_file()
         with open(test_xml_extension_file.name, 'wb') as description:
             description.write(test_xml_extension)
         self.extension_description_from_data = XMLDescription(
             test_xml_extension_file.name
         )
 
-        test_xml_extension_not_unique_file = NamedTemporaryFile()
+        test_xml_extension_not_unique_file = Temporary().new_file()
         with open(test_xml_extension_not_unique_file.name, 'wb') as description:
             description.write(test_xml_extension_not_unique)
         self.extension_multiple_toplevel_description_from_data = XMLDescription(
             test_xml_extension_not_unique_file.name
         )
 
-        test_xml_extension_invalid_file = NamedTemporaryFile()
+        test_xml_extension_invalid_file = Temporary().new_file()
         with open(test_xml_extension_invalid_file.name, 'wb') as description:
             description.write(test_xml_extension_invalid)
         self.extension_invalid_description_from_data = XMLDescription(


### PR DESCRIPTION
Moving use of mkdtemp, NamedTemporaryFile and TemporaryDirectory
into its own class called Temporary: By default all temporary
data is created below /var/tmp but can be changed via the
global commandline option --temp-dir. This Fixes #1870 


