### PR TITLE
Fixed fstab entry for swap on LVM

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-lvm/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-lvm/appliance.kiwi
@@ -18,6 +18,8 @@
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" filesystem="ext3" kernelcmdline="console=ttyS0" firmware="uefi" format="vmdk">
             <oemconfig>
+                <oem-swap>true</oem-swap>
+                <oem-swapsize>512</oem-swapsize>
                 <oem-resize>false</oem-resize>
             </oemconfig>
             <bootloader name="grub2" console="serial" timeout="10"/>
@@ -61,7 +63,11 @@
         <package name="timezone"/>
     </packages>
     <packages type="bootstrap">
+        <package name="gawk"/>
+        <package name="grep"/>
+        <package name="gzip"/>
         <package name="udev"/>
+        <package name="xz"/>
         <package name="filesystem"/>
         <package name="glibc-locale"/>
         <package name="cracklib-dict-full"/>

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -920,7 +920,7 @@ class DiskBuilder:
             options = ['defaults']
         block_operation = BlockID(device)
         if self.volume_manager_name and self.volume_manager_name == 'lvm' \
-           and mount_point == '/':
+           and (mount_point == '/' or mount_point == 'swap'):
             fstab_entry = ' '.join(
                 [
                     device, mount_point,


### PR DESCRIPTION
If an LVM setup is used together with a swapspace the
swap is created as a volume in the volume group. The
required fstab entry to activate swap was not using
the LVM exposed device but the UUID of the low level
block layer. This low level device is not created
by udev because LVM takes over precedence in this
case.

