### PR TITLE
Added support for repo customization script

### DIFF
--- a/doc/source/concept_and_workflow/repository_setup.rst
+++ b/doc/source/concept_and_workflow/repository_setup.rst
@@ -74,6 +74,28 @@ following optional attributes:
 
 - `profiles`: List of profiles to which this repository applies.
 
+- `customize`: Script to run custom modifications to the repo file(s).
+  repo files allows for several customization options which not all of them
+  are supported to be set by kiwi through the current repository schema.
+  As the options used do not follow any standard and are not compatible
+  between package managers and distributions, the only generic way to handle
+  this is through a script hook which is invoked with the repo file as
+  parameter for each file created by {kiwi}.
+
+  An example for a script call to add the `module_hotfixes` option
+  for a `dnf` compatible repository configuration could look like
+  this
+
+  .. code:: bash
+
+     repo_file=$1
+     echo 'module_hotfixes = 1' >> ${repo_file}
+
+  .. note::
+
+     If the script is provided as relative path it will
+     be searched in the image description directory
+
 .. _supported-repository-paths:
 
 Supported repository paths

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -727,6 +727,15 @@ repository_gpgcheck="true|false"
   relevant key information needs to be provided on the {kiwi}
   commandline using the `--signing-key` option
 
+customize="/path/to/custom_script"
+  Custom script hook which is invoked with the repo file as parameter
+  for each file created by {kiwi}.
+
+  .. note::
+
+     If the script is provided as relative path it will
+     be searched in the image description directory
+
 imageinclude="true|false"
   Specifies whether the given repository should be configured as a
   repository in the image or not. The default behavior is that

--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -136,7 +136,8 @@ class RepositoryApt(RepositoryBase):
         prio: int = None, dist: str = None, components: str = None,
         user: str = None, secret: str = None, credentials_file: str = None,
         repo_gpgcheck: bool = None, pkg_gpgcheck: bool = None,
-        sourcetype: str = None, use_for_bootstrap: bool = False
+        sourcetype: str = None, use_for_bootstrap: bool = False,
+        customization_script: str = None
     ) -> None:
         """
         Add apt_get repository
@@ -155,6 +156,8 @@ class RepositoryApt(RepositoryBase):
         :param str sourcetype: unused
         :param bool use_for_bootstrap: use this repository for the
             debootstrap call
+        :param str customization_script:
+            custom script called after the repo file was created
         """
         list_file = '/'.join(
             [self.shared_apt_get_dir['sources-dir'], name + '.list']
@@ -194,6 +197,8 @@ class RepositoryApt(RepositoryBase):
                     self.debootstrap_repo_set = use_for_bootstrap
                 repo_line += ' {0} {1}\n'.format(dist, components)
             repo.write(repo_line)
+        if customization_script:
+            self.run_repo_customize(customization_script, list_file)
         if prio:
             uri_parsed = urlparse(uri.replace('file://', 'file:/'))
             with open(pref_file, 'w') as pref:
@@ -211,6 +216,8 @@ class RepositoryApt(RepositoryBase):
                 pref.write(
                     'Pin-Priority: {0}{1}'.format(prio, os.linesep)
                 )
+            if customization_script:
+                self.run_repo_customize(customization_script, pref_file)
 
     def import_trusted_keys(self, signing_keys: List) -> None:
         """

--- a/kiwi/repository/base.py
+++ b/kiwi/repository/base.py
@@ -20,6 +20,7 @@ from typing import (
 )
 
 from kiwi.system.root_bind import RootBind
+from kiwi.command import Command
 
 
 class RepositoryBase:
@@ -73,7 +74,7 @@ class RepositoryBase:
         self, name: str, uri: str, repo_type: str, prio: int, dist: str,
         components: str, user: str, secret: str, credentials_file: str,
         repo_gpgcheck: bool, pkg_gpgcheck: bool, sourcetype: str,
-        use_for_bootstrap: bool = False
+        use_for_bootstrap: bool = False, customization_script: str = None
     ) -> None:
         """
         Add repository
@@ -93,6 +94,7 @@ class RepositoryBase:
         :param bool pkg_gpgcheck: unused
         :param str sourcetype: unused
         :param bool use_for_bootstrap: unused
+        :param str customization_script: unused
         """
         raise NotImplementedError
 
@@ -152,3 +154,15 @@ class RepositoryBase:
         :param str name: unused
         """
         raise NotImplementedError
+
+    @staticmethod
+    def run_repo_customize(script_path: str, repo_file) -> None:
+        """
+        Run an optional customization script
+
+        :param str script_path: unused
+        :param str repo_file: unused
+        """
+        Command.run(
+            ['bash', '--norc', script_path, repo_file]
+        )

--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -191,7 +191,8 @@ class RepositoryDnf(RepositoryBase):
         prio: int = None, dist: str = None, components: str = None,
         user: str = None, secret: str = None, credentials_file: str = None,
         repo_gpgcheck: bool = False, pkg_gpgcheck: bool = False,
-        sourcetype: str = None, use_for_bootstrap: bool = False
+        sourcetype: str = None, use_for_bootstrap: bool = False,
+        customization_script: str = None
     ) -> None:
         """
         Add dnf repository
@@ -210,6 +211,8 @@ class RepositoryDnf(RepositoryBase):
         :param str sourcetype:
             source type, one of 'baseurl', 'metalink' or 'mirrorlist'
         :param bool use_for_bootstrap: unused
+        :param str customization_script:
+            custom script called after the repo file was created
         """
         repo_file = self.shared_dnf_dir['reposd-dir'] + '/' + name + '.repo'
         self.repo_names.append(name + '.repo')
@@ -244,6 +247,8 @@ class RepositoryDnf(RepositoryBase):
             )
         with open(repo_file, 'w') as repo:
             repo_config.write(repo)
+        if customization_script:
+            self.run_repo_customize(customization_script, repo_file)
 
     def import_trusted_keys(self, signing_keys: List) -> None:
         """

--- a/kiwi/repository/pacman.py
+++ b/kiwi/repository/pacman.py
@@ -112,7 +112,8 @@ class RepositoryPacman(RepositoryBase):
         prio: int = None, dist: str = None, components: str = None,
         user: str = None, secret: str = None, credentials_file: str = None,
         repo_gpgcheck: bool = False, pkg_gpgcheck: bool = False,
-        sourcetype: str = None, use_for_bootstrap: bool = False
+        sourcetype: str = None, use_for_bootstrap: bool = False,
+        customization_script: str = None
     ) -> None:
         """
         Add pacman repository
@@ -130,6 +131,8 @@ class RepositoryPacman(RepositoryBase):
         :param bool pkg_gpgcheck: enable package signature validation
         :param str sourcetype: unused
         :param bool use_for_bootstrap: unused
+        :param str customization_script:
+            custom script called after the repo file was created
         """
         repo_file = '{0}/{1}.repo'.format(
             self.shared_pacman_dir['repos-dir'], name
@@ -151,6 +154,8 @@ class RepositoryPacman(RepositoryBase):
 
         with open(repo_file, 'w') as config:
             repo_config.write(config)
+        if customization_script:
+            self.run_repo_customize(customization_script, repo_file)
 
     def import_trusted_keys(self, signing_keys: List) -> None:
         """

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -247,7 +247,8 @@ class RepositoryZypper(RepositoryBase):
         prio: int = None, dist: str = None, components: str = None,
         user: str = None, secret: str = None, credentials_file: str = None,
         repo_gpgcheck: bool = False, pkg_gpgcheck: bool = False,
-        sourcetype: str = None, use_for_bootstrap: bool = False
+        sourcetype: str = None, use_for_bootstrap: bool = False,
+        customization_script: str = None
     ) -> None:
         """
         Add zypper repository
@@ -265,6 +266,8 @@ class RepositoryZypper(RepositoryBase):
         :param bool pkg_gpgcheck: enable package signature validation
         :param str sourcetype: unused
         :param boot use_for_bootstrap: unused
+        :param str customization_script:
+            custom script called after the repo file was created
         """
         if credentials_file:
             repo_secret = os.sep.join(
@@ -331,6 +334,8 @@ class RepositoryZypper(RepositoryBase):
             )
         with open(repo_file, 'w') as repo:
             repo_config.write(repo)
+        if customization_script:
+            self.run_repo_customize(customization_script, repo_file)
         self._restore_package_cache()
 
     def import_trusted_keys(self, signing_keys: List) -> None:

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -976,6 +976,12 @@ div {
         ## to run package signature validation. If not set, no value is
         ## appended into the repository configuration file.
         attribute package_gpgcheck { xsd:boolean }
+    k.repository.customize.attribute =
+        ## Specify the path to a customization script.
+        ## The script receives the repo file according to the
+        ## used package manager as a parameter such that custom
+        ## modifications can be placed when needed
+        attribute customize { text }
     k.repository.priority.attribute =
         ## Channel priority assigned to all packages available in
         ## this channel (0 if not set). If the exact same package
@@ -1031,6 +1037,7 @@ div {
             k.repository.imageonly.attribute
         )? &
         k.repository.repository_gpgcheck.attribute? &
+        k.repository.customize.attribute? &
         k.repository.package_gpgcheck.attribute? &
         k.repository.priority.attribute? &
         k.repository.password.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1492,6 +1492,14 @@ appended into the repository configuration file.</a:documentation>
         <data type="boolean"/>
       </attribute>
     </define>
+    <define name="k.repository.customize.attribute">
+      <attribute name="customize">
+        <a:documentation>Specify the path to a customization script.
+The script receives the repo file according to the
+used package manager as a parameter such that custom
+modifications can be placed when needed</a:documentation>
+      </attribute>
+    </define>
     <define name="k.repository.priority.attribute">
       <attribute name="priority">
         <a:documentation>Channel priority assigned to all packages available in
@@ -1574,6 +1582,9 @@ last one is picked.</a:documentation>
         </optional>
         <optional>
           <ref name="k.repository.repository_gpgcheck.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.repository.customize.attribute"/>
         </optional>
         <optional>
           <ref name="k.repository.package_gpgcheck.attribute"/>

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -23,6 +23,7 @@ from typing import (
 from textwrap import dedent
 
 # project
+from kiwi.xml_parse import repository
 from kiwi.xml_state import XMLState
 from kiwi.system.root_init import RootInit
 from kiwi.system.root_import import RootImport
@@ -153,6 +154,9 @@ class SystemPrepare:
             repo_components = xml_repo.get_components()
             repo_repository_gpgcheck = xml_repo.get_repository_gpgcheck()
             repo_package_gpgcheck = xml_repo.get_package_gpgcheck()
+            repo_customization_script = self._get_repo_customization_script(
+                xml_repo
+            )
             repo_sourcetype = xml_repo.get_sourcetype()
             repo_use_for_bootstrap = \
                 True if xml_repo.get_use_for_bootstrap() else False
@@ -187,7 +191,8 @@ class SystemPrepare:
                 repo_type, repo_priority, repo_dist, repo_components,
                 repo_user, repo_secret, uri.credentials_file_name(),
                 repo_repository_gpgcheck, repo_package_gpgcheck,
-                repo_sourcetype, repo_use_for_bootstrap
+                repo_sourcetype, repo_use_for_bootstrap,
+                repo_customization_script
             )
             if clear_cache:
                 repo.delete_repo_cache(repo_alias)
@@ -539,6 +544,14 @@ class SystemPrepare:
             manager.collection_requests + \
             manager.product_requests + \
             manager.exclude_requests
+
+    def _get_repo_customization_script(self, xml_repo: repository) -> str:
+        script_path = xml_repo.get_customize()
+        if script_path and not os.path.isabs(script_path):
+            script_path = os.path.join(
+                self.xml_state.xml_data.description_dir, script_path
+            )
+        return script_path
 
     def __del__(self):
         log.info('Cleaning up {:s} instance'.format(type(self).__name__))

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -27,6 +27,7 @@ from typing import Any
 # project
 import kiwi.defaults as defaults
 
+from kiwi.xml_parse import repository
 from kiwi.utils.fstab import Fstab
 from kiwi.xml_state import XMLState
 from kiwi.runtime_config import RuntimeConfig
@@ -150,7 +151,11 @@ class SystemSetup:
             repo_components = xml_repo.get_components()
             repo_repository_gpgcheck = xml_repo.get_repository_gpgcheck()
             repo_package_gpgcheck = xml_repo.get_package_gpgcheck()
+            repo_customization_script = self._get_repo_customization_script(
+                xml_repo
+            )
             repo_sourcetype = xml_repo.get_sourcetype()
+            repo_use_for_bootstrap = False
             uri = Uri(repo_source, repo_type)
             repo_source_translated = uri.translate(
                 check_build_environment=False
@@ -166,7 +171,8 @@ class SystemSetup:
                 repo_type, repo_priority, repo_dist, repo_components,
                 repo_user, repo_secret, uri.credentials_file_name(),
                 repo_repository_gpgcheck, repo_package_gpgcheck,
-                repo_sourcetype
+                repo_sourcetype, repo_use_for_bootstrap,
+                repo_customization_script
             )
 
     def import_cdroot_files(self, target_dir: str) -> None:
@@ -1235,3 +1241,9 @@ class SystemSetup:
         data.sync_data(
             options=sync_options
         )
+
+    def _get_repo_customization_script(self, xml_repo: repository) -> str:
+        script_path = xml_repo.get_customize()
+        if script_path and not os.path.isabs(script_path):
+            script_path = os.path.join(self.description_dir, script_path)
+        return script_path

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2064,7 +2064,7 @@ class repository(k_source):
     """The Name of the Repository"""
     subclass = None
     superclass = k_source
-    def __init__(self, source=None, type_=None, profiles=None, alias=None, sourcetype=None, components=None, distribution=None, imageinclude=None, imageonly=None, repository_gpgcheck=None, package_gpgcheck=None, priority=None, password=None, username=None, use_for_bootstrap=None):
+    def __init__(self, source=None, type_=None, profiles=None, alias=None, sourcetype=None, components=None, distribution=None, imageinclude=None, imageonly=None, repository_gpgcheck=None, customize=None, package_gpgcheck=None, priority=None, password=None, username=None, use_for_bootstrap=None):
         self.original_tagname_ = None
         super(repository, self).__init__(source, )
         self.type_ = _cast(None, type_)
@@ -2076,6 +2076,7 @@ class repository(k_source):
         self.imageinclude = _cast(bool, imageinclude)
         self.imageonly = _cast(bool, imageonly)
         self.repository_gpgcheck = _cast(bool, repository_gpgcheck)
+        self.customize = _cast(None, customize)
         self.package_gpgcheck = _cast(bool, package_gpgcheck)
         self.priority = _cast(int, priority)
         self.password = _cast(None, password)
@@ -2110,6 +2111,8 @@ class repository(k_source):
     def set_imageonly(self, imageonly): self.imageonly = imageonly
     def get_repository_gpgcheck(self): return self.repository_gpgcheck
     def set_repository_gpgcheck(self, repository_gpgcheck): self.repository_gpgcheck = repository_gpgcheck
+    def get_customize(self): return self.customize
+    def set_customize(self, customize): self.customize = customize
     def get_package_gpgcheck(self): return self.package_gpgcheck
     def set_package_gpgcheck(self, package_gpgcheck): self.package_gpgcheck = package_gpgcheck
     def get_priority(self): return self.priority
@@ -2177,6 +2180,9 @@ class repository(k_source):
         if self.repository_gpgcheck is not None and 'repository_gpgcheck' not in already_processed:
             already_processed.add('repository_gpgcheck')
             outfile.write(' repository_gpgcheck="%s"' % self.gds_format_boolean(self.repository_gpgcheck, input_name='repository_gpgcheck'))
+        if self.customize is not None and 'customize' not in already_processed:
+            already_processed.add('customize')
+            outfile.write(' customize=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.customize), input_name='customize')), ))
         if self.package_gpgcheck is not None and 'package_gpgcheck' not in already_processed:
             already_processed.add('package_gpgcheck')
             outfile.write(' package_gpgcheck="%s"' % self.gds_format_boolean(self.package_gpgcheck, input_name='package_gpgcheck'))
@@ -2255,6 +2261,10 @@ class repository(k_source):
                 self.repository_gpgcheck = False
             else:
                 raise_parse_error(node, 'Bad boolean attribute')
+        value = find_attr_value_('customize', node)
+        if value is not None and 'customize' not in already_processed:
+            already_processed.add('customize')
+            self.customize = value
         value = find_attr_value_('package_gpgcheck', node)
         if value is not None and 'package_gpgcheck' not in already_processed:
             already_processed.add('package_gpgcheck')

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -169,7 +169,7 @@
     <repository priority="42" sourcetype="baseurl">
         <source path="iso:///image/CDs/dvd.iso"/>
     </repository>
-    <repository type="rpm-md" imageinclude="true">
+    <repository type="rpm-md" imageinclude="true" customize="script">
         <source path="obs://Devel:PubCloud:AmazonEC2/SLE_12_GA"/>
     </repository>
     <repository type="rpm-md" imageonly="true">

--- a/test/unit/repository/pacman_test.py
+++ b/test/unit/repository/pacman_test.py
@@ -59,8 +59,9 @@ class TestRepositorPacman(object):
 
     @patch('kiwi.repository.pacman.ConfigParser')
     @patch('os.path.exists')
+    @patch('kiwi.command.Command.run')
     def test_add_local_repo_with_components(
-        self, mock_exists, mock_config
+        self, mock_Command_run, mock_exists, mock_config
     ):
         repo_config = Mock()
         mock_config.return_value = repo_config
@@ -70,7 +71,8 @@ class TestRepositorPacman(object):
         with patch('builtins.open', m_open, create=True):
             self.repo.add_repo(
                 'foo', '/some_uri', components='core extra',
-                repo_gpgcheck=False, pkg_gpgcheck=True
+                repo_gpgcheck=False, pkg_gpgcheck=True,
+                customization_script='custom_script'
             )
         m_open.assert_called_once_with(
             '/shared-dir/pacman/repos/foo.repo', 'w'
@@ -85,6 +87,12 @@ class TestRepositorPacman(object):
             call('extra', 'Server', 'file:///some_uri'),
             call('extra', 'SigLevel', 'Required DatabaseNever'),
         ]
+        mock_Command_run.assert_called_once_with(
+            [
+                'bash', '--norc', 'custom_script',
+                '/shared-dir/pacman/repos/foo.repo'
+            ]
+        )
 
     @patch('kiwi.repository.pacman.ConfigParser')
     @patch('os.path.exists')

--- a/test/unit/repository/zypper_test.py
+++ b/test/unit/repository/zypper_test.py
@@ -111,7 +111,10 @@ class TestRepositoryZypper:
         mock_config.return_value = repo_config
         mock_exists.return_value = True
         with patch('builtins.open', create=True) as mock_open:
-            self.repo.add_repo('foo', 'kiwi_iso_mount/uri', 'rpm-md', 42)
+            self.repo.add_repo(
+                'foo', 'kiwi_iso_mount/uri', 'rpm-md', 42,
+                customization_script='custom_script'
+            )
             mock_wipe.assert_called_once_with(
                 '../data/shared-dir/zypper/repos/foo.repo'
             )
@@ -133,6 +136,10 @@ class TestRepositoryZypper:
                         'foo'
                     ], self.repo.command_env
                 ),
+                call([
+                    'bash', '--norc', 'custom_script',
+                    '../data/shared-dir/zypper/repos/foo.repo'
+                ]),
                 call([
                     'mv', '-f',
                     '/shared-dir/packages.moved', '/shared-dir/packages'

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -222,12 +222,12 @@ class TestSystemPrepare:
             call(
                 'uri-alias', 'uri', None, 42,
                 None, None, None, None, 'credentials-file', None, None,
-                'baseurl', False
+                'baseurl', False, None
             ),
             call(
                 'uri-alias', 'uri', 'rpm-md', None,
                 None, None, None, None, 'credentials-file', None, None,
-                None, False
+                None, False, '../data/script'
             )
         ]
         assert repo.delete_repo_cache.call_args_list == [

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -1307,7 +1307,7 @@ class TestSystemSetup:
         self.setup_with_real_xml.import_repositories_marked_as_imageinclude()
         assert repo.add_repo.call_args_list[0] == call(
             'uri-alias', 'uri', 'rpm-md', None, None, None, None, None,
-            'kiwiRepoCredentials', None, None, None
+            'kiwiRepoCredentials', None, None, None, False, '../data/script'
         )
 
     @patch('os.path.exists')


### PR DESCRIPTION
repo files allows for several customization options which could not be set by kiwi through the current repository schema. As the options used do not follow any standard and are not compatible between package managers and distributions the only generic way to handle this is through a script which is invoked with the repo file as parameter for each file created
to describe a repo for the selected package manager. This allows users to update/change the repo file content
on their individual needs. In the kiwi description the path to the custom script can be specified as follows

```xml
    <repository ... customize="/path/to/custom_script">
        <source path="..."/>
    </repository>
```

This Fixes #1896

