### PR TITLE
Log deprecation errors to stderr

### DIFF
--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -837,10 +837,12 @@ function Rm {
 }
 
 function deprecated {
-    echo "DEPRECATED: $1() is obsolete"
-    echo "["
-    cat
-    echo "]"
+    {
+        echo "DEPRECATED: $1() is obsolete"
+        echo "["
+        cat
+        echo "]"
+    } >&2
     exit 1
 }
 


### PR DESCRIPTION
Make sure information about deprecated shell methods
logs their information to stderr. This will cause the
error message to be exposed to the user and not only
in the log file

