### PR TITLE
No compression with encryption

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -463,13 +463,14 @@ class DiskBuilder:
             self.diskname
         )
         # store image file name in result
+        compression = self.runtime_config.get_bundle_compression(default=True)
+        if self.luks != None:
+            compression = False
         self.result.add(
             key='disk_image',
             filename=self.diskname,
             use_for_bundle=True if not self.image_format else False,
-            compress=self.runtime_config.get_bundle_compression(
-                default=True
-            ),
+            compress=compression,
             shasum=True
         )
 


### PR DESCRIPTION

Fixes # .

Changes proposed in this pull request:
* When an image is setup to use encryption the resulting image appears
as a random stream of bytes and cannot be compressed. Simply skip
the compression in this case.

