### PR TITLE
Moved CI Linter and Unit tests to github

### DIFF
--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -1,5 +1,4 @@
----
-name: CI
+name: CIConfigFunctions
 
 on:
   push:

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -1,0 +1,25 @@
+name: CILint
+
+on: [push]
+
+jobs:
+  unit_tests:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Python${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox
+    - name: Tox
+      run: |
+        tox

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,6 @@
     - master
 
 stages:
-  - test
   - documentation
   - deploy
   - sourcepackage
@@ -17,41 +16,6 @@ variables:
   BUILD_IMAGES_PROJECT: kiwi3/kiwi-ci-containers
   TUMBLEWEED_BUILD: buildenv-tumbleweed
   FEDORA_BUILD: buildenv-fedora
-
-code_style:
-  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
-  stage: test
-  <<: *only-default
-  script:
-    - tox -e check
-  cache:
-    key: "$CI_JOB_NAME"
-    paths:
-      - .tox/3
-
-unit_py36:
-  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
-  stage: test
-  <<: *only-default
-  script:
-    - export PYTHON=python3.6
-    - tox -e unit_py3_6 "-n $(nproc)"
-  cache:
-    key: "$CI_JOB_NAME"
-    paths:
-      - .tox/3.6
-
-unit_py38:
-  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
-  stage: test
-  <<: *only-default
-  script:
-    - export PYTHON=python3.8
-    - tox -e unit_py3_8 "-n $(nproc)"
-  cache:
-    key: "$CI_JOB_NAME"
-    paths:
-      - .tox/3.8
 
 build_doc:
   image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$TUMBLEWEED_BUILD

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,7 @@ skipsdist = True
 envlist =
     check,
     unit_py3_8,
-    unit_py3_6,
-    packagedoc
+    unit_py3_6
 
 
 [testenv]


### PR DESCRIPTION
Moving the linter and unit tests to github workflows
and out of the gitlab CI system has the advantage
that pull request from forked repos will run the
tests. In the long run I think we should move away
completely from gitlab CI and use github actions
as this will reduce the number of external services
used in the kiwi project

