### PR TITLE
Start moving CI test from gitlab to actions

### DIFF
--- a/.github/workflows/ci-code-style.yml
+++ b/.github/workflows/ci-code-style.yml
@@ -1,0 +1,28 @@
+name: CI-Code-Style
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+
+jobs:
+  unit_tests:
+    name: Linter checks for KIWI python and Shell code
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Python${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Tox
+        run: |
+          sudo apt update && sudo apt install tox
+      - name: Run code checks
+        run: |
+          tox -e check

--- a/.github/workflows/ci-config-functions.yml
+++ b/.github/workflows/ci-config-functions.yml
@@ -1,5 +1,4 @@
----
-name: CI
+name: CI-Config-Functions
 
 on:
   push:
@@ -9,7 +8,7 @@ on:
 
 jobs:
   scripts_integration_tests:
-    name: Integration tests for functions.sh
+    name: Integration tests for config/functions.sh
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -31,7 +30,7 @@ jobs:
         uses: actions/checkout@v2
       - name: set up Python
         uses: actions/setup-python@v2
-      - name: install tox
+      - name: Install Tox
         run: sudo apt update && sudo apt install tox
 
       - name: Run the scripts integration tests

--- a/.github/workflows/ci-documentation.yml
+++ b/.github/workflows/ci-documentation.yml
@@ -1,0 +1,28 @@
+name: CI-Documentation
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+
+jobs:
+  unit_tests:
+    name: Test rendering Sphinx ReST documentation
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Python${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Tox
+        run: |
+          sudo apt update && sudo apt install tox
+      - name: Run sphinx build
+        run: |
+          tox -e doc

--- a/.github/workflows/ci-units-types.yml
+++ b/.github/workflows/ci-units-types.yml
@@ -1,0 +1,29 @@
+name: CI-Unit-And-Types
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+
+jobs:
+  unit_tests:
+    name: Unit and Static Type tests for KIWI python code
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Python${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Tox
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+      - name: Run unit and type tests
+        run: |
+          tox -e unit_py3_6,unit_py3_8

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,6 @@
     - master
 
 stages:
-  - test
   - documentation
   - deploy
   - sourcepackage
@@ -17,41 +16,6 @@ variables:
   BUILD_IMAGES_PROJECT: kiwi3/kiwi-ci-containers
   TUMBLEWEED_BUILD: buildenv-tumbleweed
   FEDORA_BUILD: buildenv-fedora
-
-code_style:
-  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
-  stage: test
-  <<: *only-default
-  script:
-    - tox -e check
-  cache:
-    key: "$CI_JOB_NAME"
-    paths:
-      - .tox/3
-
-unit_py36:
-  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
-  stage: test
-  <<: *only-default
-  script:
-    - export PYTHON=python3.6
-    - tox -e unit_py3_6 "-n $(nproc)"
-  cache:
-    key: "$CI_JOB_NAME"
-    paths:
-      - .tox/3.6
-
-unit_py38:
-  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
-  stage: test
-  <<: *only-default
-  script:
-    - export PYTHON=python3.8
-    - tox -e unit_py3_8 "-n $(nproc)"
-  cache:
-    key: "$CI_JOB_NAME"
-    paths:
-      - .tox/3.8
 
 build_doc:
   image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$TUMBLEWEED_BUILD


### PR DESCRIPTION
Moving the linter and unit tests to github workflows and
out of the gitlab CI system has the advantage that pull
request from forked repos will run the tests. In the long
run I think we should move away completely from gitlab CI
and use github actions as this will reduce the number of
external services used in the kiwi project. This commit
starts with the most simple parts: unit and type tests,
doc rendering and code style


