### PR TITLE
Sync data trailing slash

### DIFF
--- a/kiwi/filesystem/base.py
+++ b/kiwi/filesystem/base.py
@@ -146,7 +146,7 @@ class FileSystemBase:
             return self.filesystem_mount.mountpoint
         return None
 
-    def sync_data(self, exclude: List[str] = None):
+    def sync_data(self, exclude: List[str] = []):
         """
         Copy root data tree into filesystem
 

--- a/kiwi/utils/sync.py
+++ b/kiwi/utils/sync.py
@@ -18,6 +18,7 @@
 import os
 import logging
 from stat import ST_MODE
+from typing import List
 import xattr
 
 # project
@@ -28,19 +29,24 @@ log = logging.getLogger('kiwi')
 
 class DataSync:
     """
-    **Sync data from a source directory to a target directory
-    using the rsync protocol**
-
-    :param str source_dir: source directory path name
-    :param str target_dir: target directory path name
+    **Sync data from a source directory to a target directory**
     """
-    def __init__(self, source_dir, target_dir):
+    def __init__(self, source_dir: str, target_dir: str) -> None:
+        """
+        Create a new DataSync instance and initialize
+        sync source and target
+
+        :param str source_dir: source directory path name
+        :param str target_dir: target directory path name
+        """
         self.source_dir = source_dir
         self.target_dir = target_dir
 
-    def sync_data(self, options=None, exclude=None):
+    def sync_data(
+        self, options: List[str] = [], exclude: List[str] = []
+    ) -> None:
         """
-        Sync data from source to target using rsync
+        Sync data from source to target using the rsync protocol
 
         :param list options: rsync options
         :param list exclude: file patterns to exclude
@@ -87,7 +93,7 @@ class DataSync:
             # not changed
             os.chmod(self.target_dir, target_entry_permissions)
 
-    def target_supports_extended_attributes(self):
+    def target_supports_extended_attributes(self) -> bool:
         """
         Check if the target directory supports extended filesystem
         attributes

--- a/kiwi/utils/sync.py
+++ b/kiwi/utils/sync.py
@@ -43,14 +43,45 @@ class DataSync:
         self.target_dir = target_dir
 
     def sync_data(
-        self, options: List[str] = [], exclude: List[str] = []
+        self, options: List[str] = [], exclude: List[str] = [],
+        force_trailing_slash: bool = False
     ) -> None:
         """
         Sync data from source to target using the rsync protocol
 
         :param list options: rsync options
         :param list exclude: file patterns to exclude
+        :param bool force_trailing_slash: add '/' to source_dir if not present
+
+        A speciality of the rsync tool is that it behaves differently
+        if the given source_dir ends with a '/' or not. If it ends
+        with a slash the data structure below will be synced to the
+        target_dir. If it does not end with a slash the source_dir
+        and its contents are synced to the target_dir. For example
+
+        .. code:: bash
+
+            source
+              └── some_data
+
+            1. $ rsync -a source target
+
+            target
+              └── source
+                    └── some_data
+
+            2. $ rsync -a source/ target
+
+            target
+              └── some_data
+
+        The parameter force_trailing_slash can be used to make
+        sure rsync behaves like shown in the second case. If
+        set to true a '/' is appended to the given source_dir
+        if not already present
         """
+        if force_trailing_slash and not self.source_dir.endswith(os.sep):
+            self.source_dir += os.sep
         target_entry_permissions = None
         exclude_options = []
         rsync_options = []

--- a/test/unit/utils/sync_test.py
+++ b/test/unit/utils/sync_test.py
@@ -39,6 +39,18 @@ class TestDataSync:
                 'target_dir', mock_stat.return_value[ST_MODE]
             )
 
+    @patch('kiwi.utils.sync.Command.run')
+    @patch('os.chmod')
+    @patch('os.stat')
+    def test_sync_data_force_trailing_slash(
+        self, mock_stat, mock_chmod, mock_command
+    ):
+        mock_stat.return_value = os.stat('.')
+        self.sync.sync_data(force_trailing_slash=True)
+        mock_command.assert_called_once_with(
+            ['rsync', 'source_dir/', 'target_dir']
+        )
+
     @patch('xattr.getxattr')
     def test_target_supports_extended_attributes(self, mock_getxattr):
         assert self.sync.target_supports_extended_attributes() is True


### PR DESCRIPTION
This patch is two fold

* **Added type hints for DataSync class**

* **Added force_trailing_slash argument to sync_data**
    
   A speciality of the rsync tool is that it behaves differently
   if the given source_dir ends with a '/' or not. If it ends
   with a slash the data structure below will be synced to the
   target_dir. If it does not end with a slash the source_dir
   and its contents are synced to the target_dir. For example:

   ```    
        source
          └── some_data
   ```
 
   1. $ rsync -a source target

   ```    
        target
          └── source
                └── some_data
   ```
    
   2. $ rsync -a source/ target

   ```    
        target
          └── some_data
   ``` 

   The parameter force_trailing_slash in the DataSync sync_data()
   method can be used to make sure rsync behaves like shown in
   the second case. This Fixes #1786

