### PR TITLE
Fixed condition for GRUB_DISABLE_LINUX_UUID="true"

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -656,7 +656,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         grub_final_cmdline = re.sub(
             r'(^root=[^\s]+)|( root=[^\s]+)', '', self.cmdline
         ).strip()
-        if self.persistency_type != 'by-uuid':
+        if self.persistency_type == 'by-label':
             grub_default_entries['GRUB_DISABLE_LINUX_UUID'] = 'true'
         if self.displayname:
             grub_default_entries['GRUB_DISTRIBUTOR'] = '"{0}"'.format(

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -557,6 +557,8 @@ class TestBootLoaderConfigGrub2:
         self.bootloader.theme = 'openSUSE'
         self.bootloader.displayname = 'Bob'
         self.firmware.efi_mode.return_value = 'efi'
+        self.bootloader.persistency_type = 'by-label'
+
         self.bootloader._setup_default_grub()
 
         mock_sysconfig.assert_called_once_with('root_dir/etc/default/grub')
@@ -600,6 +602,7 @@ class TestBootLoaderConfigGrub2:
         self.bootloader.theme = 'openSUSE'
         self.bootloader.displayname = 'Bob'
         self.bootloader.cmdline = 'root=UUID=foo'
+        self.bootloader.persistency_type = 'by-label'
 
         self.bootloader._setup_default_grub()
 


### PR DESCRIPTION
The grub config parameter GRUB_DISABLE_LINUX_UUID must only
be set if the device persistence setting is not UUID. However,
in kiwi UUID device names are the default and doesn't have to
be expressed explicitly. Therefore the condition to check
for different than 'by-uuid' is wrong for the default case were
no device persistence setting exists. This results in a wrong
grub option to be set. This commit fixes it in a way to disable
UUID device names in grub if the only other device persistency
setting in kiwi named: 'by-label' is explicitly configured.
This Fixes #1842


