### PR TITLE
Added support for building rpm package from bundle

### DIFF
--- a/doc/source/commands/result_bundle.rst
+++ b/doc/source/commands/result_bundle.rst
@@ -13,6 +13,7 @@ SYNOPSIS
    kiwi-ng result bundle -h | --help
    kiwi-ng result bundle --target-dir=<directory> --id=<bundle_id> --bundle-dir=<directory>
        [--zsync_source=<download_location>]
+       [--package-as-rpm]
    kiwi-ng result bundle help
 
 .. _db_kiwi_result_bundle_desc:
@@ -56,3 +57,7 @@ OPTIONS
 
   * It is expected that all files from a bundle are placed to the same
     download location
+
+--package-as-rpm
+
+  Take all result files and create an rpm package out of it

--- a/test/unit/tasks/result_bundle_test.py
+++ b/test/unit/tasks/result_bundle_test.py
@@ -66,6 +66,7 @@ class TestResultBundleTask:
         self.task.command_args['--bundle-dir'] = 'bundle_dir'
         self.task.command_args['--id'] = 'Build_42'
         self.task.command_args['--zsync-source'] = None
+        self.task.command_args['--package-as-rpm'] = None
 
     def test_process_invalid_bundle_directory(self):
         self._init_command_args()
@@ -79,11 +80,12 @@ class TestResultBundleTask:
     @patch('kiwi.tasks.result_bundle.Command.run')
     @patch('kiwi.tasks.result_bundle.Path.create')
     @patch('kiwi.tasks.result_bundle.Path.which')
+    @patch('kiwi.tasks.result_bundle.Path.wipe')
     @patch('kiwi.tasks.result_bundle.Compress')
     @patch('kiwi.tasks.result_bundle.Checksum')
     @patch('os.path.exists')
     def test_process_result_bundle(
-        self, mock_exists, mock_checksum, mock_compress,
+        self, mock_exists, mock_checksum, mock_compress, mock_path_wipe,
         mock_path_which, mock_path_create, mock_command, mock_load
     ):
         # This file won't be copied with build id
@@ -111,6 +113,7 @@ class TestResultBundleTask:
         mock_load.assert_called_once_with(
             os.sep.join([self.abs_target_dir, 'kiwi.result'])
         )
+        mock_path_wipe.assert_called_once_with(self.abs_bundle_dir)
         mock_path_create.assert_called_once_with(self.abs_bundle_dir)
         assert mock_command.call_args_list == [
             call([
@@ -141,12 +144,77 @@ class TestResultBundleTask:
             )
         )
 
+    @patch('kiwi.tasks.result_bundle.Privileges.check_for_root_permissions')
     @patch('kiwi.tasks.result_bundle.Result.load')
     @patch('kiwi.tasks.result_bundle.Command.run')
     @patch('kiwi.tasks.result_bundle.Path.create')
+    @patch('kiwi.tasks.result_bundle.Path.which')
+    @patch('kiwi.tasks.result_bundle.Path.wipe')
+    @patch('kiwi.tasks.result_bundle.Compress')
+    @patch('kiwi.tasks.result_bundle.Checksum')
+    @patch('os.path.exists')
+    @patch('os.chdir')
+    @patch('os.unlink')
+    @patch('glob.iglob')
+    def test_process_result_bundle_as_rpm(
+        self, mock_iglob, mock_unlink, mock_chdir, mock_exists, mock_checksum,
+        mock_compress, mock_path_wipe, mock_path_which, mock_path_create,
+        mock_command, mock_load, mock_Privileges_check_for_root_permissions
+    ):
+        checksum = Mock()
+        compress = Mock()
+        mock_path_which.return_value = 'zsyncmake'
+        compress.compressed_filename = 'compressed_filename'
+        mock_compress.return_value = compress
+        mock_checksum.return_value = checksum
+        mock_exists.return_value = False
+        mock_load.return_value = self.result
+        self._init_command_args()
+        self.task.command_args['bundle'] = True
+        self.task.command_args['--package-as-rpm'] = True
+        mock_iglob.return_value = [
+            os.sep.join([self.abs_bundle_dir, 'test-image-1.2.3-Build_42'])
+        ]
+
+        m_open = mock_open()
+        with patch('builtins.open', m_open, create=True):
+            self.task.process()
+
+        mock_Privileges_check_for_root_permissions.assert_called_once_with()
+        assert mock_command.call_args_list == [
+            call(
+                [
+                    'cp', 'test-image-1.2.3',
+                    os.sep.join(
+                        [self.abs_bundle_dir, 'test-image-1.2.3-Build_42']
+                    )
+                ]
+            ),
+            call(
+                [
+                    'rpmbuild', '--nodeps', '--nocheck', '--rmspec', '-bb',
+                    os.sep.join([self.abs_bundle_dir, 'test-image.spec'])
+                ]
+            ),
+            call(
+                ['bash', '-c', 'mv noarch/*.rpm . && rmdir noarch']
+            )
+        ]
+        mock_chdir.assert_called_once_with(
+            self.abs_bundle_dir
+        )
+        mock_unlink.assert_called_once_with(
+            os.sep.join([self.abs_bundle_dir, 'test-image-1.2.3-Build_42'])
+        )
+
+    @patch('kiwi.tasks.result_bundle.Result.load')
+    @patch('kiwi.tasks.result_bundle.Command.run')
+    @patch('kiwi.tasks.result_bundle.Path.create')
+    @patch('kiwi.tasks.result_bundle.Path.wipe')
     @patch('os.path.exists')
     def test_process_result_bundle_name_includes_version(
-        self, mock_exists, mock_path_create, mock_command, mock_load
+        self, mock_exists, mock_path_wipe, mock_path_create,
+        mock_command, mock_load
     ):
         result = Result(self.xml_state)
         result.add(
@@ -167,6 +235,7 @@ class TestResultBundleTask:
         mock_load.assert_called_once_with(
             os.sep.join([self.abs_target_dir, 'kiwi.result'])
         )
+        mock_path_wipe.assert_called_once_with(self.abs_bundle_dir)
         mock_path_create.assert_called_once_with(self.abs_bundle_dir)
         assert mock_command.call_args_list == [
             call([
@@ -182,11 +251,12 @@ class TestResultBundleTask:
     @patch('kiwi.tasks.result_bundle.Command.run')
     @patch('kiwi.tasks.result_bundle.Path.create')
     @patch('kiwi.tasks.result_bundle.Path.which')
+    @patch('kiwi.tasks.result_bundle.Path.wipe')
     @patch('kiwi.tasks.result_bundle.Compress')
     @patch('kiwi.tasks.result_bundle.Checksum')
     @patch('os.path.exists')
     def test_process_result_bundle_zsyncmake_missing(
-        self, mock_exists, mock_checksum, mock_compress,
+        self, mock_exists, mock_checksum, mock_compress, mock_path_wipe,
         mock_path_which, mock_path_create, mock_command, mock_load
     ):
         checksum = Mock()


### PR DESCRIPTION
With the new option --package-as-rpm it is possible to
call the kiwi result bundler such that the image build
results gets packaged into an rpm. I think this is a
handy feature to transport image builds via repositories


