### PR TITLE
Fixed uninstall handling via dnf, microdnf, zypper

### DIFF
--- a/kiwi/package_manager/microdnf.py
+++ b/kiwi/package_manager/microdnf.py
@@ -168,20 +168,22 @@ class PackageManagerMicroDnf(PackageManagerBase):
 
         :rtype: namedtuple
         """
-        delete_items = []
-        for delete_item in self.package_requests:
-            try:
-                Command.run(['chroot', self.root_dir, 'rpm', '-q', delete_item])
-                delete_items.append(delete_item)
-            except Exception:
-                # ignore packages which are not installed
-                pass
-        if not delete_items:
-            raise KiwiRequestError(
-                'None of the requested packages to delete are installed'
-            )
-        self.cleanup_requests()
         if force:
+            delete_items = []
+            for delete_item in self.package_requests:
+                try:
+                    Command.run(
+                        ['chroot', self.root_dir, 'rpm', '-q', delete_item]
+                    )
+                    delete_items.append(delete_item)
+                except Exception:
+                    # ignore packages which are not installed
+                    pass
+            if not delete_items:
+                raise KiwiRequestError(
+                    'None of the requested packages to delete are installed'
+                )
+            self.cleanup_requests()
             delete_options = ['--nodeps', '--allmatches', '--noscripts']
             return Command.call(
                 [
@@ -191,13 +193,14 @@ class PackageManagerMicroDnf(PackageManagerBase):
             )
         else:
             chroot_dnf_args = Path.move_to_root(self.root_dir, self.dnf_args)
+            dnf_command = [
+                'chroot', self.root_dir, 'microdnf'
+            ] + chroot_dnf_args + self.custom_args + [
+                'remove'
+            ] + self.package_requests
+            self.cleanup_requests()
             return Command.call(
-                [
-                    'chroot', self.root_dir, 'microdnf'
-                ] + chroot_dnf_args + self.custom_args + [
-                    'remove'
-                ] + delete_items,
-                self.command_env
+                dnf_command, self.command_env
             )
 
     def update(self) -> command_call_type:

--- a/test/unit/package_manager/dnf_test.py
+++ b/test/unit/package_manager/dnf_test.py
@@ -101,7 +101,7 @@ class TestPackageManagerDnf:
         mock_run.side_effect = Exception
         self.manager.request_package('vim')
         with raises(KiwiRequestError):
-            self.manager.process_delete_requests()
+            self.manager.process_delete_requests(force=True)
         mock_run.assert_called_once_with(
             ['chroot', '/root-dir', 'rpm', '-q', 'vim']
         )

--- a/test/unit/package_manager/microdnf_test.py
+++ b/test/unit/package_manager/microdnf_test.py
@@ -108,7 +108,7 @@ class TestPackageManagerMicroDnf:
         mock_run.side_effect = Exception
         self.manager.request_package('vim')
         with raises(KiwiRequestError):
-            self.manager.process_delete_requests()
+            self.manager.process_delete_requests(force=True)
         mock_run.assert_called_once_with(
             ['chroot', '/root-dir', 'rpm', '-q', 'vim']
         )

--- a/test/unit/package_manager/zypper_test.py
+++ b/test/unit/package_manager/zypper_test.py
@@ -82,7 +82,8 @@ class TestPackageManagerZypper:
             ['chroot', 'root-dir', 'zypper'] + self.chroot_zypper_args + [
                 'install', '--download', 'in-advance',
                 '--auto-agree-with-licenses'
-            ] + self.manager.custom_args + ['--', 'vim'], self.chroot_command_env
+            ] + self.manager.custom_args + ['--', 'vim'],
+            self.chroot_command_env
         )
 
     @patch('kiwi.command.Command.call')
@@ -114,7 +115,7 @@ class TestPackageManagerZypper:
         mock_run.side_effect = Exception
         self.manager.request_package('vim')
         with raises(KiwiRequestError):
-            self.manager.process_delete_requests()
+            self.manager.process_delete_requests(force=True)
         mock_run.assert_called_once_with(
             ['chroot', 'root-dir', 'rpm', '-q', 'vim']
         )


### PR DESCRIPTION
The above package managers supports uninstall instructions  like 'iwl*'. In kiwi there was code checking via rpm if the packages given to uninstall actually exists. That code does not work if the given package to uninstall is an instruction that matches a pattern. Therefore if we use the uninstall section in the kiwi image description, just pass the provided information to the package manager and  don't try to be clever in kiwi itself.


