### PR TITLE
This patch fix the issue #1911 and makes secure boot images to work a…

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -748,14 +748,14 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 'Signed grub2 efi loader not found'
             )
         shim_image = Defaults.get_shim_loader(lookup_path)
-        if shim_image:
+        if shim_image and shim_image.filename:
             # The shim concept is based on a two step system including a
             # grub image(shim) that got signed by Microsoft followed by
             # a grub image that got signed by the shim. The shim image
             # is the one that gets loaded by the firmware which itself
             # loads the second stage grub image
             Command.run(
-                ['cp', shim_image, self._get_efi_image_name()]
+                ['cp', shim_image.filename, self._get_efi_image_name()]
             )
             Command.run(
                 [

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -53,9 +53,9 @@ log = logging.getLogger('kiwi')
 
 shim_loader_type = NamedTuple(
     'shim_loader_type', [
-         ('filename', str),
-         ('binaryname', str)
-     ]
+        ('filename', str),
+        ('binaryname', str)
+    ]
 )
 
 grub_loader_type = NamedTuple(

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -729,9 +729,9 @@ class Defaults:
 
         :param string root_path: image root path
 
-        :return: file path or None
+        :return: shim_loader_type | None
 
-        :rtype: str
+        :rtype: NamedTuple
         """
 
         shim_pattern_type = namedtuple(

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -747,7 +747,7 @@ class Defaults:
         ]
         for shim_file_pattern in shim_file_patterns:
             for shim_file in glob.iglob(root_path + shim_file_pattern.pattern):
-                if not shim_file:
+                if not shim_file_pattern.binaryname:
                     binaryname = os.path.basename(shim_file)
                 else:
                     binaryname = shim_file_pattern.binaryname


### PR DESCRIPTION
Signed shimx64.efi in Ubuntu 20.04 is distributed with a new name shimx64.efi.signed, so get_shim_loader() doesn't make the copy properly. This patchs fix that adding new patterns to detect this an copy the file correctly.

Ubuntu 20.04

Fixes #1911 
