### PR TITLE
Missing command is not reported properly

### DIFF
--- a/kiwi/xml_description.py
+++ b/kiwi/xml_description.py
@@ -203,7 +203,8 @@ class XMLDescription:
         """
         try:
             Command.run(
-                ['jing', schema_file, description_file]
+                ['jing', schema_file, description_file],
+                raise_on_error=True
             )
         except KiwiCommandError as issue:
             log.info('RelaxNG validation failed. See jing report:')


### PR DESCRIPTION
removal of raise_on_error means that KiwiCommandNotFound will
be never raised.

I'm not sure if there was a bigger intent, so maybe this fix breaks something else. Ping to @schaefi as author of previous removal of this option.