### PR TITLE
Allow logfile option to log on stdout

### DIFF
--- a/doc/source/commands/kiwi.rst
+++ b/doc/source/commands/kiwi.rst
@@ -101,7 +101,8 @@ GLOBAL OPTIONS
 --logfile=<filename>
 
   Specify log file. the logfile contains detailed information about
-  the process.
+  the process. The special call: `--logfile stdout` sends all
+  information to standard out instead of writing to a file
 
 --profile=<name>
 

--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -55,7 +55,8 @@ global options:
     --logfile=<filename>
         create a log file containing all log information including
         debug information even if this is was not requested by the
-        debug switch
+        debug switch. The special call: '--logfile stdout' sends all
+        information to standard out instead of writing to a file
     --debug
         print debug information
     -v --version

--- a/kiwi/logger.py
+++ b/kiwi/logger.py
@@ -116,17 +116,24 @@ class Logger(logging.Logger):
         :param str filename: logfile file path
         """
         try:
-            logfile = logging.FileHandler(
-                filename=filename, encoding='utf-8'
-            )
-            logfile.setFormatter(
+            if filename == 'stdout':
+                # special case, log usual log file contents to stdout
+                handler = logging.StreamHandler(sys.__stdout__)
+                # deactivate standard console logger by setting
+                # the highest possible log entry level
+                self.setLogLevel(logging.CRITICAL)
+            else:
+                handler = logging.FileHandler(
+                    filename=filename, encoding='utf-8'
+                )
+                self.logfile = filename
+            handler.setFormatter(
                 logging.Formatter(
                     '%(levelname)s: %(asctime)-8s | %(message)s', '%H:%M:%S'
                 )
             )
-            logfile.addFilter(LoggerSchedulerFilter())
-            self.addHandler(logfile)
-            self.logfile = filename
+            handler.addFilter(LoggerSchedulerFilter())
+            self.addHandler(handler)
         except Exception as e:
             raise KiwiLogFileSetupFailed(
                 '%s: %s' % (type(e).__name__, format(e))

--- a/test/unit/logger_test.py
+++ b/test/unit/logger_test.py
@@ -1,3 +1,4 @@
+import sys
 from mock import (
     patch, call
 )
@@ -30,6 +31,14 @@ class TestLogger:
             filename='logfile', encoding='utf-8'
         )
         assert self.log.get_logfile() == 'logfile'
+
+    @patch('logging.StreamHandler')
+    def test_set_logfile_to_stdout(self, mock_stream_handler):
+        self.log.set_logfile('stdout')
+        mock_stream_handler.assert_called_once_with(
+            sys.__stdout__
+        )
+        assert self.log.get_logfile() is None
 
     @patch('kiwi.logger.ColorFormatter')
     def test_set_color_format(self, mock_color_format):


### PR DESCRIPTION
The option setting '--logfile stdout' is now a special form
and logs the messages usually written to a file to stdout
instead. This is handy if all messages of the build are
requested but the --debug switch is not because it does more
than that, e.g calling scripts through debug'able screen
sessions



