### PR TITLE
Fixed GRUB_CMDLINE_LINUX_DEFAULT setup regression

### DIFF
--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -565,7 +565,7 @@ class BootLoaderConfigBase:
             if self.xml_state.build_type.get_overlayroot():
                 return f'root=overlay:{blkid_type}={location}'
             else:
-                return f'root={blkid_type}={location} rw'
+                return f'root={blkid_type}={location}'
         else:
             log.warning(
                 'No explicit root= cmdline provided'

--- a/test/unit/bootloader/config/base_test.py
+++ b/test/unit/bootloader/config/base_test.py
@@ -119,7 +119,7 @@ class TestBootLoaderConfigBase:
         mock_BlockID.return_value = block_operation
         mock_initrd.return_value = 'dracut'
         assert self.bootloader.get_boot_cmdline('uuid') == \
-            'splash root=UUID=uuid rw'
+            'splash root=UUID=uuid'
 
     @patch('kiwi.xml_parse.type_.get_initrd_system')
     @patch('kiwi.bootloader.config.base.BlockID')


### PR DESCRIPTION
The value for GRUB_CMDLINE_LINUX_DEFAULT should only be
changed if custom kernelcmdline values are provided. In
case there are none kiwi should not change this value.
The test to check for this condition is based on the
result cmdline reduced by the root setting. However the
default cmdline setting in kiwi appends 'rw' in addition
to the root device information. This means the default
kernelcmdline is never empty and therefore the grub
setting GRUB_CMDLINE_LINUX_DEFAULT="rw" is always set.
This commit fixes the conditional change by making sure
the default cmdline only consists out of the root
device information. This Fixes #1650

