### PR TITLE
Fix pxe docs and error reporting

### DIFF
--- a/doc/source/working_with_images/legacy_netboot_root_filesystem.rst
+++ b/doc/source/working_with_images/legacy_netboot_root_filesystem.rst
@@ -72,7 +72,7 @@ system. As diskless client, a QEMU virtual machine is used.
 
    .. code:: bash
 
-       $ sudo kiwi-ng --type pxe system build \
+       $ sudo kiwi-ng --profile Flat system build \
            --description kiwi/build-tests/{exc_description_pxe} \
            --set-repo {exc_repo_tumbleweed} \
            --target-dir /tmp/mypxe-result

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -2368,8 +2368,8 @@ class XMLState:
                 if build_type == image_type.get_image():
                     return image_type
             raise KiwiTypeNotFound(
-                'build type {0} not found in {1}'.format(
-                    build_type, self.xml_data.description
+                'Build type {0!r} not found for applied profiles: {1!r}'.format(
+                    build_type, self.profiles
                 )
             )
 
@@ -2382,7 +2382,9 @@ class XMLState:
         if image_type_sections:
             return image_type_sections[0]
         raise KiwiTypeNotFound(
-            'No build type defined in {0}'.format(self.xml_data.description)
+            'No build type defined with applied profiles: {0!r}'.format(
+                self.profiles
+            )
         )
 
     def _profiled(self, xml_abstract):


### PR DESCRIPTION
This commit is two fold

**Fixed legacy PXE documentation**
    
The documentation for building a legacy pxe image was not
using the profiles (Flat or Compressed) as the actual image
description for this example requires it. This Fixes #1923

**Fixed error reporting for stateful description**
    
Errors due to missing or no type definitions were reported
provding the internal object reference of the XML parse
result. This is useless information for users and needs
to be done better. This commit fixes the error message to
avoid showing object references and includes information
about the applied profiles used for this XML state.

