### PR TITLE
Fixed use of LUKS encrypted images with empty pass

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -296,7 +296,7 @@ class DiskBuilder:
             luks_root.create_crypto_luks(
                 passphrase=self.luks,
                 os=self.luks_os,
-                keyfile=self.luks_boot_keyfile if luks_need_keyfile else None
+                keyfile=self.luks_boot_keyfile if luks_need_keyfile else ''
             )
             if luks_need_keyfile:
                 self.luks_boot_keyfile_setup = ''.join(

--- a/kiwi/storage/luks_device.py
+++ b/kiwi/storage/luks_device.py
@@ -39,7 +39,7 @@ class LuksDevice(DeviceProvider):
 
     :param object storage_provider: Instance of class based on DeviceProvider
     """
-    def __init__(self, storage_provider: DeviceProvider):
+    def __init__(self, storage_provider: DeviceProvider) -> None:
         # bind the underlaying block device providing class instance
         # to this object (e.g loop) if present. This is done to guarantee
         # the correct destructor order when the device should be released.
@@ -73,8 +73,8 @@ class LuksDevice(DeviceProvider):
 
     def create_crypto_luks(
         self, passphrase: str, os: str = None,
-        options: list = None, keyfile: str = None
-    ):
+        options: list = None, keyfile: str = ''
+    ) -> None:
         """
         Create luks device. Please note the passphrase is readable
         at creation time of this image. Make sure your host system
@@ -156,7 +156,7 @@ class LuksDevice(DeviceProvider):
         )
         self.luks_device = '/dev/mapper/' + self.luks_name
 
-    def create_crypttab(self, filename: str):
+    def create_crypttab(self, filename: str) -> None:
         """
         Create crypttab, setting the UUID of the storage device
 
@@ -192,7 +192,7 @@ class LuksDevice(DeviceProvider):
         return self.storage_provider.is_loop()
 
     @staticmethod
-    def create_random_keyfile(filename: str):
+    def create_random_keyfile(filename: str) -> None:
         """
         Create keyfile with random data
 

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -334,6 +334,8 @@ class Profile:
             type_section.get_vga()
         self.dot_profile['kiwi_startsector'] = \
             self.xml_state.get_disk_start_sector()
+        self.dot_profile['kiwi_luks_empty_passphrase'] = \
+            True if type_section.get_luks() == '' else False
 
     def _profile_names_to_profile(self):
         # kiwi_profiles

--- a/test/data/example_dot_profile_config.xml
+++ b/test/data/example_dot_profile_config.xml
@@ -19,7 +19,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" primary="true" filesystem="ext3" installiso="true" kernelcmdline="splash" firmware="efi" ramonly="true" xen_server="true">
+        <type image="oem" primary="true" filesystem="ext3" installiso="true" kernelcmdline="splash" firmware="efi" ramonly="true" xen_server="true" luks="">
             <systemdisk>
                 <volume name="usr/lib" size="1G"/>
                 <volume name="@root" freespace="500M"/>

--- a/test/unit/system/profile_test.py
+++ b/test/unit/system/profile_test.py
@@ -93,6 +93,7 @@ class TestProfile:
             'kiwi_type': 'oem',
             'kiwi_vga': None,
             'kiwi_startsector': 2048,
+            'kiwi_luks_empty_passphrase': True,
             'kiwi_wwid_wait_timeout': None,
             'kiwi_xendomain': 'dom0',
             'kiwi_rootpartuuid': None


### PR DESCRIPTION
For initial provisioning of LUKS encrypted disk images an empty passphrase key is handy to avoid interaction in the deployment process. However, the dracut kiwi modules were lacking the information that the luks keyfile could be an empty passphrase key which must not be opened with the potential risk to get prompted for input. This commit introduces a new profile environment variable evaluated by the dracut kiwi lib code to open the LUKS pool and allows to distinguish the situation on key files with or without a passphrase
