### PR TITLE
Make sure debootstrap is called only once

### DIFF
--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -183,9 +183,15 @@ class SystemPrepareTask(CliTask):
             self.command_args['--signing-key'],
             self.global_args['--target-arch']
         )
-        system.install_bootstrap(
-            manager, self.command_args['--add-bootstrap-package']
-        )
+        if self.xml_state.get_package_manager() == 'apt' and \
+           self.command_args['--allow-existing-root']:
+            log.warning(
+                'debootstrap will only be called once on empty root, skipped'
+            )
+        else:
+            system.install_bootstrap(
+                manager, self.command_args['--add-bootstrap-package']
+            )
 
         setup = SystemSetup(
             self.xml_state, abs_root_path

--- a/test/unit/tasks/system_prepare_test.py
+++ b/test/unit/tasks/system_prepare_test.py
@@ -172,6 +172,17 @@ class TestSystemPrepareTask:
         )
         assert self.system_prepare.clean_package_manager_leftovers.called
 
+    @patch('kiwi.xml_state.XMLState.get_package_manager')
+    def test_process_system_prepare_run_debootstrap_only_once(
+        self, mock_get_package_manager
+    ):
+        self._init_command_args()
+        mock_get_package_manager.return_value = 'apt'
+        self.task.command_args['--allow-existing-root'] = True
+        with self._caplog.at_level(logging.WARNING):
+            self.task.process()
+        assert not self.system_prepare.install_bootstrap.called
+
     def test_process_system_prepare_add_package(self):
         self._init_command_args()
         self.task.command_args['--add-package'] = ['vim']


### PR DESCRIPTION
When building debian based images the bootstrap phase
is done by calling debootstrap. If kiwi is called on
an already existing root tree via --allow-existing-root
this will make debootstrap to fail in any case. This
is because for debootstrap it's an error condition if
there is already data in the root. However, for kiwi
and the explicitly requested re-use of the root tree
this is not an error. Thus this commit skips the
bootstrap by debootstrap and directly continues with
the image phase.

