### PR TITLE
Make sure fedora-release is installed

### DIFF
--- a/build-tests/arm/fedora/test-image-live/appliance.kiwi
+++ b/build-tests/arm/fedora/test-image-live/appliance.kiwi
@@ -54,5 +54,6 @@
         <package name="grub2-efi-aa64"/>
         <package name="grub2-efi-aa64-modules"/>
         <package name="grub2-efi-aa64-cdboot"/>
+        <package name="fedora-release"/>
     </packages>
 </image>

--- a/build-tests/ppc/fedora/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/ppc/fedora/test-image-disk-simple/appliance.kiwi
@@ -39,5 +39,6 @@
     <packages type="bootstrap">
         <package name="filesystem"/>
         <package name="basesystem"/>
+        <package name="fedora-release"/>
     </packages>
 </image>

--- a/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
@@ -84,5 +84,6 @@
         <package name="grub2-efi-x64-modules"/>
         <package name="grub2-efi-x64"/>
         <package name="shim" arch="x86_64"/>
+        <package name="fedora-release"/>
     </packages>
 </image>

--- a/build-tests/x86/fedora/test-image-microdnf/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-microdnf/appliance.kiwi
@@ -49,5 +49,6 @@
         <package name="grub2-efi-x64-modules"/>
         <package name="grub2-efi-x64"/>
         <package name="shim" arch="x86_64"/>
+        <package name="fedora-release"/>
     </packages>
 </image>


### PR DESCRIPTION
Fedora based integration tests should install the fedora-release
package. If no release package is specified the generic-release
package is chosen which is unexpected. This Fixes #1957

