### PR TITLE
utils/temporary: the --temp-dir does not work

### DIFF
--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -74,7 +74,7 @@ class BootImageKiwi(BootImageBase):
         """
         if self.boot_xml_state:
             self.boot_root_directory_temporary = Temporary(
-                prefix='kiwi_boot_root.', dir=self.target_dir
+                prefix='kiwi_boot_root.', path=self.target_dir
             ).new_dir()
             self.boot_root_directory = self.boot_root_directory_temporary.name
             self.temp_directories.append(

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -146,7 +146,7 @@ class InstallImageBuilder:
         * installstick="true|false"
         """
         self.media_dir = Temporary(
-            prefix='kiwi_install_media.', dir=self.target_dir
+            prefix='kiwi_install_media.', path=self.target_dir
         ).new_dir()
         # unpack cdroot user files to media dir
         self.setup.import_cdroot_files(self.media_dir.name)
@@ -164,7 +164,7 @@ class InstallImageBuilder:
         # the system image transfer is checked against a checksum
         log.info('Creating disk image checksum')
         self.squashed_contents = Temporary(
-            prefix='kiwi_install_squashfs.', dir=self.target_dir
+            prefix='kiwi_install_squashfs.', path=self.target_dir
         ).new_dir()
         checksum = Checksum(self.diskname)
         checksum.md5(self.squashed_contents.name + '/' + self.md5name)
@@ -271,7 +271,7 @@ class InstallImageBuilder:
         * installpxe="true|false"
         """
         self.pxe_dir = Temporary(
-            prefix='kiwi_pxe_install_media.', dir=self.target_dir
+            prefix='kiwi_pxe_install_media.', path=self.target_dir
         ).new_dir()
         # the system image is transfered as xz compressed variant
         log.info('xz compressing disk image')

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -114,7 +114,7 @@ class LiveImageBuilder:
         """
         # media dir to store CD contents
         self.media_dir = Temporary(
-            prefix='live-media.', dir=self.target_dir
+            prefix='live-media.', path=self.target_dir
         ).new_dir()
 
         # unpack cdroot user files to media dir
@@ -249,7 +249,7 @@ class LiveImageBuilder:
 
         log.info('--> Creating squashfs container for root image')
         self.live_container_dir = Temporary(
-            prefix='live-container.', dir=self.target_dir
+            prefix='live-container.', path=self.target_dir
         ).new_dir()
         Path.create(self.live_container_dir.name + '/LiveOS')
         shutil.copy(

--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -87,7 +87,7 @@ class RepositoryApt(RepositoryBase):
         self.keyring = '{}/trusted.gpg'.format(self.manager_base)
 
         self.runtime_apt_get_config_file = Temporary(
-            dir=self.root_dir
+            path=self.root_dir
         ).new_file()
 
         self.apt_get_args = [

--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -93,7 +93,7 @@ class RepositoryDnf(RepositoryBase):
         }
 
         self.runtime_dnf_config_file = Temporary(
-            dir=self.root_dir
+            path=self.root_dir
         ).new_file()
 
         self.dnf_args = [

--- a/kiwi/repository/pacman.py
+++ b/kiwi/repository/pacman.py
@@ -53,7 +53,7 @@ class RepositoryPacman(RepositoryBase):
         self.repo_names: List = []
 
         self.runtime_pacman_config_file = Temporary(
-            dir=self.root_dir
+            path=self.root_dir
         ).new_file()
 
         if 'check_signatures' in self.custom_args:

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -109,10 +109,10 @@ class RepositoryZypper(RepositoryBase):
         }
 
         self.runtime_zypper_config_file = Temporary(
-            dir=self.root_dir
+            path=self.root_dir
         ).new_file()
         self.runtime_zypp_config_file = Temporary(
-            dir=self.root_dir
+            path=self.root_dir
         ).new_file()
 
         self.zypper_args = [

--- a/kiwi/storage/subformat/gce.py
+++ b/kiwi/storage/subformat/gce.py
@@ -57,7 +57,7 @@ class DiskFormatGce(DiskFormatBase):
         """
         gce_tar_ball_file_list = []
         temp_image_dir = Temporary(
-            prefix='kiwi_gce_subformat.', dir=self.target_dir
+            prefix='kiwi_gce_subformat.', path=self.target_dir
         ).new_dir()
         diskname = ''.join(
             [

--- a/kiwi/utils/temporary.py
+++ b/kiwi/utils/temporary.py
@@ -31,10 +31,10 @@ class Temporary:
     **Provides namespace to handle temporary files and directories**
     """
     def __init__(
-        self, dir: str = defaults.TEMP_DIR, prefix: str = ''
+        self, dir: str = '', prefix: str = ''
     ):
         self.prefix = prefix if prefix else 'kiwi_'
-        self.dir = dir
+        self.dir = dir or defaults.TEMP_DIR
 
     def new_file(self) -> IO[bytes]:
         return NamedTemporaryFile(

--- a/kiwi/utils/temporary.py
+++ b/kiwi/utils/temporary.py
@@ -31,17 +31,17 @@ class Temporary:
     **Provides namespace to handle temporary files and directories**
     """
     def __init__(
-        self, dir: str = '', prefix: str = ''
+        self, path: str = '', prefix: str = ''
     ):
         self.prefix = prefix if prefix else 'kiwi_'
-        self.dir = dir or defaults.TEMP_DIR
+        self.path = path or defaults.TEMP_DIR
 
     def new_file(self) -> IO[bytes]:
         return NamedTemporaryFile(
-            dir=self.dir, prefix=self.prefix
+            dir=self.path, prefix=self.prefix
         )
 
     def new_dir(self) -> TemporaryDirectory:
         return TemporaryDirectory(
-            dir=self.dir, prefix=self.prefix
+            dir=self.path, prefix=self.prefix
         )

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -141,7 +141,7 @@ class TestInstallImageBuilder:
 
         tmpdir_name = [temp_squashfs, temp_media_dir]
 
-        def side_effect(prefix, dir):
+        def side_effect(prefix, path):
             return tmpdir_name.pop()
 
         bootloader_config = mock.Mock()


### PR DESCRIPTION
Using of --temp-dir argument does not make an effect,
because optional 'dir' parameter defaults to the
global TEMP_DIR value before it's changed.

This patch address this issue.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@gmail.com>