### PR TITLE
Fixed include processing

### DIFF
--- a/doc/source/image_description.rst
+++ b/doc/source/image_description.rst
@@ -101,7 +101,7 @@ Image Includes
 
 .. code:: xml
 
-   <include from="filename.xml"/>
+   <include from="file://filename.xml"/>
 
 The optional :ref:`sec.include` element allows to drop in the contents
 of the specified :file:`filename.xml` file at the place were the `include`

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -51,7 +51,7 @@ Optional include of XML file content from file
 .. code:: xml
 
    <image schemaversion="{schema_version}" name="{exc_image_base_name}">
-       <include from="description.xml"/>
+       <include from="file://description.xml"/>
    </image> 
 
 with file :file:`description.xml` as follows:
@@ -68,7 +68,9 @@ with file :file:`description.xml` as follows:
 
 This will replace the `include` statement with the contents
 of :file:`description.xml`. The validation of the result happens
-after the inclusion of all `include` references.
+after the inclusion of all `include` references. The value for
+the `from` attribute is interpreted as an URI, as of now only
+local URI types are supported.
 
 .. note::
 

--- a/kiwi/markup/base.py
+++ b/kiwi/markup/base.py
@@ -17,6 +17,7 @@
 #
 import os
 from lxml import etree
+from urllib.parse import urlparse
 
 # project
 from kiwi.utils.temporary import Temporary
@@ -108,6 +109,9 @@ class MarkupBase:
 
 class FileResolver(etree.Resolver):
     def resolve(self, url, pubid, context):
+        uri = urlparse(url)
+        if uri.path and uri.netloc:
+            url = ''.join([uri.netloc, uri.path])
         if os.path.exists(url):
             return self.resolve_filename(url, context)
         else:

--- a/kiwi/xsl/include.xsl
+++ b/kiwi/xsl/include.xsl
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 <xsl:output method="xml"
-        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+    indent="yes"
+    omit-xml-declaration="no"
+    encoding="utf-8"/>
 
 <!-- default rule -->
 <xsl:template match="*" mode="include">
@@ -17,12 +20,12 @@
     <xsl:choose>
         <xsl:when test="document($include_file_name)">
             <xsl:copy-of select="document($include_file_name)/image/*"/>
+            <xsl:apply-templates  mode="include"/>
         </xsl:when>
         <xsl:otherwise>
             <xsl:copy-of select="."/>
         </xsl:otherwise>
     </xsl:choose>
-    <xsl:apply-templates  mode="include"/>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/kiwi/xsl/master.xsl
+++ b/kiwi/xsl/master.xsl
@@ -5,6 +5,7 @@
         exclude-result-prefixes="exslt"
 >
 
+<xsl:import href="include.xsl"/>
 <xsl:import href="convert14to20.xsl"/>
 <xsl:import href="convert20to24.xsl"/>
 <xsl:import href="convert24to35.xsl"/>
@@ -46,13 +47,16 @@
 <xsl:import href="convert72to73.xsl"/>
 <xsl:import href="convert73to74.xsl"/>
 <xsl:import href="pretty.xsl"/>
-<xsl:import href="include.xsl"/>
 
 <xsl:output encoding="utf-8"/>
 
 <xsl:template match="/">
+    <xsl:variable name="preprocess">
+        <xsl:apply-templates select="/" mode="include"/>
+    </xsl:variable>
+
     <xsl:variable name="v14">
-        <xsl:apply-templates select="/" mode="conv14to20"/>
+        <xsl:apply-templates select="exslt:node-set($preprocess)" mode="conv14to20"/>
     </xsl:variable>
 
     <xsl:variable name="v20">
@@ -210,10 +214,6 @@
     <xsl:variable name="v74">
         <xsl:apply-templates select="exslt:node-set($v73)" mode="conv73to74"/>
     </xsl:variable>
-
-    <xsl:apply-templates
-        select="exslt:node-set($v74)" mode="include"
-    />
 
     <xsl:apply-templates
         select="exslt:node-set($v74)" mode="pretty"

--- a/test/data/example_runtime_checker_include_nested_reference.xml
+++ b/test/data/example_runtime_checker_include_nested_reference.xml
@@ -6,7 +6,7 @@
         <contact>ms@suse.com</contact>
         <specification>Test for missing include reference</specification>
     </description>
-    <include from="../data/nested_include.xml"/>
+    <include from="file://../data/nested_include.xml"/>
     <preferences>
         <version>1.1.0</version>
         <packagemanager>zypper</packagemanager>


### PR DESCRIPTION
This commit fixes several issue connected with the use of
the <include> directive:

First and foremost the XSLT chain was broken in a way that
the include XSLT in combination with the PrettyPrinter XSLT
were called not in the chain of stylesheets but together.
This results in XML descriptions which duplicated the content
and went invalid

Another change is, when the include XSLT is called in the chain.
This commit moves it to become the very first processing
instruction such that the included data is part of all subsequent
XSLT stylesheets. This also allows to use older schema versions
in included XML data and they get automatically converted through
the chain of XSLT stylesheets.

Last change is the evaluation of the from= attribute value. This
value is now interpreted as an URI. Currently only local URIs are
supported. The reason to do this is because XSLT when processing
a document resolves relative paths according to the file path
of the master document. As kiwi does not change the original
content that path with will be a /var/tmp location if one of
the XSLT stylesheets were used. The documentation for this change
was updated as well

