### PR TITLE
Allow to set sign keyfile in repository elements

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -793,7 +793,9 @@ repository_gpgcheck="true|false"
   to run repository signature validation. If not set, no value is
   appended into the repository configuration file. If set the
   relevant key information needs to be provided on the {kiwi}
-  commandline using the `--signing-key` option
+  commandline using the `--signing-key` option or via the `<signing>`
+  element as part of the `<repository><source>` setting in the
+  image description.
 
 customize="/path/to/custom_script"
   Custom script hook which is invoked with the repo file as parameter
@@ -916,6 +918,23 @@ the following location indicators:
 * ``obsrepositories:/``
   A placeholder for the Open Build Service (OBS) to indicate that all
   repositories are taken from the project configuration in OBS.
+
+A repository `<source>` element can optionally contain one ore more
+signing keys for the packages from this repository like shown in the
+following example:
+
+.. code:: xml
+
+   <repository alias="kiwi">
+     <source path="{exc_kiwi_repo}">
+       <signing key="/path/to/sign_key_a"/>
+       <signing key="/path/to/sign_key_b"/>
+     </source>
+   </repository>
+
+All signing keys from all repositories will be collected and
+incorporated into the keyring as used by the selected package
+manager.
 
 .. _sec.packages:
 

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1027,6 +1027,24 @@ div {
 }
 
 #==========================================
+# common element <signing>
+#
+div {
+    k.signing.key.attribute =
+        ## Specify path to a signing key for this repo
+        attribute key { text }
+    k.signing.attlist =
+        k.signing.key.attribute
+    k.signing =
+        ## The signing element holds information about
+        ## repo/package signing keys
+        element signing {
+            k.signing.attlist,
+            empty
+        }
+}
+
+#==========================================
 # common element <source>
 #
 div {
@@ -1037,7 +1055,7 @@ div {
         ## as well as a path specification
         element source {
             k.source.attlist,
-            empty
+            k.signing*
         }
 }
 

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1573,6 +1573,29 @@ last one is picked.</a:documentation>
   </div>
   <!--
     ==========================================
+    common element <signing>
+    
+  -->
+  <div>
+    <define name="k.signing.key.attribute">
+      <attribute name="key">
+        <a:documentation>Specify path to a signing key for this repo</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.signing.attlist">
+      <ref name="k.signing.key.attribute"/>
+    </define>
+    <define name="k.signing">
+      <element name="signing">
+        <a:documentation>The signing element holds information about
+repo/package signing keys</a:documentation>
+        <ref name="k.signing.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
     common element <source>
     
   -->
@@ -1588,7 +1611,9 @@ last one is picked.</a:documentation>
         <a:documentation>A Pointer to a data source. This can be a remote location
 as well as a path specification</a:documentation>
         <ref name="k.source.attlist"/>
-        <empty/>
+        <zeroOrMore>
+          <ref name="k.signing"/>
+        </zeroOrMore>
       </element>
     </define>
   </div>

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -281,7 +281,9 @@ class SystemBuildTask(CliTask):
             abs_target_dir_path,
             image_root,
             custom_args={
-                'signing_keys': self.command_args['--signing-key'],
+                'signing_keys': self.command_args[
+                    '--signing-key'
+                ] + self.xml_state.get_repositories_signing_keys(),
                 'xz_options': self.runtime_config.get_xz_options()
             }
         )

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -181,7 +181,9 @@ class SystemPrepareTask(CliTask):
         )
         manager = system.setup_repositories(
             self.command_args['--clear-cache'],
-            self.command_args['--signing-key'],
+            self.command_args[
+                '--signing-key'
+            ] + self.xml_state.get_repositories_signing_keys(),
             self.global_args['--target-arch']
         )
         run_bootstrap = True

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.29.24.
-# Python 3.6.13 (default, Mar 10 2021, 18:30:35) [GCC]
+# Python 3.6.12 (default, Dec 02 2020, 09:44:23) [GCC]
 #
 # Command line options:
 #   ('-f', '')
@@ -2208,14 +2208,89 @@ class repository(k_source):
 # end class repository
 
 
+class signing(GeneratedsSuper):
+    """The signing element holds information about repo/package signing
+    keys"""
+    subclass = None
+    superclass = None
+    def __init__(self, key=None):
+        self.original_tagname_ = None
+        self.key = _cast(None, key)
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, signing)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if signing.subclass:
+            return signing.subclass(*args_, **kwargs_)
+        else:
+            return signing(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_key(self): return self.key
+    def set_key(self, key): self.key = key
+    def hasContent_(self):
+        if (
+
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', name_='signing', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('signing')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='signing')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='signing', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='signing'):
+        if self.key is not None and 'key' not in already_processed:
+            already_processed.add('key')
+            outfile.write(' key=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.key), input_name='key')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='signing', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('key', node)
+        if value is not None and 'key' not in already_processed:
+            already_processed.add('key')
+            self.key = value
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        pass
+# end class signing
+
+
 class source(GeneratedsSuper):
     """A Pointer to a data source. This can be a remote location as well as
     a path specification"""
     subclass = None
     superclass = None
-    def __init__(self, path=None):
+    def __init__(self, path=None, signing=None):
         self.original_tagname_ = None
         self.path = _cast(None, path)
+        if signing is None:
+            self.signing = []
+        else:
+            self.signing = signing
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -2227,11 +2302,16 @@ class source(GeneratedsSuper):
         else:
             return source(*args_, **kwargs_)
     factory = staticmethod(factory)
+    def get_signing(self): return self.signing
+    def set_signing(self, signing): self.signing = signing
+    def add_signing(self, value): self.signing.append(value)
+    def insert_signing_at(self, index, value): self.signing.insert(index, value)
+    def replace_signing_at(self, index, value): self.signing[index] = value
     def get_path(self): return self.path
     def set_path(self, path): self.path = path
     def hasContent_(self):
         if (
-
+            self.signing
         ):
             return True
         else:
@@ -2253,6 +2333,7 @@ class source(GeneratedsSuper):
         if self.hasContent_():
             outfile.write('>%s' % (eol_, ))
             self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='source', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
             outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
         else:
             outfile.write('/>%s' % (eol_, ))
@@ -2261,7 +2342,12 @@ class source(GeneratedsSuper):
             already_processed.add('path')
             outfile.write(' path=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.path), input_name='path')), ))
     def exportChildren(self, outfile, level, namespaceprefix_='', name_='source', fromsubclass_=False, pretty_print=True):
-        pass
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for signing_ in self.signing:
+            signing_.export(outfile, level, namespaceprefix_, name_='signing', pretty_print=pretty_print)
     def build(self, node):
         already_processed = set()
         self.buildAttributes(node, node.attrib, already_processed)
@@ -2275,7 +2361,11 @@ class source(GeneratedsSuper):
             already_processed.add('path')
             self.path = value
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
-        pass
+        if nodeName_ == 'signing':
+            obj_ = signing.factory()
+            obj_.build(child_)
+            self.signing.append(obj_)
+            obj_.original_tagname_ = 'signing'
 # end class source
 
 
@@ -8266,6 +8356,7 @@ __all__ = [
     "profiles",
     "repository",
     "requires",
+    "signing",
     "size",
     "source",
     "strip",

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1721,6 +1721,16 @@ class XMLState:
             ]
         )
 
+    def get_repositories_signing_keys(self) -> List[str]:
+        """
+        Get list of signing keys specified on the repositories
+        """
+        key_file_list: List[str] = []
+        for repository in self.get_repository_sections() or []:
+            for signing in repository.get_source().get_signing() or []:
+                key_file_list.append(signing.get_key())
+        return key_file_list
+
     def set_repository(
         self, repo_source: str, repo_type: str, repo_alias: str,
         repo_prio: str, repo_imageinclude: bool = False,
@@ -1755,7 +1765,8 @@ class XMLState:
     def add_repository(
         self, repo_source: str, repo_type: str, repo_alias: str = None,
         repo_prio: str = '', repo_imageinclude: bool = False,
-        repo_package_gpgcheck: Optional[bool] = None
+        repo_package_gpgcheck: Optional[bool] = None,
+        repo_signing_keys: List[str] = []
     ) -> None:
         """
         Add a new repository section at the end of the list
@@ -1778,7 +1789,12 @@ class XMLState:
                 type_=repo_type,
                 alias=repo_alias,
                 priority=priority_number,
-                source=xml_parse.source(path=repo_source),
+                source=xml_parse.source(
+                    path=repo_source,
+                    signing=[
+                        xml_parse.signing(key=k) for k in repo_signing_keys
+                    ]
+                ),
                 imageinclude=repo_imageinclude,
                 package_gpgcheck=repo_package_gpgcheck
             )

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -167,13 +167,17 @@
         <user groups="kiwi,admin,users" pwdformat="plain" password="mypwd" name="kiwi"/>
     </users>
     <repository priority="42" sourcetype="baseurl">
-        <source path="iso:///image/CDs/dvd.iso"/>
+        <source path="iso:///image/CDs/dvd.iso">
+            <signing key="key_a"/>
+        </source>
     </repository>
     <repository type="rpm-md" imageinclude="true" customize="script">
         <source path="obs://Devel:PubCloud:AmazonEC2/SLE_12_GA"/>
     </repository>
     <repository type="rpm-md" imageonly="true">
-        <source path="obs://Devel:Docker:Images:SLE12SP2/SLE_12_SP2_Docker"/>
+        <source path="obs://Devel:Docker:Images:SLE12SP2/SLE_12_SP2_Docker">
+            <signing key="key_b"/>
+        </source>
     </repository>
     <packages type="image" patternType="plusRecommended">
         <namedCollection name="base"/>

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -96,7 +96,7 @@ class TestSystemBuildTask:
         self.task.command_args['--set-container-tag'] = None
         self.task.command_args['--add-container-label'] = []
         self.task.command_args['--clear-cache'] = False
-        self.task.command_args['--signing-key'] = None
+        self.task.command_args['--signing-key'] = []
 
     @patch('kiwi.logger.Logger.set_logfile')
     def test_process_system_build(self, mock_log):
@@ -156,7 +156,7 @@ class TestSystemBuildTask:
             check_architecture_supports_iso_firmware_setup.\
             assert_called_once_with()
         self.system_prepare.setup_repositories.assert_called_once_with(
-            False, None, None
+            False, [], None
         )
         self.system_prepare.install_bootstrap.assert_called_once_with(
             self.manager, []
@@ -198,7 +198,7 @@ class TestSystemBuildTask:
         self.task.command_args['--add-package'] = ['vim']
         self.task.process()
         self.system_prepare.setup_repositories.assert_called_once_with(
-            False, None, None
+            False, [], None
         )
         self.system_prepare.install_packages.assert_called_once_with(
             self.manager, ['vim']
@@ -210,7 +210,7 @@ class TestSystemBuildTask:
         self.task.command_args['--delete-package'] = ['vim']
         self.task.process()
         self.system_prepare.setup_repositories.assert_called_once_with(
-            False, None, None
+            False, [], None
         )
         self.system_prepare.delete_packages.assert_called_once_with(
             self.manager, ['vim']

--- a/test/unit/tasks/system_prepare_test.py
+++ b/test/unit/tasks/system_prepare_test.py
@@ -89,7 +89,7 @@ class TestSystemPrepareTask:
         self.task.command_args['--set-container-derived-from'] = None
         self.task.command_args['--set-container-tag'] = None
         self.task.command_args['--add-container-label'] = []
-        self.task.command_args['--signing-key'] = None
+        self.task.command_args['--signing-key'] = []
 
     def test_process_system_prepare(self):
         self._init_command_args()
@@ -144,7 +144,7 @@ class TestSystemPrepareTask:
             check_architecture_supports_iso_firmware_setup.\
             assert_called_once_with()
         self.system_prepare.setup_repositories.assert_called_once_with(
-            True, None, None
+            True, ['key_a', 'key_b'], None
         )
         self.system_prepare.install_bootstrap.assert_called_once_with(
             self.manager, []
@@ -200,7 +200,7 @@ class TestSystemPrepareTask:
         self.task.command_args['--add-package'] = ['vim']
         self.task.process()
         self.system_prepare.setup_repositories.assert_called_once_with(
-            False, None, None
+            False, ['key_a', 'key_b'], None
         )
         self.system_prepare.install_packages.assert_called_once_with(
             self.manager, ['vim']
@@ -211,7 +211,7 @@ class TestSystemPrepareTask:
         self.task.command_args['--delete-package'] = ['vim']
         self.task.process()
         self.system_prepare.setup_repositories.assert_called_once_with(
-            False, None, None
+            False, ['key_a', 'key_b'], None
         )
         self.system_prepare.delete_packages.assert_called_once_with(
             self.manager, ['vim']

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1006,3 +1006,6 @@ class TestXMLState:
         xml_data = self.description.load()
         state = XMLState(xml_data, ['vmxSimpleFlavour'], 'oem')
         state.get_installmedia_initrd_modules('add') == []
+
+    def test_get_repositories_signing_keys(self):
+        assert self.state.get_repositories_signing_keys() == ['key_a', 'key_b']


### PR DESCRIPTION
This commit add a new attribute signing_key to the repository
element. The keyfile specified is placed into the keyring as
used by the selected package manager. Signing keys specified
on the commandline and signing keys specified in the image
description will be combined. This Fixes #1883

