### PR TITLE
Make sure fedora-release is installed on Rawhide

### DIFF
--- a/build-tests/arm/rawhide/test-image-live-disk/appliance.kiwi
+++ b/build-tests/arm/rawhide/test-image-live-disk/appliance.kiwi
@@ -76,5 +76,6 @@
         <package name="grub2-efi-aa64"/>
         <package name="grub2-efi-aa64-modules"/>
         <package name="grub2-efi-aa64-cdboot"/>
+        <package name="fedora-release"/>
     </packages>
 </image>

--- a/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
@@ -90,5 +90,6 @@
         <package name="grub2-efi-x64-modules"/>
         <package name="grub2-efi-x64"/>
         <package name="shim" arch="x86_64"/>
+        <package name="fedora-release"/>
     </packages>
 </image>

--- a/build-tests/x86/rawhide/test-image-microdnf/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-microdnf/appliance.kiwi
@@ -55,5 +55,6 @@
         <package name="grub2-efi-x64-modules"/>
         <package name="grub2-efi-x64"/>
         <package name="shim" arch="x86_64"/>
+        <package name="fedora-release"/>
     </packages>
 </image>


### PR DESCRIPTION
Follow up to #1957 and #1962:
The Fedora build tests were using the generic release package and not
fedora-release. This issue has been partially fixed in #1962, but we forgot to
port the fix to the rawhide images as well. This commit adds the missing package
to the Rawhide images as well.