### PR TITLE
Added support for reading metalink in info module

### DIFF
--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -17,9 +17,15 @@
 #
 import os
 import logging
-from urllib.parse import urlparse
+from lxml import etree
+from urllib.parse import (
+    urlparse, ParseResult
+)
+from urllib.request import urlopen
+from urllib.request import Request
 import requests
 import hashlib
+from typing import Optional
 
 # project
 from kiwi.defaults import Defaults
@@ -36,20 +42,30 @@ log = logging.getLogger('kiwi')
 
 class Uri:
     """
-    **Normalize url types**
-
-    Allow to translate the available KIWI repo source types
-    into standard mime types
-
-    :param str uri: URI, remote or local repository location
-    :param str repo_type:
-        repository type name, defaults to 'rpm-md' and is only
-        effectively used when building inside of the open
-        build service which maps local repositories to a
-        specific environment
+    **Normalize and manage URI types**
     """
-    def __init__(self, uri: str, repo_type: str = 'rpm-md'):
+    def __init__(
+        self, uri: str, repo_type: str = 'rpm-md', source_type: str = ''
+    ):
+        """
+        Manage kiwi source URIs and allow transformation into
+        standard URLs
+
+        :param str uri: URI, remote, local or metalink repository location
+        :param str repo_type:
+            repository type name, defaults to 'rpm-md' and is only
+            effectively used when building inside of the open
+            build service which maps local repositories to a
+            specific environment
+        :param str source_type:
+            specify source type if the provided URI is a service.
+            Currently only the metalink source type is handled
+        """
         self.runtime_config = RuntimeConfig()
+
+        if source_type == 'metalink':
+            uri = self._resolve_metalink_uri(uri)
+
         self.repo_type = repo_type
         self.uri = uri if not uri.startswith(os.sep) else ''.join(
             [Defaults.get_default_uri_type(), uri]
@@ -147,7 +163,7 @@ class Uri:
         query = {'credentials': 'kiwiRepoCredentials'}
 
         if uri:
-            query = dict(params.split('=') for params in uri.query.split('&'))
+            query = dict(params.split('=') for params in uri.query.split('&'))  # type: ignore
 
         return query['credentials']
 
@@ -223,15 +239,17 @@ class Uri:
         uri = urlparse(self.uri)
         return uri.fragment
 
-    def _get_credentials_uri(self):
+    def _get_credentials_uri(self) -> Optional[ParseResult]:
         uri = urlparse(self.uri)
+        credentials_uri = None
         if uri.query and uri.query.startswith('credentials='):
-            return uri
+            credentials_uri = uri
+        return credentials_uri
 
-    def _local_path(self, path):
+    def _local_path(self, path: str) -> str:
         return os.path.abspath(os.path.normpath(path))
 
-    def _obs_project_download_link(self, name):
+    def _obs_project_download_link(self, name: str) -> str:
         name_parts = name.split(os.sep)
         repository = name_parts.pop()
         project = os.sep.join(name_parts)
@@ -258,7 +276,9 @@ class Uri:
                 f'{download_link}: {issue}'
             )
 
-    def _buildservice_path(self, name, urischeme, fragment=None):
+    def _buildservice_path(
+        self, name: str, urischeme: str, fragment: str = ''
+    ) -> str:
         """
         Special to openSUSE buildservice. If the buildservice builds
         the image it arranges the repos for each build in a special
@@ -281,3 +301,34 @@ class Uri:
                 [bs_source_dir, 'repos', name]
             )
         return self._local_path(local_path)
+
+    def _resolve_metalink_uri(self, uri: str) -> str:
+        selected_repo_source = uri
+        namespace_map = dict(
+            metalink="http://www.metalinker.org/"
+        )
+        expression = '//metalink:file[@name="repomd.xml"]/metalink:resources/*'
+        try:
+            metalink_location = urlopen(Request(uri))
+            xml = etree.parse(metalink_location)
+            url_list = xml.getroot().xpath(
+                expression, namespaces=namespace_map
+            )
+            source_dict = {}
+            for url in url_list:
+                if url.get('protocol') == 'https':
+                    source_dict[url.text] = int(url.get('preference'))
+            start_preference = 0
+            for url in sorted(source_dict.keys()):
+                preference = source_dict[url]
+                if preference > start_preference:
+                    selected_repo_source = url
+                    start_preference = preference
+        except Exception as issue:
+            raise KiwiUriOpenError(
+                f'Failed to resolve metalink URI: {issue}'
+            )
+        selected_repo_source = selected_repo_source.replace(
+            'repodata/repomd.xml', ''
+        )
+        return selected_repo_source

--- a/kiwi/tasks/image_info.py
+++ b/kiwi/tasks/image_info.py
@@ -146,6 +146,7 @@ class ImageInfoTask(CliTask):
         solver = Sat()
         for xml_repo in self.xml_state.get_repository_sections_used_for_build():
             repo_source = xml_repo.get_source().get_path()
+            repo_sourcetype = xml_repo.get_sourcetype() or ''
             repo_user = xml_repo.get_username()
             repo_secret = xml_repo.get_password()
             repo_type = xml_repo.get_type()
@@ -153,7 +154,8 @@ class ImageInfoTask(CliTask):
             repo_components = xml_repo.get_components()
             if not repo_type:
                 repo_type = SolverRepositoryBase(
-                    Uri(repo_source), repo_user, repo_secret
+                    Uri(uri=repo_source, source_type=repo_sourcetype),
+                    repo_user, repo_secret
                 ).get_repo_type()
             if repo_type == 'apt-deb':
                 # Debian based repos can be setup for a specific
@@ -173,14 +175,18 @@ class ImageInfoTask(CliTask):
                         )
                         solver.add_repository(
                             SolverRepository.new(
-                                Uri(repo_source_for_component, repo_type),
+                                Uri(
+                                    repo_source_for_component,
+                                    repo_type, repo_sourcetype
+                                ),
                                 repo_user, repo_secret
                             )
                         )
                     continue
             solver.add_repository(
                 SolverRepository.new(
-                    Uri(repo_source, repo_type), repo_user, repo_secret
+                    Uri(repo_source, repo_type, repo_sourcetype),
+                    repo_user, repo_secret
                 )
             )
         return solver

--- a/test/data/metalink
+++ b/test/data/metalink
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metalink version="3.0" xmlns="http://www.metalinker.org/" type="dynamic" pubdate="Mon, 22 Nov 2021 11:33:26 GMT" generator="mirrormanager" xmlns:mm0="http://fedorahosted.org/mirrormanager">
+ <files>
+  <file name="repomd.xml">
+   <mm0:timestamp>1619174877</mm0:timestamp>
+   <size>6285</size>
+   <verification>
+    <hash type="md5">6d3f3d3b3489e7c3e63203a4accfec52</hash>
+    <hash type="sha1">8865764f043de7527533f07c530205d2f68ae4d4</hash>
+    <hash type="sha256">4e48e3e6131dd6956141407656318bde5ff226fa07164a015968133feaa154df</hash>
+    <hash type="sha512">30e6cab1ceeed36bf0ad111be66daf2e438bcb79ff420fd090b6c6418bd8d265178e0e5d6515b173834125a30bd4ade60956817efccff86da5f6529a4739ef20</hash>
+   </verification>
+   <resources maxconnections="1">
+    <url protocol="http" type="http" location="DE" preference="91">http://mirror.dogado.de/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="DE" preference="91">https://mirror.dogado.de/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="DE" preference="98">https://ftp.plusline.net/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="DE" preference="98">rsync://ftp.plusline.net/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="DE" preference="98">http://ftp.plusline.net/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="DE" preference="97">http://mirror.speedpartner.de/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="DE" preference="96">https://ftp-stud.hs-esslingen.de/pub/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="DE" preference="100">http://mirror2.hs-esslingen.de/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="DE" preference="100">rsync://mirror2.hs-esslingen.de/fedora-linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="DE" preference="96">rsync://ftp-stud.hs-esslingen.de/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="DE" preference="96">http://ftp-stud.hs-esslingen.de/pub/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="DE" preference="95">rsync://ftp.halifax.rwth-aachen.de/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="DE" preference="95">http://ftp.halifax.rwth-aachen.de/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="DE" preference="95">https://ftp.halifax.rwth-aachen.de/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="DE" preference="94">http://mirror.netzwerge.de/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="DE" preference="94">https://mirror.netzwerge.de/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="DE" preference="94">rsync://mirror.netzwerge.de/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="DE" preference="93">http://ftp.fau.de/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="DE" preference="93">https://ftp.fau.de/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="DE" preference="93">rsync://ftp.fau.de/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="DE" preference="92">http://mirror.23m.com/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="DE" preference="92">https://mirror.23m.com/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="DE" preference="92">rsync://mirror.23m.com/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="DE" preference="91">https://mirrors.xtom.de/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="DE" preference="91">http://mirrors.xtom.de/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="DE" preference="91">rsync://mirrors.xtom.de/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="DE" preference="90">rsync://fedora.tu-chemnitz.de/ftp/pub/linux/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="DE" preference="90">http://fedora.tu-chemnitz.de/pub/linux/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="BG" preference="89">http://mirror.telepoint.bg/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="BG" preference="89">rsync://mirror.telepoint.bg/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="BG" preference="89">https://mirror.telepoint.bg/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="NL" preference="88">http://fedora.mirror.wearetriple.com/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="NL" preference="88">https://fedora.mirror.wearetriple.com/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="NL" preference="88">rsync://fedora.mirror.wearetriple.com/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="FI" preference="87">rsync://rsync.nic.funet.fi/ftp/pub/mirrors/fedora.redhat.com/pub/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="FI" preference="87">http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="NL" preference="86">http://mirror.serverion.com/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="NL" preference="86">https://mirror.serverion.com/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="NL" preference="86">rsync://mirror.serverion.com/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="IT" preference="85">http://fedora.mirror.garr.it/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="IT" preference="85">https://fedora.mirror.garr.it/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="NL" preference="84">http://ftp.tudelft.nl/download.fedora.redhat.com/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="CZ" preference="83">http://mirror.karneval.cz/pub/linux/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="CZ" preference="83">rsync://mirror.karneval.cz/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="CZ" preference="83">https://mirror.karneval.cz/pub/linux/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="UA" preference="82">http://fedora.ip-connect.info/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="UA" preference="82">https://fedora.ip-connect.info/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="UA" preference="82">rsync://fedora.ip-connect.info/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="EE" preference="81">https://mirrors.xtom.ee/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="EE" preference="81">rsync://mirrors.xtom.ee/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="EE" preference="81">http://mirrors.xtom.ee/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="SE" preference="80">https://ftp.lysator.liu.se/pub/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="SE" preference="80">http://ftp.lysator.liu.se/pub/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="SE" preference="80">rsync://ftp.lysator.liu.se/pub/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="PT" preference="79">http://mirrors.up.pt/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="PT" preference="79">rsync://mirrors.up.pt/pub/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="LT" preference="78">http://mirror.vpsnet.com/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="LT" preference="78">https://mirror.vpsnet.com/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="MD" preference="77">http://mirror.ihost.md/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="MD" preference="77">rsync://mirror.ihost.md/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="MD" preference="77">https://mirror.ihost.md/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="DK" preference="76">rsync://mirror.netsite.dk/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="DK" preference="76">https://mirror.netsite.dk/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="DK" preference="76">http://mirror.netsite.dk/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="SK" preference="75">https://ftp.upjs.sk/pub/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="SK" preference="75">http://ftp.upjs.sk/pub/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="SK" preference="75">rsync://ftp.upjs.sk/pub/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="NL" preference="74">http://fedora.mirror.liteserver.nl/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="NL" preference="74">rsync://mirror.liteserver.nl/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="NL" preference="74">https://fedora.mirror.liteserver.nl/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="DK" preference="73">http://mirror.easyspeedy.com/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="DK" preference="73">rsync://mirror.easyspeedy.com/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="BY" preference="72">http://ftp.byfly.by/pub/fedoraproject.org/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="BY" preference="72">https://ftp.byfly.by/pub/fedoraproject.org/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="BY" preference="72">rsync://ftp.byfly.by/fedora-linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="RU" preference="71">http://mirror.yandex.ru/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="RU" preference="71">rsync://mirror.yandex.ru/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="RU" preference="71">https://mirror.yandex.ru/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="SE" preference="70">https://ftp.acc.umu.se/mirror/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="SE" preference="70">http://ftp.acc.umu.se/mirror/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="SE" preference="70">rsync://ftp.acc.umu.se/mirror/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="GB" preference="69">https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="GB" preference="69">http://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="GB" preference="69">rsync://rsync.mirrorservice.org/dl.fedoraproject.org/pub/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="UA" preference="68">http://fedora.astra.in.ua/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="UA" preference="68">rsync://fedora.astra.in.ua/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="UA" preference="68">https://fedora.astra.in.ua/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="RU" preference="67">http://mirror.linux-ia64.org/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="RU" preference="67">rsync://rsync.mirror.linux-ia64.org/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="RU" preference="67">https://mirror.linux-ia64.org/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="LU" preference="66">http://fedora.mirror.root.lu/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="CZ" preference="65">rsync://ftp.fi.muni.cz/pub/linux/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="CZ" preference="65">http://ftp.fi.muni.cz/pub/linux/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="BG" preference="64">http://fedora.ipacct.com/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="BG" preference="64">https://fedora.ipacct.com/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="BG" preference="64">rsync://fedora.ipacct.com/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="CH" preference="63">https://mirror.init7.net/fedora/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="CH" preference="63">http://mirror.init7.net/fedora/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="FR" preference="62">http://mirror.in2p3.fr/pub/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="FR" preference="62">rsync://mirror.in2p3.fr/pub/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="FR" preference="61">rsync://distrib-coffee.ipsl.jussieu.fr/pub/linux/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="FR" preference="61">http://distrib-coffee.ipsl.jussieu.fr/pub/linux/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="FR" preference="60">https://fr2.rpmfind.net/linux/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="FR" preference="60">http://fr2.rpmfind.net/linux/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="FR" preference="60">rsync://fr2.rpmfind.net/linux/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="NL" preference="59">rsync://mirror.nl.leaseweb.net/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="NL" preference="59">http://mirror.nl.leaseweb.net/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="TR" preference="58">http://mirror.veriteknik.net.tr/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="TR" preference="58">rsync://mirror.veriteknik.net.tr/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="UA" preference="57">http://fedora.ip-connect.vn.ua/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="UA" preference="57">https://fedora.ip-connect.vn.ua/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="UA" preference="57">rsync://fedora.ip-connect.vn.ua/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="GR" preference="56">rsync://ftp.cc.uoc.gr/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="GR" preference="56">http://ftp.cc.uoc.gr/pub/linux/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="GR" preference="56">https://ftp.cc.uoc.gr/pub/linux/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="NL" preference="55">rsync://ftp.nluug.nl/Fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="NL" preference="55">http://ftp.nluug.nl/pub/os/Linux/distr/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="RS" preference="54">http://mirror.etf.bg.ac.rs/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="RO" preference="53">rsync://fedora.mirrors.telekom.ro/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="RO" preference="53">http://fedora.mirrors.telekom.ro/pub/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="PT" preference="52">http://ftp.dei.uc.pt/pub/linux/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="FR" preference="51">http://ftp.lip6.fr/ftp/pub/linux/distributions/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="FR" preference="51">rsync://ftp.lip6.fr/Fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="FR" preference="51">https://ftp.lip6.fr/ftp/pub/linux/distributions/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="CY" preference="50">http://mirror.library.ucy.ac.cy/linux/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="CY" preference="50">rsync://mirror.library.ucy.ac.cy/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="BY" preference="49">rsync://mirror.datacenter.by/fedora-linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="BY" preference="49">https://mirror.datacenter.by/pub/fedoraproject.org/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="BY" preference="49">http://mirror.datacenter.by/pub/fedoraproject.org/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="https" type="https" location="HU" preference="48">https://mirror.szerverem.hu/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="HU" preference="48">rsync://mirror.szerverem.hu/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="HU" preference="48">http://mirror.szerverem.hu/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="CZ" preference="47">http://mirror.slu.cz/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="CZ" preference="47">rsync://mirror.slu.cz/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="FR" preference="46">http://mirrors.ircam.fr/pub/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="FR" preference="46">rsync://mirrors.ircam.fr/fedora-linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="GB" preference="45">http://mirror.bytemark.co.uk/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="GB" preference="45">rsync://mirror.bytemark.co.uk/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="rsync" type="rsync" location="MD" preference="44">rsync://repo.fedora.md/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="MD" preference="44">http://repo.fedora.md/fedora/linux/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+    <url protocol="http" type="http" location="IL" preference="43">http://mirror.isoc.org.il/pub/fedora/releases/34/Everything/x86_64/os/repodata/repomd.xml</url>
+   </resources>
+  </file>
+ </files>
+</metalink>

--- a/test/unit/system/uri_test.py
+++ b/test/unit/system/uri_test.py
@@ -243,3 +243,17 @@ class TestUri:
         mock_buildservice.return_value = True
         uri = Uri('obsrepositories:/')
         assert uri.translate() == '/usr/src/packages/SOURCES/repos'
+
+    @patch('kiwi.system.uri.urlopen')
+    @patch('kiwi.system.uri.Request')
+    def test_translate_metalink_uri(self, mock_Request, mock_urlopen):
+        with open('../data/metalink') as metalink:
+            mock_urlopen.return_value = metalink
+            uri = Uri('https://metalink.com/foo', source_type='metalink')
+            assert uri.translate() == \
+                'https://ftp.plusline.net/fedora/linux/releases/34/Everything/' \
+                'x86_64/os/'
+
+        mock_urlopen.side_effect = Exception
+        with raises(KiwiUriOpenError):
+            uri = Uri('https://metalink.com/foo', source_type='metalink')

--- a/test/unit/tasks/image_info_test.py
+++ b/test/unit/tasks/image_info_test.py
@@ -127,24 +127,24 @@ class TestImageInfoTask:
 
         assert self.solver.add_repository.called
         assert mock_uri.call_args_list == [
-            call('http://us.archive.ubuntu.com/ubuntu/'),
+            call(uri='http://us.archive.ubuntu.com/ubuntu/', source_type=''),
             call(
                 'http://us.archive.ubuntu.com/ubuntu/dists/focal/'
-                'main/binary-amd64', 'apt-deb'
+                'main/binary-amd64', 'apt-deb', ''
             ),
             call(
                 'http://us.archive.ubuntu.com/ubuntu/dists/focal/'
-                'multiverse/binary-amd64', 'apt-deb'
+                'multiverse/binary-amd64', 'apt-deb', ''
             ),
             call(
                 'http://us.archive.ubuntu.com/ubuntu/dists/focal/'
-                'restricted/binary-amd64', 'apt-deb'
+                'restricted/binary-amd64', 'apt-deb', ''
             ),
             call(
                 'http://us.archive.ubuntu.com/ubuntu/dists/focal/'
-                'universe/binary-amd64', 'apt-deb'
+                'universe/binary-amd64', 'apt-deb', ''
             ),
-            call('obs://Devel:PubCloud:AmazonEC2/SLE_12_GA', 'rpm-md')
+            call('obs://Devel:PubCloud:AmazonEC2/SLE_12_GA', 'rpm-md', '')
         ]
         mock_out.assert_called_once_with(self.result_info)
 


### PR DESCRIPTION
For resolver operations through libsolv the 'kiwi image info'
module exists. So far it could not read the repos from
metalink repo definitions. This Fixes #1890


