### PR TITLE
Do not force dracut into a compression setting

### DIFF
--- a/doc/source/building_images/build_expandable_disk.rst
+++ b/doc/source/building_images/build_expandable_disk.rst
@@ -181,7 +181,7 @@ target system:
 
       .. code:: bash
 
-          scp pxeboot.{exc_image_base_name_disk}.x86_64-{exc_image_version}.initrd.xz PXE_SERVER_IP:/srv/tftpboot/boot/initrd
+          scp pxeboot.{exc_image_base_name_disk}.x86_64-{exc_image_version}.initrd PXE_SERVER_IP:/srv/tftpboot/boot/initrd
           scp pxeboot.{exc_image_base_name_disk}.x86_64-{exc_image_version}.kernel PXE_SERVER_IP:/srv/tftpboot/boot/linux
 
 3. Copy the disk image, MD5 file, system kernel, initrd and bootoptions to

--- a/doc/source/building_images/build_kis.rst
+++ b/doc/source/building_images/build_kis.rst
@@ -77,7 +77,7 @@ tested with QEMU as follows:
 
    $ sudo qemu
        -kernel /tmp/myimage/*.kernel \
-       -initrd /tmp/myimage/*.initrd.xz \
+       -initrd /tmp/myimage/*.initrd \
        -append $(cat /tmp/myimage/*.append) \
        -hda /tmp/myimage/{exc_image_base_name_pxe}.*-{exc_image_version} \
        -serial stdio

--- a/doc/source/working_with_images/legacy_netboot_root_filesystem.rst
+++ b/doc/source/working_with_images/legacy_netboot_root_filesystem.rst
@@ -87,7 +87,7 @@ system. As diskless client, a QEMU virtual machine is used.
 
    .. code:: bash
 
-       $ cp *.initrd.xz /srv/tftpboot/boot/initrd
+       $ cp *.initrd /srv/tftpboot/boot/initrd
        $ cp *.kernel /srv/tftpboot/boot/linux
 
 5. Copy the system image and its MD5 sum to :file:`/srv/tftpboot/image`:

--- a/doc/source/working_with_images/network_overlay_boot.rst
+++ b/doc/source/working_with_images/network_overlay_boot.rst
@@ -52,7 +52,7 @@ from the network:
 
    .. code:: bash
 
-       $ cp *.initrd.xz /srv/tftpboot/boot/initrd
+       $ cp *.initrd /srv/tftpboot/boot/initrd
        $ cp *.kernel /srv/tftpboot/boot/linux
 
 2. Export Root FileSystem to the Network

--- a/dracut/modules.d/99kiwi-lib/kiwi-net-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-net-lib.sh
@@ -80,7 +80,7 @@ function uri_fragment {
 #--------------------------------------
 function _is_compressed {
     local source_url=$1
-    [[ ${source_url} =~ .xz$ ]]
+    xz -l "${source_url}" &>/dev/null
 }
 
 function _is_dolly {

--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -196,7 +196,6 @@ class BootImageDracut(BootImageBase):
             modules_args += [
                 '--omit', ' {0} '.format(' '.join(self.omit_modules))
             ] if self.omit_modules else []
-            dracut_initrd_basename += '.xz'
             options = self.dracut_options + modules_args + included_files
             if kernel_details:
                 self.device_mount = MountManager(
@@ -214,8 +213,7 @@ class BootImageDracut(BootImageBase):
                         'chroot', self.boot_root_directory,
                         'dracut', '--verbose',
                         '--no-hostonly',
-                        '--no-hostonly-cmdline',
-                        '--xz'
+                        '--no-hostonly-cmdline'
                     ] + options + [
                         dracut_initrd_basename,
                         kernel_details.version

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -363,7 +363,7 @@ class InstallImageBuilder:
 
     def _create_pxe_install_kernel_and_initrd(self) -> None:
         kernelname = 'pxeboot.{0}.kernel'.format(self.pxename)
-        initrdname = 'pxeboot.{0}.initrd.xz'.format(self.pxename)
+        initrdname = 'pxeboot.{0}.initrd'.format(self.pxename)
         kernel = Kernel(self.boot_image_task.boot_root_directory)
         if kernel.get_kernel():
             kernel.copy_kernel(self.pxe_dir.name, kernelname)

--- a/test/unit/boot/image/dracut_test.py
+++ b/test/unit/boot/image/dracut_test.py
@@ -131,37 +131,43 @@ class TestBootImageKiwi:
             call(device='/proc', mountpoint='system-directory/proc')
         ]
         assert mock_command.call_args_list == [
-            call([
-                'chroot', 'system-directory',
-                'dracut', '--verbose', '--no-hostonly',
-                '--no-hostonly-cmdline', '--xz',
-                '--add', ' foo ', '--omit', ' bar ',
-                '--install', 'system-directory/etc/foo',
-                'LimeJeOS.x86_64-1.13.2.initrd.xz', '1.2.3'
-            ], stderr_to_stdout=True),
-            call([
-                'mv',
-                'system-directory/'
-                'LimeJeOS.x86_64-1.13.2.initrd.xz',
-                'some-target-dir'
-            ])
+            call(
+                [
+                    'chroot', 'system-directory',
+                    'dracut', '--verbose', '--no-hostonly',
+                    '--no-hostonly-cmdline',
+                    '--add', ' foo ', '--omit', ' bar ',
+                    '--install', 'system-directory/etc/foo',
+                    'LimeJeOS.x86_64-1.13.2.initrd', '1.2.3'
+                ], stderr_to_stdout=True),
+            call(
+                [
+                    'mv',
+                    'system-directory/'
+                    'LimeJeOS.x86_64-1.13.2.initrd',
+                    'some-target-dir'
+                ]
+            )
         ]
         mock_command.reset_mock()
         self.boot_image.create_initrd(basename='foo')
         assert mock_command.call_args_list == [
-            call([
-                'chroot', 'system-directory',
-                'dracut', '--verbose', '--no-hostonly',
-                '--no-hostonly-cmdline', '--xz',
-                '--add', ' foo ', '--omit', ' bar ',
-                '--install', 'system-directory/etc/foo',
-                'foo.xz', '1.2.3'
-            ], stderr_to_stdout=True),
-            call([
-                'mv',
-                'system-directory/foo.xz',
-                'some-target-dir'
-            ])
+            call(
+                [
+                    'chroot', 'system-directory',
+                    'dracut', '--verbose', '--no-hostonly',
+                    '--no-hostonly-cmdline',
+                    '--add', ' foo ', '--omit', ' bar ',
+                    '--install', 'system-directory/etc/foo',
+                    'foo', '1.2.3'
+                ], stderr_to_stdout=True),
+            call(
+                [
+                    'mv',
+                    'system-directory/foo',
+                    'some-target-dir'
+                ]
+            )
         ]
 
     def test_has_initrd_support(self):

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -379,11 +379,11 @@ class TestInstallImageBuilder:
         assert mock_command.call_args_list[1] == call(
             [
                 'mv', 'initrd',
-                'tmpdir/pxeboot.result-image.x86_64-1.2.3.initrd.xz'
+                'tmpdir/pxeboot.result-image.x86_64-1.2.3.initrd'
             ]
         )
         mock_chmod.assert_called_once_with(
-            'tmpdir/pxeboot.result-image.x86_64-1.2.3.initrd.xz', 420
+            'tmpdir/pxeboot.result-image.x86_64-1.2.3.initrd', 420
         )
         mock_archive.assert_called_once_with(
             'target_dir/result-image.x86_64-1.2.3.install.tar'
@@ -409,7 +409,7 @@ class TestInstallImageBuilder:
         ]
         assert mock_chmod.call_args_list == [
             call('tmpdir/result-image.x86_64-1.2.3.initrd', 420),
-            call('tmpdir/pxeboot.result-image.x86_64-1.2.3.initrd.xz', 420)
+            call('tmpdir/pxeboot.result-image.x86_64-1.2.3.initrd', 420)
         ]
         assert m_open.call_args_list == [
             call('tmpdir/result-image.x86_64-1.2.3.append', 'w'),


### PR DESCRIPTION
So far we called dracut with --xz which forces the initrd
to be xz compressed. There are other compression formats
used by the distributions and they might differe from xz.
The selection for a compression tool is done by a dist
configuration in dracut.conf.d which is provided by the
distributions as they see fit. For us this means not
forcing dracut into a specific compression setting allows
to make use of the distro provided setting and also
allows to change/override this setting by an overlay
file. This Fixes bsc#1192975

