### PR TITLE
Prevent warning message on resize exception

### DIFF
--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -183,18 +183,29 @@ function check_repart_possible {
         fi
     fi
     if [ "${min_additional_mbytes}" -gt "${disk_free_mbytes}" ];then
-        # Requested size for root exceeds free space on disk
-        local requested_size
-        if [ -n "${kiwi_oemrootMB}" ];then
-            requested_size="root:($((kiwi_oemrootMB - disk_root_mbytes)) MB)"
+        if [ "${disk_free_mbytes}" -gt 2 ];then
+            # Requested size for root exceeds free space on disk
+            local requested_size
+            if [ -n "${kiwi_oemrootMB}" ];then
+                requested_size="root:($((kiwi_oemrootMB - disk_root_mbytes)) MB)"
+            else
+                requested_size="root:(keep)"
+            fi
+            warn "Requested OEM systemsize exceeds free space on the disk:"
+            warn "Disk won't be re-partitioned !"
+            echo
+            warn "Requested size(s): ${requested_size}"
+            warn "==> Free Space on disk: ${disk_free_mbytes} MB"
         else
-            requested_size="root:(keep)"
+            # The free space on disk calculated to a very small number.
+            # This usally indicates that the disk geometry was not
+            # intentionally changed and the rest free space is a
+            # rounding number on the partition alignment. In this case
+            # no warning message is shown because it's the typical
+            # situation on reboot of a machine without disk geometry
+            # changes.
+            :
         fi
-        warn "Requested OEM systemsize exceeds free space on the disk:"
-        warn "Disk won't be re-partitioned !"
-        echo
-        warn "Requested size(s): ${requested_size}"
-        warn "==> Free Space on disk: ${disk_free_mbytes} MB"
         return 1
     fi
     return 0


### PR DESCRIPTION
On systems which are configured to run the oem resize at
every boot (default case) kiwi checks how much space is free
and if that fits the constraints configured as part of the
image description. If the constraints are not met a warning
message is displayed and the boot continuous without any
resize action happening.

This warning message however, always appears after the first
boot when the resize had happened and no rest space on disk
is present unless the disk geometry would have changed.
The situation of the reboot of the system without any disk
geometry change is the standard case and happens way more
often than the reboot with a disk geometry change.

Therefore the warning message displayed is not actually
a real warning and most often considered as an issue
when there is none. To relax this situation, this commit
only shows the warning message if the detected free space
on disk is greater than 2M, which is the condition under
which we assume an intentional (user made) disk geometry
change.

This Fixes #1958


