### PR TITLE
Care for different snapper template locations

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -470,15 +470,26 @@ class Defaults:
         return 'INSTALL'
 
     @staticmethod
-    def get_snapper_config_template_file():
+    def get_snapper_config_template_file(root: str) -> str:
         """
-        Provides the default configuration template file for snapper
+        Provides the default configuration template file for snapper.
+        The location in etc/ are preferred over files in usr/
 
-        :return: file
+        :return: file path
 
         :rtype: str
         """
-        return '/etc/snapper/config-templates/default'
+        snapper_templates = [
+            'etc/snapper/config-templates/default',
+            'usr/share/snapper/config-templates/default'
+        ]
+        snapper_default_conf = ''
+        for snapper_template in snapper_templates:
+            template_config = os.path.join(root, snapper_template)
+            if os.path.exists(template_config):
+                snapper_default_conf = template_config
+                break
+        return snapper_default_conf
 
     @staticmethod
     def get_default_video_mode():

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -387,10 +387,10 @@ class VolumeManagerBtrfs(VolumeManagerBase):
 
     def _create_snapper_quota_configuration(self):
         root_path = os.sep.join([self.mountpoint, '@/.snapshots/1/snapshot'])
-        snapper_default_conf = os.path.normpath(os.sep.join(
-            [root_path, Defaults.get_snapper_config_template_file()]
-        ))
-        if os.path.exists(snapper_default_conf):
+        snapper_default_conf = Defaults.get_snapper_config_template_file(
+            root_path
+        )
+        if snapper_default_conf:
             # snapper requires an extra parent qgroup to operate with quotas
             Command.run(
                 ['btrfs', 'qgroup', 'create', '1/0', self.mountpoint]

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -189,3 +189,11 @@ class TestDefaults:
             '/usr/lib/shim/shimx64.efi.signed',
             binaryname='shimx64.efi'
         )
+
+    @patch('os.path.exists')
+    def test_get_snapper_config_template_file(self, mock_os_path_exists):
+        mock_os_path_exists.return_value = False
+        assert Defaults.get_snapper_config_template_file('root') == ''
+        mock_os_path_exists.return_value = True
+        assert Defaults.get_snapper_config_template_file('root') == \
+            'root/etc/snapper/config-templates/default'


### PR DESCRIPTION
snapper recently changed their config template location
from etc/ to usr/. This commit handles the two locations
and Fixes bsc#1192940

