### PR TITLE
Allow repo path relative to the image description

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -70,7 +70,9 @@ This will replace the `include` statement with the contents
 of :file:`description.xml`. The validation of the result happens
 after the inclusion of all `include` references. The value for
 the `from` attribute is interpreted as an URI, as of now only
-local URI types are supported.
+local URI types are supported as well as the `this://` resource
+locator which translates into the path to the KIWI image
+description.
 
 .. note::
 

--- a/kiwi/markup/base.py
+++ b/kiwi/markup/base.py
@@ -35,7 +35,7 @@ class MarkupBase:
 
     Attributes
 
-    :param str description: description path or content
+    :param str description: description path
     """
     def __init__(self, description: str):
         self.description = description
@@ -69,7 +69,9 @@ class MarkupBase:
             )
 
         xslt_transform_parser = etree.XMLParser()
-        xslt_transform_parser.resolvers.add(FileResolver())
+        xslt_transform_parser.resolvers.add(
+            FileResolver(os.path.dirname(self.description))
+        )
         xslt_transform = etree.XSLT(
             etree.parse(
                 Defaults.get_xsl_stylesheet_file(), xslt_transform_parser
@@ -108,10 +110,20 @@ class MarkupBase:
 
 
 class FileResolver(etree.Resolver):
+    def __init__(self, description_dir):
+        self.description_dir = description_dir
+
     def resolve(self, url, pubid, context):
+        if url.startswith('this://'):
+            url = url.replace('this://', '')
+            url = 'dir://{0}'.format(
+                os.path.abspath(os.path.join(self.description_dir, url))
+            )
         uri = urlparse(url)
         if uri.path and uri.netloc:
             url = ''.join([uri.netloc, uri.path])
+        elif uri.path:
+            url = uri.path
         if os.path.exists(url):
             return self.resolve_filename(url, context)
         else:

--- a/kiwi/markup/base.py
+++ b/kiwi/markup/base.py
@@ -117,7 +117,7 @@ class FileResolver(etree.Resolver):
         if url.startswith('this://'):
             url = url.replace('this://', '')
             url = 'dir://{0}'.format(
-                os.path.abspath(os.path.join(self.description_dir, url))
+                os.path.realpath(os.path.join(self.description_dir, url))
             )
         uri = urlparse(url)
         if uri.path and uri.netloc:

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -52,6 +52,23 @@ class Uri:
         standard URLs
 
         :param str uri: URI, remote, local or metalink repository location
+            The resource type as part of the URI can be set to one of:
+            * http:
+            * https:
+            * ftp:
+            * obs:
+            * dir:
+            * file:
+            * obsrepositories:
+            * this:
+            The special this:// type resolve to the image description
+            directory. The code to resolve this is not part of the Uri
+            class because it has no state information about the image
+            description directory. Therefore the resolving of the this://
+            path happens on construction of an XMLState object as
+            part of the resolve_this_path() method. The method resolves
+            the path into a native dir:// URI which can be properly
+            handled here.
         :param str repo_type:
             repository type name, defaults to 'rpm-md' and is only
             effectively used when building inside of the open

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1815,7 +1815,7 @@ class XMLState:
                 repo_path = repo_path.replace('this://', '')
                 repo_source.set_path(
                     'dir://{0}'.format(
-                        os.path.abspath(
+                        os.path.realpath(
                             os.path.join(
                                 self.xml_data.description_dir, repo_path
                             )

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import os
 from typing import (
     List, Optional, Any, Dict, NamedTuple
 )
@@ -96,6 +97,7 @@ class XMLState:
         self.build_type = self._build_type_section(
             build_type
         )
+        self.resolve_this_path()
 
     def get_preferences_sections(self) -> List:
         """
@@ -1799,6 +1801,27 @@ class XMLState:
                 package_gpgcheck=repo_package_gpgcheck
             )
         )
+
+    def resolve_this_path(self) -> None:
+        """
+        Resolve any this:// repo source path into the path
+        representing the target inside of the image description
+        directory
+        """
+        for repository in self.get_repository_sections() or []:
+            repo_source = repository.get_source()
+            repo_path = repo_source.get_path()
+            if repo_path.startswith('this://'):
+                repo_path = repo_path.replace('this://', '')
+                repo_source.set_path(
+                    'dir://{0}'.format(
+                        os.path.abspath(
+                            os.path.join(
+                                self.xml_data.description_dir, repo_path
+                            )
+                        )
+                    )
+                )
 
     def copy_displayname(self, target_state: Any) -> None:
         """

--- a/test/data/example_include_config_from_description_dir.xml
+++ b/test/data/example_include_config_from_description_dir.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="7.4" name="LimeJeOS">
+    <description type="system">
+        <author>Marcus</author>
+        <contact>ms@suse.com</contact>
+        <specification>
+            Testing include from image description directory
+        </specification>
+    </description>
+    <preferences>
+        <version>1.13.2</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <type image="tbz"/>
+    </preferences>
+    <users>
+        <user pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>
+    </users>
+    <include from="this://include.xml"/>
+    <packages type="image" patternType="plusRecommended">
+        <namedCollection name="base"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="filesystem"/>
+    </packages>
+</image>

--- a/test/data/example_this_path_config.xml
+++ b/test/data/example_this_path_config.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="7.4" name="JeOS">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>ms@suse.com</contact>
+        <specification>
+            Test this path source in repo
+        </specification>
+    </description>
+    <preferences>
+        <version>1.1.1</version>
+        <packagemanager>zypper</packagemanager>
+        <type image="oem" filesystem="ext3" firmware="efi"/>
+    </preferences>
+    <repository>
+        <source path="this://my_repo"/>
+    </repository>
+    <packages type="bootstrap">
+        <package name="filesystem"/>
+    </packages>
+</image>

--- a/test/data/include.xml
+++ b/test/data/include.xml
@@ -1,0 +1,5 @@
+<image>
+    <repository>
+        <source path="http://example.com"/>
+    </repository>
+</image>

--- a/test/unit/markup/base_test.py
+++ b/test/unit/markup/base_test.py
@@ -3,6 +3,8 @@ from mock import patch
 from pytest import raises
 
 from kiwi.markup.base import MarkupBase
+from kiwi.xml_description import XMLDescription
+from kiwi.xml_state import XMLState
 
 from kiwi.exceptions import (
     KiwiConfigFileFormatNotSupported,
@@ -51,3 +53,16 @@ class TestMarkupBase:
             markup.apply_xslt_stylesheets(
                 '../data/example_include_config_missing_reference.xml'
             )
+
+    def test_apply_xslt_stylesheets_include_from_image_description_dir(self):
+        markup = MarkupBase(
+            '../data/example_include_config_from_description_dir.xml'
+        )
+        xml_description = markup.apply_xslt_stylesheets(
+            '../data/example_include_config_from_description_dir.xml'
+        )
+        description = XMLDescription(xml_description)
+        xml_data = description.load()
+        state = XMLState(xml_data)
+        assert state.xml_data.get_repository()[0].get_source().get_path() == \
+            'http://example.com'

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1,3 +1,4 @@
+import os
 import logging
 from collections import namedtuple
 from mock import (
@@ -1010,4 +1011,13 @@ class TestXMLState:
     @patch('kiwi.system.uri.os.path.abspath')
     def test_get_repositories_signing_keys(self, mock_root_path):
         mock_root_path.side_effect = lambda x: f'/some/path/{x}'
-        assert self.state.get_repositories_signing_keys() == ['/some/path/key_a', '/some/path/key_b']
+        assert self.state.get_repositories_signing_keys() == [
+            '/some/path/key_a', '/some/path/key_b'
+        ]
+
+    def test_this_path_resolver(self):
+        description = XMLDescription('../data/example_this_path_config.xml')
+        xml_data = description.load()
+        state = XMLState(xml_data)
+        assert state.xml_data.get_repository()[0].get_source().get_path() \
+            == 'dir://{0}/my_repo'.format(os.path.abspath('../data'))

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1020,4 +1020,4 @@ class TestXMLState:
         xml_data = description.load()
         state = XMLState(xml_data)
         assert state.xml_data.get_repository()[0].get_source().get_path() \
-            == 'dir://{0}/my_repo'.format(os.path.abspath('../data'))
+            == 'dir://{0}/my_repo'.format(os.path.realpath('../data'))


### PR DESCRIPTION
This commit adds a new URI type called this://... The
this:// part will be resolved into the absolute path to
the image description. A source path like the following:

```xml
    <source path="this://my_repo"/>
```

is resolved to

```xml
    <source path="dir:///path/to/image/description/my_repo"/>
```

This change provides the requested opportunity to reference
repos provided as part of the image description and
Fixes #1964

