### PR TITLE
Allow to specify kiwi file

### DIFF
--- a/doc/source/commands/kiwi.rst
+++ b/doc/source/commands/kiwi.rst
@@ -18,6 +18,7 @@ SYNOPSIS
            [--debug]
            [--color-output]
            [--config=<configfile>]
+           [--kiwi-file=<kiwifile>]
        image <command> [<args>...]
    kiwi-ng [--debug]
            [--color-output]
@@ -32,6 +33,7 @@ SYNOPSIS
            [--debug]
            [--color-output]
            [--config=<configfile>]
+           [--kiwi-file=<kiwifile>]
        system <command> [<args>...]
    kiwi-ng compat <legacy_args>...
    kiwi-ng -v | --version
@@ -138,6 +140,12 @@ GLOBAL OPTIONS
 
   Select image build type. The specified build type must be configured
   as part of the XML description.
+
+--kiwi-file=<kiwifile>
+
+  Basename of kiwi file which contains the main image
+  configuration elements. If not specified kiwi searches for
+  a file named `config.xml` or a file matching `*.kiwi`
 
 --version
 

--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -24,6 +24,7 @@ usage: kiwi-ng -h | --help
                [--debug]
                [--color-output]
                [--config=<configfile>]
+               [--kiwi-file=<kiwifile>]
            image <command> [<args>...]
        kiwi-ng [--logfile=<filename>]
                [--debug]
@@ -39,6 +40,7 @@ usage: kiwi-ng -h | --help
                [--debug]
                [--color-output]
                [--config=<configfile>]
+               [--kiwi-file=<kiwifile>]
            system <command> [<args>...]
        kiwi-ng compat <legacy_args>...
        kiwi-ng --compat <legacy_args>...
@@ -80,6 +82,10 @@ global options for services: image, system
     --type=<build_type>
         image build type. If not set the default XML specified
         build type will be used
+    --kiwi-file=<kiwifile>
+        Basename of kiwi file which contains the main image
+        configuration elements. If not specified kiwi searches for
+        a file named config.xml or a file matching *.kiwi
 
 global options for services: system
     --target-arch=<name>

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -118,32 +118,35 @@ class CliTask:
             if self.global_args['--color-output']:
                 log.set_color_format()
 
-    def load_xml_description(self, description_directory: str) -> None:
+    def load_xml_description(
+        self, description_directory: str, kiwi_file: str = ''
+    ) -> None:
         """
         Load, upgrade, validate XML description
 
-        Attributes
+        :param str description_directory:
+            Path to the image description
 
-        * :attr:`xml_data`
-            instance of XML data toplevel domain (image), stateless data
-
-        * :attr:`config_file`
-            used config file path
-
-        * :attr:`xml_state`
-            Instance of XMLState, stateful data
+        :param str kiwi_file:
+            Basename of kiwi file which contains the main
+            image configuration elements. If not specified
+            kiwi searches for a file named config.xml or
+            a file matching .kiwi
         """
         log.info('Loading XML description')
-        config_file = description_directory + '/config.xml'
-        if not os.path.exists(config_file):
-            # alternative config file lookup location
-            config_file = description_directory + '/image/config.xml'
-        if not os.path.exists(config_file):
-            # glob config file search, first match wins
-            glob_match = description_directory + '/*.kiwi'
-            for kiwi_file in sorted(glob.iglob(glob_match)):
-                config_file = kiwi_file
-                break
+        if kiwi_file:
+            config_file = os.sep.join([description_directory, kiwi_file])
+        else:
+            config_file = os.sep.join([description_directory, '/config.xml'])
+            if not os.path.exists(config_file):
+                # alternative config file lookup location
+                config_file = description_directory + '/image/config.xml'
+            if not os.path.exists(config_file):
+                # glob config file search, first match wins
+                glob_match = description_directory + '/*.kiwi'
+                for kiwi_file in sorted(glob.iglob(glob_match)):
+                    config_file = kiwi_file
+                    break
 
         if not os.path.exists(config_file):
             raise KiwiConfigFileNotFound(

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -18,6 +18,9 @@
 import os
 import logging
 import glob
+from typing import (
+    List, Dict, Optional, Union, Any
+)
 from operator import attrgetter
 
 # project
@@ -31,7 +34,7 @@ from kiwi.exceptions import (
     KiwiConfigFileNotFound
 )
 
-log = logging.getLogger('kiwi')
+log: Any = logging.getLogger('kiwi')
 
 
 class CliTask:
@@ -48,11 +51,11 @@ class CliTask:
         * setup logfile
         * setup color output
     """
-    def __init__(self, should_perform_task_setup=True):
+    def __init__(self, should_perform_task_setup: bool = True) -> None:
         self.cli = Cli()
 
         # initialize runtime checker
-        self.runtime_checker = None
+        self.runtime_checker: Optional[RuntimeChecker] = None
 
         # help requested
         self.cli.show_and_exit_on_help_request()
@@ -70,7 +73,7 @@ class CliTask:
         self.runtime_config = RuntimeConfig()
 
         # initialize generic runtime check dicts
-        self.checks_before_command_args = {
+        self.checks_before_command_args: Dict[str, List[str]] = {
             'check_image_version_provided': [],
             'check_efi_mode_for_disk_overlay_correctly_setup': [],
             'check_initrd_selection_required': [],
@@ -94,7 +97,7 @@ class CliTask:
             'check_image_type_unique': [],
             'check_include_references_unresolvable': []
         }
-        self.checks_after_command_args = {
+        self.checks_after_command_args: Dict[str, List[str]] = {
             'check_repositories_configured': [],
             'check_image_include_repos_publicly_resolvable': []
         }
@@ -115,7 +118,7 @@ class CliTask:
             if self.global_args['--color-output']:
                 log.set_color_format()
 
-    def load_xml_description(self, description_directory):
+    def load_xml_description(self, description_directory: str) -> None:
         """
         Load, upgrade, validate XML description
 
@@ -172,7 +175,7 @@ class CliTask:
 
         self.runtime_checker = RuntimeChecker(self.xml_state)
 
-    def quadruple_token(self, option):
+    def quadruple_token(self, option: str) -> List[Union[bool, str, None]]:
         """
         Helper method for commandline options of the form --option a,b,c,d
 
@@ -187,7 +190,7 @@ class CliTask:
         """
         return self._ntuple_token(option, 4)
 
-    def sextuple_token(self, option):
+    def sextuple_token(self, option: str) -> List[Union[bool, str, None]]:
         """
         Helper method for commandline options of the form --option a,b,c,d,e,f
 
@@ -202,7 +205,7 @@ class CliTask:
         """
         return self._ntuple_token(option, 6)
 
-    def run_checks(self, checks):
+    def run_checks(self, checks: Dict[str, List[str]]) -> None:
         """
         This method runs the given runtime checks excluding the ones disabled
         in the runtime configuration file.
@@ -218,7 +221,7 @@ class CliTask:
             }.items():
                 attrgetter(method)(self.runtime_checker)(*args)
 
-    def _pop_token(self, tokens):
+    def _pop_token(self, tokens: List[str]) -> Union[bool, str]:
         token = tokens.pop(0)
         if len(token) > 0 and token == 'true':
             return True
@@ -227,7 +230,9 @@ class CliTask:
         else:
             return token
 
-    def _ntuple_token(self, option, tuple_count):
+    def _ntuple_token(
+        self, option: str, tuple_count: int
+    ) -> List[Union[bool, str, None]]:
         """
         Helper method for commandline options of the form --option a,b,c,d,e,f
 

--- a/kiwi/tasks/image_info.py
+++ b/kiwi/tasks/image_info.py
@@ -73,7 +73,7 @@ class ImageInfoTask(CliTask):
             return self.manual.show('kiwi::image::info')
 
         self.load_xml_description(
-            self.command_args['--description']
+            self.command_args['--description'], self.global_args['--kiwi-file']
         )
 
         if self.command_args['--ignore-repos']:

--- a/kiwi/tasks/image_resize.py
+++ b/kiwi/tasks/image_resize.py
@@ -94,7 +94,7 @@ class ImageResizeTask(CliTask):
             )
 
         self.load_xml_description(
-            image_root
+            image_root, self.global_args['--kiwi-file']
         )
 
         disk_format = self.xml_state.build_type.get_format()

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -137,7 +137,7 @@ class SystemBuildTask(CliTask):
             )
 
         self.load_xml_description(
-            self.command_args['--description']
+            self.command_args['--description'], self.global_args['--kiwi-file']
         )
 
         build_checks = self.checks_before_command_args

--- a/kiwi/tasks/system_create.py
+++ b/kiwi/tasks/system_create.py
@@ -79,7 +79,7 @@ class SystemCreateTask(CliTask):
         abs_root_path = os.path.abspath(self.command_args['--root'])
 
         self.load_xml_description(
-            abs_root_path
+            abs_root_path, self.global_args['--kiwi-file']
         )
 
         self.run_checks(

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -121,7 +121,7 @@ class SystemPrepareTask(CliTask):
         Privileges.check_for_root_permissions()
 
         self.load_xml_description(
-            self.command_args['--description']
+            self.command_args['--description'], self.global_args['--kiwi-file']
         )
 
         abs_root_path = os.path.abspath(self.command_args['--root'])

--- a/kiwi/tasks/system_update.py
+++ b/kiwi/tasks/system_update.py
@@ -74,7 +74,7 @@ class SystemUpdateTask(CliTask):
         abs_root_path = os.path.abspath(self.command_args['--root'])
 
         self.load_xml_description(
-            abs_root_path
+            abs_root_path, self.global_args['--kiwi-file']
         )
 
         package_requests = False

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -43,7 +43,8 @@ class TestCli:
             '--temp-dir': '/var/tmp',
             '--target-arch': None,
             '--help': False,
-            '--config': 'config-file'
+            '--config': 'config-file',
+            '--kiwi-file': None
         }
         self.command_args = {
             '--add-repo': [],

--- a/test/unit/tasks/base_test.py
+++ b/test/unit/tasks/base_test.py
@@ -77,6 +77,8 @@ class TestCliTask:
     def test_load_xml_description_raises(self):
         with raises(KiwiConfigFileNotFound):
             self.task.load_xml_description('foo')
+        with raises(KiwiConfigFileNotFound):
+            self.task.load_xml_description('path', 'custom_kiwi_file')
 
     def teardown(self):
         sys.argv = argv_kiwi_tests


### PR DESCRIPTION
Add global --kiwi-file option
    
When building with kiwi a search on the kiwi main config file is made inside of the given --description directory. The search looks up for the file ```config.xml``` or ```*.kiwi```.  So far there was no opportunity to specify another name.  This commit adds an option in the global area named:
    
```bash
--kiwi-file name
```
    
which will make kiwi to lookup this file inside of the given ```--description``` directory and fail if it does not exist.

This Fixes #1973
