### PR TITLE
Added support for setting up release version

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -289,6 +289,22 @@ bootloader has theme support.
 Along with the version and the packagemanager at least one image type
 element must be specified to indicate which image type should be build.
 
+<preferences><release-version>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Specifies the distribution global release version as consumed
+by package managers. Currently the release version is not set or
+set to `0` for package managers which requires a value to operate.
+With the optional `release-version` section, users have an
+opportunity to specify a custom value which is passed along the package
+manager to define the distribution release.
+
+.. note::
+
+   The release version information is currently
+   used in dnf and microdnf package managers only. It might
+   happen that it gets applied to the other package manager
+   backends as well. This will happen on demand though.
+
 <preferences><type>
 ~~~~~~~~~~~~~~~~~~~
 At least one type element must be configured. It is possible to

--- a/kiwi/package_manager/__init__.py
+++ b/kiwi/package_manager/__init__.py
@@ -50,7 +50,7 @@ class PackageManager(metaclass=ABCMeta):
     @staticmethod
     def new(
         repository: object, package_manager_name: str,
-        custom_args: List=None  # noqa: E252
+        custom_args: List = [], release_version: str = ''
     ):
         name_map = {
             'zypper': ['zypper', 'Zypper'],
@@ -66,7 +66,7 @@ class PackageManager(metaclass=ABCMeta):
             )
             module_name = 'PackageManager{0}'.format(module_name)
             manager = package_manager.__dict__[module_name](
-                repository, custom_args
+                repository, custom_args, release_version
             )
         except Exception as issue:
             raise KiwiPackageManagerSetupError(

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -34,7 +34,8 @@ class PackageManagerBase:
     :param list product_requests: list of products to install
     """
     def __init__(
-        self, repository: RepositoryBase, custom_args: List = []
+        self, repository: RepositoryBase, custom_args: List = [],
+        release_version: str = ''
     ) -> None:
         self.repository = repository
         self.root_dir = repository.root_dir
@@ -42,6 +43,7 @@ class PackageManagerBase:
         self.collection_requests: List[str] = []
         self.product_requests: List[str] = []
         self.exclude_requests: List[str] = []
+        self.release_version = release_version or '0'
 
         self.post_init(custom_args or [])
 

--- a/kiwi/package_manager/dnf.py
+++ b/kiwi/package_manager/dnf.py
@@ -99,12 +99,15 @@ class PackageManagerDnf(PackageManagerBase):
         :rtype: namedtuple
         """
         Command.run(
-            ['dnf'] + self.dnf_args + ['makecache']
+            ['dnf'] + self.dnf_args + [
+                f'--releasever={self.release_version}'
+            ] + ['makecache']
         )
         dnf_command = [
             'dnf'
         ] + self.dnf_args + [
-            '--installroot', self.root_dir
+            '--installroot', self.root_dir,
+            f'--releasever={self.release_version}'
         ] + self.custom_args + [
             'install'
         ] + self.package_requests + self.collection_requests
@@ -134,7 +137,9 @@ class PackageManagerDnf(PackageManagerBase):
         )
         dnf_command = [
             'chroot', self.root_dir, 'dnf'
-        ] + chroot_dnf_args + self.custom_args + exclude_args + [
+        ] + chroot_dnf_args + [
+            f'--releasever={self.release_version}'
+        ] + self.custom_args + exclude_args + [
             'install'
         ] + self.package_requests + self.collection_requests
         self.cleanup_requests()
@@ -181,7 +186,9 @@ class PackageManagerDnf(PackageManagerBase):
             chroot_dnf_args = Path.move_to_root(self.root_dir, self.dnf_args)
             dnf_command = [
                 'chroot', self.root_dir, 'dnf'
-            ] + chroot_dnf_args + self.custom_args + [
+            ] + chroot_dnf_args + [
+                f'--releasever={self.release_version}'
+            ] + self.custom_args + [
                 'autoremove'
             ] + self.package_requests
             self.cleanup_requests()
@@ -201,7 +208,9 @@ class PackageManagerDnf(PackageManagerBase):
         return Command.call(
             [
                 'chroot', self.root_dir, 'dnf'
-            ] + chroot_dnf_args + self.custom_args + [
+            ] + chroot_dnf_args + [
+                f'--releasever={self.release_version}'
+            ] + self.custom_args + [
                 'upgrade'
             ],
             self.command_env

--- a/kiwi/package_manager/microdnf.py
+++ b/kiwi/package_manager/microdnf.py
@@ -111,7 +111,8 @@ class PackageManagerMicroDnf(PackageManagerBase):
             'microdnf'
         ] + ['--refresh'] + self.dnf_args + [
             '--installroot', self.root_dir,
-            '--releasever=0', '--noplugins',
+            f'--releasever={self.release_version}',
+            '--noplugins',
             '--setopt=cachedir={0}'.format(
                 self.repository.shared_dnf_dir['cache-dir']
             ),
@@ -148,7 +149,9 @@ class PackageManagerMicroDnf(PackageManagerBase):
         )
         microdnf_command = [
             'chroot', self.root_dir, 'microdnf'
-        ] + chroot_dnf_args + self.custom_args + exclude_args + [
+        ] + chroot_dnf_args + [
+            f'--releasever={self.release_version}'
+        ] + self.custom_args + exclude_args + [
             'install'
         ] + self.package_requests
         self.cleanup_requests()
@@ -195,7 +198,9 @@ class PackageManagerMicroDnf(PackageManagerBase):
             chroot_dnf_args = Path.move_to_root(self.root_dir, self.dnf_args)
             dnf_command = [
                 'chroot', self.root_dir, 'microdnf'
-            ] + chroot_dnf_args + self.custom_args + [
+            ] + chroot_dnf_args + [
+                f'--releasever={self.release_version}'
+            ] + self.custom_args + [
                 'remove'
             ] + self.package_requests
             self.cleanup_requests()
@@ -215,7 +220,9 @@ class PackageManagerMicroDnf(PackageManagerBase):
         return Command.call(
             [
                 'chroot', self.root_dir, 'microdnf'
-            ] + chroot_dnf_args + self.custom_args + [
+            ] + chroot_dnf_args + [
+                f'--releasever={self.release_version}'
+            ] + self.custom_args + [
                 'upgrade'
             ],
             self.command_env

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -849,6 +849,20 @@ div {
 }
 
 #==========================================
+# common element <release-version>
+#
+div {
+    k.release-version.content = text
+    k.release-version.attlist = empty
+    k.release-version =
+        ## Name of the Package Manager
+        element release-version {
+            k.release-version.attlist,
+            k.release-version.content
+        }
+}
+
+#==========================================
 # common element <profile>
 #
 div {
@@ -3011,6 +3025,7 @@ div {
             k.keytable? &
             k.locale? &
             k.packagemanager? &
+            k.release-version? &
             k.rpm-locale-filtering? &
             k.rpm-check-signatures? &
             k.rpm-excludedocs? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1307,6 +1307,26 @@ the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
   </div>
   <!--
     ==========================================
+    common element <release-version>
+    
+  -->
+  <div>
+    <define name="k.release-version.content">
+      <text/>
+    </define>
+    <define name="k.release-version.attlist">
+      <empty/>
+    </define>
+    <define name="k.release-version">
+      <element name="release-version">
+        <a:documentation>Name of the Package Manager</a:documentation>
+        <ref name="k.release-version.attlist"/>
+        <ref name="k.release-version.content"/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
     common element <profile>
     
   -->
@@ -4626,6 +4646,9 @@ definition</a:documentation>
           </optional>
           <optional>
             <ref name="k.packagemanager"/>
+          </optional>
+          <optional>
+            <ref name="k.release-version"/>
           </optional>
           <optional>
             <ref name="k.rpm-locale-filtering"/>

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -124,6 +124,7 @@ class SystemPrepare:
         repository_sections = \
             self.xml_state.get_repository_sections_used_for_build()
         package_manager = self.xml_state.get_package_manager()
+        release_version = self.xml_state.get_release_version()
         rpm_locale_list = self.xml_state.get_rpm_locale()
         if self.xml_state.get_rpm_check_signatures():
             repository_options.append('check_signatures')
@@ -199,7 +200,9 @@ class SystemPrepare:
             self.uri_list.append(uri)
         repo.cleanup_unused_repos()
         return PackageManager.new(
-            repo, package_manager
+            repository=repo,
+            package_manager_name=package_manager,
+            release_version=release_version
         )
 
     def install_bootstrap(
@@ -374,9 +377,13 @@ class SystemPrepare:
             try:
                 if manager is None:
                     package_manager = self.xml_state.get_package_manager()
+                    release_version = self.xml_state.get_release_version()
                     manager = PackageManager.new(
-                        Repository.new(self.root_bind, package_manager),
-                        package_manager
+                        repository=Repository.new(
+                            self.root_bind, package_manager
+                        ),
+                        package_manager_name=package_manager,
+                        release_version=release_version
                     )
                 self.delete_packages(
                     manager, to_become_deleted_packages, force
@@ -497,9 +504,11 @@ class SystemPrepare:
         at run time such as macros
         """
         package_manager = self.xml_state.get_package_manager()
+        release_version = self.xml_state.get_release_version()
         manager = PackageManager.new(
-            Repository.new(self.root_bind, package_manager),
-            package_manager
+            repository=Repository.new(self.root_bind, package_manager),
+            package_manager_name=package_manager,
+            release_version=release_version
         )
         manager.clean_leftovers()
 

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.29.24.
-# Python 3.6.13 (default, Mar 10 2021, 18:30:35) [GCC]
+# Python 3.6.12 (default, Dec 02 2020, 09:44:23) [GCC]
 #
 # Command line options:
 #   ('-f', '')
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/david/work/kiwi/.tox/3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/ms/Project/kiwi/.tox/3.6/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -7713,7 +7713,7 @@ class preferences(GeneratedsSuper):
     sections based on profiles combine to create on vaild definition"""
     subclass = None
     superclass = None
-    def __init__(self, profiles=None, arch=None, bootsplash_theme=None, bootloader_theme=None, keytable=None, locale=None, packagemanager=None, rpm_locale_filtering=None, rpm_check_signatures=None, rpm_excludedocs=None, showlicense=None, timezone=None, type_=None, version=None):
+    def __init__(self, profiles=None, arch=None, bootsplash_theme=None, bootloader_theme=None, keytable=None, locale=None, packagemanager=None, release_version=None, rpm_locale_filtering=None, rpm_check_signatures=None, rpm_excludedocs=None, showlicense=None, timezone=None, type_=None, version=None):
         self.original_tagname_ = None
         self.profiles = _cast(None, profiles)
         self.arch = _cast(None, arch)
@@ -7737,6 +7737,10 @@ class preferences(GeneratedsSuper):
             self.packagemanager = []
         else:
             self.packagemanager = packagemanager
+        if release_version is None:
+            self.release_version = []
+        else:
+            self.release_version = release_version
         if rpm_locale_filtering is None:
             self.rpm_locale_filtering = []
         else:
@@ -7801,6 +7805,11 @@ class preferences(GeneratedsSuper):
     def add_packagemanager(self, value): self.packagemanager.append(value)
     def insert_packagemanager_at(self, index, value): self.packagemanager.insert(index, value)
     def replace_packagemanager_at(self, index, value): self.packagemanager[index] = value
+    def get_release_version(self): return self.release_version
+    def set_release_version(self, release_version): self.release_version = release_version
+    def add_release_version(self, value): self.release_version.append(value)
+    def insert_release_version_at(self, index, value): self.release_version.insert(index, value)
+    def replace_release_version_at(self, index, value): self.release_version[index] = value
     def get_rpm_locale_filtering(self): return self.rpm_locale_filtering
     def set_rpm_locale_filtering(self, rpm_locale_filtering): self.rpm_locale_filtering = rpm_locale_filtering
     def add_rpm_locale_filtering(self, value): self.rpm_locale_filtering.append(value)
@@ -7854,6 +7863,7 @@ class preferences(GeneratedsSuper):
             self.keytable or
             self.locale or
             self.packagemanager or
+            self.release_version or
             self.rpm_locale_filtering or
             self.rpm_check_signatures or
             self.rpm_excludedocs or
@@ -7913,6 +7923,9 @@ class preferences(GeneratedsSuper):
         for packagemanager_ in self.packagemanager:
             showIndent(outfile, level, pretty_print)
             outfile.write('<packagemanager>%s</packagemanager>%s' % (self.gds_encode(self.gds_format_string(quote_xml(packagemanager_), input_name='packagemanager')), eol_))
+        for release_version_ in self.release_version:
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<release-version>%s</release-version>%s' % (self.gds_encode(self.gds_format_string(quote_xml(release_version_), input_name='release-version')), eol_))
         for rpm_locale_filtering_ in self.rpm_locale_filtering:
             showIndent(outfile, level, pretty_print)
             outfile.write('<rpm-locale-filtering>%s</rpm-locale-filtering>%s' % (self.gds_format_boolean(rpm_locale_filtering_, input_name='rpm-locale-filtering'), eol_))
@@ -7980,6 +7993,10 @@ class preferences(GeneratedsSuper):
                 packagemanager_ = ""
             packagemanager_ = self.gds_validate_string(packagemanager_, node, 'packagemanager')
             self.packagemanager.append(packagemanager_)
+        elif nodeName_ == 'release-version':
+            release_version_ = child_.text
+            release_version_ = self.gds_validate_string(release_version_, node, 'release_version')
+            self.release_version.append(release_version_)
         elif nodeName_ == 'rpm-locale-filtering':
             sval_ = child_.text
             if sval_ in ('true', '1'):

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -309,6 +309,22 @@ class XMLState:
                 return package_manager[0]
         return Defaults.get_default_package_manager()
 
+    def get_release_version(self) -> str:
+        """
+        Get configured release version from selected preferences section
+
+        :return: Content of the <release-version> section or ''
+
+        :rtype: str
+        """
+        release_version = ''
+        for preferences in self.get_preferences_sections():
+            release_version = preferences.get_release_version()
+            if release_version:
+                release_version = release_version[0]
+                break
+        return release_version
+
     def get_packages_sections(self, section_types: List) -> List:
         """
         List of packages sections matching given section type(s)

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -41,6 +41,7 @@
     <preferences>
         <locale>en_US,de_DE</locale>
         <rpm-locale-filtering>true</rpm-locale-filtering>
+        <release-version>15.3</release-version>
     </preferences>
     <preferences>
         <version>1.13.2</version>

--- a/test/unit/package_manager/dnf_test.py
+++ b/test/unit/package_manager/dnf_test.py
@@ -43,12 +43,16 @@ class TestPackageManagerDnf:
         self.manager.request_collection('collection')
         self.manager.process_install_requests_bootstrap()
         mock_run.assert_called_once_with(
-            ['dnf', '--config', '/root-dir/dnf.conf', '-y', 'makecache']
+            [
+                'dnf', '--config', '/root-dir/dnf.conf', '-y',
+                '--releasever=0', 'makecache'
+            ]
         )
         mock_call.assert_called_once_with(
             [
                 'dnf', '--config', '/root-dir/dnf.conf', '-y',
-                '--installroot', '/root-dir', 'install', 'vim', '@collection'
+                '--installroot', '/root-dir', '--releasever=0',
+                'install', 'vim', '@collection'
             ], ['env']
         )
 
@@ -61,7 +65,8 @@ class TestPackageManagerDnf:
         mock_call.assert_called_once_with(
             [
                 'chroot', '/root-dir', 'dnf', '--config', '/dnf.conf', '-y',
-                '--exclude=skipme', 'install', 'vim', '@collection'
+                '--releasever=0', '--exclude=skipme',
+                'install', 'vim', '@collection'
             ], ['env']
         )
 
@@ -88,7 +93,8 @@ class TestPackageManagerDnf:
         mock_call.assert_called_once_with(
             [
                 'chroot', '/root-dir', 'dnf',
-                '--config', '/dnf.conf', '-y', 'autoremove', 'vim'
+                '--config', '/dnf.conf', '-y',
+                '--releasever=0', 'autoremove', 'vim'
             ],
             ['env']
         )
@@ -112,7 +118,8 @@ class TestPackageManagerDnf:
         mock_call.assert_called_once_with(
             [
                 'chroot', '/root-dir', 'dnf',
-                '--config', '/dnf.conf', '-y', 'upgrade'
+                '--config', '/dnf.conf', '-y',
+                '--releasever=0', 'upgrade'
             ], ['env']
         )
 

--- a/test/unit/package_manager/init_test.py
+++ b/test/unit/package_manager/init_test.py
@@ -17,28 +17,28 @@ class TestPackageManager:
     def test_manager_zypper(self, mock_manager):
         repository = Mock()
         PackageManager.new(repository, 'zypper')
-        mock_manager.assert_called_once_with(repository, None)
+        mock_manager.assert_called_once_with(repository, [], '')
 
     @patch('kiwi.package_manager.dnf.PackageManagerDnf')
     def test_manager_dnf(self, mock_manager):
         repository = Mock()
         PackageManager.new(repository, 'dnf')
-        mock_manager.assert_called_once_with(repository, None)
+        mock_manager.assert_called_once_with(repository, [], '')
 
     @patch('kiwi.package_manager.microdnf.PackageManagerMicroDnf')
     def test_manager_microdnf(self, mock_manager):
         repository = Mock()
         PackageManager.new(repository, 'microdnf')
-        mock_manager.assert_called_once_with(repository, None)
+        mock_manager.assert_called_once_with(repository, [], '')
 
     @patch('kiwi.package_manager.apt.PackageManagerApt')
     def test_manager_apt(self, mock_manager):
         repository = Mock()
         PackageManager.new(repository, 'apt')
-        mock_manager.assert_called_once_with(repository, None)
+        mock_manager.assert_called_once_with(repository, [], '')
 
     @patch('kiwi.package_manager.pacman.PackageManagerPacman')
     def test_manager_pacman(self, mock_manager):
         repository = Mock()
         PackageManager.new(repository, 'pacman')
-        mock_manager.assert_called_once_with(repository, None)
+        mock_manager.assert_called_once_with(repository, [], '')

--- a/test/unit/package_manager/microdnf_test.py
+++ b/test/unit/package_manager/microdnf_test.py
@@ -68,7 +68,7 @@ class TestPackageManagerMicroDnf:
         mock_call.assert_called_once_with(
             [
                 'chroot', '/root-dir', 'microdnf', '--config', '/dnf.conf',
-                '-y', '--exclude=skipme', 'install', 'vim'
+                '-y', '--releasever=0', '--exclude=skipme', 'install', 'vim'
             ], ['env']
         )
 
@@ -95,7 +95,8 @@ class TestPackageManagerMicroDnf:
         mock_call.assert_called_once_with(
             [
                 'chroot', '/root-dir', 'microdnf',
-                '--config', '/dnf.conf', '-y', 'remove', 'vim'
+                '--config', '/dnf.conf', '-y',
+                '--releasever=0', 'remove', 'vim'
             ],
             ['env']
         )
@@ -119,7 +120,7 @@ class TestPackageManagerMicroDnf:
         mock_call.assert_called_once_with(
             [
                 'chroot', '/root-dir', 'microdnf',
-                '--config', '/dnf.conf', '-y', 'upgrade'
+                '--config', '/dnf.conf', '-y', '--releasever=0', 'upgrade'
             ], ['env']
         )
 

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -99,6 +99,9 @@ class TestXMLState:
     def test_get_package_manager(self):
         assert self.state.get_package_manager() == 'zypper'
 
+    def get_release_version(self):
+        assert self.state.get_release_version() == '15.3'
+
     @patch('kiwi.xml_state.XMLState.get_preferences_sections')
     def test_get_default_package_manager(self, mock_preferences):
         mock_preferences.return_value = []


### PR DESCRIPTION
Currently the release version is not set or set to '0' for package managers which requires a value to operate. However, in order to support leveraging the same description across different releases it is important to have the opportunity to specify a setting for the release version. This commit adds a new optional attribute to the preferences section which allows to specify a custom value which serves as the release version:

```xml
<preferences>
    <release_version>TEXT</release_version>
</preferences>
```

If not specified the default setting as before applies. Please note the release version information is currently used in dnf and microdnf package managers only. It might happen that it gets applied to the other package manager backends as well. This will happen on demand though.

Related to Issue #1918. This Fixes #1927


