### PR TITLE
Fix spelling errors in documentation and source code comments

### DIFF
--- a/doc/source/commands/image_info.rst
+++ b/doc/source/commands/image_info.rst
@@ -49,7 +49,7 @@ OPTIONS
 --ignore-repos
 
   Ignore all repository configurations from the XML description.
-  Using that option is usally done with a sequence of --add-repo
+  Using that option is usually done with a sequence of --add-repo
   options otherwise there are no repositories available for the
   processing the requested image information which could lead
   to an error.

--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -100,7 +100,7 @@ OPTIONS
 --ignore-repos
 
   Ignore all repository configurations from the XML description.
-  Using that option is usally done with a sequence of --add-repo
+  Using that option is usually done with a sequence of --add-repo
   options otherwise there are no repositories available for the
   image build which would lead to an error.
 
@@ -164,7 +164,7 @@ OPTIONS
 --signing-key=<key-file>
 
   set the key file to be trusted and imported into the package
-  manager database before performing any opertaion. This is useful
+  manager database before performing any operation. This is useful
   if an image build should take and validate repository and package
   signatures during build time. This option can be specified multiple
   times

--- a/doc/source/commands/system_create.rst
+++ b/doc/source/commands/system_create.rst
@@ -46,7 +46,7 @@ OPTIONS
 --signing-key=<key-file>
 
   set the key file to be trusted and imported into the package
-  manager database before performing any opertaion. This is useful
+  manager database before performing any operation. This is useful
   if an image build should take and validate repository and package
   signatures during build time. In create step this option only
   affects the boot image. This option can be specified multiple

--- a/doc/source/commands/system_prepare.rst
+++ b/doc/source/commands/system_prepare.rst
@@ -97,7 +97,7 @@ OPTIONS
 --ignore-repos
 
   Ignore all repository configurations from the XML description.
-  Using that option is usally done with a sequence of --add-repo
+  Using that option is usually done with a sequence of --add-repo
   options otherwise there are no repositories available for the
   image build which would lead to an error.
 
@@ -165,7 +165,7 @@ OPTIONS
 --signing-key=<key-file>
 
   set the key file to be trusted and imported into the package
-  manager database before performing any opertaion. This is useful
+  manager database before performing any operation. This is useful
   if an image build should take and validate repository and package
   signatures during build time. This option can be specified multiple
   times.

--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -198,7 +198,7 @@ function check_repart_possible {
             warn "==> Free Space on disk: ${disk_free_mbytes} MB"
         else
             # The free space on disk calculated to a very small number.
-            # This usally indicates that the disk geometry was not
+            # This usually indicates that the disk geometry was not
             # intentionally changed and the rest free space is a
             # rounding number on the partition alignment. In this case
             # no warning message is shown because it's the typical


### PR DESCRIPTION
While packaging `kiwi` for Debian, Debian's linter tool `lintian` discovered a number of spelling errors:

```
I: kiwi: typo-in-manual-page usr/share/man/man8/kiwi::image::resize.8.gz "allow to" "allow one to"
I: kiwi: typo-in-manual-page usr/share/man/man8/kiwi::system::build.8.gz "Allow to" "Allow one to"
I: kiwi: typo-in-manual-page usr/share/man/man8/kiwi::system::build.8.gz opertaion operation
I: kiwi: typo-in-manual-page usr/share/man/man8/kiwi::system::build.8.gz usally usually
I: kiwi: typo-in-manual-page usr/share/man/man8/kiwi::system::create.8.gz opertaion operation
I: kiwi: typo-in-manual-page usr/share/man/man8/kiwi::system::prepare.8.gz "allow to" "allow one to"
I: kiwi: typo-in-manual-page usr/share/man/man8/kiwi::system::prepare.8.gz opertaion operation
I: kiwi: typo-in-manual-page usr/share/man/man8/kiwi::system::prepare.8.gz usally usually
```

These two PR fix the obvious spelling errors plus a single spelling error in a source code comment.

The sentences with `allow to` are fine as they currently are.