### PR TITLE
Compress container images in builder class

### DIFF
--- a/kiwi.yml
+++ b/kiwi.yml
@@ -39,9 +39,9 @@
 
 # Setup process parameters for container image creation
 #container:
-#  # Specify compression algorithm for container images
-#  # Possible values are xz or none
-#  - compress: xz
+#  # Specify compression for container images
+#  # Possible values are true, false, xz or none.
+#  - compress: true
 
 
 # Setup process parameters for ISO image creation

--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -152,7 +152,7 @@ class ContainerBuilder:
             key='container',
             filename=self.filename,
             use_for_bundle=True,
-            compress=False,
+            compress=self.runtime_config.get_container_compression(),
             shasum=True
         )
         self.result.add(

--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -20,9 +20,7 @@ import logging
 
 # project
 from kiwi.defaults import Defaults
-from kiwi.runtime_config import RuntimeConfig
 from kiwi.oci_tools import OCI
-from kiwi.utils.compress import Compress
 
 log = logging.getLogger('kiwi')
 
@@ -67,8 +65,6 @@ class ContainerImageOCI:
             self.oci_config = custom_args
         else:
             self.oci_config = {}
-
-        self.runtime_config = RuntimeConfig()
 
         # for builds inside the buildservice we include a reference to the
         # specific build. Thus disturl label only exists inside the
@@ -160,11 +156,7 @@ class ContainerImageOCI:
             filename, self.archive_transport, image_ref, additional_refs
         )
 
-        if self.runtime_config.get_container_compression():
-            compressor = Compress(filename)
-            return compressor.xz(self.runtime_config.get_xz_options())
-        else:
-            return filename
+        return filename
 
     def _append_buildservice_disturl_label(self):
         with open(os.sep + Defaults.get_buildservice_env_name()) as env:

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1632,13 +1632,13 @@ class Defaults:
     @staticmethod
     def get_container_compression():
         """
-        Provides default container compression algorithm
+        Provides default container compression
 
-        :return: name
+        :return: True
 
-        :rtype: str
+        :rtype: bool
         """
-        return 'xz'
+        return True
 
     @staticmethod
     def get_default_container_name():

--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -231,27 +231,27 @@ class RuntimeConfig:
 
     def get_container_compression(self):
         """
-        Return compression algorithm to use for compression of container images
+        Return compression for container images
 
         container:
-          - compress: xz|none
+          - compress: xz|none|true|false
 
         if no or invalid configuration data is provided, the default
-        compression algorithm from the Defaults class is returned
+        compression from the Defaults class is returned
 
-        :return: A name
+        :return: True or False
 
-        :rtype: str
+        :rtype: bool
         """
         container_compression = self._get_attribute(
             element='container', attribute='compress'
         )
-        if not container_compression:
+        if container_compression is None:
             return Defaults.get_container_compression()
-        elif 'xz' in container_compression:
-            return container_compression
-        elif 'none' in container_compression:
-            return None
+        elif 'xz' == container_compression or container_compression is True:
+            return True
+        elif 'none' == container_compression or container_compression is False:
+            return False
         else:
             log.warning(
                 'Skipping invalid container compression: {0}'.format(

--- a/test/data/kiwi_config/other/.config/kiwi/config.yml
+++ b/test/data/kiwi_config/other/.config/kiwi/config.yml
@@ -2,4 +2,4 @@ bundle:
   - has_package_changes: true
 
 container:
-  - compress: xz
+  - compress: true

--- a/test/unit/builder/container_test.py
+++ b/test/unit/builder/container_test.py
@@ -18,6 +18,9 @@ class TestContainerBuilder:
         self.runtime_config.get_max_size_constraint = mock.Mock(
             return_value=None
         )
+        self.runtime_config.get_container_compression = mock.Mock(
+            return_value=True
+        )
         kiwi.builder.container.RuntimeConfig = mock.Mock(
             return_value=self.runtime_config
         )
@@ -119,7 +122,7 @@ class TestContainerBuilder:
         mock_setup.new.return_value = container_setup
         container_image = mock.Mock()
         container_image.create = mock.Mock(
-            return_value='target_dir/image_name.x86_64-1.2.3.docker.tar.xz'
+            return_value='target_dir/image_name.x86_64-1.2.3.docker.tar'
         )
         mock_image.new.return_value = container_image
         self.setup.export_package_verification.return_value = '.verified'
@@ -140,9 +143,9 @@ class TestContainerBuilder:
         assert self.container.result.add.call_args_list == [
             call(
                 key='container',
-                filename='target_dir/image_name.x86_64-1.2.3.docker.tar.xz',
+                filename='target_dir/image_name.x86_64-1.2.3.docker.tar',
                 use_for_bundle=True,
-                compress=False,
+                compress=True,
                 shasum=True
             ),
             call(
@@ -190,7 +193,7 @@ class TestContainerBuilder:
 
         container_image = mock.Mock()
         container_image.create = mock.Mock(
-            return_value='target_dir/image_name.x86_64-1.2.3.docker.tar.xz'
+            return_value='target_dir/image_name.x86_64-1.2.3.docker.tar'
         )
         mock_image.new.return_value = container_image
 
@@ -226,9 +229,9 @@ class TestContainerBuilder:
         assert container.result.add.call_args_list == [
             call(
                 key='container',
-                filename='target_dir/image_name.x86_64-1.2.3.docker.tar.xz',
+                filename='target_dir/image_name.x86_64-1.2.3.docker.tar',
                 use_for_bundle=True,
-                compress=False,
+                compress=True,
                 shasum=True
             ),
             call(

--- a/test/unit/container/oci_test.py
+++ b/test/unit/container/oci_test.py
@@ -159,11 +159,10 @@ class TestContainerImageOCI:
             'result.tar', 'oci-archive', 'latest', []
         )
 
-    @patch('kiwi.container.oci.Compress')
     @patch('kiwi.container.oci.OCI')
     @patch('kiwi.container.oci.Defaults.get_shared_cache_location')
     def test_create_derived_docker_archive(
-        self, mock_cache, mock_OCI, mock_compress
+        self, mock_cache, mock_OCI
     ):
         mock_cache.return_value = 'var/cache/kiwi'
         mock_oci = mock.Mock()
@@ -200,5 +199,3 @@ class TestContainerImageOCI:
             'result.tar', 'docker-archive', 'foo/bar:latest',
             ['foo/bar:current', 'foo/bar:foobar']
         )
-
-        mock_compress.assert_called_once_with('result.tar')

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -59,7 +59,7 @@ class TestRuntimeConfig:
             'http://example.com'
         assert runtime_config.get_obs_api_server_url() == \
             'https://api.example.com'
-        assert runtime_config.get_container_compression() is None
+        assert runtime_config.get_container_compression() is False
         assert runtime_config.get_iso_tool_category() == 'xorriso'
         assert runtime_config.get_oci_archive_tool() == 'umoci'
         assert runtime_config.get_package_changes() is True
@@ -84,7 +84,7 @@ class TestRuntimeConfig:
             Defaults.get_obs_download_server_url()
         assert runtime_config.get_obs_api_server_url() == \
             Defaults.get_obs_api_server_url()
-        assert runtime_config.get_container_compression() == 'xz'
+        assert runtime_config.get_container_compression() is True
         assert runtime_config.get_iso_tool_category() == 'xorriso'
         assert runtime_config.get_oci_archive_tool() == 'umoci'
         assert runtime_config.get_package_changes() is False
@@ -94,7 +94,7 @@ class TestRuntimeConfig:
             runtime_config = RuntimeConfig(reread=True)
 
         with self._caplog.at_level(logging.WARNING):
-            assert runtime_config.get_container_compression() == 'xz'
+            assert runtime_config.get_container_compression() is True
             assert 'Skipping invalid container compression: foo' in \
                 self._caplog.text
         with self._caplog.at_level(logging.WARNING):
@@ -106,5 +106,5 @@ class TestRuntimeConfig:
         with patch.dict('os.environ', {'HOME': '../data/kiwi_config/other'}):
             runtime_config = RuntimeConfig(reread=True)
 
-        assert runtime_config.get_container_compression() == 'xz'
+        assert runtime_config.get_container_compression() is True
         assert runtime_config.get_package_changes() is True


### PR DESCRIPTION
This commit changes the stage at which container images are compressed
to match the criteria applied to other image types. Instead of
compressing the image in OCI devoted classes now it is happening
in builder class by setting Result instance properties.

Fixes #1996

Signed-off-by: David Cassany <dcassany@suse.com>
