### PR TITLE
Disable intersphinx

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,8 +31,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx',
+    'sphinx.ext.autodoc'
 ]
 
 docopt_ignore = [
@@ -291,8 +290,6 @@ man_pages = [
         8
     )
 ]
-
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # If true, show URL addresses after external links.
 #man_show_urls = False


### PR DESCRIPTION
intersphinx is a doc extension which links to the documentation of
objects in other projects whenever Sphinx encounters a cross-reference
that has no matching target in the current documentation set, it
looks for targets in the documentation sets configured in the
intersphinx_mapping. However, the kiwi docs do not use this feature
thus it can be disabled.

