### PR TITLE
Added support for collection modules

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -1027,7 +1027,7 @@ any of its required packages and any recommended packages.
 
 .. note:: Collections on SUSE
 
-   On SUSE based distributions collections are names patterns and are
+   On SUSE based distributions collections are called `patterns` and are
    just simple packages. To get the names of the patterns such that
    they can be used in a namedCollection type the following command:
    `$ zypper patterns`. If for some reason the collection name cannot
@@ -1039,10 +1039,41 @@ any of its required packages and any recommended packages.
 
 .. note:: Collections on RedHat
 
-   On RedHat based distributions collections are named groups and are
+   On RedHat based distributions collections are called `groups` and are
    extra metadata. To get the names of these groups type the following
    command: `$ dnf group list`. Please note that group names are allowed
    to contain whitespace characters.
+
+<packages><collectionModule>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. code:: xml
+
+   <packages type="bootstrap">
+       <collectionModule name="module" stream="stream" enable="true|false"/>
+   </packages>
+
+In CentOS Stream >= 8 and Red Hat Enterprise Linux >= 8, there are
+Application Streams that are offered in the form of modules
+(using Fedora Modularity technology). To build images that use
+this content {kiwi} offers to enable/disable modules when using
+the `dnf` or `microdnf` package manager backend. Modules are setup
+prior the bootstrap phase and its setup persists as part of the
+image.
+
+There are the following constraints when adding `collectionModule`
+elements:
+
+* `collectionModule` elements can only be specified as part of the
+  `<packages type="bootstrap">` section. This is because the setup of
+  modules must be done once and as early as possible in the process
+  of installing the image root tree.
+
+* Disabling a module can only be done as a whole and therefore the
+  `stream` attribute is not allowed for disabling modules. For
+  enabling modules the stream` attribute is optional
+
+* The `enable` attribute is mandatory because it should be an explicit
+  setting if a module is effectively used or not.
 
 <packages><archive>
 ~~~~~~~~~~~~~~~~~~~

--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -18,7 +18,9 @@
 import re
 import os
 import logging
-from typing import List
+from typing import (
+    List, Dict
+)
 
 # project
 from kiwi.command import command_call_type
@@ -108,6 +110,17 @@ class PackageManagerApt(PackageManagerBase):
         log.warning(
             'Package exclusion for (%s) not supported for apt-get', name
         )
+
+    def setup_repository_modules(
+        self, collection_modules: Dict[str, List[str]]
+    ) -> None:
+        """
+        Repository modules not supported for apt-get
+        The method does nothing in this scope
+
+        :param dict collection_modules: unused
+        """
+        pass
 
     def process_install_requests_bootstrap(
         self, root_bind: RootBind = None

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -15,7 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-from typing import List
+from typing import (
+    List, Dict
+)
 
 from kiwi.api_helper import decommissioned
 from kiwi.command import command_call_type
@@ -98,6 +100,18 @@ class PackageManagerBase:
         Implementation in specialized package manager class
 
         :param str name: unused
+        """
+        raise NotImplementedError
+
+    def setup_repository_modules(
+        self, collection_modules: Dict[str, List[str]]
+    ) -> None:
+        """
+        Setup repository modules and streams
+
+        Implementation in specialized package manager class
+
+        :param dict collection_modules: unused
         """
         raise NotImplementedError
 

--- a/kiwi/package_manager/pacman.py
+++ b/kiwi/package_manager/pacman.py
@@ -17,7 +17,9 @@
 #
 import re
 import logging
-from typing import List
+from typing import (
+    List, Dict
+)
 
 # project
 from kiwi.command import command_call_type
@@ -96,6 +98,17 @@ class PackageManagerPacman(PackageManagerBase):
         :param str name: package name
         """
         self.exclude_requests.append(name)
+
+    def setup_repository_modules(
+        self, collection_modules: Dict[str, List[str]]
+    ) -> None:
+        """
+        Repository modules not supported for pacman.
+        The method does nothing in this scope
+
+        :param dict collection_modules: unused
+        """
+        pass
 
     def process_install_requests_bootstrap(
         self, root_bind: RootBind = None

--- a/kiwi/package_manager/zypper.py
+++ b/kiwi/package_manager/zypper.py
@@ -17,7 +17,9 @@
 #
 import re
 import os
-from typing import List
+from typing import (
+    List, Dict
+)
 
 
 # project
@@ -98,6 +100,17 @@ class PackageManagerZypper(PackageManagerBase):
         :param str name: package name
         """
         self.exclude_requests.append(name)
+
+    def setup_repository_modules(
+        self, collection_modules: Dict[str, List[str]]
+    ) -> None:
+        """
+        Repository modules not supported for zypper.
+        The method does nothing in this scope
+
+        :param dict collection_modules: unused
+        """
+        pass
 
     def process_install_requests_bootstrap(
         self, root_bind: RootBind = None

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -363,6 +363,53 @@ div {
         }
 }
 
+
+#==========================================
+# common element <collectionModule>
+#
+div {
+    sch:pattern [
+        id = "collection_module_scope"
+        sch:rule [
+            context = "collectionModule"
+            sch:assert [
+                test = "../@type='bootstrap'"
+                "collectionModule is only available in the bootstrap "~
+                "packages section"
+            ]
+        ]
+    ]
+    sch:pattern [
+        id = "collection_module_disable_constraint"
+        sch:rule [
+            context = "collectionModule"
+            sch:assert [
+                test = "@enable='true' or not(@stream)"
+                "@stream attribute is not allowed to disable a module"
+            ]
+        ]
+    ]
+    k.collectionModule.name.attribute =
+        attribute name { safe-posix-name }
+    k.collectionModule.stream.attribute =
+        attribute stream { safe-posix-name }
+    k.collectionModule.arch.attribute = k.arch.attribute
+    k.collectionModule.enable.attribute =
+        ## Specify the module to become enabled (for the optionally
+        ## given stream) or disabled.
+        attribute enable { xsd:boolean }
+    k.collectionModule.attlist =
+        k.collectionModule.name.attribute &
+        k.collectionModule.enable.attribute &
+        k.collectionModule.stream.attribute? &
+        k.collectionModule.arch.attribute?
+    k.collectionModule =
+        element collectionModule {
+            k.collectionModule.attlist,
+            empty
+        }
+}
+
 #==========================================
 # common element <oem-boot-title>
 #
@@ -2999,6 +3046,7 @@ div {
             k.archive* &
             k.ignore* &
             k.namedCollection* &
+            k.collectionModule* &
             k.product* &
             k.package*
         }

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -627,6 +627,61 @@ file was fetched</a:documentation>
   </div>
   <!--
     ==========================================
+    common element <collectionModule>
+    
+  -->
+  <div>
+    <sch:pattern id="collection_module_scope">
+      <sch:rule context="collectionModule">
+        <sch:assert test="../@type='bootstrap'">collectionModule is only available in the bootstrap packages section</sch:assert>
+      </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="collection_module_disable_constraint">
+      <sch:rule context="collectionModule">
+        <sch:assert test="@enable='true' or not(@stream)">@stream attribute is not allowed to disable a module</sch:assert>
+      </sch:rule>
+    </sch:pattern>
+    <define name="k.collectionModule.name.attribute">
+      <attribute name="name">
+        <ref name="safe-posix-name"/>
+      </attribute>
+    </define>
+    <define name="k.collectionModule.stream.attribute">
+      <attribute name="stream">
+        <ref name="safe-posix-name"/>
+      </attribute>
+    </define>
+    <define name="k.collectionModule.arch.attribute">
+      <ref name="k.arch.attribute"/>
+    </define>
+    <define name="k.collectionModule.enable.attribute">
+      <attribute name="enable">
+        <a:documentation>Specify the module to become enabled (for the optionally
+given stream) or disabled.</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+    </define>
+    <define name="k.collectionModule.attlist">
+      <interleave>
+        <ref name="k.collectionModule.name.attribute"/>
+        <ref name="k.collectionModule.enable.attribute"/>
+        <optional>
+          <ref name="k.collectionModule.stream.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.collectionModule.arch.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="k.collectionModule">
+      <element name="collectionModule">
+        <ref name="k.collectionModule.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
     common element <oem-boot-title>
     
   -->
@@ -4591,6 +4646,9 @@ or plusRecommended</a:documentation>
           </zeroOrMore>
           <zeroOrMore>
             <ref name="k.namedCollection"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="k.collectionModule"/>
           </zeroOrMore>
           <zeroOrMore>
             <ref name="k.product"/>

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -246,6 +246,9 @@ class SystemPrepare:
             bootstrap_collections,
             bootstrap_products
         )
+        manager.setup_repository_modules(
+            self.xml_state.get_collection_modules()
+        )
         process = CommandProcess(
             command=manager.process_install_requests_bootstrap(self.root_bind),
             log_topic='bootstrap'

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.29.24.
-# Python 3.6.12 (default, Dec 02 2020, 09:44:23) [GCC]
+# Python 3.6.13 (default, Mar 10 2021, 18:30:35) [GCC]
 #
 # Command line options:
 #   ('-f', '')
@@ -1547,6 +1547,130 @@ class namedCollection(GeneratedsSuper):
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class namedCollection
+
+
+class collectionModule(GeneratedsSuper):
+    subclass = None
+    superclass = None
+    def __init__(self, name=None, enable=None, stream=None, arch=None):
+        self.original_tagname_ = None
+        self.name = _cast(None, name)
+        self.enable = _cast(bool, enable)
+        self.stream = _cast(None, stream)
+        self.arch = _cast(None, arch)
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, collectionModule)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if collectionModule.subclass:
+            return collectionModule.subclass(*args_, **kwargs_)
+        else:
+            return collectionModule(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_name(self): return self.name
+    def set_name(self, name): self.name = name
+    def get_enable(self): return self.enable
+    def set_enable(self, enable): self.enable = enable
+    def get_stream(self): return self.stream
+    def set_stream(self, stream): self.stream = stream
+    def get_arch(self): return self.arch
+    def set_arch(self, arch): self.arch = arch
+    def validate_safe_posix_name(self, value):
+        # Validate type safe-posix-name, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_safe_posix_name_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_safe_posix_name_patterns_, ))
+    validate_safe_posix_name_patterns_ = [['^[a-zA-Z0-9_\\-\\.]+$']]
+    def validate_arch_name(self, value):
+        # Validate type arch-name, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_arch_name_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_arch_name_patterns_, ))
+    validate_arch_name_patterns_ = [['^.*$']]
+    def hasContent_(self):
+        if (
+
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', name_='collectionModule', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('collectionModule')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='collectionModule')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='collectionModule', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='collectionModule'):
+        if self.name is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            outfile.write(' name=%s' % (quote_attrib(self.name), ))
+        if self.enable is not None and 'enable' not in already_processed:
+            already_processed.add('enable')
+            outfile.write(' enable="%s"' % self.gds_format_boolean(self.enable, input_name='enable'))
+        if self.stream is not None and 'stream' not in already_processed:
+            already_processed.add('stream')
+            outfile.write(' stream=%s' % (quote_attrib(self.stream), ))
+        if self.arch is not None and 'arch' not in already_processed:
+            already_processed.add('arch')
+            outfile.write(' arch=%s' % (quote_attrib(self.arch), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='collectionModule', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('name', node)
+        if value is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            self.name = value
+            self.name = ' '.join(self.name.split())
+            self.validate_safe_posix_name(self.name)    # validate type safe-posix-name
+        value = find_attr_value_('enable', node)
+        if value is not None and 'enable' not in already_processed:
+            already_processed.add('enable')
+            if value in ('true', '1'):
+                self.enable = True
+            elif value in ('false', '0'):
+                self.enable = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
+        value = find_attr_value_('stream', node)
+        if value is not None and 'stream' not in already_processed:
+            already_processed.add('stream')
+            self.stream = value
+            self.stream = ' '.join(self.stream.split())
+            self.validate_safe_posix_name(self.stream)    # validate type safe-posix-name
+        value = find_attr_value_('arch', node)
+        if value is not None and 'arch' not in already_processed:
+            already_processed.add('arch')
+            self.arch = value
+            self.arch = ' '.join(self.arch.split())
+            self.validate_arch_name(self.arch)    # validate type arch-name
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        pass
+# end class collectionModule
 
 
 class product(GeneratedsSuper):
@@ -7532,7 +7656,7 @@ class packages(GeneratedsSuper):
     """Specifies Packages/Patterns Used in Different Stages"""
     subclass = None
     superclass = None
-    def __init__(self, type_=None, profiles=None, patternType=None, archive=None, ignore=None, namedCollection=None, product=None, package=None):
+    def __init__(self, type_=None, profiles=None, patternType=None, archive=None, ignore=None, namedCollection=None, collectionModule=None, product=None, package=None):
         self.original_tagname_ = None
         self.type_ = _cast(None, type_)
         self.profiles = _cast(None, profiles)
@@ -7549,6 +7673,10 @@ class packages(GeneratedsSuper):
             self.namedCollection = []
         else:
             self.namedCollection = namedCollection
+        if collectionModule is None:
+            self.collectionModule = []
+        else:
+            self.collectionModule = collectionModule
         if product is None:
             self.product = []
         else:
@@ -7583,6 +7711,11 @@ class packages(GeneratedsSuper):
     def add_namedCollection(self, value): self.namedCollection.append(value)
     def insert_namedCollection_at(self, index, value): self.namedCollection.insert(index, value)
     def replace_namedCollection_at(self, index, value): self.namedCollection[index] = value
+    def get_collectionModule(self): return self.collectionModule
+    def set_collectionModule(self, collectionModule): self.collectionModule = collectionModule
+    def add_collectionModule(self, value): self.collectionModule.append(value)
+    def insert_collectionModule_at(self, index, value): self.collectionModule.insert(index, value)
+    def replace_collectionModule_at(self, index, value): self.collectionModule[index] = value
     def get_product(self): return self.product
     def set_product(self, product): self.product = product
     def add_product(self, value): self.product.append(value)
@@ -7604,6 +7737,7 @@ class packages(GeneratedsSuper):
             self.archive or
             self.ignore or
             self.namedCollection or
+            self.collectionModule or
             self.product or
             self.package
         ):
@@ -7652,6 +7786,8 @@ class packages(GeneratedsSuper):
             ignore_.export(outfile, level, namespaceprefix_, name_='ignore', pretty_print=pretty_print)
         for namedCollection_ in self.namedCollection:
             namedCollection_.export(outfile, level, namespaceprefix_, name_='namedCollection', pretty_print=pretty_print)
+        for collectionModule_ in self.collectionModule:
+            collectionModule_.export(outfile, level, namespaceprefix_, name_='collectionModule', pretty_print=pretty_print)
         for product_ in self.product:
             product_.export(outfile, level, namespaceprefix_, name_='product', pretty_print=pretty_print)
         for package_ in self.package:
@@ -7694,6 +7830,11 @@ class packages(GeneratedsSuper):
             obj_.build(child_)
             self.namedCollection.append(obj_)
             obj_.original_tagname_ = 'namedCollection'
+        elif nodeName_ == 'collectionModule':
+            obj_ = collectionModule.factory()
+            obj_.build(child_)
+            self.collectionModule.append(obj_)
+            obj_.original_tagname_ = 'collectionModule'
         elif nodeName_ == 'product':
             obj_ = product.factory()
             obj_.build(child_)
@@ -8349,6 +8490,7 @@ __all__ = [
     "archive",
     "argument",
     "bootloader",
+    "collectionModule",
     "containerconfig",
     "description",
     "dracut",

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -623,6 +623,43 @@ class XMLState:
         """
         return self.get_collection_type('image')
 
+    def get_collection_modules(self) -> Dict[str, List[str]]:
+        """
+        Dict of collection modules to enable and/or disable
+
+        :return:
+            Dict of the form:
+
+            .. code:: python
+
+                {
+                    'enable': [
+                        "module:stream", "module"
+                    ],
+                    'disable': [
+                        "module"
+                    ]
+                }
+
+        :rtype: dict
+        """
+        modules: Dict[str, List[str]] = {
+            'disable': [],
+            'enable': []
+        }
+        for packages in self.get_bootstrap_packages_sections():
+            for collection_module in packages.get_collectionModule():
+                module_name = collection_module.get_name()
+                if collection_module.get_enable() is False:
+                    modules['disable'].append(module_name)
+                else:
+                    stream = collection_module.get_stream()
+                    if stream:
+                        modules['enable'].append(f'{module_name}:{stream}')
+                    else:
+                        modules['enable'].append(module_name)
+        return modules
+
     def get_collections(self, section_type: str = 'image') -> List:
         """
         List of collection names from the packages sections matching

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -215,6 +215,9 @@
         <ignore name="baz"/>
     </packages>
     <packages type="bootstrap">
+        <collectionModule name="mod_a" stream="stream" enable="true"/>
+        <collectionModule name="mod_b" enable="true"/>
+        <collectionModule name="mod_c" enable="false"/>
         <package name="filesystem"/>
         <namedCollection name="bootstrap-collection"/>
         <product name="kiwi"/>

--- a/test/unit/package_manager/apt_test.py
+++ b/test/unit/package_manager/apt_test.py
@@ -56,6 +56,9 @@ class TestPackageManagerApt:
         with self._caplog.at_level(logging.WARNING):
             assert self.manager.exclude_requests == []
 
+    def test_setup_repository_modules(self):
+        self.manager.setup_repository_modules({})
+
     def test_process_install_requests_bootstrap_no_dist(self):
         self.manager.distribution = None
         with raises(KiwiDebootstrapError):

--- a/test/unit/package_manager/base_test.py
+++ b/test/unit/package_manager/base_test.py
@@ -30,6 +30,10 @@ class TestPackageManagerBase:
         with raises(NotImplementedError):
             self.manager.request_package_exclusion('name')
 
+    def test_setup_repository_modules(self):
+        with raises(NotImplementedError):
+            self.manager.setup_repository_modules({})
+
     def test_process_install_requests_bootstrap(self):
         with raises(NotImplementedError):
             self.manager.process_install_requests_bootstrap()

--- a/test/unit/package_manager/microdnf_test.py
+++ b/test/unit/package_manager/microdnf_test.py
@@ -1,4 +1,6 @@
-from mock import patch
+from mock import (
+    patch, call
+)
 from pytest import raises
 import mock
 
@@ -41,6 +43,49 @@ class TestPackageManagerMicroDnf:
     def test_request_package_exclusion(self):
         self.manager.request_package_exclusion('name')
         assert self.manager.exclude_requests == ['name']
+
+    @patch('kiwi.command.Command.run')
+    def test_setup_repository_modules(self, mock_run):
+        self.manager.setup_repository_modules(
+            {
+                'disable': ['mod_c'],
+                'enable': ['mod_a:stream', 'mod_b']
+            }
+        )
+        microdnf_call_args = [
+            'microdnf', '--refresh', '--config', '/root-dir/dnf.conf',
+            '-y', '--installroot', '/root-dir', '--releasever=0',
+            '--noplugins', '--setopt=cachedir=cache',
+            '--setopt=reposdir=repos',
+            '--setopt=varsdir=vars'
+        ]
+        assert mock_run.call_args_list == [
+            call(
+                microdnf_call_args + [
+                    'module', 'disable', 'mod_c'
+                ], ['env']
+            ),
+            call(
+                microdnf_call_args + [
+                    'module', 'reset', 'mod_a'
+                ], ['env']
+            ),
+            call(
+                microdnf_call_args + [
+                    'module', 'enable', 'mod_a:stream'
+                ], ['env']
+            ),
+            call(
+                microdnf_call_args + [
+                    'module', 'reset', 'mod_b'
+                ], ['env']
+            ),
+            call(
+                microdnf_call_args + [
+                    'module', 'enable', 'mod_b'
+                ], ['env']
+            )
+        ]
 
     @patch('kiwi.command.Command.call')
     @patch('kiwi.command.Command.run')

--- a/test/unit/package_manager/pacman_test.py
+++ b/test/unit/package_manager/pacman_test.py
@@ -1,5 +1,7 @@
 from mock import patch, call
-from pytest import raises
+from pytest import (
+    raises, fixture
+)
 import mock
 
 from kiwi.package_manager.pacman import PackageManagerPacman
@@ -8,6 +10,10 @@ from kiwi.exceptions import KiwiRequestError
 
 
 class TestPackageManagerPacman:
+    @fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self._caplog = caplog
+
     def setup(self):
         repository = mock.Mock()
         repository.root_dir = '/root-dir'
@@ -38,6 +44,9 @@ class TestPackageManagerPacman:
     def test_request_package_exclusion(self):
         self.manager.request_package_exclusion('name')
         assert self.manager.exclude_requests == ['name']
+
+    def test_setup_repository_modules(self):
+        self.manager.setup_repository_modules({})
 
     @patch('kiwi.command.Command.call')
     @patch('kiwi.command.Command.run')

--- a/test/unit/package_manager/zypper_test.py
+++ b/test/unit/package_manager/zypper_test.py
@@ -48,6 +48,9 @@ class TestPackageManagerZypper:
         self.manager.request_package_exclusion('name')
         assert self.manager.exclude_requests == ['name']
 
+    def test_setup_repository_modules(self):
+        self.manager.setup_repository_modules({})
+
     @patch('kiwi.command.Command.call')
     def test_process_install_requests_bootstrap(self, mock_call):
         self.manager.request_package('vim')

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -293,6 +293,9 @@ class TestSystemPrepare:
         self.manager.request_product.assert_called_once_with(
             'kiwi'
         )
+        self.manager.setup_repository_modules.assert_called_once_with(
+            {'disable': ['mod_c'], 'enable': ['mod_a:stream', 'mod_b']}
+        )
         self.manager.process_install_requests_bootstrap.assert_called_once_with(
             self.system.root_bind
         )

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1024,3 +1024,9 @@ class TestXMLState:
         state = XMLState(xml_data)
         assert state.xml_data.get_repository()[0].get_source().get_path() \
             == 'dir://{0}/my_repo'.format(os.path.realpath('../data'))
+
+    def test_get_collection_modules(self):
+        assert self.state.get_collection_modules() == {
+            'disable': ['mod_c'],
+            'enable': ['mod_a:stream', 'mod_b']
+        }


### PR DESCRIPTION
In CentOS Stream 8 and Red Hat Enterprise Linux 8, there are
Application Streams that are offered in the form of modules
(using Fedora Modularity technology). To build images that use
this content KIWI needs to support to enable/disable various
modules. This commit allows to configure collection modules
in a new element as shown below

```xml
<packages type="bootstrap">
    <collectionModule name="module" stream="stream" enable="true|false"/>
</packages>
```

This Fixes Issue #1999


