### PR TITLE
index.rst: Change title (bsc#1189294#c2)

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,7 +1,7 @@
 .. kiwi documentation master file
 
 Building Linux System Appliances with {kiwi-product} |version|
-=================================================================
+==============================================================================
 
 .. note::
    This documentation covers {kiwi-product} |version|- the command line

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,7 +1,7 @@
 .. kiwi documentation master file
 
-Building Linux System Appliances with {kiwi-product} |version|)
-===============================================================
+Building Linux System Appliances with {kiwi-product} |version|
+=================================================================
 
 .. note::
    This documentation covers {kiwi-product} |version|- the command line

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,7 +1,7 @@
 .. kiwi documentation master file
 
-{kiwi} Documentation
-=====================
+Building Linux System Appliances with {kiwi-product} |version|)
+===============================================================
 
 .. note::
    This documentation covers {kiwi-product} |version|- the command line


### PR DESCRIPTION
Reference: bsc#1189294#c2 

Changes proposed in this pull request:
* title change: 'KIWI NG 9: KIWI NG Documentation' -> 'Building Linux System Appliances with KIWI Next Generation (KIWI NG <VERSION>)
* suggested in  for more clarity

The change has been discussed with and approved by main author (@schaefi) upfront.
