### PR TITLE
Pass custom boostrap packages to builtin_kiwi initrd

### DIFF
--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -218,7 +218,7 @@ class BootImageBase:
             )
         )
 
-    def prepare(self) -> None:
+    def prepare(self, plus_packages=None) -> None:
         """
         Prepare new root system to create initrd from. Implementation
         is only needed if there is no other root system available

--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -68,7 +68,7 @@ class BootImageKiwi(BootImageBase):
         self.temp_directories: List[str] = []
         self.load_boot_xml_description()
 
-    def prepare(self) -> None:
+    def prepare(self, plus_packages=None) -> None:
         """
         Prepare new root system suitable to create a kiwi initrd from it
         """
@@ -94,7 +94,7 @@ class BootImageKiwi(BootImageBase):
                 signing_keys=self.signing_keys, target_arch=self.target_arch
             )
             system.install_bootstrap(
-                manager
+                manager, plus_packages
             )
             system.install_system(
                 manager

--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -151,7 +151,7 @@ class BootImageDracut(BootImageBase):
             with open(config_file, 'w') as config_handle:
                 config_handle.writelines(dracut_config)
 
-    def prepare(self) -> None:
+    def prepare(self, plus_packages=None) -> None:
         """
         Prepare dracut caller environment
 

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -129,6 +129,10 @@ class DiskBuilder:
         if custom_args and 'signing_keys' in custom_args:
             self.signing_keys = custom_args['signing_keys']
 
+        self.add_bootstrap_package = None
+        if custom_args and 'add_bootstrap_package' in custom_args:
+            self.add_bootstrap_package = custom_args['add_bootstrap_package']
+
         self.boot_image = BootImage.new(
             xml_state, target_dir, root_dir, signing_keys=self.signing_keys
         )
@@ -232,7 +236,7 @@ class DiskBuilder:
         # prepare initrd
         if self.boot_image.has_initrd_support():
             log.info('Preparing boot system')
-            self.boot_image.prepare()
+            self.boot_image.prepare(self.add_bootstrap_package)
 
         # precalculate needed disk size
         disksize_mbytes = self.disk_setup.get_disksize_mbytes()

--- a/kiwi/builder/kis.py
+++ b/kiwi/builder/kis.py
@@ -72,6 +72,9 @@ class KisBuilder:
         self.xz_options = custom_args['xz_options'] if custom_args \
             and 'xz_options' in custom_args else None
 
+        self.add_bootstrap_package = custom_args['add_bootstrap_package'] if custom_args \
+            and 'add_bootstrap_package' in custom_args else None
+
         self.boot_image_task = BootImage.new(
             xml_state, target_dir, root_dir,
             signing_keys=self.boot_signing_keys
@@ -134,7 +137,7 @@ class KisBuilder:
         # prepare initrd
         if self.boot_image_task.has_initrd_support():
             log.info('Creating boot image')
-            self.boot_image_task.prepare()
+            self.boot_image_task.prepare(self.add_bootstrap_package)
 
         # export modprobe configuration to boot image
         self.system_setup.export_modprobe_setup(

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -286,7 +286,8 @@ class SystemBuildTask(CliTask):
                 'signing_keys': self.command_args[
                     '--signing-key'
                 ] + self.xml_state.get_repositories_signing_keys(),
-                'xz_options': self.runtime_config.get_xz_options()
+                'xz_options': self.runtime_config.get_xz_options(),
+                'add_bootstrap_package': self.command_args['--add-bootstrap-package']
             }
         )
         result = image_builder.create()

--- a/test/unit/boot/image/builtin_kiwi_test.py
+++ b/test/unit/boot/image/builtin_kiwi_test.py
@@ -67,7 +67,7 @@ class TestBootImageKiwi:
             signing_keys=None, target_arch=None
         )
         self.system_prepare.install_bootstrap.assert_called_once_with(
-            self.manager
+            self.manager, None
         )
         self.system_prepare.install_system.assert_called_once_with(
             self.manager

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -350,7 +350,9 @@ class TestDiskBuilder:
             '/dev/boot-device'
         )
 
-        self.boot_image_task.prepare.assert_called_once_with()
+        self.boot_image_task.prepare.assert_called_once_with(
+            None
+        )
 
         call = filesystem.create_on_device.call_args_list[0]
         assert filesystem.create_on_device.call_args_list[0] == \
@@ -480,7 +482,9 @@ class TestDiskBuilder:
             'target_dir/LimeJeOS-openSUSE-13.2.x86_64-1.13.2.raw',
             '/dev/boot-device'
         )
-        self.boot_image_task.prepare.assert_called_once_with()
+        self.boot_image_task.prepare.assert_called_once_with(
+            None
+        )
         call = filesystem.create_on_device.call_args_list[0]
         assert filesystem.create_on_device.call_args_list[0] == \
             call(label='EFI')

--- a/test/unit/builder/kis_test.py
+++ b/test/unit/builder/kis_test.py
@@ -125,7 +125,9 @@ class TestKisBuilder:
         checksum.md5.assert_called_once_with(
             'target_dir/some-image.x86_64-1.2.3.md5'
         )
-        self.boot_image_task.prepare.assert_called_once_with()
+        self.boot_image_task.prepare.assert_called_once_with(
+            None
+        )
         self.setup.export_modprobe_setup.assert_called_once_with(
             'initrd_dir'
         )


### PR DESCRIPTION
Changes proposed in this pull request:

PR https://github.com/OSInside/kiwi/pull/1186 added option to specify extra packages on command line to be included in the bootstrap. This works well for dracut initrd. However when users use netboot or oemboot kiwi initrd, these specified packages are not added as those initrd systems use separate build root during create phase.

This PR adds this option also for these initrd systems.
