### PR TITLE
Switch to stdlib json package

### DIFF
--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -31,7 +31,6 @@ types-pkg_resources
 types-requests
 types-PyYAML
 types-mock
-types-simplejson
 
 # Generate Data Structures from XML Schema
 # http://pythonhosted.org/generateDS

--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -19,6 +19,3 @@ requests
 
 # markup support
 anymarkup
-
-# json support that also knows about tuples
-simplejson

--- a/kiwi/system/result.py
+++ b/kiwi/system/result.py
@@ -16,7 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import logging
-import simplejson
+import json
 import pickle
 import os
 from typing import (
@@ -152,7 +152,7 @@ class Result:
             if portable:
                 with open(filename + '.json', 'w') as result_portable:
                     result_portable.write(
-                        simplejson.dumps(
+                        json.dumps(
                             self.result_files, sort_keys=True, indent=4
                         ) + os.linesep
                     )

--- a/package/python-kiwi-pkgbuild-template
+++ b/package/python-kiwi-pkgbuild-template
@@ -21,7 +21,7 @@ build() {
 }
 
 package_python-kiwi(){
-  depends=(python-docopt python-simplejson python-future python-lxml python-requests python-setuptools python-six python-pyxattr python-yaml grub qemu squashfs-tools gptfdisk pacman e2fsprogs xfsprogs btrfs-progs libisoburn lvm2 mtools parted multipath-tools rsync tar shadow screen kiwi-man-pages)
+  depends=(python-docopt python-future python-lxml python-requests python-setuptools python-six python-pyxattr python-yaml grub qemu squashfs-tools gptfdisk pacman e2fsprogs xfsprogs btrfs-progs libisoburn lvm2 mtools parted multipath-tools rsync tar shadow screen kiwi-man-pages)
   optdepends=('gnupg: keyring creation for APT package manager')
   cd kiwi-${pkgver}
   python setup.py install --root="${pkgdir}/" --optimize=1 --skip-build

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -336,7 +336,6 @@ Requires:       python%{python3_pkgversion}-yaml
 %else
 Requires:       python%{python3_pkgversion}-PyYAML
 %endif
-Requires:       python%{python3_pkgversion}-simplejson
 Requires:       python%{python3_pkgversion}-docopt
 Requires:       python%{python3_pkgversion}-lxml
 Requires:       python%{python3_pkgversion}-requests

--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,7 @@ config = {
         'lxml',
         'pyxattr',
         'requests',
-        'PyYAML',
-        'simplejson'
+        'PyYAML'
     ],
     'packages': ['kiwi'],
     'cmdclass': {

--- a/test/unit/system/result_test.py
+++ b/test/unit/system/result_test.py
@@ -41,8 +41,8 @@ class TestResult:
             self.result.print_results()
 
     @patch('pickle.dump')
-    @patch('simplejson.dumps')
-    def test_dump(self, mock_simplejson_dumps, mock_pickle_dump):
+    @patch('json.dumps')
+    def test_dump(self, mock_json_dumps, mock_pickle_dump):
         m_open = mock_open()
         with patch('builtins.open', m_open, create=True):
             assert self.result.dump('kiwi.result') is None
@@ -54,7 +54,7 @@ class TestResult:
         mock_pickle_dump.assert_called_once_with(
             self.result, m_open.return_value
         )
-        mock_simplejson_dumps.assert_called_once_with(
+        mock_json_dumps.assert_called_once_with(
             self.result.result_files, sort_keys=True, indent=4
         )
 


### PR DESCRIPTION
simplejson is a backport of the stdlib json package for older
python versions. It went into stdlib with 3.4, and it is being developed
there since then. the comment was that simplejson supports tuples, but
I see no difference with python 3.6+:

>>> myvar=(1,2,3)
>>> import json
>>> json.dumps(myvar)
'[1, 2, 3]'
>>> import simplejson
>>> simplejson.dumps(myvar)
'[1, 2, 3]'

On the other hand, json is simply faster than simplejson, and it is one
less dependency to worry about. here's a comparison (x86_64 AMD Renoir,
1 million invocations)

      json dumps 0.918306345003657 seconds
      simplejson dumps 1.505740466993302 seconds
      json loads 0.793854812043719 seconds
      simplejson loads 0.879414324008394 seconds

Fixes # .

Changes proposed in this pull request:
*
*
