### PR TITLE
Add util-linux dep for -systemdeps-disk-images subpackage

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -278,6 +278,11 @@ Requires:       parted
 Requires:       kpartx
 Requires:       cryptsetup
 Requires:       mdadm
+Requires:       util-linux
+# lsblk is part of util-linux-systemd on openSUSE
+%if 0%{?suse_version}
+Requires:       util-linux-systemd
+%endif
 
 %description -n kiwi-systemdeps-disk-images
 Host setup helper to pull in all packages required/useful on


### PR DESCRIPTION
Without this dependency, kiwi fails to work properly in minimal image
build environments, like in a mock chroot where util-linux is not installed.

