### PR TITLE
Allow firmware="custom" setting

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1195,6 +1195,7 @@ class Defaults:
             'ppc64': 'ofw',
             'ppc64le': 'ofw',
             'arm64': 'efi',
+            'aarch64': 'efi',
             'armv5el': 'efi',
             'armv5tel': 'efi',
             'armv6hl': 'efi',

--- a/kiwi/firmware.py
+++ b/kiwi/firmware.py
@@ -46,7 +46,7 @@ class FirmWare:
         if not self.firmware:
             self.firmware = Defaults.get_default_firmware(self.arch)
 
-        if self.firmware:
+        if self.firmware and self.firmware != 'custom':
             firmware_types = Defaults.get_firmware_types()
             if self.firmware not in firmware_types[self.arch]:
                 raise KiwiNotImplementedError(

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1543,10 +1543,12 @@ div {
         ## systems like efi, coreboot, etc.. This attribute is
         ## used to differentiate the image according to the firmware
         ## which boots up the system. It mostly has an impact on
-        ## the disk layout and the partition table type. By default
-        ## the standard x86 bios firmware setup is used
+        ## the disk layout and the partition table type. The default
+        ## firmware setting is based on the architecture. If no
+        ## action should be taken on behalf of a firmware setting
+        ## or kiwi's default selection, set the firmware to: custom
         attribute firmware {
-            "bios" | "ec2" | "efi" | "uefi" | "ofw" | "opal"
+            "bios" | "ec2" | "efi" | "uefi" | "ofw" | "opal" | "custom"
         }
         >> sch:pattern [ id = "firmware" is-a = "image_type"
             sch:param [ name = "attr" value = "firmware" ]

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2245,8 +2245,10 @@ uses a standard BIOS but there are also other firmware
 systems like efi, coreboot, etc.. This attribute is
 used to differentiate the image according to the firmware
 which boots up the system. It mostly has an impact on
-the disk layout and the partition table type. By default
-the standard x86 bios firmware setup is used</a:documentation>
+the disk layout and the partition table type. The default
+firmware setting is based on the architecture. If no
+action should be taken on behalf of a firmware setting
+or kiwi's default selection, set the firmware to: custom</a:documentation>
         <choice>
           <value>bios</value>
           <value>ec2</value>
@@ -2254,6 +2256,7 @@ the standard x86 bios firmware setup is used</a:documentation>
           <value>uefi</value>
           <value>ofw</value>
           <value>opal</value>
+          <value>custom</value>
         </choice>
       </attribute>
       <sch:pattern id="firmware" is-a="image_type">

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.29.24.
-# Python 3.6.13 (default, Mar 10 2021, 18:30:35) [GCC]
+# Python 3.6.15 (default, Sep 23 2021, 15:41:43) [GCC]
 #
 # Command line options:
 #   ('-f', '')


### PR DESCRIPTION
The firmware attribute in kiwi is used to indicate for
which boot firmware the image should be build. Specifying
the target firmware is helpful to create for example the
correct disk layout. If no firmware is specified KIWI
decides for a default according to the image architecture.
This selection is not 100% accurate and as we don't know
the later target system. Especially for embedded devices
the correct disk layout and other settings can be
board specific and KIWI's default settings regarding the
firmware could be invalid. For compatibility reasons we
cannot switch off the default selection case and therefore
a new attribute value "custom" is introduced with this
commit. If set KIWI does not select any firmware and
consequently all settings caused by a firmware setup will
be skipped. On the other hand this means all needed
settings for the target to boot and not done by KIWI
needs to be specified explicitly and as needed.

