### PR TITLE
Add commandline option --bootinclude

### DIFF
--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -27,6 +27,7 @@ SYNOPSIS
        [--set-container-tag=<name>]
        [--add-container-label=<label>...]
        [--signing-key=<key-file>...]
+       [--bootinclude=<package>...]
    kiwi-ng system build help
 
 .. _db_kiwi_system_build_desc:
@@ -168,6 +169,12 @@ OPTIONS
   if an image build should take and validate repository and package
   signatures during build time. This option can be specified multiple
   times
+
+--bootinclude=<package>
+
+  adds the package to the custom kiwi boot image description.
+  This option is only effective if kiwi's builtin initrd system
+  is used.
 
 --target-dir=<directory>
 

--- a/doc/source/commands/system_create.rst
+++ b/doc/source/commands/system_create.rst
@@ -15,6 +15,7 @@ SYNOPSIS
    kiwi-ng system create -h | --help
    kiwi-ng system create --root=<directory> --target-dir=<directory>
        [--signing-key=<key-file>...]
+       [--bootinclude=<package>...]
    kiwi-ng system create help
 
 .. _db_kiwi_system_create_desc:
@@ -51,3 +52,9 @@ OPTIONS
   signatures during build time. In create step this option only
   affects the boot image. This option can be specified multiple
   times
+
+--bootinclude=<package>
+
+  adds the package to the custom kiwi boot image description.
+  This option is only effective if kiwi's builtin initrd system
+  is used.

--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -218,7 +218,7 @@ class BootImageBase:
             )
         )
 
-    def prepare(self) -> None:
+    def prepare(self, plus_packages: List[str] = []) -> None:
         """
         Prepare new root system to create initrd from. Implementation
         is only needed if there is no other root system available
@@ -296,7 +296,9 @@ class BootImageBase:
                 boot_image_profile, boot_kernel_profile
             )
 
-    def import_system_description_elements(self) -> None:
+    def import_system_description_elements(
+        self, plus_packages: List[str] = []
+    ) -> None:
         """
         Copy information from the system image relevant to create the
         boot image to the boot image state XML description
@@ -337,7 +339,7 @@ class BootImageBase:
             preferences_subsection_names, self.boot_xml_state
         )
         self.xml_state.copy_bootincluded_packages(
-            self.boot_xml_state
+            self.boot_xml_state, plus_packages
         )
         self.xml_state.copy_bootincluded_archives(
             self.boot_xml_state

--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -68,9 +68,13 @@ class BootImageKiwi(BootImageBase):
         self.temp_directories: List[str] = []
         self.load_boot_xml_description()
 
-    def prepare(self) -> None:
+    def prepare(self, plus_packages: List[str] = []) -> None:
         """
         Prepare new root system suitable to create a kiwi initrd from it
+
+        :param list plus_packages:
+            additional packages to be added into the boot
+            image description
         """
         if self.boot_xml_state:
             self.boot_root_directory_temporary = Temporary(
@@ -82,7 +86,7 @@ class BootImageKiwi(BootImageBase):
             )
             boot_image_name = self.boot_xml_state.xml_data.get_name()
 
-            self.import_system_description_elements()
+            self.import_system_description_elements(plus_packages)
 
             log.info('Preparing boot image')
             system = SystemPrepare(

--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -151,11 +151,13 @@ class BootImageDracut(BootImageBase):
             with open(config_file, 'w') as config_handle:
                 config_handle.writelines(dracut_config)
 
-    def prepare(self) -> None:
+    def prepare(self, plus_packages: List[str] = []) -> None:
         """
         Prepare dracut caller environment
 
         * Setup machine_id(s) to be generic and rebuild by dracut on boot
+
+        :param list plus_packages: unused
         """
         setup = SystemSetup(
             self.xml_state, self.boot_root_directory

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -129,6 +129,10 @@ class DiskBuilder:
         if custom_args and 'signing_keys' in custom_args:
             self.signing_keys = custom_args['signing_keys']
 
+        self.kiwi_boot_image_plus_packages = custom_args[
+            'bootinclude'
+        ] if custom_args and 'bootinclude' in custom_args else []
+
         self.boot_image = BootImage.new(
             xml_state, target_dir, root_dir, signing_keys=self.signing_keys
         )
@@ -232,7 +236,7 @@ class DiskBuilder:
         # prepare initrd
         if self.boot_image.has_initrd_support():
             log.info('Preparing boot system')
-            self.boot_image.prepare()
+            self.boot_image.prepare(self.kiwi_boot_image_plus_packages)
 
         # precalculate needed disk size
         disksize_mbytes = self.disk_setup.get_disksize_mbytes()

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -122,6 +122,10 @@ class InstallImageBuilder:
         self.xz_options = custom_args['xz_options'] if custom_args \
             and 'xz_options' in custom_args else None
 
+        self.kiwi_boot_image_plus_packages = custom_args[
+            'bootinclude'
+        ] if custom_args and 'bootinclude' in custom_args else []
+
         self.mbrid = SystemIdentifier()
         self.mbrid.calculate_id()
 
@@ -131,7 +135,7 @@ class InstallImageBuilder:
             self.boot_image_task = BootImage.new(
                 xml_state, target_dir, root_dir
             )
-            self.boot_image_task.prepare()
+            self.boot_image_task.prepare(self.kiwi_boot_image_plus_packages)
         else:
             self.boot_image_task = boot_image_task
 

--- a/kiwi/builder/kis.py
+++ b/kiwi/builder/kis.py
@@ -69,6 +69,10 @@ class KisBuilder:
         self.boot_signing_keys = custom_args['signing_keys'] if custom_args \
             and 'signing_keys' in custom_args else None
 
+        self.kiwi_boot_image_plus_packages = custom_args[
+            'bootinclude'
+        ] if custom_args and 'bootinclude' in custom_args else []
+
         self.xz_options = custom_args['xz_options'] if custom_args \
             and 'xz_options' in custom_args else None
 
@@ -134,7 +138,7 @@ class KisBuilder:
         # prepare initrd
         if self.boot_image_task.has_initrd_support():
             log.info('Creating boot image')
-            self.boot_image_task.prepare()
+            self.boot_image_task.prepare(self.kiwi_boot_image_plus_packages)
 
         # export modprobe configuration to boot image
         self.system_setup.export_modprobe_setup(

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -73,6 +73,10 @@ class LiveImageBuilder:
             Defaults.get_publisher()
         self.custom_args = custom_args
 
+        self.kiwi_boot_image_plus_packages = custom_args[
+            'bootinclude'
+        ] if custom_args and 'bootinclude' in custom_args else []
+
         if not self.live_type:
             self.live_type = Defaults.get_default_live_iso_type()
 
@@ -180,7 +184,7 @@ class LiveImageBuilder:
         )
 
         # prepare dracut initrd call
-        self.boot_image.prepare()
+        self.boot_image.prepare(self.kiwi_boot_image_plus_packages)
 
         # create dracut initrd for live image
         log.info('Creating live ISO boot image')

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -31,6 +31,7 @@ usage: kiwi-ng system build -h | --help
            [--set-container-tag=<name>]
            [--add-container-label=<label>...]
            [--signing-key=<key-file>...]
+           [--bootinclude=<package>...]
        kiwi-ng system build help
 
 commands:
@@ -84,6 +85,10 @@ options:
         priority, the imageinclude flag and the package_gpgcheck flag
     --signing-key=<key-file>
         includes the key-file as a trusted key for package manager validations
+    --bootinclude=<package>
+        adds the package to the custom kiwi boot image description.
+        This option is only effective if kiwi's builtin initrd system
+        is used.
     --target-dir=<directory>
         the target directory to store the system image file(s)
 """
@@ -286,7 +291,8 @@ class SystemBuildTask(CliTask):
                 'signing_keys': self.command_args[
                     '--signing-key'
                 ] + self.xml_state.get_repositories_signing_keys(),
-                'xz_options': self.runtime_config.get_xz_options()
+                'xz_options': self.runtime_config.get_xz_options(),
+                'bootinclude': self.command_args['--bootinclude']
             }
         )
         result = image_builder.create()

--- a/kiwi/tasks/system_create.py
+++ b/kiwi/tasks/system_create.py
@@ -19,6 +19,7 @@
 usage: kiwi-ng system create -h | --help
        kiwi-ng system create --root=<directory> --target-dir=<directory>
            [--signing-key=<key-file>...]
+           [--bootinclude=<package>...]
        kiwi-ng system create help
 
 commands:
@@ -37,6 +38,10 @@ options:
         the target directory to store the system image file(s)
     --signing-key=<key-file>
         includes the key-file as a trusted key for package manager validations
+    --bootinclude=<package>
+        adds the package to the custom kiwi boot image description.
+        This option is only effective if kiwi's builtin initrd system
+        is used.
 """
 import os
 import logging
@@ -107,7 +112,8 @@ class SystemCreateTask(CliTask):
             abs_root_path,
             custom_args={
                 'signing_keys': self.command_args['--signing-key'],
-                'xz_options': self.runtime_config.get_xz_options()
+                'xz_options': self.runtime_config.get_xz_options(),
+                'bootinclude': self.command_args['--bootinclude']
             }
         )
         result = image_builder.create()

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -2038,7 +2038,9 @@ class XMLState:
                 )
                 set_type_method(attribute_value)
 
-    def copy_bootincluded_packages(self, target_state: Any) -> None:
+    def copy_bootincluded_packages(
+        self, target_state: Any, plus_packages: List[str] = []
+    ) -> None:
         """
         Copy packages marked as bootinclude to the packages type=image
         (or type=bootstrap if no type=image was found) section in the
@@ -2047,6 +2049,7 @@ class XMLState:
         present there
 
         :param object target_state: XMLState instance
+        :param list plus_packages: List of additional packages
         """
         target_packages_sections = \
             target_state.get_image_packages_sections()
@@ -2075,6 +2078,12 @@ class XMLState:
                         package_names_added.append(
                             package.package_section.get_name()
                         )
+            if plus_packages:
+                for package_name in plus_packages:
+                    target_packages_section.add_package(
+                        xml_parse.package(name=package_name)
+                    )
+                    package_names_added.append(package_name)
             delete_packages_sections = target_state.get_packages_sections(
                 ['delete']
             )

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -350,7 +350,7 @@ class TestDiskBuilder:
             '/dev/boot-device'
         )
 
-        self.boot_image_task.prepare.assert_called_once_with()
+        self.boot_image_task.prepare.assert_called_once_with([])
 
         call = filesystem.create_on_device.call_args_list[0]
         assert filesystem.create_on_device.call_args_list[0] == \
@@ -480,7 +480,7 @@ class TestDiskBuilder:
             'target_dir/LimeJeOS-openSUSE-13.2.x86_64-1.13.2.raw',
             '/dev/boot-device'
         )
-        self.boot_image_task.prepare.assert_called_once_with()
+        self.boot_image_task.prepare.assert_called_once_with([])
         call = filesystem.create_on_device.call_args_list[0]
         assert filesystem.create_on_device.call_args_list[0] == \
             call(label='EFI')

--- a/test/unit/builder/kis_test.py
+++ b/test/unit/builder/kis_test.py
@@ -125,7 +125,7 @@ class TestKisBuilder:
         checksum.md5.assert_called_once_with(
             'target_dir/some-image.x86_64-1.2.3.md5'
         )
-        self.boot_image_task.prepare.assert_called_once_with()
+        self.boot_image_task.prepare.assert_called_once_with([])
         self.setup.export_modprobe_setup.assert_called_once_with(
             'initrd_dir'
         )

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -247,7 +247,7 @@ class TestLiveImageBuilder:
         )
         self.bootloader.write.assert_called_once_with()
 
-        self.boot_image_task.prepare.assert_called_once_with()
+        self.boot_image_task.prepare.assert_called_once_with([])
         self.boot_image_task.create_initrd.assert_called_once_with(
             self.mbrid
         )

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -97,6 +97,7 @@ class TestSystemBuildTask:
         self.task.command_args['--add-container-label'] = []
         self.task.command_args['--clear-cache'] = False
         self.task.command_args['--signing-key'] = []
+        self.task.command_args['--bootinclude'] = []
 
     @patch('kiwi.logger.Logger.set_logfile')
     @patch('kiwi.xml_state.XMLState.get_repositories_signing_keys')

--- a/test/unit/tasks/system_create_test.py
+++ b/test/unit/tasks/system_create_test.py
@@ -64,6 +64,7 @@ class TestSystemCreateTask:
         self.task.command_args['--root'] = '../data/root-dir'
         self.task.command_args['--target-dir'] = 'some-target'
         self.task.command_args['--signing-key'] = ['some-key-file']
+        self.task.command_args['--bootinclude'] = []
 
     def test_process_system_create(self):
         self._init_command_args()

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -654,6 +654,14 @@ class TestXMLState:
         )
         assert self.boot_state.build_type.get_firmware() == 'efi'
 
+    def test_copy_bootincluded_packages_with_plus_packages(self):
+        self.state.copy_bootincluded_packages(
+            self.boot_state, ['plus_A', 'plus_B']
+        )
+        bootstrap_packages = self.boot_state.get_bootstrap_packages()
+        assert 'plus_A' in bootstrap_packages
+        assert 'plus_B' in bootstrap_packages
+
     def test_copy_bootincluded_packages_with_no_image_packages(self):
         self.state.copy_bootincluded_packages(self.boot_state)
         bootstrap_packages = self.boot_state.get_bootstrap_packages()


### PR DESCRIPTION
If the kiwi builtin boot image(initrd) is used instead
of dracut via the initrd_system="kiwi" attribute, there is
an opportunity to tell kiwi to add packages listed
in the system image description also to the list of packages
used for building the root system from which the boot
image(initrd) is created. We call this feature a bootinclude.

As of now the user had to specify that a package should be
used for the system and the boot image as part of the image
description <package> definition like in the following
example:

```xml
<package name="foo" bootinclude="true"/>
```

With this commit the information can also be provided on
the commandline like in the following example

```
kiwi-ng system build ... --bootinclude foo
```

The option can be specified multiple times if more than
one package should be marked to be used for the boot image
prepare step.
