### PR TITLE
Change packages target for bootincludes

### DIFF
--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -2040,20 +2040,15 @@ class XMLState:
 
     def copy_bootincluded_packages(self, target_state: Any) -> None:
         """
-        Copy packages marked as bootinclude to the packages type=image
-        (or type=bootstrap if no type=image was found) section in the
-        target xml state. The package will also be removed from the
-        packages type=delete section in the target xml state if
-        present there
+        Copy packages marked as bootinclude to the packages
+        type=bootstrap section in the target xml state. The package
+        will also be removed from the packages type=delete section
+        in the target xml state if present there
 
         :param object target_state: XMLState instance
         """
         target_packages_sections = \
-            target_state.get_image_packages_sections()
-        if not target_packages_sections:
-            # no packages type=image section was found, add to bootstrap
-            target_packages_sections = \
-                target_state.get_bootstrap_packages_sections()
+            target_state.get_bootstrap_packages_sections()
         if target_packages_sections:
             target_packages_section = \
                 target_packages_sections[0]

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -669,10 +669,14 @@ class TestXMLState:
         )
         boot_state = XMLState(boot_description.load(), ['std'])
         self.state.copy_bootincluded_packages(boot_state)
-        image_packages = boot_state.get_system_packages()
-        assert 'plymouth-branding-openSUSE' in image_packages
-        assert 'grub2-branding-openSUSE' in image_packages
-        assert 'gfxboot-branding-openSUSE' in image_packages
+        image_packages = boot_state.get_image_packages_sections()
+        bootstrap_packages = boot_state.get_bootstrap_packages()
+        assert 'plymouth-branding-openSUSE' in bootstrap_packages
+        assert 'grub2-branding-openSUSE' in bootstrap_packages
+        assert 'gfxboot-branding-openSUSE' in bootstrap_packages
+        assert 'plymouth-branding-openSUSE' not in image_packages
+        assert 'grub2-branding-openSUSE' not in image_packages
+        assert 'gfxboot-branding-openSUSE' not in image_packages
         to_delete_packages = boot_state.get_to_become_deleted_packages()
         assert 'gfxboot-branding-openSUSE' not in to_delete_packages
 


### PR DESCRIPTION
Packages marked with bootinclude="true" will be added to the
referenced kiwi boot image description if the initrd_system
is set to "kiwi" instead of "dracut". The package marked was
primarily added to the type="image" section and got only
added to the type="bootstrap" section if no image type section
existed. However, it has turned out that this approach has
the disadvantage that packages which must be installed as
part of the bootstraping (e.g certificates) cannot be handled.
This commit changes the behavior of the bootinclude to include
the package always to the type="bootstrap" section.


