### PR TITLE
Added debug option --debug-run-scripts-in-screen

### DIFF
--- a/doc/source/commands/kiwi.rst
+++ b/doc/source/commands/kiwi.rst
@@ -16,11 +16,13 @@ SYNOPSIS
            [--type=<build_type>]
            [--logfile=<filename>]
            [--debug]
+           [--debug-run-scripts-in-screen]
            [--color-output]
            [--config=<configfile>]
            [--kiwi-file=<kiwifile>]
        image <command> [<args>...]
    kiwi-ng [--debug]
+           [--debug-run-scripts-in-screen]
            [--color-output]
            [--config=<configfile>]
        result <command> [<args>...]
@@ -31,6 +33,7 @@ SYNOPSIS
            [--type=<build_type>]
            [--logfile=<filename>]
            [--debug]
+           [--debug-run-scripts-in-screen]
            [--color-output]
            [--config=<configfile>]
            [--kiwi-file=<kiwifile>]
@@ -99,6 +102,10 @@ GLOBAL OPTIONS
 --debug
 
   Print debug information on the commandline.
+
+--debug-run-scripts-in-screen
+
+  Run scripts called by kiwi in a screen session.
 
 --logfile=<filename>
 

--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -22,12 +22,14 @@ usage: kiwi-ng -h | --help
                [--type=<build_type>]
                [--logfile=<filename>]
                [--debug]
+               [--debug-run-scripts-in-screen]
                [--color-output]
                [--config=<configfile>]
                [--kiwi-file=<kiwifile>]
            image <command> [<args>...]
        kiwi-ng [--logfile=<filename>]
                [--debug]
+               [--debug-run-scripts-in-screen]
                [--color-output]
                [--config=<configfile>]
            result <command> [<args>...]
@@ -38,6 +40,7 @@ usage: kiwi-ng -h | --help
                [--type=<build_type>]
                [--logfile=<filename>]
                [--debug]
+               [--debug-run-scripts-in-screen]
                [--color-output]
                [--config=<configfile>]
                [--kiwi-file=<kiwifile>]
@@ -61,6 +64,8 @@ global options:
         information to standard out instead of writing to a file
     --debug
         print debug information
+    --debug-run-scripts-in-screen
+        run scripts called by kiwi in a screen session
     -v --version
         show program version
     help

--- a/kiwi/logger.py
+++ b/kiwi/logger.py
@@ -70,6 +70,7 @@ class Logger(logging.Logger):
             sys.__stderr__
         )
         self.log_level = self.level
+        self.log_flags: Dict[str, bool] = {}
 
     def getLogLevel(self) -> int:
         """
@@ -81,6 +82,17 @@ class Logger(logging.Logger):
         """
         return self.log_level
 
+    def getLogFlags(self) -> Dict[str, bool]:
+        """
+        Return logging flags
+
+        :return:
+            Dictionary with flags and their activation status
+
+        :rtype: dict
+        """
+        return self.log_flags
+
     def setLogLevel(self, level: int) -> None:
         """
         Set custom log level for all console handlers
@@ -90,6 +102,17 @@ class Logger(logging.Logger):
         self.log_level = level
         for handler_type in self.console_handlers:
             self.console_handlers[handler_type].setLevel(level)
+
+    def setLogFlag(self, flag: str, value: bool = True) -> None:
+        """
+        Set logging flag for further properties of the logging facility
+        Available flags are:
+
+        * run-scripts-in-screen
+
+        :param str flag: name
+        """
+        self.log_flags[flag] = value
 
     def set_color_format(self) -> None:
         """

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -998,10 +998,8 @@ class SystemSetup:
         script_path = os.path.join(self.root_dir, 'image', name)
         if os.path.exists(script_path):
             options = option_list or []
-            if log.getLogLevel() == logging.DEBUG and not \
-               Defaults.is_buildservice_worker():
-                # In debug mode run scripts in a screen session to
-                # allow attaching and debugging
+            if log.getLogFlags().get('run-scripts-in-screen'):
+                # Run scripts in a screen session if requested
                 command = ['screen', '-t', '-X', 'chroot', self.root_dir]
             else:
                 # In standard mode run scripts without a terminal
@@ -1039,10 +1037,8 @@ class SystemSetup:
                 'cd', working_directory, '&&',
                 'bash', '--norc', script_path, ' '.join(option_list)
             ]
-            if log.getLogLevel() == logging.DEBUG and not \
-               Defaults.is_buildservice_worker():
-                # In debug mode run scripts in a screen session to
-                # allow attaching and debugging
+            if log.getLogFlags().get('run-scripts-in-screen'):
+                # Run scripts in a screen session if requested
                 config_script = Command.call(
                     ['screen', '-t', '-X', 'bash', '-c', ' '.join(bash_command)]
                 )

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -109,6 +109,10 @@ class CliTask:
             else:
                 log.setLogLevel(logging.INFO)
 
+            # set log flags
+            if self.global_args['--debug-run-scripts-in-screen']:
+                log.setLogFlag('run-scripts-in-screen')
+
             # set log file
             if self.global_args['--logfile']:
                 log.set_logfile(

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -37,6 +37,7 @@ class TestCli:
             '<legacy_args>': [],
             '--version': False,
             '--debug': False,
+            '--debug-run-scripts-in-screen': False,
             'result': False,
             '--profile': [],
             '--shared-cache-dir': '/var/cache/kiwi',

--- a/test/unit/logger_test.py
+++ b/test/unit/logger_test.py
@@ -67,3 +67,8 @@ class TestLogger:
     def test_getLogLevel(self):
         self.log.setLogLevel(42)
         assert self.log.getLogLevel() == 42
+
+    def test_getLogFlags(self):
+        assert self.log.getLogFlags().get('run-scripts-in-screen') is None
+        self.log.setLogFlag('run-scripts-in-screen')
+        assert self.log.getLogFlags().get('run-scripts-in-screen') is True

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -706,7 +706,7 @@ class TestSystemSetup:
         )
 
     @patch('kiwi.system.setup.Defaults.is_buildservice_worker')
-    @patch('kiwi.logger.Logger.getLogLevel')
+    @patch('kiwi.logger.Logger.getLogFlags')
     @patch('kiwi.system.setup.Profile')
     @patch('kiwi.command.Command.call')
     @patch('kiwi.command_process.CommandProcess.poll_and_watch')
@@ -716,11 +716,13 @@ class TestSystemSetup:
     @patch('copy.deepcopy')
     def test_call_disk_script(
         self, mock_copy_deepcopy, mock_access, mock_stat, mock_os_path,
-        mock_watch, mock_command, mock_Profile, mock_getLogLevel,
+        mock_watch, mock_command, mock_Profile, mock_getLogFlags,
         mock_is_buildservice_worker
     ):
         mock_is_buildservice_worker.return_value = False
-        mock_getLogLevel.return_value = logging.DEBUG
+        mock_getLogFlags.return_value = {
+            'run-scripts-in-screen': True
+        }
         mock_copy_deepcopy.return_value = {}
         profile = Mock()
         mock_Profile.return_value = profile
@@ -796,17 +798,19 @@ class TestSystemSetup:
         ])
 
     @patch('kiwi.system.setup.Defaults.is_buildservice_worker')
-    @patch('kiwi.logger.Logger.getLogLevel')
+    @patch('kiwi.logger.Logger.getLogFlags')
     @patch('kiwi.command.Command.call')
     @patch('kiwi.command_process.CommandProcess.poll_and_watch')
     @patch('os.path.exists')
     @patch('os.path.abspath')
     def test_call_edit_boot_install_script(
         self, mock_abspath, mock_exists, mock_watch, mock_command,
-        mock_getLogLevel, mock_is_buildservice_worker
+        mock_getLogFlags, mock_is_buildservice_worker
     ):
         mock_is_buildservice_worker.return_value = False
-        mock_getLogLevel.return_value = logging.DEBUG
+        mock_getLogFlags.return_value = {
+            'run-scripts-in-screen': True
+        }
         result_type = namedtuple(
             'result_type', ['stderr', 'returncode']
         )

--- a/test/unit/tasks/base_test.py
+++ b/test/unit/tasks/base_test.py
@@ -20,6 +20,7 @@ class TestCliTask:
         self._caplog = caplog
 
     @patch('kiwi.logger.Logger.setLogLevel')
+    @patch('kiwi.logger.Logger.setLogFlag')
     @patch('kiwi.logger.Logger.set_logfile')
     @patch('kiwi.logger.Logger.set_color_format')
     @patch('kiwi.cli.Cli.show_and_exit_on_help_request')
@@ -30,11 +31,12 @@ class TestCliTask:
     def setup(
         self, mock_runtime_config, mock_global_args, mock_command_args,
         mock_load_command, mock_help_check, mock_color,
-        mock_setlog, mock_setlevel
+        mock_setlog, mock_setLogFlag, mock_setLogLevel
     ):
         Defaults.set_platform_name('x86_64')
         mock_global_args.return_value = {
             '--debug': True,
+            '--debug-run-scripts-in-screen': True,
             '--logfile': 'log',
             '--color-output': True,
             '--profile': ['vmxFlavour'],
@@ -53,7 +55,8 @@ class TestCliTask:
         mock_load_command.assert_called_once_with()
         mock_command_args.assert_called_once_with()
         mock_global_args.assert_called_once_with()
-        mock_setlevel.assert_called_once_with(logging.DEBUG)
+        mock_setLogLevel.assert_called_once_with(logging.DEBUG)
+        mock_setLogFlag.assert_called_once_with('run-scripts-in-screen')
         mock_setlog.assert_called_once_with('log')
         mock_color.assert_called_once_with()
         mock_runtime_config.assert_called_once_with()


### PR DESCRIPTION
Instead of running scripts in screen if the --debug switch is
set, we allow to explicitly switch on this behavior via
a new option. This Fixes #2010


