### PR TITLE
Fixed regression in compression detection

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-net-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-net-lib.sh
@@ -27,7 +27,7 @@ function fetch_file {
     if _is_dolly "${source_url}";then
         fetch="dolly"
     fi
-    if _is_compressed "${source_url}";then
+    if _is_xz_compressed "${source_url}";then
         fetch="${fetch} | xz -d"
     fi
     if [ -z "${source_uncompressed_bytes}" ];then
@@ -78,9 +78,9 @@ function uri_fragment {
 #======================================
 # Methods considered private
 #--------------------------------------
-function _is_compressed {
+function _is_xz_compressed {
     local source_url=$1
-    xz -l "${source_url}" &>/dev/null
+    [[ ${source_url} =~ .xz$ ]]
 }
 
 function _is_dolly {


### PR DESCRIPTION
The change from  282529de8f612dee32d54ee868c2365dcd829220
Introduced a bad regression. The assumption was made that the
xz tool could be used to detect if a file is compressed or not.
However, this requires the file to be locally present. In the
scope of the method call is_compressed() and within a remote
deployment e.g PXE this is not the case. Therefore the former
way to "detect" the compression according to the .xz postfix
of the source filename was restored. In addition the function
name was changed to is_xz_compressed() because that's what the
method can do and not more. This Fixes #2015

