### PR TITLE
Automate build-tests OBS service refresh

### DIFF
--- a/.github/workflows/ci-update-build-tests.yml
+++ b/.github/workflows/ci-update-build-tests.yml
@@ -1,0 +1,18 @@
+name: CI-Update-Build-Tests
+
+on:
+  push:
+    branches:
+      - "master"
+    paths:
+      - "build-tests/**"
+
+jobs:
+  trigger_obs_services:
+    name: Trigger OBS services connected to build-tests data
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Send API requests to Open Build Service
+        run: helper/update_obs_services.sh ${{ secrets.OBS_VIRT_APP_IMG_TOKEN }}

--- a/helper/update_obs_services.sh
+++ b/helper/update_obs_services.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+api_target="https://api.opensuse.org/trigger/runservice"
+api_token=$1
+
+while read -r build_test; do
+    build_test_path=$(dirname "${build_test}")
+    dist=$(echo "${build_test_path}" | cut -f 3 -d/)
+    arch=$(echo "${build_test_path}" | cut -f 2 -d/)
+    project="Virtualization:Appliances:Images:Testing_${arch}:${dist}"
+    package=$(basename "${build_test_path}")
+    curl_target="${api_target}?project=${project}&package=${package}"
+
+    echo "Updating Test: ${package} for: ${project}"
+    curl --fail-with-body -H "Authorization: Token ${api_token}" \
+        -X POST "${curl_target}"
+done < <(find build-tests -name "appliance.kiwi")


### PR DESCRIPTION
This commit provides a new github action which sends
API requests to the OBS api to refresh the source
services for the integration tests on the OBS server
side. This Fixes #1980

