### PR TITLE
Fix booting GRUB submenu entries with hybrid images (linux/linuxefi)

### DIFF
--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -52,12 +52,13 @@ class BootLoaderTemplateGrub2:
         self.header_hybrid = dedent('''
             set linux=linux
             set initrd=initrd
-            if [ "$${grub_cpu}" = "x86_64" -o "$${grub_cpu}" = "i386" ];then
+            if [ "$${grub_cpu}" = "x86_64" -o "$${grub_cpu}" = "i386" ]; then
                 if [ "$${grub_platform}" = "efi" ]; then
                     set linux=linuxefi
                     set initrd=initrdefi
                 fi
             fi
+            export linux initrd
         ''').strip() + os.linesep
 
         self.header_gfxterm = dedent('''

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -777,12 +777,13 @@ class TestBootLoaderConfigGrub2:
                     'set linux=linux\n'
                     'set initrd=initrd\n'
                     'if [ "${grub_cpu}" = "x86_64" -o '
-                    '"${grub_cpu}" = "i386" ];then\n'
+                    '"${grub_cpu}" = "i386" ]; then\n'
                     '    if [ "${grub_platform}" = "efi" ]; then\n'
                     '        set linux=linuxefi\n'
                     '        set initrd=initrdefi\n'
                     '    fi\n'
                     'fi\n'
+                    'export linux initrd\n'
                 ),
                 call(
                     'root=rootdev nomodeset console=ttyS0 console=tty0'
@@ -842,12 +843,13 @@ class TestBootLoaderConfigGrub2:
                     'set linux=linux\n'
                     'set initrd=initrd\n'
                     'if [ "${grub_cpu}" = "x86_64" -o '
-                    '"${grub_cpu}" = "i386" ];then\n'
+                    '"${grub_cpu}" = "i386" ]; then\n'
                     '    if [ "${grub_platform}" = "efi" ]; then\n'
                     '        set linux=linuxefi\n'
                     '        set initrd=initrdefi\n'
                     '    fi\n'
                     'fi\n'
+                    'export linux initrd\n'
                 ),
                 call(
                     '\t$linux ${rel_dirname}/${basename} ...\n'


### PR DESCRIPTION
Variables assigned with "set" are not visible in submenus for some reason.
Export $linux and $initrd, so that they also work in submenu entries.

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1192523