### PR TITLE
Don't copy GRUB modules for EFI with secure boot enabled

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -435,7 +435,6 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             self._setup_efi_image(mbrid=mbrid, lookup_path=lookup_path)
             self._copy_efi_modules_to_boot_directory(lookup_path)
         elif self.firmware.efi_mode() == 'uefi':
-            self._copy_efi_modules_to_boot_directory(lookup_path)
             self._setup_secure_boot_efi_image(
                 lookup_path=lookup_path, mbrid=mbrid
             )

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -1724,13 +1724,6 @@ class TestBootLoaderConfigGrub2:
                     ),
                     call(
                         [
-                            'rsync', '-a', '--exclude', '/*.module',
-                            'root_dir/usr/share/grub2/x86_64-efi/',
-                            'root_dir/boot/grub2/x86_64-efi'
-                        ]
-                    ),
-                    call(
-                        [
                             'cp', 'root_dir/usr/lib64/efi/shim.efi',
                             'root_dir/EFI/BOOT/bootx64.efi'
                         ]


### PR DESCRIPTION
When booting grub.efi with secure boot enabled, modules can't be loaded
and thus the grub.efi image needs to be complete. Save some space in live
images by not copying them into the ISO filesystem.

Fixes part of #1750

I built livecd-tumbleweed-x11 and was able to boot it on x86_64 with and without EFI just like before, but it's now 6MiB (>1%!) smaller.