### PR TITLE
Don't include the ESP in the ISO9660 partition as well (#1750)

### DIFF
--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -237,6 +237,13 @@ class InstallImageBuilder:
         )
         bootloader_config.write()
 
+        if self.firmware.efi_mode():
+            efi_loader = Temporary(
+                prefix='efi-loader.', path=self.target_dir
+            ).new_file()
+            bootloader_config._create_embedded_fat_efi_image(efi_loader.name)
+            self.custom_iso_args['meta_data']['efi_loader'] = efi_loader.name
+
         # create initrd for install image
         log.info('Creating install image boot image')
         self._create_iso_install_kernel_and_initrd()

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -179,6 +179,13 @@ class LiveImageBuilder:
             working_directory=self.root_dir
         )
 
+        if self.firmware.efi_mode():
+            efi_loader = Temporary(
+                prefix='efi-loader.', path=self.target_dir
+            ).new_file()
+            bootloader_config._create_embedded_fat_efi_image(efi_loader.name)
+            custom_iso_args['meta_data']['efi_loader'] = efi_loader.name
+
         # prepare dracut initrd call
         self.boot_image.prepare()
 

--- a/kiwi/filesystem/isofs.py
+++ b/kiwi/filesystem/isofs.py
@@ -46,6 +46,7 @@ class FileSystemIsoFs(FileSystemBase):
         meta_data = self.custom_args['meta_data']
         efi_mode = meta_data.get('efi_mode')
         ofw_mode = meta_data.get('ofw_mode')
+        efi_loader = meta_data.get('efi_loader')
         iso_tool = IsoTools.new(self.root_dir)
 
         iso = Iso(self.root_dir)
@@ -54,6 +55,7 @@ class FileSystemIsoFs(FileSystemBase):
 
         iso_tool.init_iso_creation_parameters(meta_data)
 
-        iso_tool.add_efi_loader_parameters()
+        if efi_loader:
+            iso_tool.add_efi_loader_parameters(efi_loader)
 
         iso_tool.create_iso(filename)

--- a/kiwi/iso_tools/base.py
+++ b/kiwi/iso_tools/base.py
@@ -72,7 +72,7 @@ class IsoToolsBase:
         """
         raise NotImplementedError
 
-    def add_efi_loader_parameters(self) -> None:
+    def add_efi_loader_parameters(self, loader_file: str) -> None:
         """
         Add ISO creation parameters to embed the EFI loader
 

--- a/kiwi/iso_tools/xorriso.py
+++ b/kiwi/iso_tools/xorriso.py
@@ -136,7 +136,7 @@ class IsoToolsXorrIso(IsoToolsBase):
             '-boot_image', 'any', 'load_size=2048'
         ]
 
-    def add_efi_loader_parameters(self) -> None:
+    def add_efi_loader_parameters(self, loader_file: str) -> None:
         """
         Add ISO creation parameters to embed the EFI loader
 
@@ -147,16 +147,14 @@ class IsoToolsXorrIso(IsoToolsBase):
         file refer to _create_embedded_fat_efi_image() from
         bootloader/config/grub2.py
         """
-        loader_file = os.sep.join([self.source_dir, self.boot_path, 'efi'])
-        if os.path.exists(loader_file):
-            self.iso_loaders += [
-                '-append_partition', '2', '0xef', loader_file,
-                '-boot_image', 'any', 'next',
-                '-boot_image', 'any',
-                'efi_path=--interval:appended_partition_2:all::',
-                '-boot_image', 'any', 'platform_id=0xef',
-                '-boot_image', 'any', 'emul_type=no_emulation'
-            ]
+        self.iso_loaders += [
+            '-append_partition', '2', '0xef', loader_file,
+            '-boot_image', 'any', 'next',
+            '-boot_image', 'any',
+            'efi_path=--interval:appended_partition_2:all::',
+            '-boot_image', 'any', 'platform_id=0xef',
+            '-boot_image', 'any', 'emul_type=no_emulation'
+        ]
 
     def create_iso(
         self, filename: str, hidden_files: List[str] = None

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -277,9 +277,8 @@ class TestBootLoaderConfigGrub2:
 
     @patch('os.path.exists')
     @patch.object(BootLoaderConfigGrub2, '_copy_grub_config_to_efi_path')
-    @patch('kiwi.bootloader.config.grub2.Command.run')
     def test_write(
-        self, mock_command, mock_copy_grub_config_to_efi_path, mock_exists
+        self, mock_copy_grub_config_to_efi_path, mock_exists
     ):
         mock_exists.return_value = True
         self.bootloader.config = 'some-data'
@@ -298,20 +297,24 @@ class TestBootLoaderConfigGrub2:
             file_handle.write.assert_called_once_with(
                 'some-data'
             )
+
+    @patch('kiwi.bootloader.config.grub2.Command.run')
+    def test_create_embedded_fat_efi_image(self, mock_command):
+        self.bootloader._create_embedded_fat_efi_image('tmp-esp-image')
         assert mock_command.call_args_list == [
             call(
                 [
-                    'qemu-img', 'create', 'root_dir/boot/x86_64/efi', '20M'
+                    'qemu-img', 'create', 'tmp-esp-image', '20M'
                 ]
             ),
             call(
                 [
-                    'mkdosfs', '-n', 'BOOT', 'root_dir/boot/x86_64/efi'
+                    'mkdosfs', '-n', 'BOOT', 'tmp-esp-image'
                 ]
             ),
             call(
                 [
-                    'mcopy', '-Do', '-s', '-i', 'root_dir/boot/x86_64/efi',
+                    'mcopy', '-Do', '-s', '-i', 'tmp-esp-image',
                     'root_dir/EFI', '::'
                 ]
             )

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -139,10 +139,13 @@ class TestInstallImageBuilder:
         temp_media_dir = Mock()
         temp_media_dir.new_dir.return_value.name = 'temp_media_dir'
 
-        tmpdir_name = [temp_squashfs, temp_media_dir]
+        temp_esp_file = Mock()
+        temp_esp_file.new_file.return_value.name = 'temp_esp'
+
+        tmp_names = [temp_esp_file, temp_squashfs, temp_media_dir]
 
         def side_effect(prefix, path):
-            return tmpdir_name.pop()
+            return tmp_names.pop()
 
         bootloader_config = mock.Mock()
         mock_BootLoaderConfig.return_value = bootloader_config
@@ -195,6 +198,9 @@ class TestInstallImageBuilder:
             mbrid=self.mbrid
         )
         bootloader_config.write.assert_called_once_with()
+        bootloader_config._create_embedded_fat_efi_image.assert_called_once_with(
+            'temp_esp'
+        )
         self.boot_image_task.create_initrd.assert_called_once_with(
             self.mbrid, 'initrd_kiwi_install', install_initrd=True
         )
@@ -222,7 +228,7 @@ class TestInstallImageBuilder:
             'target_dir/result-image.x86_64-1.2.3.install.iso'
         )
 
-        tmpdir_name = [temp_squashfs, temp_media_dir]
+        tmp_names = [temp_esp_file, temp_squashfs, temp_media_dir]
         self.install_image.initrd_system = 'dracut'
 
         m_open.reset_mock()
@@ -249,7 +255,7 @@ class TestInstallImageBuilder:
         ]
 
         mock_BootLoaderConfig.reset_mock()
-        tmpdir_name = [temp_squashfs, temp_media_dir]
+        tmp_names = [temp_esp_file, temp_squashfs, temp_media_dir]
         self.firmware.efi_mode.return_value = None
 
         with patch('builtins.open', m_open, create=True):
@@ -259,6 +265,7 @@ class TestInstallImageBuilder:
             'isolinux', self.xml_state, root_dir='root_dir',
             boot_dir='temp_media_dir'
         )
+        bootloader_config._create_embedded_fat_efi_image.assert_not_called()
 
     @patch('kiwi.builder.install.IsoToolsBase.setup_media_loader_directory')
     @patch('kiwi.builder.install.Temporary')

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -272,6 +272,7 @@ class TestLiveImageBuilder:
                     'publisher': 'Custom publisher',
                     'volume_id': 'volid',
                     'efi_mode': 'uefi',
+                    'efi_loader': 'kiwi-tmpfile',
                     'udf': True
                 }
             },

--- a/test/unit/filesystem/isofs_test.py
+++ b/test/unit/filesystem/isofs_test.py
@@ -42,8 +42,6 @@ class TestFileSystemIsoFs:
 
         iso_tool.init_iso_creation_parameters.assert_called_once_with({})
 
-        iso_tool.add_efi_loader_parameters.assert_called_once_with()
-
         iso_tool.create_iso.assert_called_once_with('myimage')
 
     @patch('kiwi.filesystem.isofs.IsoTools')
@@ -61,6 +59,10 @@ class TestFileSystemIsoFs:
         iso.header_end_name = 'header_end'
         mock_iso.return_value = iso
         self.isofs.custom_args['meta_data']['efi_mode'] = 'uefi'
+        self.isofs.custom_args['meta_data']['efi_loader'] = 'esp-image-file'
         with self._caplog.at_level(logging.WARNING):
             self.isofs.create_on_file('myimage')
             iso_tool.create_iso.assert_called_once_with('myimage')
+            iso_tool.add_efi_loader_parameters.assert_called_once_with(
+                'esp-image-file'
+            )

--- a/test/unit/iso_tools/base_test.py
+++ b/test/unit/iso_tools/base_test.py
@@ -30,7 +30,7 @@ class TestIsoToolsBase:
 
     def test_add_efi_loader_parameters(self):
         with raises(NotImplementedError):
-            self.iso_tool.add_efi_loader_parameters()
+            self.iso_tool.add_efi_loader_parameters('loader_file')
 
     def test_has_iso_hybrid_capability(self):
         with raises(NotImplementedError):

--- a/test/unit/iso_tools/xorriso_test.py
+++ b/test/unit/iso_tools/xorriso_test.py
@@ -98,12 +98,10 @@ class TestIsoToolsXorrIso:
             '-boot_image', 'any', 'load_size=2048'
         ]
 
-    @patch('os.path.exists')
-    def test_add_efi_loader_parameters(self, mock_exists):
-        mock_exists.return_value = True
-        self.iso_tool.add_efi_loader_parameters()
+    def test_add_efi_loader_parameters(self):
+        self.iso_tool.add_efi_loader_parameters('target_dir/efi-loader')
         assert self.iso_tool.iso_loaders == [
-            '-append_partition', '2', '0xef', 'source-dir/boot/x86_64/efi',
+            '-append_partition', '2', '0xef', 'target_dir/efi-loader',
             '-boot_image', 'any', 'next',
             '-boot_image', 'any',
             'efi_path=--interval:appended_partition_2:all::',


### PR DESCRIPTION
I'm not very familiar with kiwi code, so I'm not sure what the best way to implement this is.
Currently kiwi puts everything generated for the final `xorriso` call into the media directory, which is written to the ISO9660 filesystem. Some arguments are written into the image though, which means that those just waste space in the filesystem.
Is there some other place where stuff like the `efi` loader and `eltorito.img` could go?

For now I'm using `Temporary().new_file()`.

Fixes the biggest part of #1750.

Note: Somewhat untested and unit tests haven't been adjusted.