### PR TITLE
Fixed image builds without kernel

### DIFF
--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -204,6 +204,8 @@ class BootImageBase:
         )
         kernel_info = kernel.get_kernel()
         if not kernel_info:
+            if self.xml_state.get_initrd_system() == 'none':
+                return boot_names_type(kernel_name='none', initrd_name='none')
             raise KiwiDiskBootImageError(
                 'No kernel in boot image tree %s found' %
                 self.boot_root_directory

--- a/kiwi/system/kernel.py
+++ b/kiwi/system/kernel.py
@@ -161,9 +161,10 @@ class Kernel:
         :rtype: list
         """
         kernel_names = []
-        kernel_dirs = sorted(
-            os.listdir(''.join([self.root_dir, '/lib/modules']))
-        )
+        kernel_dirs = []
+        kernel_module_dir = ''.join([self.root_dir, '/lib/modules'])
+        if os.path.isdir(kernel_module_dir):
+            kernel_dirs = sorted(os.listdir(kernel_module_dir))
         if kernel_dirs:
             # append lookup for the real kernel image names
             # depending on the arch and os they are different

--- a/test/unit/boot/image/base_test.py
+++ b/test/unit/boot/image/base_test.py
@@ -104,6 +104,16 @@ class TestBootImageBase:
             self.boot_image.get_boot_names()
 
     @patch('kiwi.boot.image.base.Kernel')
+    def test_get_boot_names_with_initrd_system_set_to_none(self, mock_Kernel):
+        kernel = Mock()
+        mock_Kernel.return_value = kernel
+        kernel.get_kernel.return_value = None
+        self.xml_state.get_initrd_system.return_value = 'none'
+        boot_names = self.boot_image.get_boot_names()
+        assert boot_names.kernel_name == 'none'
+        assert boot_names.initrd_name == 'none'
+
+    @patch('kiwi.boot.image.base.Kernel')
     @patch('kiwi.boot.image.base.Path.which')
     @patch('kiwi.boot.image.base.log.warning')
     @patch('glob.iglob')

--- a/test/unit/system/kernel_test.py
+++ b/test/unit/system/kernel_test.py
@@ -10,7 +10,9 @@ from kiwi.exceptions import KiwiKernelLookupError
 
 class TestKernel:
     @patch('os.listdir')
-    def setup(self, mock_listdir):
+    @patch('os.path.isdir')
+    def setup(self, mock_path_isdir, mock_listdir):
+        mock_path_isdir.return_value = True
         mock_listdir.return_value = ['1.2.3-default']
         self.kernel = Kernel('root-dir')
         assert self.kernel.kernel_names == [


### PR DESCRIPTION
If an image is build without a kernel kiwi fails due to
some code paths expecting the presence of kernel modules
and or kernel binaries. This commit fixes this and allows
creating an image without installing a kernel.


