### PR TITLE
Add support for custom GRUB templates

### DIFF
--- a/doc/source/building_images/build_simple_disk.rst
+++ b/doc/source/building_images/build_simple_disk.rst
@@ -102,48 +102,15 @@ Setting up the Bootloader of the Image
 .. code:: xml
 
    <preferences>
-     <bootloader name="grub2"/>
+     <type>
+        <bootloader name="grub2"/>
+     </type>
    </preferences>
 
-The `bootloader` element is used to select the bootloader. At the moment
-`grub2`, `isolinux`, `zipl` and `grub2_s390x_emu` (a combination of zipl
-and a userspace GRUB2) are supported. The special `custom` entry allows
-to skip the bootloader configuration and installation and leaves this up
-to the user which can be done by using the `editbootinstall` and
-`editbootconfig` custom scripts.
+The `bootloader` element defines which bootloader will be used in the
+image and offers several options for customizing its configuration.
 
-In addition to the mandatory name attribute the following optional
-attributes are supported:
-
-console="console|gfxterm|serial":
-  Specifies the bootloader console. The attribute is available for the
-  grub and isolinux bootloader types. By default a graphics console
-  setup is used
-
-serial_line="string":
-  Specifies the bootloader serial line setup. The setup
-  is effective if the bootloader console is set to use
-  the serial line. The attribute is available for the grub
-  bootloader only
-
-timeout="number":
-  Specifies the boot timeout in seconds prior to launching
-  the default boot option. By default the timeout is set to 10 seconds. It
-  makes sense to set this value to `0` for images intended to be started
-  non-interactively (e.g. virtual machines).
-
-timeout_style="countdown|hidden":
-  Specifies the boot timeout style to control the way in which
-  the timeout interacts with displaying the menu. If set the
-  display of the bootloader menu is delayed after the timeout
-  expired. In countdown mode an indication of the remaining time
-  is displayed. The attribute is available for the grub loader only
-
-targettype="CDL|LDL|FBA|SCSI":
-  Specifies the device type of the disk zipl should boot.
-  On zFCP devices use `SCSI`, on DASD devices use `CDL` or `LDL` on
-  emulated DASD devices use `FBA`. The attribute is available for the
-  zipl loader only
+For details, see: :ref:`preferences-type-bootloader`
 
 .. _disk-the-size-element:
 

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -709,10 +709,107 @@ publisher="string":
 The following sections shows the supported child elements of the `type`
 element including references to their usage in a detailed type setup:
 
+.. _preferences-type-bootloader:
+
 <preferences><type><bootloader>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Used to describe the bootloader setup in the oem disk image type.
-For details see: :ref:`disk-bootloader`
+The `bootloader` element is used to select the bootloader. At the moment,
+`grub2`, `isolinux`, `zipl` and `grub2_s390x_emu` (a combination of zipl
+and a userspace GRUB2) are supported. The special `custom` entry allows
+to skip the bootloader configuration and installation and leaves this up
+to the user, which can be done by using the `editbootinstall` and
+`editbootconfig` custom scripts.
+
+In addition to the mandatory name attribute, the following optional
+attributes are supported:
+
+console="console|gfxterm|serial":
+  Specifies the bootloader console. The attribute is available for the
+  grub and isolinux bootloader types. By default, a graphics console
+  setup is used.
+
+grub_template="filename":
+  Specifies a custom grub bootloader template file which will be used
+  instead of the one provided with Kiwi. A static bootloader template to
+  create the grub config file is only used in Kiwi if the native method
+  via the grub mkconfig toolchain does not work properly. As of today,
+  this is only the case for live and install ISO images. Thus, this
+  setting only affects the oem and iso image types.
+
+  The template file should contain a `Template string
+  <https://docs.python.org/3.4/library/string.html#template-strings>`_
+  and can use the following variables:
+
+  +-----------------------+----------------------------------------------+
+  | Variable              | Description                                  |
+  +=======================+==============================================+
+  | search_params         | parameters needed for grub's `search`        |
+  |                       | command to locate the root volume            |
+  +-----------------------+----------------------------------------------+
+  | default_boot          | number of the default menu item to boot      |
+  +-----------------------+----------------------------------------------+
+  | kernel_file           | the name of the kernel file                  |
+  +-----------------------+----------------------------------------------+
+  | initrd_file           | the name of the initial ramdisk file         |
+  +-----------------------+----------------------------------------------+
+  | boot_options          | kernel command line options for booting      |
+  |                       | normally                                     |
+  +-----------------------+----------------------------------------------+
+  | failsafe_boot_options | kernel command line options for booting in   |
+  |                       | failsafe mode                                |
+  +-----------------------+----------------------------------------------+
+  | gfxmode               | the resolution to use for the bootloader;    |
+  |                       | passed to grub's `gfxmode` command           |
+  +-----------------------+----------------------------------------------+
+  | theme                 | the name of a graphical theme to use         |
+  +-----------------------+----------------------------------------------+
+  | boot_timeout          | the boot menu timeout, set by the `timeout`  |
+  |                       | attribute                                    |
+  +-----------------------+----------------------------------------------+
+  | boot_timeout_style    | the boot timeout style, set by the           |
+  |                       | `timeout_style` attribute                    |
+  +-----------------------+----------------------------------------------+
+  | serial_line_setup     | directives used to initialize the serial     |
+  |                       | port, set by the `serial_line` attribute     |
+  +-----------------------+----------------------------------------------+
+  | title                 | a title for the image: this will be the      |
+  |                       | `<image>` tag's `displayname` attribute or   |
+  |                       | its `name` attribute if `displayname` is not |
+  |                       | set; see: :ref:`sec.image`                   |
+  +-----------------------+----------------------------------------------+
+  | bootpath              | the bootloader lookup path                   |
+  +-----------------------+----------------------------------------------+
+  | boot_directory_name   | the name of the grub directory               |
+  +-----------------------+----------------------------------------------+
+  | efi_image_name        | architecture-specific EFI boot binary name   |
+  +-----------------------+----------------------------------------------+
+  | terminal_setup        | the bootloader console mode, set by the      |
+  |                       | `console` attribute                          |
+  +-----------------------+----------------------------------------------+
+
+serial_line="string":
+  Specifies the bootloader serial line setup. The setup is effective if
+  the bootloader console is set to use the serial line. The attribute is
+  available for the grub bootloader only.
+
+timeout="number":
+  Specifies the boot timeout in seconds prior to launching the default
+  boot option. By default, the timeout is set to 10 seconds. It makes
+  sense to set this value to `0` for images intended to be started
+  non-interactively (e.g. virtual machines).
+
+timeout_style="countdown|hidden":
+  Specifies the boot timeout style to control the way in which the timeout
+  interacts with displaying the menu. If set, the display of the
+  bootloader menu is delayed after the timeout expired. In countdown mode,
+  an indication of the remaining time is displayed. The attribute is
+  available for the grub loader only.
+
+targettype="CDL|LDL|FBA|SCSI":
+  Specifies the device type of the disk zipl should boot.
+  On zFCP devices, use `SCSI`; on DASD devices, use `CDL` or `LDL`; on
+  emulated DASD devices, use `FBA`. The attribute is available for the
+  zipl loader only.
 
 <preferences><type><containerconfig>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2377,6 +2377,18 @@ div {
             sch:param [ name = "attr" value = "name" ]
             sch:param [ name = "types" value = "oem iso" ]
         ]
+    k.bootloader.grub_template.attribute =
+        ## Specifies a custom grub bootloader template file which will be used
+        ## instead of the one provided with Kiwi. A static bootloader template to
+        ## create the grub config file is only used in Kiwi if the native method
+        ## via the grub mkconfig toolchain does not work properly. As of today,
+        ## this is only the case for live and install ISO images. Thus, this
+        ## setting only affects the oem and iso image types.
+        attribute grub_template { text }
+        >> sch:pattern [ id = "loader_grub_template" is-a = "bootloader_image_type"
+            sch:param [ name = "attr" value = "grub_template" ]
+            sch:param [ name = "types" value = "oem iso" ]
+        ]
     k.bootloader.console.attribute =
         ## Specifies the bootloader console.
         ## The value is available for grub and isolinux bootloader
@@ -2435,7 +2447,8 @@ div {
         k.bootloader.serial_line.attribute? &
         k.bootloader.timeout.attribute? &
         k.bootloader.timeout_style.attribute? &
-        k.bootloader.targettype.attribute?
+        k.bootloader.targettype.attribute? &
+        k.bootloader.grub_template.attribute?
 
     k.bootloader =
         ## The bootloader section is used to select the bootloader

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -3590,6 +3590,20 @@ editbootconfig custom scripts</a:documentation>
         <sch:param name="types" value="oem iso"/>
       </sch:pattern>
     </define>
+    <define name="k.bootloader.grub_template.attribute">
+      <attribute name="grub_template">
+        <a:documentation>Specifies a custom grub bootloader template file which will be used
+instead of the one provided with Kiwi. A static bootloader template to
+create the grub config file is only used in Kiwi if the native method
+via the grub mkconfig toolchain does not work properly. As of today,
+this is only the case for live and install ISO images. Thus, this
+setting only affects the oem and iso image types.</a:documentation>
+      </attribute>
+      <sch:pattern id="loader_grub_template" is-a="bootloader_image_type">
+        <sch:param name="attr" value="grub_template"/>
+        <sch:param name="types" value="oem iso"/>
+      </sch:pattern>
+    </define>
     <define name="k.bootloader.console.attribute">
       <attribute name="console">
         <a:documentation>Specifies the bootloader console.
@@ -3676,6 +3690,9 @@ for 4k DASD devices use CDL</a:documentation>
         </optional>
         <optional>
           <ref name="k.bootloader.targettype.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.bootloader.grub_template.attribute"/>
         </optional>
       </interleave>
     </define>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -4886,7 +4886,7 @@ class bootloader(GeneratedsSuper):
     provide configuration parameters for it"""
     subclass = None
     superclass = None
-    def __init__(self, name=None, console=None, serial_line=None, timeout=None, timeout_style=None, targettype=None):
+    def __init__(self, name=None, console=None, serial_line=None, timeout=None, timeout_style=None, targettype=None, grub_template=None):
         self.original_tagname_ = None
         self.name = _cast(None, name)
         self.console = _cast(None, console)
@@ -4894,6 +4894,7 @@ class bootloader(GeneratedsSuper):
         self.timeout = _cast(int, timeout)
         self.timeout_style = _cast(None, timeout_style)
         self.targettype = _cast(None, targettype)
+        self.grub_template = _cast(None, grub_template)
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -4917,6 +4918,8 @@ class bootloader(GeneratedsSuper):
     def set_timeout_style(self, timeout_style): self.timeout_style = timeout_style
     def get_targettype(self): return self.targettype
     def set_targettype(self, targettype): self.targettype = targettype
+    def get_grub_template(self): return self.grub_template
+    def set_grub_template(self, grub_template): self.grub_template = grub_template
     def validate_grub_console(self, value):
         # Validate type grub_console, a restriction on xs:token.
         if value is not None and Validate_simpletypes_:
@@ -4970,6 +4973,9 @@ class bootloader(GeneratedsSuper):
         if self.targettype is not None and 'targettype' not in already_processed:
             already_processed.add('targettype')
             outfile.write(' targettype=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.targettype), input_name='targettype')), ))
+        if self.grub_template is not None and 'grub_template' not in already_processed:
+            already_processed.add('grub_template')
+            outfile.write(' grub_template=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.grub_template), input_name='grub_template')), ))
     def exportChildren(self, outfile, level, namespaceprefix_='', name_='bootloader', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node):
@@ -5014,6 +5020,10 @@ class bootloader(GeneratedsSuper):
             already_processed.add('targettype')
             self.targettype = value
             self.targettype = ' '.join(self.targettype.split())
+        value = find_attr_value_('grub_template', node)
+        if value is not None and 'grub_template' not in already_processed:
+            already_processed.add('grub_template')
+            self.grub_template = value
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class bootloader


### PR DESCRIPTION
This allows the user to specify a template file to customize
the bootloader menu. This only applies to oem and iso image
types: other image types use the grub mkconfig toolchain.

Fixes #1970

Changes since #2031:
* added unit tests