### PR TITLE
Allow calling podman within chroot

### DIFF
--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -25,6 +25,36 @@ export LC_ALL=C
 #======================================
 # Common Functions
 #--------------------------------------
+function mountCgroups {
+    mount -t tmpfs cgroup_root /sys/fs/cgroup
+    for group in devices blkio cpuset pids; do
+        mkdir -p /sys/fs/cgroup/"${group}"
+        mount -t cgroup "${group}" -o "${group}" /sys/fs/cgroup/"${group}"
+    done
+}
+
+function umountCgroups {
+    for group in devices blkio cpuset pids; do
+        umount /sys/fs/cgroup/"${group}"
+    done
+    umount /sys/fs/cgroup
+}
+
+function setupContainerRuntime {
+    cat >/etc/containers/containers.conf <<- EOF
+	[engine]
+	no_pivot_root = true
+	cgroups = "disabled"
+	events_logger = "none"
+	cgroup_manager = "cgroupfs"
+	EOF
+
+    cat >/etc/containers/storage.conf <<- EOF
+	[storage]
+	driver = "vfs"
+	EOF
+}
+
 function baseSystemdServiceInstalled {
     local service=$1
     local sd_dirs="

--- a/kiwi/system/root_bind.py
+++ b/kiwi/system/root_bind.py
@@ -69,7 +69,8 @@ class RootBind:
             '/proc',
             '/dev',
             '/var/run/dbus',
-            '/sys'
+            '/sys',
+            '/run'
         ]
         # share the following directory with the host
         self.shared_location = '/' + Defaults.get_shared_cache_location()
@@ -82,6 +83,16 @@ class RootBind:
             fails to mount
         """
         try:
+            # Yes this bind mount to yourself looks weird and should not
+            # be needed at all. The reason why it exists is to overcome
+            # an issue that appears if you run containers in kiwi scripts
+            # via e.g podman or docker. There is some information about the
+            # topic here: https://github.com/moby/moby/issues/34817
+            shared_mount = MountManager(
+                device=self.root_dir, mountpoint=self.root_dir
+            )
+            shared_mount.bind_mount()
+            self.mount_stack.append(shared_mount)
             for location in self.bind_locations:
                 location_mount_target = os.path.normpath(os.sep.join([
                     self.root_dir, location

--- a/test/unit/system/root_bind_test.py
+++ b/test/unit/system/root_bind_test.py
@@ -89,10 +89,13 @@ class TestRootBind:
         shared_mount = Mock()
         mock_mount.return_value = shared_mount
         assert self.bind_root.mount_kernel_file_systems() is None
-        mock_mount.assert_called_once_with(
-            device='/proc', mountpoint='root-dir/proc'
-        )
-        shared_mount.bind_mount.assert_called_once_with()
+        assert mock_mount.call_args_list == [
+            call(device='root-dir', mountpoint='root-dir'),
+            call(device='/proc', mountpoint='root-dir/proc')
+        ]
+        assert shared_mount.bind_mount.call_args_list == [
+            call(), call()
+        ]
 
     @patch('kiwi.system.root_bind.MountManager')
     def test_umount_kernel_file_systems(self, mock_mount):


### PR DESCRIPTION
Added helper functions and env preparation code
to allow calling podman from within a chroot. This
allows to run podman from e.g config.sh and also
inside of OBS workers

