### PR TITLE
Fixed grub loader/entries setup

### DIFF
--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -777,7 +777,8 @@ class TestBootLoaderConfigGrub2:
                 'root=rootdev nomodeset console=ttyS0 console=tty0\n' \
                 'root=PARTUUID=xx'
             file_handle_grubenv.read.return_value = 'root=rootdev'
-            file_handle_menu.read.return_value = 'options foo bar'
+            file_handle_menu.read.return_value = \
+                'options foo\nlinux unexpected/boot/vmlinuz\ninitrd /boot/initrd'
 
             self.bootloader.setup_disk_image_config(
                 boot_options={
@@ -833,9 +834,12 @@ class TestBootLoaderConfigGrub2:
             file_handle_grubenv.write.assert_called_once_with(
                 'root=overlay:UUID=ID'
             )
-            file_handle_menu.write.assert_called_once_with(
-                'options some-cmdline root=UUID=foo'
-            )
+            assert 'options some-cmdline root=UUID=foo' in \
+                file_handle_menu.write.call_args_list[0][0][0].split(os.linesep)
+            assert 'linux /boot/vmlinuz' in \
+                file_handle_menu.write.call_args_list[1][0][0].split(os.linesep)
+            assert 'initrd /boot/initrd' in \
+                file_handle_menu.write.call_args_list[1][0][0].split(os.linesep)
 
     @patch.object(BootLoaderConfigGrub2, '_mount_system')
     @patch.object(BootLoaderConfigGrub2, '_copy_grub_config_to_efi_path')


### PR DESCRIPTION
If called in non standard environments like an OBS worker
the grub tooling does not work correctly and produces invalid
results. For these cases kiwi provides a collection of fix_
methods to change the produced results. This commit covers
the invalid path in loader/entries/*.conf files pointing to
the kernel and the initrd as they exist in the image-root
directory. This results for example in settings like:

* linux /usr/src/packages/KIWI-oem/build/image-root/boot/vmlinuz-5.14.0-43.el9.x86_64

when it should be:

* linux /boot/vmlinuz-5.14.0-43.el9.x86_64

This Fixes #2038


