### PR TITLE
Fix ramdisk deployments from PXE

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-mount-ramdisk.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-mount-ramdisk.sh
@@ -15,6 +15,10 @@ function mount_ramdisk {
         die "Missing ${boot_options} file"
     fi
 
+    # Add a space to /config.bootoptions to make sure the
+    # following token based read captures all entries
+    echo -n ' ' >> "${boot_options}"
+
     root_dev=$(
         while read -r -d ' ' opt; do echo "${opt}";done < "${boot_options}" |\
         grep root= | cut -f2- -d=


### PR DESCRIPTION
This commit fixes PXE deployments on ramdisk. In such cases the
former fix from df4e62a4 is not sufficient as there is no `root=`
parameter within the kernel cmd line and hence this logic is never
executed.

Signed-off-by: David Cassany <dcassany@suse.com>
