### PR TITLE
Fix the uninstall(force) on Debian based dists

### DIFF
--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -219,6 +219,16 @@ class PackageManagerBase:
         """
         pass
 
+    def post_process_delete_requests(
+        self, root_bind: RootBind = None
+    ) -> None:
+        """
+        Process extra code required after deleting packages
+
+        Implementation in specialized package manager class
+        """
+        pass
+
     @staticmethod
     def has_failed(returncode: int) -> bool:
         """

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -469,6 +469,7 @@ class SystemPrepare:
                         manager.match_package_deleted
                     )
                 )
+                manager.post_process_delete_requests(self.root_bind)
             except Exception as issue:
                 raise KiwiSystemDeletePackagesFailed(
                     self.issue_message.format(

--- a/test/unit/package_manager/base_test.py
+++ b/test/unit/package_manager/base_test.py
@@ -41,6 +41,9 @@ class TestPackageManagerBase:
     def test_post_process_install_requests_bootstrap(self):
         self.manager.post_process_install_requests_bootstrap()
 
+    def test_post_process_delete_requests(self):
+        self.manager.post_process_delete_requests()
+
     def test_process_install_requests(self):
         with raises(NotImplementedError):
             self.manager.process_install_requests()

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -403,6 +403,9 @@ class TestSystemPrepare:
         self.manager.process_delete_requests.assert_has_calls(
             [call(False), call(True)]
         )
+        self.manager.post_process_delete_requests.assert_has_calls(
+            [call(self.system.root_bind), call(self.system.root_bind)]
+        )
 
     @patch('kiwi.system.prepare.CommandProcess.poll_show_progress')
     def test_pinch_system_raises(self, mock_poll):


### PR DESCRIPTION
Packages marked for uninstall via <package name="delete|uninstall"/>
failed to become removed for several reasons. The way this was done
in kiwi did not work because dpkg needs to be called differently
and with some nasty pre-processing in order to allow for force
deletion. In force mode we also allow to remove packages marked as
essential. In gracefull uninstall mode this commit makes sure the
environment is prepared and does not fail for false-positive
reasons.


