### PR TITLE
Ensure SELinux labels are set based on the policy

### DIFF
--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -476,7 +476,7 @@ class SystemSetup:
         Command.run(
             [
                 'chroot', self.root_dir,
-                'setfiles', security_context_file, '/', '-v'
+                'setfiles', security_context_file, '/', '-v', '-F'
             ]
         )
 

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -1302,7 +1302,7 @@ class TestSystemSetup:
         mock_command.assert_called_once_with(
             [
                 'chroot', 'root_dir',
-                'setfiles', 'security_context_file', '/', '-v'
+                'setfiles', 'security_context_file', '/', '-v', '-F'
             ]
         )
 


### PR DESCRIPTION
When running kiwi from a filesystem tree that has custom labels applied
(such as when using kiwi from within a container on an SELinux-enabled
host), the filesystem labeling doesn't correctly apply on some files
and folders with a warning about the location being customized by
the administrator. This causes all kinds of strange results with
the built images and makes them unbootable.

To resolve this, tell setfiles to forcibly set files and folders
with the default context from the installed policy.