### PR TITLE
Fix use of xattrs for container sync

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -314,7 +314,10 @@ class Defaults:
 
         :rtype: list
         """
-        return ['-a', '-H', '-X', '-A', '--one-file-system', '--inplace']
+        return [
+            '--archive', '--hard-links', '--xattrs', '--acls',
+            '--one-file-system', '--inplace'
+        ]
 
     @staticmethod
     def get_exclude_list_for_root_data_sync():

--- a/kiwi/oci_tools/buildah.py
+++ b/kiwi/oci_tools/buildah.py
@@ -161,7 +161,12 @@ class OCIBuildah(OCIBase):
         self._sync_data(
             ''.join([root_dir, os.sep]), self.oci_root_dir,
             exclude_list=exclude_list,
-            options=Defaults.get_sync_options() + ['--delete']
+            options=Defaults.get_sync_options() + [
+                '--filter', '-x! user.*',
+                '--filter', '-x! security.ima*',
+                '--filter', '-x! security.capability*',
+                '--delete'
+            ]
         )
 
     def import_rootfs(self, root_dir, exclude_list=None):

--- a/kiwi/oci_tools/umoci.py
+++ b/kiwi/oci_tools/umoci.py
@@ -123,7 +123,12 @@ class OCIUmoci(OCIBase):
             ''.join([root_dir, os.sep]),
             os.sep.join([self.oci_root_dir, 'rootfs']),
             exclude_list=exclude_list,
-            options=Defaults.get_sync_options() + ['--delete']
+            options=Defaults.get_sync_options() + [
+                '--filter', '-x! user.*',
+                '--filter', '-x! security.ima*',
+                '--filter', '-x! security.capability*',
+                '--delete'
+            ]
         )
 
     def import_rootfs(self, root_dir, exclude_list=None):

--- a/kiwi/utils/sync.py
+++ b/kiwi/utils/sync.py
@@ -89,11 +89,11 @@ class DataSync:
             rsync_options = options
         if not self.target_supports_extended_attributes():
             warn_me = False
-            if '-X' in rsync_options:
-                rsync_options.remove('-X')
+            if '--xattrs' in rsync_options:
+                rsync_options.remove('--xattrs')
                 warn_me = True
-            if '-A' in rsync_options:
-                rsync_options.remove('-A')
+            if '--acls' in rsync_options:
+                rsync_options.remove('--acls')
                 warn_me = True
             if warn_me:
                 log.warning(

--- a/test/unit/filesystem/base_test.py
+++ b/test/unit/filesystem/base_test.py
@@ -60,7 +60,10 @@ class TestFileSystemBase:
         mock_sync.assert_called_once_with('root_dir', 'tmpdir')
         data_sync.sync_data.assert_called_once_with(
             exclude=['exclude_me'],
-            options=['-a', '-H', '-X', '-A', '--one-file-system', '--inplace']
+            options=[
+                '--archive', '--hard-links', '--xattrs',
+                '--acls', '--one-file-system', '--inplace'
+            ]
         )
         mock_mount.assert_called_once_with(
             device='/dev/loop0'

--- a/test/unit/oci_tools/buildah_test.py
+++ b/test/unit/oci_tools/buildah_test.py
@@ -67,8 +67,12 @@ class TestOCIBuildah:
         sync.sync_data.assert_called_once_with(
             exclude=['/dev', '/proc'],
             options=[
-                '-a', '-H', '-X', '-A', '--one-file-system',
-                '--inplace', '--delete'
+                '--archive', '--hard-links', '--xattrs', '--acls',
+                '--one-file-system', '--inplace',
+                '--filter', '-x! user.*',
+                '--filter', '-x! security.ima*',
+                '--filter', '-x! security.capability*',
+                '--delete'
             ]
         )
 
@@ -83,7 +87,10 @@ class TestOCIBuildah:
         )
         sync.sync_data.assert_called_once_with(
             exclude=['/dev', '/proc'],
-            options=['-a', '-H', '-X', '-A', '--one-file-system', '--inplace']
+            options=[
+                '--archive', '--hard-links', '--xattrs', '--acls',
+                '--one-file-system', '--inplace'
+            ]
         )
 
     @patch('kiwi.oci_tools.umoci.Command.run')

--- a/test/unit/oci_tools/umoci_test.py
+++ b/test/unit/oci_tools/umoci_test.py
@@ -51,8 +51,12 @@ class TestOCIUmoci:
         sync.sync_data.assert_called_once_with(
             exclude=['/dev', '/proc'],
             options=[
-                '-a', '-H', '-X', '-A', '--one-file-system',
-                '--inplace', '--delete'
+                '--archive', '--hard-links', '--xattrs', '--acls',
+                '--one-file-system', '--inplace',
+                '--filter', '-x! user.*',
+                '--filter', '-x! security.ima*',
+                '--filter', '-x! security.capability*',
+                '--delete'
             ]
         )
 
@@ -67,7 +71,10 @@ class TestOCIUmoci:
         )
         sync.sync_data.assert_called_once_with(
             exclude=['/dev', '/proc'],
-            options=['-a', '-H', '-X', '-A', '--one-file-system', '--inplace']
+            options=[
+                '--archive', '--hard-links', '--xattrs', '--acls',
+                '--one-file-system', '--inplace'
+            ]
         )
 
     @patch('kiwi.oci_tools.umoci.Temporary')

--- a/test/unit/utils/sync_test.py
+++ b/test/unit/utils/sync_test.py
@@ -26,12 +26,15 @@ class TestDataSync:
         mock_xattr_support.return_value = False
         with self._caplog.at_level(logging.WARNING):
             self.sync.sync_data(
-                options=['-a', '-H', '-X', '-A', '--one-file-system'],
+                options=[
+                    '--archive', '--hard-links', '--xattrs',
+                    '--acls', '--one-file-system'
+                ],
                 exclude=['exclude_me']
             )
             mock_command.assert_called_once_with(
                 [
-                    'rsync', '-a', '-H', '--one-file-system',
+                    'rsync', '--archive', '--hard-links', '--one-file-system',
                     '--exclude', '/exclude_me', 'source_dir', 'target_dir'
                 ]
             )

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -232,7 +232,10 @@ class TestVolumeManagerBase:
         )
         data_sync.sync_data.assert_called_once_with(
             exclude=['exclude_me'],
-            options=['-a', '-H', '-X', '-A', '--one-file-system', '--inplace']
+            options=[
+                '--archive', '--hard-links', '--xattrs',
+                '--acls', '--one-file-system', '--inplace'
+            ]
         )
         assert self.volume_manager.get_mountpoint() == 'mountpoint'
 

--- a/test/unit/volume_manager/btrfs_test.py
+++ b/test/unit/volume_manager/btrfs_test.py
@@ -437,7 +437,10 @@ class TestVolumeManagerBtrfs:
         )
         sync.sync_data.assert_called_once_with(
             exclude=['exclude_me'],
-            options=['-a', '-H', '-X', '-A', '--one-file-system', '--inplace']
+            options=[
+                '--archive', '--hard-links', '--xattrs',
+                '--acls', '--one-file-system', '--inplace'
+            ]
         )
         assert m_open.call_args_list == [
             call('tmpdir/@/.snapshots/1/info.xml', 'w'),
@@ -496,7 +499,10 @@ class TestVolumeManagerBtrfs:
         )
         sync.sync_data.assert_called_once_with(
             exclude=['exclude_me'],
-            options=['-a', '-H', '-X', '-A', '--one-file-system', '--inplace']
+            options=[
+                '--archive', '--hard-links', '--xattrs', '--acls',
+                '--one-file-system', '--inplace'
+            ]
         )
         assert m_open.call_args_list == [
             call('tmpdir/@/.snapshots/1/info.xml', 'w'),
@@ -530,7 +536,10 @@ class TestVolumeManagerBtrfs:
         )
         sync.sync_data.assert_called_once_with(
             exclude=['exclude_me'],
-            options=['-a', '-H', '-X', '-A', '--one-file-system', '--inplace']
+            options=[
+                '--archive', '--hard-links', '--xattrs', '--acls',
+                '--one-file-system', '--inplace'
+            ]
         )
 
     @patch('kiwi.volume_manager.btrfs.Command.run')


### PR DESCRIPTION
when syncing data for containers only a subset of xattr
attributes can be applied. This Fixes #2009


