### PR TITLE
Followup fix for force deleting debian packages

### DIFF
--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -311,7 +311,8 @@ class PackageManagerApt(PackageManagerBase):
                 [
                     '--remove',
                     '--force-remove-reinstreq',
-                    '--force-remove-essential'
+                    '--force-remove-essential',
+                    '--force-depends'
                 ]
             )
             apt_get_command.extend(delete_items)

--- a/test/unit/package_manager/apt_test.py
+++ b/test/unit/package_manager/apt_test.py
@@ -200,7 +200,7 @@ class TestPackageManagerApt:
             [
                 'chroot', 'root-dir', 'dpkg',
                 '--remove', '--force-remove-reinstreq',
-                '--force-remove-essential', 'vim'
+                '--force-remove-essential', '--force-depends', 'vim'
             ],
             ['env']
         )


### PR DESCRIPTION
Pass --force-depends to allow uninstall even if the
dependency checker complains


