### PR TITLE
Followup fix for force deleting debian packages

### DIFF
--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -17,6 +17,7 @@
 #
 import re
 import os
+import glob
 import logging
 from typing import (
     List, Dict
@@ -303,8 +304,10 @@ class PackageManagerApt(PackageManagerBase):
             # are still cases when it does not work depending on the many
             # code that runs on deleting
             for package in delete_items:
-                Path.wipe(f'/var/lib/dpkg/info/{package}.preinst')
-                Path.wipe(f'/var/lib/dpkg/info/{package}.prerm')
+                delete_pattern = \
+                    f'{self.root_dir}/var/lib/dpkg/info/{package}*.pre*'
+                for delete_file in glob.iglob(delete_pattern):
+                    Path.wipe(delete_file)
 
             apt_get_command = ['chroot', self.root_dir, 'dpkg']
             apt_get_command.extend(

--- a/test/unit/package_manager/apt_test.py
+++ b/test/unit/package_manager/apt_test.py
@@ -172,9 +172,11 @@ class TestPackageManagerApt:
     @patch('kiwi.command.Command.call')
     @patch('kiwi.command.Command.run')
     @patch('kiwi.package_manager.apt.Path.wipe')
+    @patch('glob.iglob')
     def test_process_delete_requests_force(
-        self, mock_Path_wipe, mock_run, mock_call
+        self, mock_iglob, mock_Path_wipe, mock_run, mock_call
     ):
+        mock_iglob.return_value = ['glob-result']
         self.manager.request_package('vim')
         self.manager.process_delete_requests(True)
         assert mock_run.call_args_list == [
@@ -204,10 +206,10 @@ class TestPackageManagerApt:
             ],
             ['env']
         )
-        assert mock_Path_wipe.call_args_list == [
-            call('/var/lib/dpkg/info/vim.preinst'),
-            call('/var/lib/dpkg/info/vim.prerm')
-        ]
+        mock_iglob.assert_called_once_with(
+            'root-dir/var/lib/dpkg/info/vim*.pre*'
+        )
+        mock_Path_wipe.assert_called_once_with('glob-result')
 
     @patch('kiwi.command.Command.run')
     def test_post_process_delete_requests(self, mock_run):


### PR DESCRIPTION
The force uninstall deletes pre scripts prior removal
because if they fail the package will not be removed.
For a force uninstall we consider this ok. However,
the deletion of the scripts did not happen in the
image root. This patch fixes it
