### PR TITLE
Ensure backward compatibility on deprecated methods

### DIFF
--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -877,7 +877,7 @@ function deprecated {
         cat
         echo "]"
     } >&2
-    exit 1
+    exit 0
 }
 
 


### PR DESCRIPTION
This commit ensures backward compatibility for deprecated
config bash script utilities.

Fixes bsc#1195229

Signed-off-by: David Cassany <dcassany@suse.com>