### PR TITLE
Fixed UUID used in grub early boot script

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1058,7 +1058,7 @@ class DiskBuilder:
             )
             boot_uuid_unmapped = disk.get_uuid(
                 device_map['luks_root'].get_device()
-            ) if self.luks else boot_uuid
+            ) if self.luks and self.boot_is_crypto else boot_uuid
             self.bootloader_config.setup_disk_boot_images(
                 boot_uuid_unmapped
             )


### PR DESCRIPTION
In case the system is luks encrypted the UUID of the root
partition was used in the grub early boot script. However,
this condition is only correct if in addition to the luks
encryption the boot area is on crypto too. If boot is not
on crypto the UUID must be the boot partition and not root.
Only if root AND boot is on crypto the kiwi created early
boot script includes the grub cryptomount calls.


