### PR TITLE
Fixed handling of oem reboot settings

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -8,25 +8,6 @@ type fetch_file >/dev/null 2>&1 || . /lib/kiwi-net-lib.sh
 #======================================
 # Functions
 #--------------------------------------
-function report_and_quit {
-    local text_message="$1"
-    run_dialog --timeout 60 --msgbox "\"${text_message}\"" 5 80
-    if getargbool 0 rd.debug; then
-        die "${text_message}"
-    else
-        reboot -f
-    fi
-}
-
-function initialize {
-    local profile=/.profile
-
-    test -f ${profile} || \
-        report_and_quit "No profile setup found"
-
-    import_file ${profile}
-}
-
 function scan_multipath_devices {
     # """
     # starts multipath daemon from multipath module

--- a/dracut/modules.d/99kiwi-dump-reboot/kiwi-dump-reboot-system.sh
+++ b/dracut/modules.d/99kiwi-dump-reboot/kiwi-dump-reboot-system.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+type initialize >/dev/null 2>&1 || . /lib/kiwi-lib.sh
 type report_and_quit >/dev/null 2>&1 || . /lib/kiwi-dump-image.sh
 type get_selected_disk >/dev/null 2>&1 || . /lib/kiwi-dump-image.sh
 type run_dialog >/dev/null 2>&1 || . /lib/kiwi-dialog-lib.sh
@@ -7,7 +8,31 @@ type run_dialog >/dev/null 2>&1 || . /lib/kiwi-dialog-lib.sh
 # Functions
 #--------------------------------------
 function boot_installed_system {
+    declare kiwi_oemreboot=${kiwi_oemreboot}
+    declare kiwi_oemrebootinteractive=${kiwi_oemrebootinteractive}
+    declare kiwi_oemshutdown=${kiwi_oemshutdown}
+    declare kiwi_oemshutdowninteractive=${kiwi_oemshutdowninteractive}
+    local ask_reboot_text="Reboot System ?"
+    local ask_shutdown_text="Shutdown System ?"
     local boot_options
+    kiwi_oemreboot=$(bool "${kiwi_oemreboot}")
+    kiwi_oemrebootinteractive=$(bool "${kiwi_oemrebootinteractive}")
+    kiwi_oemshutdown=$(bool "${kiwi_oemshutdown}")
+    kiwi_oemshutdowninteractive=$(bool "${kiwi_oemshutdowninteractive}")
+
+    if [ "${kiwi_oemrebootinteractive}" = "true" ];then
+        ask_and_reboot "${ask_reboot_text}"
+    fi
+    if [ "${kiwi_oemreboot}" = "true" ];then
+        reboot -f
+    fi
+    if [ "${kiwi_oemshutdowninteractive}" = "true" ];then
+        ask_and_shutdown "${ask_shutdown_text}"
+    fi
+    if [ "${kiwi_oemshutdown}" = "true" ];then
+        reboot -f -p
+    fi
+
     # if rd.kiwi.install.pass.bootparam is given, pass on most
     # boot options to the kexec kernel
     if getargbool 0 rd.kiwi.install.pass.bootparam; then
@@ -36,6 +61,7 @@ function boot_installed_system {
 #======================================
 # Reboot into system
 #--------------------------------------
+initialize
 
 if getargbool 0 rd.kiwi.ramdisk; then
     # For ramdisk deployment a kexec boot is not possible as it

--- a/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
@@ -124,3 +124,31 @@ function _fbiterm_ok {
     fi
     return 0
 }
+
+function report_and_quit {
+    local text_message="$1"
+    run_dialog --timeout 60 --msgbox "\"${text_message}\"" 5 80
+    if getargbool 0 rd.debug; then
+        die "${text_message}"
+    else
+        reboot -f
+    fi
+}
+
+function ask_and_reboot {
+    local text_message="$1"
+    if ! run_dialog --yesno "\"${text_message}\"" 7 80; then
+        die "${text_message}"
+    else
+        reboot -f
+    fi
+}
+
+function ask_and_shutdown {
+    local text_message="$1"
+    if ! run_dialog --yesno "\"${text_message}\"" 7 80; then
+        die "${text_message}"
+    else
+        reboot -f -p
+    fi
+}

--- a/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
@@ -167,3 +167,17 @@ function bool {
         echo "false"
     fi
 }
+
+function initialize {
+    # """
+    # Source profile variables into runtime environment
+    # The method will exit from the initrd if the profile
+    # file does not exist
+    # """
+    local profile=/.profile
+
+    test -f ${profile} || \
+        report_and_quit "No profile setup found"
+
+    import_file ${profile}
+}


### PR DESCRIPTION
There are oem settings called oem-reboot, oem-reboot-interactive
as well as oem-shutdown and oem-shutdown-interactive. When used
the information is passed along to the profile but not evaluated
by any initrd code. I don't know where on the way we lost the
code that actually works with these settings but this commit
makes them effective.


