### PR TITLE
Fixed unit tests

### DIFF
--- a/test/unit/archive/tar_test.py
+++ b/test/unit/archive/tar_test.py
@@ -11,7 +11,7 @@ from kiwi.exceptions import KiwiCommandCapabilitiesError
 
 class TestArchiveTar:
     @patch('kiwi.archive.tar.Command.run')
-    def setup(self, mock_command):
+    def setup(self, mock_ArchiveTar, mock_command):
         command = mock.Mock()
         command.output = 'version 1.27.0'
         mock_command.return_value = command

--- a/test/unit/boot/image/base_test.py
+++ b/test/unit/boot/image/base_test.py
@@ -17,7 +17,7 @@ from kiwi.exceptions import (
 
 class TestBootImageBase:
     @patch('kiwi.boot.image.base.os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_BootImageBase, mock_exists):
         Defaults.set_platform_name('x86_64')
         self.boot_names_type = namedtuple(
             'boot_names_type', ['kernel_name', 'initrd_name']

--- a/test/unit/boot/image/builtin_kiwi_test.py
+++ b/test/unit/boot/image/builtin_kiwi_test.py
@@ -20,7 +20,9 @@ class TestBootImageKiwi:
     @patch('kiwi.boot.image.builtin_kiwi.Temporary')
     @patch('kiwi.boot.image.builtin_kiwi.os.path.exists')
     @patch('kiwi.defaults.Defaults.get_boot_image_description_path')
-    def setup(self, mock_boot_path, mock_exists, mock_Temporary):
+    def setup(
+        self, mock_BootImageKiwi, mock_boot_path, mock_exists, mock_Temporary
+    ):
         mock_Temporary.return_value.new_dir.return_value.name = \
             'boot-root-directory'
         mock_boot_path.return_value = '../data'

--- a/test/unit/boot/image/dracut_test.py
+++ b/test/unit/boot/image/dracut_test.py
@@ -12,7 +12,7 @@ from kiwi.xml_state import XMLState
 class TestBootImageKiwi:
     @patch('kiwi.boot.image.dracut.Command.run')
     @patch('kiwi.boot.image.base.os.path.exists')
-    def setup(self, mock_exists, mock_cmd):
+    def setup(self, mock_BootImageDracut, mock_exists, mock_cmd):
         Defaults.set_platform_name('x86_64')
         mock_exists.return_value = True
         command_type = namedtuple('command', ['output'])

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -37,7 +37,7 @@ class TestBootLoaderConfigGrub2:
 
     @patch('kiwi.bootloader.config.grub2.FirmWare')
     @patch('kiwi.bootloader.config.base.BootLoaderConfigBase.get_boot_theme')
-    def setup(self, mock_theme, mock_firmware):
+    def setup(self, mock_BootLoaderConfigGrub2, mock_theme, mock_firmware):
         Defaults.set_platform_name('x86_64')
         self.command_type = namedtuple(
             'command_return_type', ['output']

--- a/test/unit/bootloader/config/isolinux_test.py
+++ b/test/unit/bootloader/config/isolinux_test.py
@@ -18,7 +18,7 @@ class TestBootLoaderConfigIsoLinux:
         self._caplog = caplog
 
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_BootLoaderConfigIsoLinux, mock_exists):
         Defaults.set_platform_name('x86_64')
         mock_exists.return_value = True
         self.state = mock.Mock()

--- a/test/unit/builder/container_test.py
+++ b/test/unit/builder/container_test.py
@@ -12,7 +12,7 @@ from kiwi.exceptions import KiwiContainerBuilderError
 
 class TestContainerBuilder:
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_ContainerBuilder, mock_exists):
         Defaults.set_platform_name('x86_64')
         self.runtime_config = mock.Mock()
         self.runtime_config.get_max_size_constraint = mock.Mock(

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -34,7 +34,7 @@ class TestDiskBuilder:
         self._caplog = caplog
 
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_DiskBuilder, mock_exists):
         Defaults.set_platform_name('x86_64')
 
         def side_effect(filename):

--- a/test/unit/builder/filesystem_test.py
+++ b/test/unit/builder/filesystem_test.py
@@ -15,7 +15,7 @@ from kiwi.builder.filesystem import FileSystemBuilder
 
 class TestFileSystemBuilder:
     @patch('kiwi.builder.filesystem.FileSystemSetup')
-    def setup(self, mock_fs_setup):
+    def setup(self, mock_FileSystemBuilder, mock_fs_setup):
         Defaults.set_platform_name('x86_64')
         self.loop_provider = Mock()
         self.loop_provider.get_device = Mock(

--- a/test/unit/builder/kis_test.py
+++ b/test/unit/builder/kis_test.py
@@ -19,7 +19,7 @@ class TestKisBuilder:
 
     @patch('kiwi.builder.kis.FileSystemBuilder')
     @patch('kiwi.builder.kis.BootImage')
-    def setup(self, mock_boot, mock_filesystem):
+    def setup(self, mock_KisBuilder, mock_boot, mock_filesystem):
         self.setup = Mock()
         self.runtime_config = Mock()
         self.runtime_config.get_max_size_constraint = Mock(

--- a/test/unit/container/appx_test.py
+++ b/test/unit/container/appx_test.py
@@ -11,7 +11,9 @@ from kiwi.exceptions import KiwiContainerSetupError
 class TestContainerImageAppx:
     @patch('kiwi.container.appx.RuntimeConfig')
     @patch('os.path.exists')
-    def setup(self, mock_os_path_exists, mock_RuntimeConfig):
+    def setup(
+        self, mock_ContainerImageAppx, mock_os_path_exists, mock_RuntimeConfig
+    ):
         mock_os_path_exists.return_value = True
         self.appx = ContainerImageAppx(
             'root_dir', {

--- a/test/unit/container/oci_test.py
+++ b/test/unit/container/oci_test.py
@@ -18,7 +18,7 @@ class TestContainerImageOCI:
         self._caplog = caplog
 
     @patch('kiwi.oci_tools.umoci.CommandCapabilities.has_option_in_help')
-    def setup(self, mock_cmd_caps):
+    def setup(self, mock_ContainerImageOCI, mock_cmd_caps):
         mock_cmd_caps.return_value = True
         self.runtime_config = mock.Mock()
         self.runtime_config.get_container_compression = mock.Mock(

--- a/test/unit/container/setup/appx_test.py
+++ b/test/unit/container/setup/appx_test.py
@@ -12,7 +12,7 @@ from kiwi.exceptions import KiwiContainerSetupError
 
 class TestContainerSetupAppx:
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_ContainerSetupAppx, mock_exists):
         mock_exists.return_value = True
         self.appx = ContainerSetupAppx(
             'root_dir', {

--- a/test/unit/container/setup/base_test.py
+++ b/test/unit/container/setup/base_test.py
@@ -11,7 +11,7 @@ from kiwi.exceptions import KiwiContainerSetupError
 
 class TestContainerSetupBase:
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_ContainerSetupBase, mock_exists):
         mock_exists.return_value = True
 
         self.container = ContainerSetupBase('root_dir')

--- a/test/unit/container/setup/oci_test.py
+++ b/test/unit/container/setup/oci_test.py
@@ -7,7 +7,7 @@ from kiwi.container.setup.oci import ContainerSetupOCI
 
 class TestContainerSetupOCI:
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_ContainerSetupOCI, mock_exists):
         mock_exists.return_value = True
 
         self.container = ContainerSetupOCI(

--- a/test/unit/filesystem/btrfs_test.py
+++ b/test/unit/filesystem/btrfs_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.btrfs import FileSystemBtrfs
 
 class TestFileSystemBtrfs:
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_FileSystemBtrfs, mock_exists):
         mock_exists.return_value = True
         provider = mock.Mock()
         provider.get_device = mock.Mock(

--- a/test/unit/filesystem/clicfs_test.py
+++ b/test/unit/filesystem/clicfs_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.clicfs import FileSystemClicFs
 
 class TestFileSystemClicFs:
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_FileSystemClicFs, mock_exists):
         mock_exists.return_value = True
         self.clicfs = FileSystemClicFs(mock.Mock(), 'root_dir')
 

--- a/test/unit/filesystem/ext2_test.py
+++ b/test/unit/filesystem/ext2_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.ext2 import FileSystemExt2
 
 class TestFileSystemExt2:
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_FileSystemExt2, mock_exists):
         mock_exists.return_value = True
         provider = mock.Mock()
         provider.get_device = mock.Mock(

--- a/test/unit/filesystem/ext3_test.py
+++ b/test/unit/filesystem/ext3_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.ext3 import FileSystemExt3
 
 class TestFileSystemExt3:
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_FileSystemExt3, mock_exists):
         mock_exists.return_value = True
         provider = mock.Mock()
         provider.get_device = mock.Mock(

--- a/test/unit/filesystem/ext4_test.py
+++ b/test/unit/filesystem/ext4_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.ext4 import FileSystemExt4
 
 class TestFileSystemExt4:
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_FileSystemExt4, mock_exists):
         mock_exists.return_value = True
         provider = mock.Mock()
         provider.get_device = mock.Mock(

--- a/test/unit/filesystem/fat16_test.py
+++ b/test/unit/filesystem/fat16_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.fat16 import FileSystemFat16
 
 class TestFileSystemFat16:
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_FileSystemFat16, mock_exists):
         mock_exists.return_value = True
         provider = mock.Mock()
         provider.get_device = mock.Mock(

--- a/test/unit/filesystem/fat32_test.py
+++ b/test/unit/filesystem/fat32_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.fat32 import FileSystemFat32
 
 class TestFileSystemFat32:
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_FileSystemFat32, mock_exists):
         mock_exists.return_value = True
         provider = mock.Mock()
         provider.get_device = mock.Mock(

--- a/test/unit/filesystem/isofs_test.py
+++ b/test/unit/filesystem/isofs_test.py
@@ -12,7 +12,7 @@ class TestFileSystemIsoFs:
         self._caplog = caplog
 
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_FileSystemIsoFs, mock_exists):
         mock_exists.return_value = True
         self.isofs = FileSystemIsoFs(mock.Mock(), 'root_dir')
 

--- a/test/unit/filesystem/setup_test.py
+++ b/test/unit/filesystem/setup_test.py
@@ -12,7 +12,7 @@ class TestFileSystemSetup:
         self._caplog = caplog
 
     @patch('kiwi.filesystem.setup.SystemSize')
-    def setup(self, mock_size):
+    def setup(self, mock_FileSystemSetup, mock_size):
         size = mock.Mock()
         size.accumulate_mbyte_file_sizes = mock.Mock(
             return_value=42

--- a/test/unit/filesystem/squashfs_test.py
+++ b/test/unit/filesystem/squashfs_test.py
@@ -8,7 +8,7 @@ from kiwi.filesystem.squashfs import FileSystemSquashFs
 
 class TestFileSystemSquashfs:
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_FileSystemSquashFs, mock_exists):
         mock_exists.return_value = True
         self.squashfs = FileSystemSquashFs(mock.Mock(), 'root_dir')
 

--- a/test/unit/filesystem/swap_test.py
+++ b/test/unit/filesystem/swap_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.swap import FileSystemSwap
 
 class TestFileSystemSwap:
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_FileSystemSwap, mock_exists):
         mock_exists.return_value = True
         provider = mock.Mock()
         provider.get_device = mock.Mock(

--- a/test/unit/filesystem/xfs_test.py
+++ b/test/unit/filesystem/xfs_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.xfs import FileSystemXfs
 
 class TestFileSystemXfs:
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_FileSystemXfs, mock_exists):
         mock_exists.return_value = True
         provider = mock.Mock()
         provider.get_device = mock.Mock(

--- a/test/unit/oci_tools/buildah_test.py
+++ b/test/unit/oci_tools/buildah_test.py
@@ -17,7 +17,7 @@ class TestOCIBuildah:
         self._caplog = caplog
 
     @patch('kiwi.oci_tools.base.datetime')
-    def setup(self, mock_datetime):
+    def setup(self, mock_OCIBuildah, mock_datetime):
         strftime = Mock()
         strftime.strftime = Mock(return_value='current_date')
         mock_datetime.utcnow = Mock(
@@ -26,7 +26,7 @@ class TestOCIBuildah:
         self.oci = OCIBuildah()
 
     @patch('kiwi.oci_tools.umoci.Command.run')
-    def teardown(self, mock_cmd_run):
+    def teardown(self, mock_OCIBuildah, mock_cmd_run):
         del self.oci
         mock_cmd_run.reset_mock()
 

--- a/test/unit/oci_tools/umoci_test.py
+++ b/test/unit/oci_tools/umoci_test.py
@@ -9,7 +9,9 @@ class TestOCIUmoci:
     @patch('kiwi.oci_tools.umoci.CommandCapabilities.has_option_in_help')
     @patch('kiwi.oci_tools.base.datetime')
     @patch('kiwi.oci_tools.umoci.Temporary')
-    def setup(self, mock_Temporary, mock_datetime, mock_cmd_caps):
+    def setup(
+        self, mock_OCIUmoci, mock_Temporary, mock_datetime, mock_cmd_caps
+    ):
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         mock_cmd_caps.return_value = True
         strftime = Mock()

--- a/test/unit/partitioner/dasd_test.py
+++ b/test/unit/partitioner/dasd_test.py
@@ -16,7 +16,7 @@ class TestPartitionerDasd:
 
     @patch('kiwi.partitioner.dasd.Command.run')
     @patch('kiwi.partitioner.dasd.Temporary.new_file')
-    def setup(self, mock_temp, mock_command):
+    def setup(self, mock_PartitionerDasd, mock_temp, mock_command):
         self.tempfile = mock.Mock()
         self.tempfile.name = 'tempfile'
 

--- a/test/unit/repository/apt_test.py
+++ b/test/unit/repository/apt_test.py
@@ -11,7 +11,7 @@ class TestRepositoryApt:
     @patch('kiwi.repository.apt.Temporary.new_file')
     @patch('kiwi.repository.apt.PackageManagerTemplateAptGet')
     @patch('kiwi.repository.apt.Path.create')
-    def setup(self, mock_path, mock_template, mock_temp):
+    def setup(self, mock_RepositoryApt, mock_path, mock_template, mock_temp):
         self.apt_conf = mock.Mock()
         mock_template.return_value = self.apt_conf
 

--- a/test/unit/repository/dnf_test.py
+++ b/test/unit/repository/dnf_test.py
@@ -15,7 +15,7 @@ class TestRepositoryDnf:
     @patch('kiwi.repository.dnf.Temporary.new_file')
     @patch('kiwi.repository.dnf.ConfigParser')
     @patch('kiwi.repository.dnf.Path.create')
-    def setup(self, mock_path, mock_config, mock_temp):
+    def setup(self, mock_RepositoryDnf, mock_path, mock_config, mock_temp):
         runtime_dnf_config = mock.Mock()
         mock_config.return_value = runtime_dnf_config
         tmpfile = mock.Mock()

--- a/test/unit/repository/pacman_test.py
+++ b/test/unit/repository/pacman_test.py
@@ -12,7 +12,7 @@ class TestRepositorPacman(object):
     @patch('kiwi.repository.pacman.Temporary.new_file')
     @patch('kiwi.repository.pacman.ConfigParser')
     @patch('kiwi.repository.pacman.Path.create')
-    def setup(self, mock_path, mock_config, mock_temp):
+    def setup(self, mock_RepositoryPacman, mock_path, mock_config, mock_temp):
         runtime_pacman_config = Mock()
         mock_config.return_value = runtime_pacman_config
         tmpfile = Mock()

--- a/test/unit/repository/zypper_test.py
+++ b/test/unit/repository/zypper_test.py
@@ -14,7 +14,7 @@ from kiwi.exceptions import KiwiCommandError
 class TestRepositoryZypper:
     @patch('kiwi.command.Command.run')
     @patch('kiwi.repository.zypper.Temporary.new_file')
-    def setup(self, mock_temp, mock_command):
+    def setup(self, mock_RepositoryZypper, mock_temp, mock_command):
 
         self.context_manager_mock = mock.Mock()
         self.file_mock = mock.Mock()

--- a/test/unit/solver/sat_test.py
+++ b/test/unit/solver/sat_test.py
@@ -22,7 +22,7 @@ class TestSat:
         self._caplog = caplog
 
     @patch('importlib.import_module')
-    def setup(self, mock_import_module):
+    def setup(self, mock_Sat, mock_import_module):
         self.sat = Sat()
         self.solver = MagicMock()
         self.transaction = Mock()

--- a/test/unit/storage/disk_test.py
+++ b/test/unit/storage/disk_test.py
@@ -19,7 +19,7 @@ class TestDisk:
         self._caplog = caplog
 
     @patch('kiwi.storage.disk.Partitioner.new')
-    def setup(self, mock_partitioner):
+    def setup(self, mock_Disk, mock_partitioner):
         self.tempfile = mock.Mock()
         self.tempfile.name = 'tempfile'
 

--- a/test/unit/storage/loop_device_test.py
+++ b/test/unit/storage/loop_device_test.py
@@ -15,7 +15,7 @@ class TestLoopDevice:
         self._caplog = caplog
 
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_LoopDevice, mock_exists):
         mock_exists.return_value = False
         self.loop = LoopDevice('loop-file', 20, 4096)
 

--- a/test/unit/storage/mapped_device_test.py
+++ b/test/unit/storage/mapped_device_test.py
@@ -10,7 +10,7 @@ from kiwi.exceptions import KiwiMappedDeviceError
 
 class TestMappedDevice:
     @patch('os.path.exists')
-    def setup(self, mock_path):
+    def setup(self, mock_MappedDevice, mock_path):
         mock_path.return_value = True
         self.device_provider = Mock()
         self.device_provider.is_loop = Mock()

--- a/test/unit/storage/subformat/base_test.py
+++ b/test/unit/storage/subformat/base_test.py
@@ -16,7 +16,7 @@ from kiwi.exceptions import (
 
 class TestDiskFormatBase:
     @patch('kiwi.storage.subformat.base.DiskFormatBase.post_init')
-    def setup(self, mock_post_init):
+    def setup(self, mock_DiskFormatBase, mock_post_init):
         Defaults.set_platform_name('x86_64')
         xml_data = Mock()
         xml_data.get_name = Mock(

--- a/test/unit/system/kernel_test.py
+++ b/test/unit/system/kernel_test.py
@@ -11,7 +11,7 @@ from kiwi.exceptions import KiwiKernelLookupError
 class TestKernel:
     @patch('os.listdir')
     @patch('os.path.isdir')
-    def setup(self, mock_path_isdir, mock_listdir):
+    def setup(self, mock_Kernel, mock_path_isdir, mock_listdir):
         mock_path_isdir.return_value = True
         mock_listdir.return_value = ['1.2.3-default']
         self.kernel = Kernel('root-dir')

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -30,7 +30,10 @@ class TestSystemPrepare:
     @patch('kiwi.system.prepare.RootInit')
     @patch('kiwi.system.prepare.RootBind')
     @patch('kiwi.logger.Logger.get_logfile')
-    def setup(self, mock_get_logfile, mock_root_bind, mock_root_init):
+    def setup(
+        self, mock_SystemPrepare, mock_get_logfile,
+        mock_root_bind, mock_root_init
+    ):
         Defaults.set_platform_name('x86_64')
         mock_get_logfile.return_value = None
         description = XMLDescription(

--- a/test/unit/system/root_import/oci_test.py
+++ b/test/unit/system/root_import/oci_test.py
@@ -18,7 +18,7 @@ class TestRootImportOCI:
         self._caplog = caplog
 
     @patch('os.path.exists')
-    def setup(self, mock_path):
+    def setup(self, mock_RootImportOCI, mock_path):
         mock_path.return_value = True
         with patch.dict('os.environ', {'HOME': '../data'}):
             self.oci_import = RootImportOCI(

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -29,7 +29,7 @@ class TestSystemSetup:
         self._caplog = caplog
 
     @patch('kiwi.system.setup.RuntimeConfig')
-    def setup(self, mock_RuntimeConfig):
+    def setup(self, mock_SystemSetup, mock_RuntimeConfig):
         Defaults.set_platform_name('x86_64')
         self.runtime_config = Mock()
         self.runtime_config.get_package_changes = Mock(

--- a/test/unit/tasks/base_test.py
+++ b/test/unit/tasks/base_test.py
@@ -29,8 +29,8 @@ class TestCliTask:
     @patch('kiwi.cli.Cli.get_global_args')
     @patch('kiwi.tasks.base.RuntimeConfig')
     def setup(
-        self, mock_runtime_config, mock_global_args, mock_command_args,
-        mock_load_command, mock_help_check, mock_color,
+        self, mock_CliTask, mock_runtime_config, mock_global_args,
+        mock_command_args, mock_load_command, mock_help_check, mock_color,
         mock_setlog, mock_setLogFlag, mock_setLogLevel
     ):
         Defaults.set_platform_name('x86_64')

--- a/test/unit/utils/checksum_test.py
+++ b/test/unit/utils/checksum_test.py
@@ -12,7 +12,7 @@ from kiwi.exceptions import KiwiFileNotFound
 
 class TestChecksum:
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_Checksum, mock_exists):
         self.ascii = encoding.getregentry().name
         read_results = [bytes(b''), bytes(b'data'), bytes(b''), bytes(b'data')]
 

--- a/test/unit/utils/compress_test.py
+++ b/test/unit/utils/compress_test.py
@@ -20,7 +20,7 @@ class TestCompress:
         self._caplog = caplog
 
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(self, mock_Compress, mock_exists):
         mock_exists.return_value = True
         self.compress = Compress('some-file', True)
 

--- a/test/unit/utils/fstab_test.py
+++ b/test/unit/utils/fstab_test.py
@@ -13,8 +13,11 @@ class TestFstab(object):
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
-    def setup(self):
+    def setup(self, mock_Fstab):
         self.fstab = Fstab()
+        self.fstab.read('../data/fstab')
+
+    def test_read(self):
         with self._caplog.at_level(logging.WARNING):
             self.fstab.read('../data/fstab')
             assert format(

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -11,7 +11,7 @@ from kiwi.exceptions import KiwiVolumeManagerSetupError
 
 class TestVolumeManagerBase:
     @patch('os.path.exists')
-    def setup(self, mock_path):
+    def setup(self, mock_VolumeManagerBase, mock_path):
         self.volume_type = namedtuple(
             'volume_type', [
                 'name',

--- a/test/unit/volume_manager/btrfs_test.py
+++ b/test/unit/volume_manager/btrfs_test.py
@@ -24,7 +24,7 @@ class TestVolumeManagerBtrfs:
         self._caplog = caplog
 
     @patch('os.path.exists')
-    def setup(self, mock_path):
+    def setup(self, mock_VolumeManagerBtrfs, mock_path):
         self.volumes = [
             volume_type(
                 name='LVRoot', size='freespace:100', realpath='/',

--- a/test/unit/volume_manager/lvm_test.py
+++ b/test/unit/volume_manager/lvm_test.py
@@ -19,7 +19,7 @@ class TestVolumeManagerLVM:
         self._caplog = caplog
 
     @patch('os.path.exists')
-    def setup(self, mock_path):
+    def setup(self, mock_VolumeManagerLVM, mock_path):
         self.volumes = [
             volume_type(
                 name='LVRoot', size='freespace:100', realpath='/',


### PR DESCRIPTION
The pytest interface setup() method call has changed
in a way that an additional parameter is passed to
the method which leads to a python error at invocation
time if the setup method does not define it.

