### PR TITLE
Fixup inplace podman storage and container conf

### DIFF
--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -44,7 +44,6 @@ function setupContainerRuntime {
     cat >/etc/containers/containers.conf <<- EOF
 	[engine]
 	no_pivot_root = true
-	cgroups = "disabled"
 	events_logger = "none"
 	cgroup_manager = "cgroupfs"
 	EOF
@@ -52,6 +51,8 @@ function setupContainerRuntime {
     cat >/etc/containers/storage.conf <<- EOF
 	[storage]
 	driver = "vfs"
+	graphroot = "/var/lib/containers/storage"
+	runroot = "/var/run/containers/storage"
 	EOF
 }
 


### PR DESCRIPTION
Newer versions of podman requires runroot and graphroot
to be explicitly set in storage.conf.

Newer versions of podman no longer reads the engine.cgroups
setting on containers.conf and prints a 'Failed to decode the
keys [\"engine.cgroups\"]' warning message

This commit fixes storage.conf and containers.conf written
by kiwi if the setupContainerRuntime method is used in
scripts.


