### PR TITLE
Added overlayroot_write_partition attribute

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -572,6 +572,15 @@ overlayroot="true|false"
   will not have any effect because the write partition will be
   resized on first boot to the available disk space.
 
+overlayroot_write_partition="true|false"
+  For the `oem` type only, allows to specify if the extra read-write
+  partition in an `overlayroot` setup should be created or not.
+  By default the partition is created and the kiwi-overlay dracut
+  module also expect it to be present. However, the overlayroot
+  feature can also be used without an initrd and under certain
+  circumstances it is handy to configure if the partition table
+  should contain the read-write partition or not.
+
 bootfilesystem="ext2|ext3|ext4|fat32|fat16":
   If an extra boot partition is required this attribute
   specify which filesystem should be used for it. The

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -577,9 +577,9 @@ overlayroot_write_partition="true|false"
   partition in an `overlayroot` setup should be created or not.
   By default the partition is created and the kiwi-overlay dracut
   module also expect it to be present. However, the overlayroot
-  feature can also be used without an initrd and under certain
-  circumstances it is handy to configure if the partition table
-  should contain the read-write partition or not.
+  feature can also be used without dracut (`initrd_system="none"`)
+  and under certain circumstances it is handy to configure if the
+  partition table should contain the read-write partition or not.
 
 bootfilesystem="ext2|ext3|ext4|fat32|fat16":
   If an extra boot partition is required this attribute

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1537,6 +1537,22 @@ div {
             sch:param [ name = "attr" value = "overlayroot" ]
             sch:param [ name = "types" value = "oem" ]
         ]
+    k.type.overlayroot_write_partition.attribute =
+        ## Specifies to create an extra read-write partition
+        ## in combination with the overlayroot attribute on the
+        ## target disk. By default the partition is created
+        ## and the kiwi-overlay dracut module also expect it
+        ## to be present. However, the overlayroot feature could
+        ## also be used without an initrd and under certain
+        ## circumstances it is handy to configure if the
+        ## partition table should contain the read-write
+        ## partition or not. Available for the disk
+        ## image type oem
+        attribute overlayroot_write_partition { xsd:boolean }
+        >> sch:pattern [ id = "overlayroot_write_partition" is-a = "image_type"
+            sch:param [ name = "attr" value = "overlayroot_write_partition" ]
+            sch:param [ name = "types" value = "oem" ]
+        ]
     k.type.firmware.attribute =
         ## Specifies the boot firmware of the system. Most systems
         ## uses a standard BIOS but there are also other firmware
@@ -1935,6 +1951,7 @@ div {
         k.type.luksOS.attribute? &
         k.type.mdraid.attribute? &
         k.type.overlayroot.attribute? &
+        k.type.overlayroot_write_partition.attribute? &
         k.type.primary.attribute? &
         k.type.ramonly.attribute? &
         k.type.rootfs_label.attribute? &

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1543,11 +1543,11 @@ div {
         ## target disk. By default the partition is created
         ## and the kiwi-overlay dracut module also expect it
         ## to be present. However, the overlayroot feature could
-        ## also be used without an initrd and under certain
-        ## circumstances it is handy to configure if the
-        ## partition table should contain the read-write
-        ## partition or not. Available for the disk
-        ## image type oem
+        ## also be used without dracut (initrd_system="none")
+        ## and under certain circumstances it is handy to
+        ## configure if the partition table should contain
+        ## the read-write partition or not. Available for
+        ## the disk image type oem
         attribute overlayroot_write_partition { xsd:boolean }
         >> sch:pattern [ id = "overlayroot_write_partition" is-a = "image_type"
             sch:param [ name = "attr" value = "overlayroot_write_partition" ]

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2238,6 +2238,25 @@ image type oem</a:documentation>
         <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
+    <define name="k.type.overlayroot_write_partition.attribute">
+      <attribute name="overlayroot_write_partition">
+        <a:documentation>Specifies to create an extra read-write partition
+in combination with the overlayroot attribute on the
+target disk. By default the partition is created
+and the kiwi-overlay dracut module also expect it
+to be present. However, the overlayroot feature could
+also be used without an initrd and under certain
+circumstances it is handy to configure if the
+partition table should contain the read-write
+partition or not. Available for the disk
+image type oem</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="overlayroot_write_partition" is-a="image_type">
+        <sch:param name="attr" value="overlayroot_write_partition"/>
+        <sch:param name="types" value="oem"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.firmware.attribute">
       <attribute name="firmware">
         <a:documentation>Specifies the boot firmware of the system. Most systems
@@ -2859,6 +2878,9 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.overlayroot.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.overlayroot_write_partition.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.primary.attribute"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2718,7 +2718,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2763,6 +2763,7 @@ class type_(GeneratedsSuper):
         self.luksOS = _cast(None, luksOS)
         self.mdraid = _cast(None, mdraid)
         self.overlayroot = _cast(bool, overlayroot)
+        self.overlayroot_write_partition = _cast(bool, overlayroot_write_partition)
         self.primary = _cast(bool, primary)
         self.ramonly = _cast(bool, ramonly)
         self.rootfs_label = _cast(None, rootfs_label)
@@ -2960,6 +2961,8 @@ class type_(GeneratedsSuper):
     def set_mdraid(self, mdraid): self.mdraid = mdraid
     def get_overlayroot(self): return self.overlayroot
     def set_overlayroot(self, overlayroot): self.overlayroot = overlayroot
+    def get_overlayroot_write_partition(self): return self.overlayroot_write_partition
+    def set_overlayroot_write_partition(self, overlayroot_write_partition): self.overlayroot_write_partition = overlayroot_write_partition
     def get_primary(self): return self.primary
     def set_primary(self, primary): self.primary = primary
     def get_ramonly(self): return self.ramonly
@@ -3192,6 +3195,9 @@ class type_(GeneratedsSuper):
         if self.overlayroot is not None and 'overlayroot' not in already_processed:
             already_processed.add('overlayroot')
             outfile.write(' overlayroot="%s"' % self.gds_format_boolean(self.overlayroot, input_name='overlayroot'))
+        if self.overlayroot_write_partition is not None and 'overlayroot_write_partition' not in already_processed:
+            already_processed.add('overlayroot_write_partition')
+            outfile.write(' overlayroot_write_partition="%s"' % self.gds_format_boolean(self.overlayroot_write_partition, input_name='overlayroot_write_partition'))
         if self.primary is not None and 'primary' not in already_processed:
             already_processed.add('primary')
             outfile.write(' primary="%s"' % self.gds_format_boolean(self.primary, input_name='primary'))
@@ -3549,6 +3555,15 @@ class type_(GeneratedsSuper):
                 self.overlayroot = True
             elif value in ('false', '0'):
                 self.overlayroot = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
+        value = find_attr_value_('overlayroot_write_partition', node)
+        if value is not None and 'overlayroot_write_partition' not in already_processed:
+            already_processed.add('overlayroot_write_partition')
+            if value in ('true', '1'):
+                self.overlayroot_write_partition = True
+            elif value in ('false', '0'):
+                self.overlayroot_write_partition = False
             else:
                 raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('primary', node)

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ exclude=xml_parse.py
 # we ignore warnings about quoting of escape sequences (W605)
 ignore = E501, W605
 # we allow a custom complexity level
-max-complexity = 19
+max-complexity = 21
 
 [doc8]
 max-line-length = 90

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -557,6 +557,7 @@ class TestDiskBuilder:
     ):
         mock_rand.return_value = 15
         self.disk_builder.root_filesystem_is_overlay = True
+        self.disk_builder.root_filesystem_has_write_partition = False
         self.disk_builder.volume_manager_name = None
         squashfs = Mock()
         mock_squashfs.return_value = squashfs
@@ -566,6 +567,8 @@ class TestDiskBuilder:
         mock_temp.return_value = tempfile
         mock_exists.return_value = True
         self.disk_builder.initrd_system = 'dracut'
+        self.disk.public_partition_id_map = self.id_map
+        self.disk.public_partition_id_map['kiwi_ROPart'] = 1
 
         m_open = mock_open()
         with patch('builtins.open', m_open, create=True):
@@ -720,7 +723,11 @@ class TestDiskBuilder:
         self.disk_builder.volume_manager_name = None
         self.disk_builder.luks = 'passphrase'
         self.disk_setup.need_boot_partition.return_value = False
+        self.disk_builder.root_filesystem_is_overlay = True
+        self.disk_builder.root_filesystem_has_write_partition = False
         self.disk_builder.boot_is_crypto = True
+        self.disk.public_partition_id_map = self.id_map
+        self.disk.public_partition_id_map['kiwi_ROPart'] = 1
 
         with patch('builtins.open'):
             self.disk_builder.create_disk()


### PR DESCRIPTION
For the oem type only, allows to specify if the extra read-write
partition in an overlayroot setup should be created or not.
By default the partition is created and the kiwi-overlay dracut
module also expect it to be present. However, the overlayroot
feature can also be used without an initrd and under certain
circumstances it is handy to configure if the partition table
should contain the read-write partition or not.

