### PR TITLE
Add support for pre_disk_sync.sh script

### DIFF
--- a/doc/source/concept_and_workflow/shell_scripts.rst
+++ b/doc/source/concept_and_workflow/shell_scripts.rst
@@ -6,9 +6,10 @@ User Defined Scripts
 .. note:: **Abstract**
 
    This chapter describes the purpose of the user defined scripts
-   :file:`config.sh`, :file:`image.sh` and :file:`disk.sh`, which can
-   be used to further customize an image in ways that are not possible
-   via the image description alone.
+   :file:`config.sh`, :file:`image.sh`, :file:`pre_disk_sync.sh`
+   and :file:`disk.sh`, which can be used to further customize an
+   image in ways that are not possible via the image description
+   alone.
 
 {kiwi} supports the following optional scripts that it runs in a
 root environment (chroot) containing your new appliance:
@@ -37,16 +38,23 @@ images.sh
   a modification to a config file that should be done when building
   a live iso but not when building a virtual disk image.
 
+pre_disk_sync.sh
+  is executed for the disk image type `oem` only and runs
+  right before the synchronization of the root tree into the disk image
+  loop file. The :file:`pre_disk_sync.sh` can be used to change
+  content of the root tree as a last action before the sync to
+  the disk image is performed. This is useful for example to delete
+  components from the system which were needed before or cannot
+  be modified afterwards when syncing into a read-only filesystem.
+
 disk.sh
   is executed for the disk image type `oem` only and runs after the
-  synchronisation of the root tree into the disk image loop file.
-  At call time of the script the device name of the currently mapped
-  root device is passed as a parameter. The chroot environment for
-  this script call is the virtual disk itself and not the root tree
-  as with :file:`config.sh` and :file:`images.sh`. The script :file:`disk.sh`
-  is usually used to apply changes at parts of the system that are not an
-  element of the file based root tree such as the partition table, the
-  bootloader or filesystem attributes.
+  synchronization of the root tree into the disk image loop file.
+  The chroot environment for this script call is the virtual disk itself
+  and not the root tree as with :file:`config.sh` and :file:`images.sh`.
+  The script :file:`disk.sh` is usually used to apply changes at parts of
+  the system that are not an element of the file based root tree such as
+  the partition table, the bootloader or filesystem attributes.
 
 {kiwi} executes scripts via the operating system if their executable
 bit is set (in that case a shebang is mandatory) otherwise they will be

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -447,6 +447,15 @@ class DiskBuilder:
         # set SELinux file security contexts if context exists
         self._setup_selinux_file_contexts()
 
+        # run pre sync script hook
+        if self.system_setup.script_exists(
+            defaults.PRE_DISK_SYNC_SCRIPT
+        ):
+            disk_system = SystemSetup(
+                self.xml_state, self.root_dir
+            )
+            disk_system.call_pre_disk_script()
+
         # syncing system data to disk image
         self._sync_system_to_image(
             device_map, system, system_boot, system_efi, system_spare,

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -37,6 +37,7 @@ from kiwi.exceptions import KiwiBootLoaderGrubDataError
 
 # Default module variables
 POST_DISK_SYNC_SCRIPT = 'disk.sh'
+PRE_DISK_SYNC_SCRIPT = 'pre_disk_sync.sh'
 POST_BOOTSTRAP_SCRIPT = 'post_bootstrap.sh'
 POST_PREPARE_SCRIPT = 'config.sh'
 PRE_CREATE_SCRIPT = 'images.sh'

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -597,6 +597,14 @@ class SystemSetup:
             defaults.POST_DISK_SYNC_SCRIPT
         )
 
+    def call_pre_disk_script(self) -> None:
+        """
+        Call pre_disk_sync.sh script chrooted
+        """
+        self._call_script(
+            defaults.PRE_DISK_SYNC_SCRIPT
+        )
+
     def call_post_bootstrap_script(self) -> None:
         """
         Call post_bootstrap.sh script chrooted
@@ -936,6 +944,10 @@ class SystemSetup:
             ),
             defaults.PRE_CREATE_SCRIPT: script_type(
                 filepath=defaults.PRE_CREATE_SCRIPT,
+                raise_if_not_exists=False
+            ),
+            defaults.PRE_DISK_SYNC_SCRIPT: script_type(
+                filepath=defaults.PRE_DISK_SYNC_SCRIPT,
                 raise_if_not_exists=False
             ),
             defaults.POST_DISK_SYNC_SCRIPT: script_type(

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -469,8 +469,12 @@ class TestDiskBuilder:
                 'prep_device': '/dev/prep-device'
             }
         )
-        self.setup.script_exists.assert_called_once_with('disk.sh')
+        assert self.setup.script_exists.call_args_list == [
+            call('pre_disk_sync.sh'),
+            call('disk.sh')
+        ]
         disk_system.import_description.assert_called_once_with()
+        disk_system.call_pre_disk_script.assert_called_once_with()
         disk_system.call_disk_script.assert_called_once_with()
         self.setup.call_edit_boot_config_script.assert_called_once_with(
             'btrfs', 1
@@ -481,23 +485,17 @@ class TestDiskBuilder:
             '/dev/boot-device'
         )
         self.boot_image_task.prepare.assert_called_once_with()
-        call = filesystem.create_on_device.call_args_list[0]
         assert filesystem.create_on_device.call_args_list[0] == \
             call(label='EFI')
-        call = filesystem.create_on_device.call_args_list[1]
         assert filesystem.create_on_device.call_args_list[1] == \
             call(label='BOOT')
-        call = filesystem.create_on_device.call_args_list[2]
         assert filesystem.create_on_device.call_args_list[2] == \
             call(label='ROOT')
 
-        call = filesystem.sync_data.call_args_list[0]
         assert filesystem.sync_data.call_args_list[0] == \
             call()
-        call = filesystem.sync_data.call_args_list[1]
         assert filesystem.sync_data.call_args_list[1] == \
             call(['efi/*'])
-        call = filesystem.sync_data.call_args_list[2]
         assert filesystem.sync_data.call_args_list[2] == \
             call([
                 'image', '.profile', '.kconfig', 'run/*', 'tmp/*',


### PR DESCRIPTION
The optional pre_disk_sync.sh script is executed for the
disk image type oem only and runs right before the synchronisation
of the root tree into the disk image loop file. The script hook
can be used to change content of the root tree as a last action
before the sync to the disk image is performed. This is useful
for example to delete components from the system which were
needed before or cannot be modified afterwards when syncing
into a read-only filesystem.


