### PR TITLE
Follow up fix on force deleting debs

### DIFF
--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -298,15 +298,19 @@ class PackageManagerApt(PackageManagerBase):
         )
         if force:
             # force deleting debs only worked well for me when ignoring
-            # the pre-inst and pre-remove codings. I don't know why this
+            # the pre/post-inst and pre/post-remove codings. No idea why it
             # ends in so many conflicts but if you want to force get rid
             # of stuff this was the only way I could come up with. There
             # are still cases when it does not work depending on the many
             # code that runs on deleting
             for package in delete_items:
-                delete_pattern = \
+                pre_delete_pattern = \
                     f'{self.root_dir}/var/lib/dpkg/info/{package}*.pre*'
-                for delete_file in glob.iglob(delete_pattern):
+                post_delete_pattern = \
+                    f'{self.root_dir}/var/lib/dpkg/info/{package}*.post*'
+                for delete_file in glob.iglob(pre_delete_pattern):
+                    Path.wipe(delete_file)
+                for delete_file in glob.iglob(post_delete_pattern):
                     Path.wipe(delete_file)
 
             apt_get_command = ['chroot', self.root_dir, 'dpkg']

--- a/test/unit/package_manager/apt_test.py
+++ b/test/unit/package_manager/apt_test.py
@@ -206,10 +206,13 @@ class TestPackageManagerApt:
             ],
             ['env']
         )
-        mock_iglob.assert_called_once_with(
-            'root-dir/var/lib/dpkg/info/vim*.pre*'
-        )
-        mock_Path_wipe.assert_called_once_with('glob-result')
+        mock_iglob.call_args_list == [
+            call('root-dir/var/lib/dpkg/info/vim*.pre*'),
+            call('root-dir/var/lib/dpkg/info/vim*.post*')
+        ]
+        mock_Path_wipe.call_args_list == [
+            call('glob-result'), call('glob-result')
+        ]
 
     @patch('kiwi.command.Command.run')
     def test_post_process_delete_requests(self, mock_run):


### PR DESCRIPTION
Also remove eventual post scripting prior force removal
of deb packages. Similar inconsistencies as with the pre
scripts can occur on force removal. We want the operation
to be successful in force mode even if that means to
leave a dirty state.


