### PR TITLE
Added debootstrap log info to exception message

### DIFF
--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -203,6 +203,22 @@ class PackageManagerApt(PackageManagerBase):
                 '%s: %s' % (type(e).__name__, format(e))
             )
 
+    def get_error_details(self) -> str:
+        """
+        Provide further error details
+
+        Read the debootstrap log if available
+
+        :rtype: str
+        """
+        debootstrap_log_file = os.path.join(
+            self.root_dir, 'debootstrap/debootstrap.log'
+        )
+        if os.path.exists(debootstrap_log_file):
+            with open(debootstrap_log_file) as log_fd:
+                return log_fd.read() or 'logfile is empty'
+        return f'logfile {debootstrap_log_file!r} does not exist'
+
     def post_process_install_requests_bootstrap(
         self, root_bind: RootBind = None
     ) -> None:

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -245,6 +245,20 @@ class PackageManagerBase:
         """
         return True if returncode != 0 else False
 
+    def get_error_details(self) -> str:
+        """
+        Provide further error details
+
+        In case the package manager call failed this
+        method will return package manager specific error
+        information if there is any
+
+        :return: further error data as str or empty str
+
+        :rtype: str
+        """
+        return ''
+
     def clean_leftovers(self) -> None:
         """
         Cleans package manager related data not needed in the

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -265,7 +265,7 @@ class SystemPrepare:
                 raise KiwiBootStrapPhaseFailed(
                     self.issue_message.format(
                         headline='Bootstrap package installation failed',
-                        reason=issue
+                        reason=f'{issue}: {manager.get_error_details()}'
                     )
                 )
         manager.post_process_install_requests_bootstrap(self.root_bind)

--- a/test/unit/package_manager/apt_test.py
+++ b/test/unit/package_manager/apt_test.py
@@ -85,6 +85,33 @@ class TestPackageManagerApt:
         with raises(KiwiDebootstrapError):
             self.manager.process_install_requests_bootstrap(mock_root_bind)
 
+    @patch('kiwi.package_manager.apt.os.path.exists')
+    def test_get_error_details(self, mock_exists):
+        mock_exists.return_value = True
+        with patch('builtins.open', create=True) as mock_open:
+            file_handle = mock_open.return_value.__enter__.return_value
+            file_handle.read.return_value = 'log-data'
+            assert self.manager.get_error_details() == \
+                file_handle.read.return_value
+        mock_open.assert_called_once_with(
+            'root-dir/debootstrap/debootstrap.log'
+        )
+
+    @patch('kiwi.package_manager.apt.os.path.exists')
+    def test_get_error_details_no_log_file(self, mock_exists):
+        mock_exists.return_value = False
+        assert self.manager.get_error_details() == \
+            "logfile 'root-dir/debootstrap/debootstrap.log' does not exist"
+
+    @patch('kiwi.package_manager.apt.os.path.exists')
+    def test_get_error_details_logfile_is_empty(self, mock_exists):
+        mock_exists.return_value = True
+        with patch('builtins.open', create=True) as mock_open:
+            file_handle = mock_open.return_value.__enter__.return_value
+            file_handle.read.return_value = ''
+            assert self.manager.get_error_details() == \
+                'logfile is empty'
+
     @patch('kiwi.command.Command.call')
     @patch('kiwi.package_manager.apt.Path.wipe')
     @patch('kiwi.package_manager.apt.os.path.exists')

--- a/test/unit/package_manager/base_test.py
+++ b/test/unit/package_manager/base_test.py
@@ -91,5 +91,8 @@ class TestPackageManagerBase:
         assert self.manager.collection_requests == []
         assert self.manager.exclude_requests == []
 
+    def test_get_error_details(self):
+        assert self.manager.get_error_details() == ''
+
     def test_clean_leftovers(self):
         self.manager.clean_leftovers()

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -123,12 +123,13 @@ class TestSystemPrepare:
 
     @patch('kiwi.system.prepare.CommandProcess.poll_show_progress')
     def test_install_bootstrap_packages_raises(self, mock_poll):
+        self.manager.get_error_details.return_value = 'error-details'
         mock_poll.side_effect = Exception('some_error')
         with raises(KiwiBootStrapPhaseFailed) as issue:
             self.system.install_bootstrap(self.manager)
         assert issue.value.message == self.system.issue_message.format(
             headline='Bootstrap package installation failed',
-            reason='some_error'
+            reason='some_error: error-details'
         )
 
     @patch('kiwi.system.prepare.CommandProcess.poll_show_progress')


### PR DESCRIPTION
In case debootstrap fails there is more detailed information
in a logfile written by debootstrap itself. This commit changes
the exception information to contain this log information if
present. Related to Issue #1800

