### PR TITLE
Added overlayroot_readonly_partsize attribute

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -581,6 +581,20 @@ overlayroot_write_partition="true|false"
   and under certain circumstances it is handy to configure if the
   partition table should contain the read-write partition or not.
 
+overlayroot_readonly_partsize="mbsize"
+  Specifies the size in MB of the partition which stores the
+  squashfs compressed read-only root filesystem in an
+  overlayroot setup. If not specified kiwi calculates
+  the needed size by a preliminary creation of the
+  squashfs compressed file. However this is only accurate
+  if no changes to the root filesystem data happens
+  after this calculation, which cannot be guaranteed as
+  there is at least one optional script hook which is
+  allowed and applied after the calculation. In addition the
+  pre-calculation requires some time in the build process.
+  If the value can be provided beforehand this also speeds
+  up the build process significantly
+
 bootfilesystem="ext2|ext3|ext4|fat32|fat16":
   If an extra boot partition is required this attribute
   specify which filesystem should be used for it. The

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1553,6 +1553,21 @@ div {
             sch:param [ name = "attr" value = "overlayroot_write_partition" ]
             sch:param [ name = "types" value = "oem" ]
         ]
+    k.type.overlayroot_readonly_partsize.attribute =
+        ## Specifies the size in MB of the partition which stores the
+        ## squashfs compressed read-only root filesystem in an
+        ## overlayroot setup. If not specified kiwi calculates
+        ## the needed size by a preliminary creation of the
+        ## squashfs compressed file. However this is only accurate
+        ## if no changes to the root filesystem data happens
+        ## after this calculation, which cannot be guaranteed as
+        ## there is at least one optional script hook which is
+        ## allowed and applied after the calculation.
+        attribute overlayroot_readonly_partsize { xsd:nonNegativeInteger }
+        >> sch:pattern [ id = "overlayroot_readonly_partsize" is-a = "image_type"
+            sch:param [ name = "attr" value = "overlayroot_readonly_partsize" ]
+            sch:param [ name = "types" value = "oem" ]
+        ]
     k.type.firmware.attribute =
         ## Specifies the boot firmware of the system. Most systems
         ## uses a standard BIOS but there are also other firmware
@@ -1952,6 +1967,7 @@ div {
         k.type.mdraid.attribute? &
         k.type.overlayroot.attribute? &
         k.type.overlayroot_write_partition.attribute? &
+        k.type.overlayroot_readonly_partsize.attribute? &
         k.type.primary.attribute? &
         k.type.ramonly.attribute? &
         k.type.rootfs_label.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2245,15 +2245,33 @@ in combination with the overlayroot attribute on the
 target disk. By default the partition is created
 and the kiwi-overlay dracut module also expect it
 to be present. However, the overlayroot feature could
-also be used without an initrd and under certain
-circumstances it is handy to configure if the
-partition table should contain the read-write
-partition or not. Available for the disk
-image type oem</a:documentation>
+also be used without dracut (initrd_system="none")
+and under certain circumstances it is handy to
+configure if the partition table should contain
+the read-write partition or not. Available for
+the disk image type oem</a:documentation>
         <data type="boolean"/>
       </attribute>
       <sch:pattern id="overlayroot_write_partition" is-a="image_type">
         <sch:param name="attr" value="overlayroot_write_partition"/>
+        <sch:param name="types" value="oem"/>
+      </sch:pattern>
+    </define>
+    <define name="k.type.overlayroot_readonly_partsize.attribute">
+      <attribute name="overlayroot_readonly_partsize">
+        <a:documentation>Specifies the size in MB of the partition which stores the
+squashfs compressed read-only root filesystem in an
+overlayroot setup. If not specified kiwi calculates
+the needed size by a preliminary creation of the
+squashfs compressed file. However this is only accurate
+if no changes to the root filesystem data happens
+after this calculation, which cannot be guaranteed as
+there is at least one optional script hook which is
+allowed and applied after the calculation.</a:documentation>
+        <data type="nonNegativeInteger"/>
+      </attribute>
+      <sch:pattern id="overlayroot_readonly_partsize" is-a="image_type">
+        <sch:param name="attr" value="overlayroot_readonly_partsize"/>
         <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
@@ -2881,6 +2899,9 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.overlayroot_write_partition.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.overlayroot_readonly_partsize.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.primary.attribute"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2718,7 +2718,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2764,6 +2764,7 @@ class type_(GeneratedsSuper):
         self.mdraid = _cast(None, mdraid)
         self.overlayroot = _cast(bool, overlayroot)
         self.overlayroot_write_partition = _cast(bool, overlayroot_write_partition)
+        self.overlayroot_readonly_partsize = _cast(int, overlayroot_readonly_partsize)
         self.primary = _cast(bool, primary)
         self.ramonly = _cast(bool, ramonly)
         self.rootfs_label = _cast(None, rootfs_label)
@@ -2963,6 +2964,8 @@ class type_(GeneratedsSuper):
     def set_overlayroot(self, overlayroot): self.overlayroot = overlayroot
     def get_overlayroot_write_partition(self): return self.overlayroot_write_partition
     def set_overlayroot_write_partition(self, overlayroot_write_partition): self.overlayroot_write_partition = overlayroot_write_partition
+    def get_overlayroot_readonly_partsize(self): return self.overlayroot_readonly_partsize
+    def set_overlayroot_readonly_partsize(self, overlayroot_readonly_partsize): self.overlayroot_readonly_partsize = overlayroot_readonly_partsize
     def get_primary(self): return self.primary
     def set_primary(self, primary): self.primary = primary
     def get_ramonly(self): return self.ramonly
@@ -3198,6 +3201,9 @@ class type_(GeneratedsSuper):
         if self.overlayroot_write_partition is not None and 'overlayroot_write_partition' not in already_processed:
             already_processed.add('overlayroot_write_partition')
             outfile.write(' overlayroot_write_partition="%s"' % self.gds_format_boolean(self.overlayroot_write_partition, input_name='overlayroot_write_partition'))
+        if self.overlayroot_readonly_partsize is not None and 'overlayroot_readonly_partsize' not in already_processed:
+            already_processed.add('overlayroot_readonly_partsize')
+            outfile.write(' overlayroot_readonly_partsize="%s"' % self.gds_format_integer(self.overlayroot_readonly_partsize, input_name='overlayroot_readonly_partsize'))
         if self.primary is not None and 'primary' not in already_processed:
             already_processed.add('primary')
             outfile.write(' primary="%s"' % self.gds_format_boolean(self.primary, input_name='primary'))
@@ -3566,6 +3572,15 @@ class type_(GeneratedsSuper):
                 self.overlayroot_write_partition = False
             else:
                 raise_parse_error(node, 'Bad boolean attribute')
+        value = find_attr_value_('overlayroot_readonly_partsize', node)
+        if value is not None and 'overlayroot_readonly_partsize' not in already_processed:
+            already_processed.add('overlayroot_readonly_partsize')
+            try:
+                self.overlayroot_readonly_partsize = int(value)
+            except ValueError as exp:
+                raise_parse_error(node, 'Bad integer attribute: %s' % exp)
+            if self.overlayroot_readonly_partsize < 0:
+                raise_parse_error(node, 'Invalid NonNegativeInteger')
         value = find_attr_value_('primary', node)
         if value is not None and 'primary' not in already_processed:
             already_processed.add('primary')

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -592,7 +592,7 @@ class TestDiskBuilder:
             ], filename='kiwi-tempname')
         ]
         self.disk.create_root_readonly_partition.assert_called_once_with(11)
-        assert mock_command.call_args_list[2] == call(
+        assert mock_command.call_args_list[3] == call(
             ['dd', 'if=kiwi-tempname', 'of=/dev/readonly-root-device']
         )
         assert m_open.return_value.write.call_args_list == [


### PR DESCRIPTION
Specifies the size in MB of the partition which stores the
squashfs compressed read-only root filesystem in an
overlayroot setup. This Fixes #2068

