### PR TITLE
Update unit test to work in obs

### DIFF
--- a/test/unit/container/oci_test.py
+++ b/test/unit/container/oci_test.py
@@ -18,7 +18,12 @@ class TestContainerImageOCI:
         self._caplog = caplog
 
     @patch('kiwi.oci_tools.umoci.CommandCapabilities.has_option_in_help')
-    def setup(self, mock_ContainerImageOCI, mock_cmd_caps):
+    @patch('kiwi.defaults.Defaults.is_buildservice_worker')
+    def setup(
+        self, mock_ContainerImageOCI, mock_is_buildservice_worker,
+        mock_cmd_caps
+    ):
+        mock_is_buildservice_worker.return_value = False
         mock_cmd_caps.return_value = True
         self.runtime_config = mock.Mock()
         self.runtime_config.get_container_compression = mock.Mock(
@@ -35,7 +40,9 @@ class TestContainerImageOCI:
         )
 
     @patch('kiwi.oci_tools.umoci.CommandCapabilities.has_option_in_help')
-    def test_init_custom_args(self, mock_cmd_caps):
+    @patch('kiwi.defaults.Defaults.is_buildservice_worker')
+    def test_init_custom_args(self, mock_is_buildservice_worker, mock_cmd_caps):
+        mock_is_buildservice_worker.return_value = False
         mock_cmd_caps.return_value = True
         custom_args = {
             'container_name': 'foo',
@@ -57,7 +64,11 @@ class TestContainerImageOCI:
         assert container.oci_config == custom_args
 
     @patch('kiwi.oci_tools.umoci.CommandCapabilities.has_option_in_help')
-    def test_init_without_custom_args(self, mock_cmd_caps):
+    @patch('kiwi.defaults.Defaults.is_buildservice_worker')
+    def test_init_without_custom_args(
+        self, mock_is_buildservice_worker, mock_cmd_caps
+    ):
+        mock_is_buildservice_worker.return_value = False
         mock_cmd_caps.return_value = True
         container = ContainerImageOCI('root_dir', 'oci-archive')
         assert container.oci_config == {

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -48,7 +48,9 @@ class TestRuntimeConfig:
             RuntimeConfig(reread=True)
             m_open.assert_called_once_with('/etc/kiwi.yml', 'r')
 
-    def test_config_sections_from_home_base_config(self):
+    @patch('kiwi.runtime_checker.Defaults.is_buildservice_worker')
+    def test_config_sections_from_home_base_config(self, mock_is_buildservice_worker):
+        mock_is_buildservice_worker.return_value = False
         with patch.dict('os.environ', {'HOME': '../data/kiwi_config/ok'}):
             runtime_config = RuntimeConfig(reread=True)
 

--- a/test/unit/system/uri_test.py
+++ b/test/unit/system/uri_test.py
@@ -172,7 +172,11 @@ class TestUri:
         assert uri.translate() == 'http://example.com/foo'
 
     @patch('kiwi.system.uri.requests.get')
-    def test_translate_obs_project(self, mock_request_get):
+    @patch('kiwi.defaults.Defaults.is_buildservice_worker')
+    def test_translate_obs_project(
+        self, mock_is_buildservice_worker, mock_request_get
+    ):
+        mock_is_buildservice_worker.return_value = False
         uri = Uri('obs://openSUSE:Leap:42.2/standard', 'yast2')
         uri.runtime_config = self.runtime_config
         uri.translate()


### PR DESCRIPTION
Some unit tests fails if they run in an obs environment.
This is because the implementation checks the runtime
envoironment and behaves differently if the system is
an obs worker. The unit tests has to explicitly set this
condition right for the test

