### PR TITLE
Test unit compat nose vs xunit

### DIFF
--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -11,7 +11,7 @@ setuptools
 tox
 
 # python unit testing framework
-pytest==6.2.5
+pytest
 pytest-cov
 pytest-xdist
 

--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -11,7 +11,7 @@ setuptools
 tox
 
 # python unit testing framework
-pytest
+pytest==6.2.5
 pytest-cov
 pytest-xdist
 

--- a/test/unit/archive/cpio_test.py
+++ b/test/unit/archive/cpio_test.py
@@ -7,6 +7,9 @@ class TestArchiveCpio:
     def setup(self):
         self.archive = ArchiveCpio('foo.cpio')
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.archive.cpio.Command.run')
     def test_create(self, mock_command):
         self.archive.create('source-dir', ['/boot', '/var/cache'])

--- a/test/unit/archive/tar_test.py
+++ b/test/unit/archive/tar_test.py
@@ -18,6 +18,10 @@ class TestArchiveTar:
         self.archive = ArchiveTar('foo.tar')
 
     @patch('kiwi.archive.tar.Command.run')
+    def setup_method(self, cls, mock_command):
+        self.setup()
+
+    @patch('kiwi.archive.tar.Command.run')
     def test_invalid_tar_command_version(self, mock_command):
         command = mock.Mock()
         command.output = 'version cannot be parsed'

--- a/test/unit/archive/tar_test.py
+++ b/test/unit/archive/tar_test.py
@@ -11,7 +11,7 @@ from kiwi.exceptions import KiwiCommandCapabilitiesError
 
 class TestArchiveTar:
     @patch('kiwi.archive.tar.Command.run')
-    def setup(self, mock_ArchiveTar, mock_command):
+    def setup(self, mock_command):
         command = mock.Mock()
         command.output = 'version 1.27.0'
         mock_command.return_value = command

--- a/test/unit/boot/image/base_test.py
+++ b/test/unit/boot/image/base_test.py
@@ -46,6 +46,10 @@ class TestBootImageBase:
             self.xml_state, 'some-target-dir', 'system-directory'
         )
 
+    @patch('kiwi.boot.image.base.os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     def test_boot_image_raises(self):
         with raises(KiwiTargetDirectoryNotFound):
             BootImageBase(

--- a/test/unit/boot/image/base_test.py
+++ b/test/unit/boot/image/base_test.py
@@ -17,7 +17,7 @@ from kiwi.exceptions import (
 
 class TestBootImageBase:
     @patch('kiwi.boot.image.base.os.path.exists')
-    def setup(self, mock_BootImageBase, mock_exists):
+    def setup(self, mock_exists):
         Defaults.set_platform_name('x86_64')
         self.boot_names_type = namedtuple(
             'boot_names_type', ['kernel_name', 'initrd_name']

--- a/test/unit/boot/image/builtin_kiwi_test.py
+++ b/test/unit/boot/image/builtin_kiwi_test.py
@@ -20,9 +20,7 @@ class TestBootImageKiwi:
     @patch('kiwi.boot.image.builtin_kiwi.Temporary')
     @patch('kiwi.boot.image.builtin_kiwi.os.path.exists')
     @patch('kiwi.defaults.Defaults.get_boot_image_description_path')
-    def setup(
-        self, mock_BootImageKiwi, mock_boot_path, mock_exists, mock_Temporary
-    ):
+    def setup(self, mock_boot_path, mock_exists, mock_Temporary):
         mock_Temporary.return_value.new_dir.return_value.name = \
             'boot-root-directory'
         mock_boot_path.return_value = '../data'

--- a/test/unit/boot/image/builtin_kiwi_test.py
+++ b/test/unit/boot/image/builtin_kiwi_test.py
@@ -52,6 +52,12 @@ class TestBootImageKiwi:
             self.xml_state, 'some-target-dir'
         )
 
+    @patch('kiwi.boot.image.builtin_kiwi.Temporary')
+    @patch('kiwi.boot.image.builtin_kiwi.os.path.exists')
+    @patch('kiwi.defaults.Defaults.get_boot_image_description_path')
+    def setup_method(self, cls, mock_boot_path, mock_exists, mock_Temporary):
+        self.setup()
+
     def test_include_file(self):
         # is a nop for builtin kiwi initrd and does nothing
         self.boot_image.include_file('/root/a')
@@ -190,3 +196,6 @@ class TestBootImageKiwi:
 
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()

--- a/test/unit/boot/image/dracut_test.py
+++ b/test/unit/boot/image/dracut_test.py
@@ -12,7 +12,7 @@ from kiwi.xml_state import XMLState
 class TestBootImageKiwi:
     @patch('kiwi.boot.image.dracut.Command.run')
     @patch('kiwi.boot.image.base.os.path.exists')
-    def setup(self, mock_BootImageDracut, mock_exists, mock_cmd):
+    def setup(self, mock_exists, mock_cmd):
         Defaults.set_platform_name('x86_64')
         mock_exists.return_value = True
         command_type = namedtuple('command', ['output'])

--- a/test/unit/boot/image/dracut_test.py
+++ b/test/unit/boot/image/dracut_test.py
@@ -31,6 +31,11 @@ class TestBootImageKiwi:
             '--list-modules', '--no-kernel'
         ])
 
+    @patch('kiwi.boot.image.dracut.Command.run')
+    @patch('kiwi.boot.image.base.os.path.exists')
+    def setup_method(self, cls, mock_exists, mock_cmd):
+        self.setup()
+
     @patch('kiwi.boot.image.dracut.SystemSetup')
     def test_prepare(self, mock_setup):
         setup = Mock()

--- a/test/unit/boot/image/init_test.py
+++ b/test/unit/boot/image/init_test.py
@@ -14,6 +14,9 @@ class TestBootImage:
             return_value='kiwi'
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_boot_image_not_implemented(self):
         self.xml_state.get_initrd_system.return_value = 'foo'
         with raises(KiwiBootImageSetupError):

--- a/test/unit/bootloader/config/base_test.py
+++ b/test/unit/bootloader/config/base_test.py
@@ -30,6 +30,9 @@ class TestBootLoaderConfigBase:
             self.state, 'root_dir'
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_write(self):
         with raises(NotImplementedError):
             self.bootloader.write()

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -37,7 +37,7 @@ class TestBootLoaderConfigGrub2:
 
     @patch('kiwi.bootloader.config.grub2.FirmWare')
     @patch('kiwi.bootloader.config.base.BootLoaderConfigBase.get_boot_theme')
-    def setup(self, mock_BootLoaderConfigGrub2, mock_theme, mock_firmware):
+    def setup(self, mock_theme, mock_firmware):
         Defaults.set_platform_name('x86_64')
         self.command_type = namedtuple(
             'command_return_type', ['output']

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -121,6 +121,11 @@ class TestBootLoaderConfigGrub2:
             [self.bootloader.cmdline, 'failsafe-options']
         )
 
+    @patch('kiwi.bootloader.config.grub2.FirmWare')
+    @patch('kiwi.bootloader.config.base.BootLoaderConfigBase.get_boot_theme')
+    def setup_method(self, cls, mock_theme, mock_firmware):
+        self.setup()
+
     @patch('kiwi.bootloader.config.grub2.Path.which')
     def test_post_init_grub2_boot_directory(self, mock_which):
         Defaults.set_platform_name('i686')

--- a/test/unit/bootloader/config/isolinux_test.py
+++ b/test/unit/bootloader/config/isolinux_test.py
@@ -18,7 +18,7 @@ class TestBootLoaderConfigIsoLinux:
         self._caplog = caplog
 
     @patch('os.path.exists')
-    def setup(self, mock_BootLoaderConfigIsoLinux, mock_exists):
+    def setup(self, mock_exists):
         Defaults.set_platform_name('x86_64')
         mock_exists.return_value = True
         self.state = mock.Mock()

--- a/test/unit/bootloader/config/isolinux_test.py
+++ b/test/unit/bootloader/config/isolinux_test.py
@@ -93,6 +93,10 @@ class TestBootLoaderConfigIsoLinux:
             self.state, 'root_dir'
         )
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     def test_post_init_ix86_platform(self):
         Defaults.set_platform_name('i686')
         bootloader = BootLoaderConfigIsoLinux(self.state, 'root_dir')

--- a/test/unit/bootloader/install/base_test.py
+++ b/test/unit/bootloader/install/base_test.py
@@ -10,6 +10,9 @@ class TestBootLoaderInstallBase:
             'root_dir', Mock()
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_install(self):
         with raises(NotImplementedError):
             self.bootloader.install()

--- a/test/unit/bootloader/install/grub2_test.py
+++ b/test/unit/bootloader/install/grub2_test.py
@@ -84,6 +84,9 @@ class TestBootLoaderInstallGrub2:
             'root_dir', device_provider, self.custom_args
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
     def test_post_init_ppc_no_prep_device(self, mock_grub_path):
         self.bootloader.arch = 'ppc64'

--- a/test/unit/bootloader/template/grub2_test.py
+++ b/test/unit/bootloader/template/grub2_test.py
@@ -5,6 +5,9 @@ class TestBootLoaderTemplateGrub2:
     def setup(self):
         self.grub2 = BootLoaderTemplateGrub2()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_get_multiboot_install_template(self):
         assert self.grub2.get_multiboot_install_template().substitute(
             search_params='--fs-uuid --set=root 0815',

--- a/test/unit/bootloader/template/isolinux_test.py
+++ b/test/unit/bootloader/template/isolinux_test.py
@@ -5,6 +5,9 @@ class TestBootLoaderTemplateIsoLinux:
     def setup(self):
         self.isolinux = BootLoaderTemplateIsoLinux()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_get_template(self):
         assert self.isolinux.get_template().substitute(
             default_boot='LimeJeOS-SLE12-Community',

--- a/test/unit/builder/archive_test.py
+++ b/test/unit/builder/archive_test.py
@@ -34,6 +34,9 @@ class TestArchiveBuilder:
             self.xml_state, 'target_dir', 'root_dir'
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_create_unknown_archive_type(self):
         xml_state = mock.Mock()
         xml_state.get_build_type_name = mock.Mock(
@@ -75,3 +78,6 @@ class TestArchiveBuilder:
 
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()

--- a/test/unit/builder/container_test.py
+++ b/test/unit/builder/container_test.py
@@ -12,7 +12,7 @@ from kiwi.exceptions import KiwiContainerBuilderError
 
 class TestContainerBuilder:
     @patch('os.path.exists')
-    def setup(self, mock_ContainerBuilder, mock_exists):
+    def setup(self, mock_exists):
         Defaults.set_platform_name('x86_64')
         self.runtime_config = mock.Mock()
         self.runtime_config.get_max_size_constraint = mock.Mock(

--- a/test/unit/builder/container_test.py
+++ b/test/unit/builder/container_test.py
@@ -62,6 +62,10 @@ class TestContainerBuilder:
         )
         self.container.result = mock.Mock()
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     def test_init_derived(self):
         assert self.container.base_image == 'root_dir/image/imported_root'
 

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -203,8 +203,15 @@ class TestDiskBuilder:
         self.disk_builder.build_type_name = 'oem'
         self.disk_builder.image_format = None
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()
 
     def test_setup_warn_no_initrd_support(self):
         self.boot_image_task.has_initrd_support = Mock(

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -34,7 +34,7 @@ class TestDiskBuilder:
         self._caplog = caplog
 
     @patch('os.path.exists')
-    def setup(self, mock_DiskBuilder, mock_exists):
+    def setup(self, mock_exists):
         Defaults.set_platform_name('x86_64')
 
         def side_effect(filename):

--- a/test/unit/builder/filesystem_test.py
+++ b/test/unit/builder/filesystem_test.py
@@ -66,6 +66,10 @@ class TestFileSystemBuilder:
             return_value=self.setup
         )
 
+    @patch('kiwi.builder.filesystem.FileSystemSetup')
+    def setup_method(self, cls, mock_fs_setup):
+        self.setup()
+
     def test_create_unknown_filesystem(self):
         self.xml_state.get_build_type_name = Mock(
             return_value='super-fs'
@@ -163,3 +167,6 @@ class TestFileSystemBuilder:
 
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()

--- a/test/unit/builder/filesystem_test.py
+++ b/test/unit/builder/filesystem_test.py
@@ -15,7 +15,7 @@ from kiwi.builder.filesystem import FileSystemBuilder
 
 class TestFileSystemBuilder:
     @patch('kiwi.builder.filesystem.FileSystemSetup')
-    def setup(self, mock_FileSystemBuilder, mock_fs_setup):
+    def setup(self, mock_fs_setup):
         Defaults.set_platform_name('x86_64')
         self.loop_provider = Mock()
         self.loop_provider.get_device = Mock(

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -92,6 +92,9 @@ class TestInstallImageBuilder:
             self.xml_state, 'root_dir', 'target_dir', self.boot_image_task
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.builder.install.BootImage')
     def test_init_dracut_based(self, mock_boot_image):
         InstallImageBuilder(

--- a/test/unit/builder/kis_test.py
+++ b/test/unit/builder/kis_test.py
@@ -79,6 +79,11 @@ class TestKisBuilder:
 
     @patch('kiwi.builder.kis.FileSystemBuilder')
     @patch('kiwi.builder.kis.BootImage')
+    def setup_method(self, cls, mock_boot, mock_filesystem):
+        self.setup()
+
+    @patch('kiwi.builder.kis.FileSystemBuilder')
+    @patch('kiwi.builder.kis.BootImage')
     def test_setup_warn_no_initrd_support(self, mock_boot, mock_filesystem):
         boot_image_task = MagicMock()
         boot_image_task.has_initrd_support = Mock(

--- a/test/unit/builder/kis_test.py
+++ b/test/unit/builder/kis_test.py
@@ -19,7 +19,7 @@ class TestKisBuilder:
 
     @patch('kiwi.builder.kis.FileSystemBuilder')
     @patch('kiwi.builder.kis.BootImage')
-    def setup(self, mock_KisBuilder, mock_boot, mock_filesystem):
+    def setup(self, mock_boot, mock_filesystem):
         self.setup = Mock()
         self.runtime_config = Mock()
         self.runtime_config.get_max_size_constraint = Mock(

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -110,8 +110,14 @@ class TestLiveImageBuilder:
         self.result = Mock()
         self.live_image.result = self.result
 
+    def setup_method(self, cls):
+        self.setup()
+
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()
 
     def test_init_for_ix86_platform(self):
         Defaults.set_platform_name('i686')

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -72,8 +72,14 @@ class TestCli:
         self.cli = Cli()
         self.loaded_command = self.cli.load_command()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()
 
     @patch('kiwi.cli.Help.show')
     def test_show_and_exit_on_help_request(self, help_show):

--- a/test/unit/command_process_test.py
+++ b/test/unit/command_process_test.py
@@ -56,6 +56,9 @@ class TestCommandProcess:
         self.flow_out = self.create_flow_method(self.outdata)
         self.flow_err = self.create_flow_method(self.errdata)
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.command.Command')
     def test_returncode(self, mock_command):
         command = mock.Mock()

--- a/test/unit/container/appx_test.py
+++ b/test/unit/container/appx_test.py
@@ -21,6 +21,11 @@ class TestContainerImageAppx:
 
     @patch('kiwi.container.appx.RuntimeConfig')
     @patch('os.path.exists')
+    def setup_method(self, cls, mock_os_path_exists, mock_RuntimeConfig):
+        self.setup()
+
+    @patch('kiwi.container.appx.RuntimeConfig')
+    @patch('os.path.exists')
     def test_init_raises(self, mock_os_path_exists, mock_RuntimeConfig):
         mock_os_path_exists.return_value = True
         with raises(KiwiContainerSetupError):

--- a/test/unit/container/appx_test.py
+++ b/test/unit/container/appx_test.py
@@ -11,9 +11,7 @@ from kiwi.exceptions import KiwiContainerSetupError
 class TestContainerImageAppx:
     @patch('kiwi.container.appx.RuntimeConfig')
     @patch('os.path.exists')
-    def setup(
-        self, mock_ContainerImageAppx, mock_os_path_exists, mock_RuntimeConfig
-    ):
+    def setup(self, mock_os_path_exists, mock_RuntimeConfig):
         mock_os_path_exists.return_value = True
         self.appx = ContainerImageAppx(
             'root_dir', {

--- a/test/unit/container/oci_test.py
+++ b/test/unit/container/oci_test.py
@@ -38,6 +38,11 @@ class TestContainerImageOCI:
 
     @patch('kiwi.oci_tools.umoci.CommandCapabilities.has_option_in_help')
     @patch('kiwi.defaults.Defaults.is_buildservice_worker')
+    def setup_method(self, cls, mock_is_buildservice_worker, mock_cmd_caps):
+        self.setup()
+
+    @patch('kiwi.oci_tools.umoci.CommandCapabilities.has_option_in_help')
+    @patch('kiwi.defaults.Defaults.is_buildservice_worker')
     def test_init_custom_args(self, mock_is_buildservice_worker, mock_cmd_caps):
         mock_is_buildservice_worker.return_value = False
         mock_cmd_caps.return_value = True

--- a/test/unit/container/oci_test.py
+++ b/test/unit/container/oci_test.py
@@ -19,10 +19,7 @@ class TestContainerImageOCI:
 
     @patch('kiwi.oci_tools.umoci.CommandCapabilities.has_option_in_help')
     @patch('kiwi.defaults.Defaults.is_buildservice_worker')
-    def setup(
-        self, mock_ContainerImageOCI, mock_is_buildservice_worker,
-        mock_cmd_caps
-    ):
+    def setup(self, mock_is_buildservice_worker, mock_cmd_caps):
         mock_is_buildservice_worker.return_value = False
         mock_cmd_caps.return_value = True
         self.runtime_config = mock.Mock()

--- a/test/unit/container/setup/appx_test.py
+++ b/test/unit/container/setup/appx_test.py
@@ -29,6 +29,10 @@ class TestContainerSetupAppx:
             }
         )
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     def test_setup_raises_no_manifest_file(self):
         with patch('os.path.exists', return_value=True):
             appx = ContainerSetupAppx(

--- a/test/unit/container/setup/appx_test.py
+++ b/test/unit/container/setup/appx_test.py
@@ -12,7 +12,7 @@ from kiwi.exceptions import KiwiContainerSetupError
 
 class TestContainerSetupAppx:
     @patch('os.path.exists')
-    def setup(self, mock_ContainerSetupAppx, mock_exists):
+    def setup(self, mock_exists):
         mock_exists.return_value = True
         self.appx = ContainerSetupAppx(
             'root_dir', {

--- a/test/unit/container/setup/base_test.py
+++ b/test/unit/container/setup/base_test.py
@@ -11,7 +11,7 @@ from kiwi.exceptions import KiwiContainerSetupError
 
 class TestContainerSetupBase:
     @patch('os.path.exists')
-    def setup(self, mock_ContainerSetupBase, mock_exists):
+    def setup(self, mock_exists):
         mock_exists.return_value = True
 
         self.container = ContainerSetupBase('root_dir')

--- a/test/unit/container/setup/base_test.py
+++ b/test/unit/container/setup/base_test.py
@@ -17,6 +17,10 @@ class TestContainerSetupBase:
         self.container = ContainerSetupBase('root_dir')
 
     @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
+    @patch('os.path.exists')
     def test_container_root_dir_does_not_exist(self, mock_exists):
         mock_exists.return_value = False
         with raises(KiwiContainerSetupError):

--- a/test/unit/container/setup/oci_test.py
+++ b/test/unit/container/setup/oci_test.py
@@ -7,7 +7,7 @@ from kiwi.container.setup.oci import ContainerSetupOCI
 
 class TestContainerSetupOCI:
     @patch('os.path.exists')
-    def setup(self, mock_ContainerSetupOCI, mock_exists):
+    def setup(self, mock_exists):
         mock_exists.return_value = True
 
         self.container = ContainerSetupOCI(

--- a/test/unit/container/setup/oci_test.py
+++ b/test/unit/container/setup/oci_test.py
@@ -20,6 +20,10 @@ class TestContainerSetupOCI:
         self.container.setup_root_console = mock.Mock()
         self.container.deactivate_systemd_service = mock.Mock()
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     def test_setup(self):
         self.container.setup()
         self.container.deactivate_bootloader_setup.assert_called_once_with()

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -20,8 +20,14 @@ class TestDefaults:
     def setup(self):
         self.defaults = Defaults()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()
 
     def test_get(self):
         assert self.defaults.get('kiwi_align') == 1048576

--- a/test/unit/filesystem/base_test.py
+++ b/test/unit/filesystem/base_test.py
@@ -18,6 +18,9 @@ class TestFileSystemBase:
         }
         self.fsbase = FileSystemBase(provider, 'root_dir', custom_args)
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_root_dir_does_not_exist(self):
         fsbase = FileSystemBase(mock.Mock(), 'root_dir_not_existing')
         with raises(KiwiFileSystemSyncError):

--- a/test/unit/filesystem/btrfs_test.py
+++ b/test/unit/filesystem/btrfs_test.py
@@ -18,6 +18,10 @@ class TestFileSystemBtrfs:
             return_value='some-mount-point'
         )
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     @patch('kiwi.filesystem.btrfs.Command.run')
     def test_create_on_device(self, mock_command):
         self.btrfs.create_on_device('label')

--- a/test/unit/filesystem/btrfs_test.py
+++ b/test/unit/filesystem/btrfs_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.btrfs import FileSystemBtrfs
 
 class TestFileSystemBtrfs:
     @patch('os.path.exists')
-    def setup(self, mock_FileSystemBtrfs, mock_exists):
+    def setup(self, mock_exists):
         mock_exists.return_value = True
         provider = mock.Mock()
         provider.get_device = mock.Mock(

--- a/test/unit/filesystem/clicfs_test.py
+++ b/test/unit/filesystem/clicfs_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.clicfs import FileSystemClicFs
 
 class TestFileSystemClicFs:
     @patch('os.path.exists')
-    def setup(self, mock_FileSystemClicFs, mock_exists):
+    def setup(self, mock_exists):
         mock_exists.return_value = True
         self.clicfs = FileSystemClicFs(mock.Mock(), 'root_dir')
 

--- a/test/unit/filesystem/clicfs_test.py
+++ b/test/unit/filesystem/clicfs_test.py
@@ -11,6 +11,10 @@ class TestFileSystemClicFs:
         mock_exists.return_value = True
         self.clicfs = FileSystemClicFs(mock.Mock(), 'root_dir')
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     @patch('kiwi.filesystem.clicfs.Command.run')
     @patch('kiwi.filesystem.clicfs.Temporary')
     @patch('kiwi.filesystem.clicfs.LoopDevice')

--- a/test/unit/filesystem/ext2_test.py
+++ b/test/unit/filesystem/ext2_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.ext2 import FileSystemExt2
 
 class TestFileSystemExt2:
     @patch('os.path.exists')
-    def setup(self, mock_FileSystemExt2, mock_exists):
+    def setup(self, mock_exists):
         mock_exists.return_value = True
         provider = mock.Mock()
         provider.get_device = mock.Mock(

--- a/test/unit/filesystem/ext2_test.py
+++ b/test/unit/filesystem/ext2_test.py
@@ -18,6 +18,10 @@ class TestFileSystemExt2:
             return_value='some-mount-point'
         )
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     @patch('kiwi.filesystem.ext2.Command.run')
     def test_create_on_device(self, mock_command):
         self.ext2.create_on_device('label')

--- a/test/unit/filesystem/ext3_test.py
+++ b/test/unit/filesystem/ext3_test.py
@@ -18,6 +18,10 @@ class TestFileSystemExt3:
             return_value='some-mount-point'
         )
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     @patch('kiwi.filesystem.ext3.Command.run')
     def test_create_on_device(self, mock_command):
         self.ext3.create_on_device('label')

--- a/test/unit/filesystem/ext3_test.py
+++ b/test/unit/filesystem/ext3_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.ext3 import FileSystemExt3
 
 class TestFileSystemExt3:
     @patch('os.path.exists')
-    def setup(self, mock_FileSystemExt3, mock_exists):
+    def setup(self, mock_exists):
         mock_exists.return_value = True
         provider = mock.Mock()
         provider.get_device = mock.Mock(

--- a/test/unit/filesystem/ext4_test.py
+++ b/test/unit/filesystem/ext4_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.ext4 import FileSystemExt4
 
 class TestFileSystemExt4:
     @patch('os.path.exists')
-    def setup(self, mock_FileSystemExt4, mock_exists):
+    def setup(self, mock_exists):
         mock_exists.return_value = True
         provider = mock.Mock()
         provider.get_device = mock.Mock(

--- a/test/unit/filesystem/ext4_test.py
+++ b/test/unit/filesystem/ext4_test.py
@@ -18,6 +18,10 @@ class TestFileSystemExt4:
             return_value='some-mount-point'
         )
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     @patch('kiwi.filesystem.ext4.Command.run')
     def test_create_on_device(self, mock_command):
         self.ext4.create_on_device('label')

--- a/test/unit/filesystem/fat16_test.py
+++ b/test/unit/filesystem/fat16_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.fat16 import FileSystemFat16
 
 class TestFileSystemFat16:
     @patch('os.path.exists')
-    def setup(self, mock_FileSystemFat16, mock_exists):
+    def setup(self, mock_exists):
         mock_exists.return_value = True
         provider = mock.Mock()
         provider.get_device = mock.Mock(

--- a/test/unit/filesystem/fat16_test.py
+++ b/test/unit/filesystem/fat16_test.py
@@ -18,6 +18,10 @@ class TestFileSystemFat16:
             return_value='some-mount-point'
         )
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     @patch('kiwi.filesystem.fat16.Command.run')
     def test_create_on_device(self, mock_command):
         self.fat16.create_on_device('label')

--- a/test/unit/filesystem/fat32_test.py
+++ b/test/unit/filesystem/fat32_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.fat32 import FileSystemFat32
 
 class TestFileSystemFat32:
     @patch('os.path.exists')
-    def setup(self, mock_FileSystemFat32, mock_exists):
+    def setup(self, mock_exists):
         mock_exists.return_value = True
         provider = mock.Mock()
         provider.get_device = mock.Mock(

--- a/test/unit/filesystem/fat32_test.py
+++ b/test/unit/filesystem/fat32_test.py
@@ -18,6 +18,10 @@ class TestFileSystemFat32:
             return_value='some-mount-point'
         )
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     @patch('kiwi.filesystem.fat32.Command.run')
     def test_create_on_device(self, mock_command):
         self.fat32.create_on_device('label')

--- a/test/unit/filesystem/isofs_test.py
+++ b/test/unit/filesystem/isofs_test.py
@@ -12,7 +12,7 @@ class TestFileSystemIsoFs:
         self._caplog = caplog
 
     @patch('os.path.exists')
-    def setup(self, mock_FileSystemIsoFs, mock_exists):
+    def setup(self, mock_exists):
         mock_exists.return_value = True
         self.isofs = FileSystemIsoFs(mock.Mock(), 'root_dir')
 

--- a/test/unit/filesystem/isofs_test.py
+++ b/test/unit/filesystem/isofs_test.py
@@ -16,6 +16,10 @@ class TestFileSystemIsoFs:
         mock_exists.return_value = True
         self.isofs = FileSystemIsoFs(mock.Mock(), 'root_dir')
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     def test_post_init(self):
         self.isofs.post_init({'some_args': 'data'})
         assert self.isofs.custom_args['meta_data'] == {}

--- a/test/unit/filesystem/setup_test.py
+++ b/test/unit/filesystem/setup_test.py
@@ -32,6 +32,10 @@ class TestFileSystemSetup:
             self.xml_state, 'root_dir'
         )
 
+    @patch('kiwi.filesystem.setup.SystemSize')
+    def setup_method(self, cls, mock_size):
+        self.setup()
+
     def test_init_with_unpartitioned(self):
         self.xml_state.get_build_type_unpartitioned_bytes = mock.Mock(
             return_value=1024

--- a/test/unit/filesystem/setup_test.py
+++ b/test/unit/filesystem/setup_test.py
@@ -12,7 +12,7 @@ class TestFileSystemSetup:
         self._caplog = caplog
 
     @patch('kiwi.filesystem.setup.SystemSize')
-    def setup(self, mock_FileSystemSetup, mock_size):
+    def setup(self, mock_size):
         size = mock.Mock()
         size.accumulate_mbyte_file_sizes = mock.Mock(
             return_value=42

--- a/test/unit/filesystem/squashfs_test.py
+++ b/test/unit/filesystem/squashfs_test.py
@@ -12,6 +12,10 @@ class TestFileSystemSquashfs:
         mock_exists.return_value = True
         self.squashfs = FileSystemSquashFs(mock.Mock(), 'root_dir')
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     @patch('kiwi.filesystem.squashfs.Command.run')
     def test_create_on_file(self, mock_command):
         Defaults.set_platform_name('x86_64')

--- a/test/unit/filesystem/squashfs_test.py
+++ b/test/unit/filesystem/squashfs_test.py
@@ -8,7 +8,7 @@ from kiwi.filesystem.squashfs import FileSystemSquashFs
 
 class TestFileSystemSquashfs:
     @patch('os.path.exists')
-    def setup(self, mock_FileSystemSquashFs, mock_exists):
+    def setup(self, mock_exists):
         mock_exists.return_value = True
         self.squashfs = FileSystemSquashFs(mock.Mock(), 'root_dir')
 

--- a/test/unit/filesystem/swap_test.py
+++ b/test/unit/filesystem/swap_test.py
@@ -18,6 +18,10 @@ class TestFileSystemSwap:
             return_value='some-mount-point'
         )
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     @patch('kiwi.filesystem.swap.Command.run')
     def test_create_on_device(self, mock_command):
         self.swap.create_on_device('label')

--- a/test/unit/filesystem/swap_test.py
+++ b/test/unit/filesystem/swap_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.swap import FileSystemSwap
 
 class TestFileSystemSwap:
     @patch('os.path.exists')
-    def setup(self, mock_FileSystemSwap, mock_exists):
+    def setup(self, mock_exists):
         mock_exists.return_value = True
         provider = mock.Mock()
         provider.get_device = mock.Mock(

--- a/test/unit/filesystem/xfs_test.py
+++ b/test/unit/filesystem/xfs_test.py
@@ -18,6 +18,10 @@ class TestFileSystemXfs:
             return_value='some-mount-point'
         )
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     @patch('kiwi.filesystem.xfs.Command.run')
     def test_create_on_device(self, mock_command):
         self.xfs.create_on_device('label')

--- a/test/unit/filesystem/xfs_test.py
+++ b/test/unit/filesystem/xfs_test.py
@@ -7,7 +7,7 @@ from kiwi.filesystem.xfs import FileSystemXfs
 
 class TestFileSystemXfs:
     @patch('os.path.exists')
-    def setup(self, mock_FileSystemXfs, mock_exists):
+    def setup(self, mock_exists):
         mock_exists.return_value = True
         provider = mock.Mock()
         provider.get_device = mock.Mock(

--- a/test/unit/firmware_test.py
+++ b/test/unit/firmware_test.py
@@ -50,6 +50,9 @@ class TestFirmWare:
 
         Defaults.set_platform_name('x86_64')
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_firmware_unsupported(self):
         xml_state = mock.Mock()
         xml_state.build_type.get_firmware = mock.Mock(

--- a/test/unit/help_test.py
+++ b/test/unit/help_test.py
@@ -10,6 +10,9 @@ class TestHelp:
     def setup(self):
         self.help = Help()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_show(self):
         with raises(KiwiHelpNoCommandGiven):
             self.help.show(None)

--- a/test/unit/iso_tools/base_test.py
+++ b/test/unit/iso_tools/base_test.py
@@ -12,6 +12,9 @@ class TestIsoToolsBase:
         Defaults.set_platform_name('x86_64')
         self.iso_tool = IsoToolsBase('source-dir')
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_create_iso(self):
         with raises(NotImplementedError):
             self.iso_tool.create_iso('filename')

--- a/test/unit/iso_tools/init_test.py
+++ b/test/unit/iso_tools/init_test.py
@@ -11,6 +11,9 @@ class TestIsoTools:
         self.runtime_config = mock.Mock()
         self.runtime_config.get_iso_tool_category = mock.Mock()
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.iso_tools.xorriso.IsoToolsXorrIso')
     @patch('kiwi.iso_tools.RuntimeConfig')
     def test_iso_tools_xorriso(

--- a/test/unit/iso_tools/iso_test.py
+++ b/test/unit/iso_tools/iso_test.py
@@ -14,6 +14,9 @@ class TestIso:
         Defaults.set_platform_name('x86_64')
         self.iso = Iso('source-dir')
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('os.path.exists')
     def test_setup_isolinux_boot_path_raises(self, mock_exists):
         mock_exists.return_value = False

--- a/test/unit/iso_tools/xorriso_test.py
+++ b/test/unit/iso_tools/xorriso_test.py
@@ -12,6 +12,9 @@ class TestIsoToolsXorrIso:
         Defaults.set_platform_name('x86_64')
         self.iso_tool = IsoToolsXorrIso('source-dir')
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.iso_tools.xorriso.Path.which')
     def test_get_tool_name(self, mock_which):
         mock_which.return_value = 'tool_found'

--- a/test/unit/kiwi_compat_test.py
+++ b/test/unit/kiwi_compat_test.py
@@ -11,6 +11,9 @@ class TestKiwiCompat:
     def teardown(self):
         sys.argv = argv_kiwi_tests
 
+    def teardown_method(self, cls):
+        self.teardown()
+
     @patch('logging.error')
     def test_compat_mode_invalid_arguments(self, mock_log_error):
         sys.argv = [

--- a/test/unit/logger_color_formatter_test.py
+++ b/test/unit/logger_color_formatter_test.py
@@ -8,6 +8,9 @@ class TestColorFormatter:
     def setup(self):
         self.color_formatter = ColorFormatter('%(levelname)s: %(message)s')
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('logging.Formatter.format')
     def test_format(self, mock_format):
         MyRecord = namedtuple(

--- a/test/unit/logger_filter_test.py
+++ b/test/unit/logger_filter_test.py
@@ -14,6 +14,9 @@ class TestLoggerSchedulerFilter:
     def setup(self):
         self.scheduler_filter = LoggerSchedulerFilter()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_filter(self):
         MyRecord = namedtuple(
             'MyRecord',
@@ -32,6 +35,9 @@ class TestInfoFilter:
     def setup(self):
         self.info_filter = InfoFilter()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_filter(self):
         MyRecord = namedtuple(
             'MyRecord',
@@ -44,6 +50,9 @@ class TestInfoFilter:
 class TestDebugFilter:
     def setup(self):
         self.debug_filter = DebugFilter()
+
+    def setup_method(self, cls):
+        self.setup()
 
     def test_filter(self):
         MyRecord = namedtuple(
@@ -58,6 +67,9 @@ class TestErrorFilter:
     def setup(self):
         self.error_filter = ErrorFilter()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_filter(self):
         MyRecord = namedtuple(
             'MyRecord',
@@ -70,6 +82,9 @@ class TestErrorFilter:
 class TestWarningFilter:
     def setup(self):
         self.error_filter = WarningFilter()
+
+    def setup_method(self, cls):
+        self.setup()
 
     def test_filter(self):
         MyRecord = namedtuple(

--- a/test/unit/logger_test.py
+++ b/test/unit/logger_test.py
@@ -13,6 +13,9 @@ class TestLogger:
     def setup(self):
         self.log = Logger('kiwi')
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('sys.stdout')
     def test_progress(self, mock_stdout):
         self.log.progress(50, 100, 'foo')

--- a/test/unit/markup/any_test.py
+++ b/test/unit/markup/any_test.py
@@ -13,6 +13,9 @@ class TestMarkupXML:
     def setup(self):
         self.markup = MarkupAny('../data/example_config.xml')
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('anymarkup.parse_file')
     def test_raises_markup_conversion_error(self, mock_anymarkup_parse_file):
         mock_anymarkup_parse_file.side_effect = Exception

--- a/test/unit/markup/base_test.py
+++ b/test/unit/markup/base_test.py
@@ -17,6 +17,9 @@ class TestMarkupBase:
     def setup(self):
         self.markup = MarkupBase('../data/example_config.xml')
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_get_xml_description(self):
         with raises(NotImplementedError):
             self.markup.get_xml_description()

--- a/test/unit/markup/xml_test.py
+++ b/test/unit/markup/xml_test.py
@@ -9,6 +9,9 @@ class TestMarkupXML:
     def setup(self):
         self.markup = MarkupXML('../data/example_config.xml')
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_get_xml_description(self):
         assert 'xslt-' in self.markup.get_xml_description()
 

--- a/test/unit/mount_manager_test.py
+++ b/test/unit/mount_manager_test.py
@@ -19,6 +19,9 @@ class TestMountManager:
             '/dev/some-device', '/some/mountpoint'
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.mount_manager.Temporary')
     def test_setup_empty_mountpoint(self, mock_Temporary):
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'

--- a/test/unit/oci_tools/base_test.py
+++ b/test/unit/oci_tools/base_test.py
@@ -7,6 +7,9 @@ class TestOCIBase:
     def setup(self):
         self.oci = OCIBase()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_init_container(self):
         with raises(NotImplementedError):
             self.oci.init_container()

--- a/test/unit/oci_tools/buildah_test.py
+++ b/test/unit/oci_tools/buildah_test.py
@@ -25,10 +25,18 @@ class TestOCIBuildah:
         )
         self.oci = OCIBuildah()
 
+    @patch('kiwi.oci_tools.base.datetime')
+    def setup_method(self, cls, mock_datetime):
+        self.setup()
+
     @patch('kiwi.oci_tools.umoci.Command.run')
     def teardown(self, mock_cmd_run):
         del self.oci
         mock_cmd_run.reset_mock()
+
+    @patch('kiwi.oci_tools.umoci.Command.run')
+    def teardown_method(self, cls, mock_cmd_run):
+        self.teardown()
 
     @patch('kiwi.oci_tools.buildah.random.choice')
     @patch('kiwi.oci_tools.buildah.Command.run')

--- a/test/unit/oci_tools/buildah_test.py
+++ b/test/unit/oci_tools/buildah_test.py
@@ -17,7 +17,7 @@ class TestOCIBuildah:
         self._caplog = caplog
 
     @patch('kiwi.oci_tools.base.datetime')
-    def setup(self, mock_OCIBuildah, mock_datetime):
+    def setup(self, mock_datetime):
         strftime = Mock()
         strftime.strftime = Mock(return_value='current_date')
         mock_datetime.utcnow = Mock(
@@ -26,7 +26,7 @@ class TestOCIBuildah:
         self.oci = OCIBuildah()
 
     @patch('kiwi.oci_tools.umoci.Command.run')
-    def teardown(self, mock_OCIBuildah, mock_cmd_run):
+    def teardown(self, mock_cmd_run):
         del self.oci
         mock_cmd_run.reset_mock()
 

--- a/test/unit/oci_tools/init_test.py
+++ b/test/unit/oci_tools/init_test.py
@@ -15,6 +15,9 @@ class TestOCI:
         self.runtime_config = Mock()
         self.runtime_config.get_oci_archive_tool = Mock()
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.oci_tools.umoci.OCIUmoci')
     @patch('kiwi.oci_tools.RuntimeConfig')
     def test_oci_tool_umoci(

--- a/test/unit/oci_tools/umoci_test.py
+++ b/test/unit/oci_tools/umoci_test.py
@@ -19,6 +19,12 @@ class TestOCIUmoci:
         )
         self.oci = OCIUmoci()
 
+    @patch('kiwi.oci_tools.umoci.CommandCapabilities.has_option_in_help')
+    @patch('kiwi.oci_tools.base.datetime')
+    @patch('kiwi.oci_tools.umoci.Temporary')
+    def setup_method(self, cls, mock_Temporary, mock_datetime, mock_cmd_caps):
+        self.setup()
+
     @patch('kiwi.oci_tools.umoci.Command.run')
     def test_init_container(self, mock_Command_run):
         self.oci.init_container()

--- a/test/unit/oci_tools/umoci_test.py
+++ b/test/unit/oci_tools/umoci_test.py
@@ -9,9 +9,7 @@ class TestOCIUmoci:
     @patch('kiwi.oci_tools.umoci.CommandCapabilities.has_option_in_help')
     @patch('kiwi.oci_tools.base.datetime')
     @patch('kiwi.oci_tools.umoci.Temporary')
-    def setup(
-        self, mock_OCIUmoci, mock_Temporary, mock_datetime, mock_cmd_caps
-    ):
+    def setup(self, mock_Temporary, mock_datetime, mock_cmd_caps):
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         mock_cmd_caps.return_value = True
         strftime = Mock()

--- a/test/unit/package_manager/apt_test.py
+++ b/test/unit/package_manager/apt_test.py
@@ -37,6 +37,9 @@ class TestPackageManagerApt:
         )
         self.manager = PackageManagerApt(repository)
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_request_package(self):
         self.manager.request_package('name')
         assert self.manager.package_requests == ['name']

--- a/test/unit/package_manager/base_test.py
+++ b/test/unit/package_manager/base_test.py
@@ -10,6 +10,9 @@ class TestPackageManagerBase:
         repository.root_dir = 'root-dir'
         self.manager = PackageManagerBase(repository)
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_request_package(self):
         with raises(NotImplementedError):
             self.manager.request_package('name')

--- a/test/unit/package_manager/dnf_test.py
+++ b/test/unit/package_manager/dnf_test.py
@@ -22,6 +22,9 @@ class TestPackageManagerDnf:
         )
         self.manager = PackageManagerDnf(repository)
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_request_package(self):
         self.manager.request_package('name')
         assert self.manager.package_requests == ['name']

--- a/test/unit/package_manager/microdnf_test.py
+++ b/test/unit/package_manager/microdnf_test.py
@@ -28,6 +28,9 @@ class TestPackageManagerMicroDnf:
         }
         self.manager = PackageManagerMicroDnf(repository)
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_request_package(self):
         self.manager.request_package('name')
         assert self.manager.package_requests == ['name']

--- a/test/unit/package_manager/pacman_test.py
+++ b/test/unit/package_manager/pacman_test.py
@@ -28,6 +28,9 @@ class TestPackageManagerPacman:
         )
         self.manager = PackageManagerPacman(repository)
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_request_package(self):
         self.manager.request_package('name')
         assert self.manager.package_requests == ['name']

--- a/test/unit/package_manager/zypper_test.py
+++ b/test/unit/package_manager/zypper_test.py
@@ -32,6 +32,9 @@ class TestPackageManagerZypper:
         self.chroot_command_env['ZYPP_CONF'] = \
             Path.move_to_root('root-dir', [zypp_conf])[0]
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_request_package(self):
         self.manager.request_package('name')
         assert self.manager.package_requests == ['name']

--- a/test/unit/partitioner/base_test.py
+++ b/test/unit/partitioner/base_test.py
@@ -12,6 +12,9 @@ class TestPartitionerBase:
         )
         self.partitioner = PartitionerBase(disk_provider)
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_get_id(self):
         assert self.partitioner.get_id() == 0
 

--- a/test/unit/partitioner/dasd_test.py
+++ b/test/unit/partitioner/dasd_test.py
@@ -31,6 +31,11 @@ class TestPartitionerDasd:
 
     @patch('kiwi.partitioner.dasd.Command.run')
     @patch('kiwi.partitioner.dasd.Temporary.new_file')
+    def setup_method(self, cls, mock_temp, mock_command):
+        self.setup()
+
+    @patch('kiwi.partitioner.dasd.Command.run')
+    @patch('kiwi.partitioner.dasd.Temporary.new_file')
     def test_create(self, mock_temp, mock_command):
         mock_command.side_effect = Exception
         mock_temp.return_value = self.tempfile

--- a/test/unit/partitioner/dasd_test.py
+++ b/test/unit/partitioner/dasd_test.py
@@ -16,7 +16,7 @@ class TestPartitionerDasd:
 
     @patch('kiwi.partitioner.dasd.Command.run')
     @patch('kiwi.partitioner.dasd.Temporary.new_file')
-    def setup(self, mock_PartitionerDasd, mock_temp, mock_command):
+    def setup(self, mock_temp, mock_command):
         self.tempfile = mock.Mock()
         self.tempfile.name = 'tempfile'
 

--- a/test/unit/partitioner/gpt_test.py
+++ b/test/unit/partitioner/gpt_test.py
@@ -23,6 +23,9 @@ class TestPartitionerGpt:
         )
         self.partitioner = PartitionerGpt(disk_provider)
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.partitioner.gpt.Command.run')
     @patch('kiwi.partitioner.gpt.PartitionerGpt.set_flag')
     def test_create(self, mock_flag, mock_command):

--- a/test/unit/partitioner/msdos_test.py
+++ b/test/unit/partitioner/msdos_test.py
@@ -24,6 +24,9 @@ class TestPartitionerMsDos:
         )
         self.partitioner = PartitionerMsDos(disk_provider)
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.partitioner.msdos.Command.run')
     @patch('kiwi.partitioner.msdos.PartitionerMsDos.set_flag')
     @patch('kiwi.partitioner.msdos.Temporary.new_file')

--- a/test/unit/repository/apt_test.py
+++ b/test/unit/repository/apt_test.py
@@ -11,7 +11,7 @@ class TestRepositoryApt:
     @patch('kiwi.repository.apt.Temporary.new_file')
     @patch('kiwi.repository.apt.PackageManagerTemplateAptGet')
     @patch('kiwi.repository.apt.Path.create')
-    def setup(self, mock_RepositoryApt, mock_path, mock_template, mock_temp):
+    def setup(self, mock_path, mock_template, mock_temp):
         self.apt_conf = mock.Mock()
         mock_template.return_value = self.apt_conf
 

--- a/test/unit/repository/apt_test.py
+++ b/test/unit/repository/apt_test.py
@@ -50,6 +50,12 @@ class TestRepositoryApt:
             assert repo.custom_args == []
             assert repo.unauthenticated == 'true'
 
+    @patch('kiwi.repository.apt.Temporary.new_file')
+    @patch('kiwi.repository.apt.PackageManagerTemplateAptGet')
+    @patch('kiwi.repository.apt.Path.create')
+    def setup_method(self, cls, mock_path, mock_template, mock_temp):
+        self.setup()
+
     def test_use_default_location(self):
         template = mock.Mock()
         template.substitute.return_value = 'template-data'

--- a/test/unit/repository/base_test.py
+++ b/test/unit/repository/base_test.py
@@ -11,6 +11,9 @@ class TestRepositoryBase:
         self.repo.root_dir = 'root-dir'
         self.repo.shared_location = 'shared-dir'
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_use_default_location(self):
         with raises(NotImplementedError):
             self.repo.use_default_location()

--- a/test/unit/repository/dnf_test.py
+++ b/test/unit/repository/dnf_test.py
@@ -51,6 +51,12 @@ class TestRepositoryDnf:
         ]
 
     @patch('kiwi.repository.dnf.Temporary.new_file')
+    @patch('kiwi.repository.dnf.ConfigParser')
+    @patch('kiwi.repository.dnf.Path.create')
+    def setup_method(self, cls, mock_path, mock_config, mock_temp):
+        self.setup()
+
+    @patch('kiwi.repository.dnf.Temporary.new_file')
     @patch('kiwi.repository.dnf.Path.create')
     def test_post_init_no_custom_args(self, mock_path, mock_temp):
         with patch('builtins.open', create=True):

--- a/test/unit/repository/dnf_test.py
+++ b/test/unit/repository/dnf_test.py
@@ -15,7 +15,7 @@ class TestRepositoryDnf:
     @patch('kiwi.repository.dnf.Temporary.new_file')
     @patch('kiwi.repository.dnf.ConfigParser')
     @patch('kiwi.repository.dnf.Path.create')
-    def setup(self, mock_RepositoryDnf, mock_path, mock_config, mock_temp):
+    def setup(self, mock_path, mock_config, mock_temp):
         runtime_dnf_config = mock.Mock()
         mock_config.return_value = runtime_dnf_config
         tmpfile = mock.Mock()

--- a/test/unit/repository/pacman_test.py
+++ b/test/unit/repository/pacman_test.py
@@ -12,7 +12,7 @@ class TestRepositorPacman(object):
     @patch('kiwi.repository.pacman.Temporary.new_file')
     @patch('kiwi.repository.pacman.ConfigParser')
     @patch('kiwi.repository.pacman.Path.create')
-    def setup(self, mock_RepositoryPacman, mock_path, mock_config, mock_temp):
+    def setup(self, mock_path, mock_config, mock_temp):
         runtime_pacman_config = Mock()
         mock_config.return_value = runtime_pacman_config
         tmpfile = Mock()

--- a/test/unit/repository/pacman_test.py
+++ b/test/unit/repository/pacman_test.py
@@ -51,6 +51,12 @@ class TestRepositorPacman(object):
                 call('options', 'Include', '/shared-dir/pacman/repos/*.repo')
             ]
 
+    @patch('kiwi.repository.pacman.Temporary.new_file')
+    @patch('kiwi.repository.pacman.ConfigParser')
+    @patch('kiwi.repository.pacman.Path.create')
+    def setup_method(self, cls, mock_path, mock_config, mock_temp):
+        self.setup()
+
     def test_runtime_config(self):
         assert self.repo.runtime_config()['pacman_args'] == \
             self.repo.pacman_args

--- a/test/unit/repository/template/apt_test.py
+++ b/test/unit/repository/template/apt_test.py
@@ -5,6 +5,9 @@ class TestPackageManagerTemplateAptGet:
     def setup(self):
         self.apt = PackageManagerTemplateAptGet()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_get_host_template(self):
         assert self.apt.get_host_template().substitute(
             apt_shared_base='/var/cache/kiwi/apt-get',

--- a/test/unit/repository/zypper_test.py
+++ b/test/unit/repository/zypper_test.py
@@ -14,7 +14,7 @@ from kiwi.exceptions import KiwiCommandError
 class TestRepositoryZypper:
     @patch('kiwi.command.Command.run')
     @patch('kiwi.repository.zypper.Temporary.new_file')
-    def setup(self, mock_RepositoryZypper, mock_temp, mock_command):
+    def setup(self, mock_temp, mock_command):
 
         self.context_manager_mock = mock.Mock()
         self.file_mock = mock.Mock()

--- a/test/unit/repository/zypper_test.py
+++ b/test/unit/repository/zypper_test.py
@@ -15,7 +15,6 @@ class TestRepositoryZypper:
     @patch('kiwi.command.Command.run')
     @patch('kiwi.repository.zypper.Temporary.new_file')
     def setup(self, mock_temp, mock_command):
-
         self.context_manager_mock = mock.Mock()
         self.file_mock = mock.Mock()
         self.enter_mock = mock.Mock()
@@ -34,6 +33,11 @@ class TestRepositoryZypper:
             self.repo = RepositoryZypper(
                 self.root_bind, ['exclude_docs', '_install_langs%en_US:de_DE']
             )
+
+    @patch('kiwi.command.Command.run')
+    @patch('kiwi.repository.zypper.Temporary.new_file')
+    def setup_method(self, cls, mock_temp, mock_command):
+        self.setup()
 
     @patch('kiwi.command.Command.run')
     @patch('kiwi.repository.zypper.Temporary.new_file')

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -37,6 +37,9 @@ class TestRuntimeChecker:
         )
         self.runtime_checker = RuntimeChecker(self.xml_state)
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.runtime_checker.Uri')
     def test_check_image_include_repos_publicly_resolvable(self, mock_Uri):
         uri = Mock()
@@ -440,3 +443,6 @@ class TestRuntimeChecker:
 
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -17,6 +17,9 @@ class TestRuntimeConfig:
     def setup(self):
         Defaults.set_custom_runtime_config_file(None)
 
+    def setup_method(self, cls):
+        self.setup()
+
     @fixture(autouse=True)
     def inject_fixtures(self, caplog):
         self._caplog = caplog

--- a/test/unit/solver/repository/base_test.py
+++ b/test/unit/solver/repository/base_test.py
@@ -17,8 +17,10 @@ from kiwi.exceptions import KiwiUriOpenError
 class TestSolverRepositoryBase:
     def setup(self):
         self.uri = mock.Mock()
-
         self.solver = SolverRepositoryBase(self.uri)
+
+    def setup_method(self, cls):
+        self.setup()
 
     @patch.object(SolverRepositoryBase, '_get_repomd_xml')
     @patch.object(SolverRepositoryBase, '_get_deb_packages')

--- a/test/unit/solver/repository/deb_test.py
+++ b/test/unit/solver/repository/deb_test.py
@@ -10,6 +10,9 @@ class TestSolverRepositoryDeb:
         self.uri = Mock()
         self.solver = SolverRepositoryDeb(self.uri)
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch.object(SolverRepositoryBase, '_get_deb_packages')
     @patch.object(SolverRepositoryBase, '_create_solvables')
     @patch.object(SolverRepositoryBase, '_create_temporary_metadata_dir')

--- a/test/unit/solver/repository/init_test.py
+++ b/test/unit/solver/repository/init_test.py
@@ -13,6 +13,9 @@ class TestSolverRepository:
         self.uri = Mock()
         self.uri.repo_type = 'some-unknown-type'
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_solver_repository_type_not_implemented(self):
         with raises(KiwiSolverRepositorySetupError):
             SolverRepository.new(self.uri)

--- a/test/unit/solver/repository/rpm_dir_test.py
+++ b/test/unit/solver/repository/rpm_dir_test.py
@@ -14,6 +14,9 @@ class TestSolverRepositoryRpmDir:
         self.uri = Mock()
         self.solver = SolverRepositoryRpmDir(self.uri)
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test__setup_repository_metadata_raises(self):
         with raises(KiwiRpmDirNotRemoteError):
             self.solver._setup_repository_metadata()

--- a/test/unit/solver/repository/rpm_md_test.py
+++ b/test/unit/solver/repository/rpm_md_test.py
@@ -14,6 +14,9 @@ class TestSolverRepositoryRpmMd:
         self.uri = mock.Mock()
         self.solver = SolverRepositoryRpmMd(self.uri)
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch.object(SolverRepositoryBase, 'download_from_repository')
     @patch.object(SolverRepositoryBase, '_create_solvables')
     @patch.object(SolverRepositoryBase, '_create_temporary_metadata_dir')

--- a/test/unit/solver/repository/suse_test.py
+++ b/test/unit/solver/repository/suse_test.py
@@ -14,6 +14,9 @@ class TestSolverRepositorySUSE:
         self.uri = mock.Mock()
         self.solver = SolverRepositorySUSE(self.uri)
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch.object(SolverRepositoryBase, 'download_from_repository')
     @patch.object(SolverRepositoryBase, '_create_solvables')
     @patch.object(SolverRepositoryBase, '_create_temporary_metadata_dir')

--- a/test/unit/solver/sat_test.py
+++ b/test/unit/solver/sat_test.py
@@ -45,6 +45,10 @@ class TestSat:
         self.sat.pool.setarch.reset_mock()
 
     @patch('importlib.import_module')
+    def setup_method(self, cls, mock_import_module):
+        self.setup()
+
+    @patch('importlib.import_module')
     def test_setup_no_sat_plugin(self, mock_import_module):
         mock_import_module.side_effect = Exception
         with raises(KiwiSatSolverPluginError):

--- a/test/unit/solver/sat_test.py
+++ b/test/unit/solver/sat_test.py
@@ -22,7 +22,7 @@ class TestSat:
         self._caplog = caplog
 
     @patch('importlib.import_module')
-    def setup(self, mock_Sat, mock_import_module):
+    def setup(self, mock_import_module):
         self.sat = Sat()
         self.solver = MagicMock()
         self.transaction = Mock()

--- a/test/unit/storage/device_provider_test.py
+++ b/test/unit/storage/device_provider_test.py
@@ -12,6 +12,9 @@ class TestDeviceProvider:
     def setup(self):
         self.provider = DeviceProvider()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_get_device(self):
         with raises(KiwiDeviceProviderError):
             self.provider.get_device()

--- a/test/unit/storage/disk_test.py
+++ b/test/unit/storage/disk_test.py
@@ -38,6 +38,10 @@ class TestDisk:
         )
         self.disk = Disk('gpt', self.storage_provider)
 
+    @patch('kiwi.storage.disk.Partitioner.new')
+    def setup_method(self, cls, mock_partitioner):
+        self.setup()
+
     @patch('os.path.exists')
     def test_get_device(self, mock_exists):
         mock_exists.return_value = True

--- a/test/unit/storage/disk_test.py
+++ b/test/unit/storage/disk_test.py
@@ -19,7 +19,7 @@ class TestDisk:
         self._caplog = caplog
 
     @patch('kiwi.storage.disk.Partitioner.new')
-    def setup(self, mock_Disk, mock_partitioner):
+    def setup(self, mock_partitioner):
         self.tempfile = mock.Mock()
         self.tempfile.name = 'tempfile'
 

--- a/test/unit/storage/loop_device_test.py
+++ b/test/unit/storage/loop_device_test.py
@@ -19,6 +19,10 @@ class TestLoopDevice:
         mock_exists.return_value = False
         self.loop = LoopDevice('loop-file', 20, 4096)
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     def test_loop_setup_invalid(self):
         with raises(KiwiLoopSetupError):
             LoopDevice('loop-file-does-not-exist-and-no-size-given')

--- a/test/unit/storage/loop_device_test.py
+++ b/test/unit/storage/loop_device_test.py
@@ -15,7 +15,7 @@ class TestLoopDevice:
         self._caplog = caplog
 
     @patch('os.path.exists')
-    def setup(self, mock_LoopDevice, mock_exists):
+    def setup(self, mock_exists):
         mock_exists.return_value = False
         self.loop = LoopDevice('loop-file', 20, 4096)
 

--- a/test/unit/storage/luks_device_test.py
+++ b/test/unit/storage/luks_device_test.py
@@ -25,6 +25,9 @@ class TestLuksDevice:
         )
         self.luks = LuksDevice(storage_device)
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_create_crypto_luks_unsupported_os_options(self):
         with raises(KiwiLuksSetupError):
             self.luks.create_crypto_luks('passphrase', 'some-os')

--- a/test/unit/storage/mapped_device_test.py
+++ b/test/unit/storage/mapped_device_test.py
@@ -19,6 +19,10 @@ class TestMappedDevice:
         )
 
     @patch('os.path.exists')
+    def setup_method(self, cls, mock_path):
+        self.setup()
+
+    @patch('os.path.exists')
     def test_device_not_existingr(self, mock_path):
         mock_path.return_value = False
         with raises(KiwiMappedDeviceError):

--- a/test/unit/storage/mapped_device_test.py
+++ b/test/unit/storage/mapped_device_test.py
@@ -10,7 +10,7 @@ from kiwi.exceptions import KiwiMappedDeviceError
 
 class TestMappedDevice:
     @patch('os.path.exists')
-    def setup(self, mock_MappedDevice, mock_path):
+    def setup(self, mock_path):
         mock_path.return_value = True
         self.device_provider = Mock()
         self.device_provider.is_loop = Mock()

--- a/test/unit/storage/raid_device_test.py
+++ b/test/unit/storage/raid_device_test.py
@@ -19,6 +19,9 @@ class TestRaidDevice:
         )
         self.raid = RaidDevice(storage_device)
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_create_degraded_raid_invalid_level(self):
         with raises(KiwiRaidSetupError):
             self.raid.create_degraded_raid('bogus-level')

--- a/test/unit/storage/setup_test.py
+++ b/test/unit/storage/setup_test.py
@@ -107,6 +107,9 @@ class TestDiskSetup:
             XMLState(description.load()), 'root_dir'
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_need_boot_partition_on_request(self):
         self._init_bootpart_check()
         self.setup.bootpart_requested = True

--- a/test/unit/storage/subformat/base_test.py
+++ b/test/unit/storage/subformat/base_test.py
@@ -42,6 +42,10 @@ class TestDiskFormatBase:
         )
         mock_post_init.assert_called_once_with({})
 
+    @patch('kiwi.storage.subformat.base.DiskFormatBase.post_init')
+    def setup_method(self, cls, mock_post_init):
+        self.setup()
+
     def test_create_image_format(self):
         with raises(NotImplementedError):
             self.disk_format.create_image_format()

--- a/test/unit/storage/subformat/base_test.py
+++ b/test/unit/storage/subformat/base_test.py
@@ -16,7 +16,7 @@ from kiwi.exceptions import (
 
 class TestDiskFormatBase:
     @patch('kiwi.storage.subformat.base.DiskFormatBase.post_init')
-    def setup(self, mock_DiskFormatBase, mock_post_init):
+    def setup(self, mock_post_init):
         Defaults.set_platform_name('x86_64')
         xml_data = Mock()
         xml_data.get_name = Mock(

--- a/test/unit/storage/subformat/gce_test.py
+++ b/test/unit/storage/subformat/gce_test.py
@@ -29,6 +29,9 @@ class TestDiskFormatGce:
             self.xml_state, 'root_dir', 'target_dir'
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_post_init(self):
         self.disk_format.post_init({'option': 'value', '--tag': 'tag'})
         assert self.disk_format.tag == 'tag'

--- a/test/unit/storage/subformat/init_test.py
+++ b/test/unit/storage/subformat/init_test.py
@@ -13,6 +13,9 @@ class TestDiskFormat:
         self.xml_state = Mock()
         self.xml_state.get_build_type_format_options.return_value = {}
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_format_not_implemented(self):
         with raises(KiwiDiskFormatSetupError):
             DiskFormat.new('foo', self.xml_state, 'root_dir', 'target_dir')

--- a/test/unit/storage/subformat/ova_test.py
+++ b/test/unit/storage/subformat/ova_test.py
@@ -68,6 +68,9 @@ class TestDiskFormatOva:
             self.xml_state, 'root_dir', 'target_dir'
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_post_init(self):
         self.disk_format.post_init({})
 

--- a/test/unit/storage/subformat/qcow2_test.py
+++ b/test/unit/storage/subformat/qcow2_test.py
@@ -29,6 +29,9 @@ class TestDiskFormatQcow2:
             self.xml_state, 'root_dir', 'target_dir'
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_post_init(self):
         self.disk_format.post_init({'option': 'value'})
         assert self.disk_format.options == ['-o', 'option=value']

--- a/test/unit/storage/subformat/template/vagrant_config_test.py
+++ b/test/unit/storage/subformat/template/vagrant_config_test.py
@@ -6,9 +6,11 @@ from textwrap import dedent
 
 
 class TestVagrantConfigTemplate:
-
     def setup(self):
         self.vagrant_config = VagrantConfigTemplate()
+
+    def setup_method(self, cls):
+        self.setup()
 
     def test_default_Vagrantfile(self):
         Vagrantfile = dedent('''

--- a/test/unit/storage/subformat/template/virtualbox_ovf_test.py
+++ b/test/unit/storage/subformat/template/virtualbox_ovf_test.py
@@ -6,9 +6,11 @@ from kiwi.storage.subformat.template.virtualbox_ovf import (
 
 
 class TestVirtualboxOvfTemplate:
-
     def setup(self):
         self.ovf_template = VirtualboxOvfTemplate()
+
+    def setup_method(self, cls):
+        self.setup()
 
     def test_ovf_parameters(self):
         args = {

--- a/test/unit/storage/subformat/template/vmware_settings_test.py
+++ b/test/unit/storage/subformat/template/vmware_settings_test.py
@@ -7,6 +7,9 @@ class TestVmwareSettingsTempla:
     def setup(self):
         self.vmware = VmwareSettingsTemplate()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_get_template_default(self):
         assert self.vmware.get_template().substitute(
             virtual_hardware_version='8',

--- a/test/unit/storage/subformat/vagrant_base_test.py
+++ b/test/unit/storage/subformat/vagrant_base_test.py
@@ -48,6 +48,9 @@ class TestDiskFormatVagrantBase:
         assert self.disk_format.image_format == ''
         assert self.disk_format.provider is None
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_create_box_img_not_implemented(self):
         with raises(NotImplementedError):
             self.disk_format.create_box_img('arbitrary')

--- a/test/unit/storage/subformat/vagrant_libvirt_test.py
+++ b/test/unit/storage/subformat/vagrant_libvirt_test.py
@@ -40,6 +40,9 @@ class TestDiskFormatVagrantLibVirt:
         assert self.disk_format.image_format == 'vagrant.libvirt.box'
         assert self.disk_format.provider == 'libvirt'
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.storage.subformat.vagrant_libvirt.Command.run')
     @patch('kiwi.storage.subformat.vagrant_libvirt.DiskFormatQcow2')
     def test_create_box_img(

--- a/test/unit/storage/subformat/vagrant_virtualbox_test.py
+++ b/test/unit/storage/subformat/vagrant_virtualbox_test.py
@@ -46,6 +46,9 @@ class TestDiskFormatVagrantVirtualBox:
             {'vagrantconfig': self.vagrantconfig}
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.storage.subformat.vagrant_virtualbox.Command.run')
     @patch('kiwi.storage.subformat.vagrant_virtualbox.DiskFormatVmdk')
     def test_create_box_img(self, mock_vmdk, mock_command):

--- a/test/unit/storage/subformat/vdi_test.py
+++ b/test/unit/storage/subformat/vdi_test.py
@@ -28,6 +28,9 @@ class TestDiskFormatVdi:
             self.xml_state, 'root_dir', 'target_dir'
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_post_init(self):
         self.disk_format.post_init({'option': 'value'})
         assert self.disk_format.options == ['-o', 'option=value']

--- a/test/unit/storage/subformat/vhd_test.py
+++ b/test/unit/storage/subformat/vhd_test.py
@@ -29,6 +29,9 @@ class TestDiskFormatVhd:
             self.xml_state, 'root_dir', 'target_dir'
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_post_init(self):
         self.disk_format.post_init({'option': 'value'})
         assert self.disk_format.options == ['-o', 'option=value']

--- a/test/unit/storage/subformat/vhdfixed_test.py
+++ b/test/unit/storage/subformat/vhdfixed_test.py
@@ -34,6 +34,9 @@ class TestDiskFormatVhdFixed:
             self.xml_state, 'root_dir', 'target_dir', {'force_size': None}
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_post_init(self):
         self.disk_format.post_init({'option': 'value', '--tag': 'tag'})
         assert self.disk_format.options == [

--- a/test/unit/storage/subformat/vhdx_test.py
+++ b/test/unit/storage/subformat/vhdx_test.py
@@ -29,6 +29,9 @@ class TestDiskFormatVhdx:
             self.xml_state, 'root_dir', 'target_dir'
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_post_init(self):
         self.disk_format.post_init({'option': 'value'})
         assert self.disk_format.options == [

--- a/test/unit/storage/subformat/vmdk_test.py
+++ b/test/unit/storage/subformat/vmdk_test.py
@@ -103,6 +103,9 @@ class TestDiskFormatVmdk:
             self.xml_state, 'root_dir', 'target_dir'
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_post_init(self):
         self.disk_format.post_init(
             {'option': 'value', 'adapter_type=pvscsi': None}

--- a/test/unit/system/identifier_test.py
+++ b/test/unit/system/identifier_test.py
@@ -9,6 +9,9 @@ class TestSystemIdentifier:
     def setup(self):
         self.identifier = SystemIdentifier()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_get_id(self):
         assert self.identifier.get_id() is None
 

--- a/test/unit/system/kernel_test.py
+++ b/test/unit/system/kernel_test.py
@@ -24,6 +24,11 @@ class TestKernel:
             'vmlinux-1.2.3-default'
         ]
 
+    @patch('os.listdir')
+    @patch('os.path.isdir')
+    def setup_method(self, cls, mock_path_isdir, mock_listdir):
+        self.setup()
+
     def test_get_kernel_raises_if_no_kernel_found(self):
         self.kernel.kernel_names = []
         with raises(KiwiKernelLookupError):

--- a/test/unit/system/kernel_test.py
+++ b/test/unit/system/kernel_test.py
@@ -11,7 +11,7 @@ from kiwi.exceptions import KiwiKernelLookupError
 class TestKernel:
     @patch('os.listdir')
     @patch('os.path.isdir')
-    def setup(self, mock_Kernel, mock_path_isdir, mock_listdir):
+    def setup(self, mock_path_isdir, mock_listdir):
         mock_path_isdir.return_value = True
         mock_listdir.return_value = ['1.2.3-default']
         self.kernel = Kernel('root-dir')

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -69,6 +69,12 @@ class TestSystemPrepare:
         root_bind.setup_intermediate_config.assert_called_once_with()
         root_bind.mount_kernel_file_systems.assert_called_once_with()
 
+    @patch('kiwi.system.prepare.RootInit')
+    @patch('kiwi.system.prepare.RootBind')
+    @patch('kiwi.logger.Logger.get_logfile')
+    def setup_method(self, cls, mock_get_logfile, mock_root_bind, mock_root_init):
+        self.setup()
+
     @patch('kiwi.system.prepare.RootImport.new')
     @patch('kiwi.system.prepare.RootInit')
     @patch('kiwi.system.prepare.RootBind')

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -30,10 +30,7 @@ class TestSystemPrepare:
     @patch('kiwi.system.prepare.RootInit')
     @patch('kiwi.system.prepare.RootBind')
     @patch('kiwi.logger.Logger.get_logfile')
-    def setup(
-        self, mock_SystemPrepare, mock_get_logfile,
-        mock_root_bind, mock_root_init
-    ):
+    def setup(self, mock_get_logfile, mock_root_bind, mock_root_init):
         Defaults.set_platform_name('x86_64')
         mock_get_logfile.return_value = None
         description = XMLDescription(

--- a/test/unit/system/profile_test.py
+++ b/test/unit/system/profile_test.py
@@ -16,6 +16,9 @@ class TestProfile:
             XMLState(description.load())
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.path.Path.which')
     def test_create(self, mock_which):
         mock_which.return_value = 'cp'

--- a/test/unit/system/result_test.py
+++ b/test/unit/system/result_test.py
@@ -18,8 +18,10 @@ class TestResult:
 
     def setup(self):
         self.xml_state = MagicMock()
-
         self.result = Result(self.xml_state)
+
+    def setup_method(self, cls):
+        self.setup()
 
     def test_add(self):
         assert self.result.add('foo', 'bar') is None

--- a/test/unit/system/root_bind_test.py
+++ b/test/unit/system/root_bind_test.py
@@ -38,8 +38,14 @@ class TestRootBind:
         self.bind_root.mount_stack = [self.mount_manager]
         self.bind_root.dir_stack = ['/mountpoint']
 
+    def setup_method(self, cls):
+        self.setup()
+
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()
 
     @patch('kiwi.system.root_bind.MountManager.bind_mount')
     @patch('kiwi.system.root_bind.RootBind.cleanup')

--- a/test/unit/system/root_import/oci_test.py
+++ b/test/unit/system/root_import/oci_test.py
@@ -18,7 +18,7 @@ class TestRootImportOCI:
         self._caplog = caplog
 
     @patch('os.path.exists')
-    def setup(self, mock_RootImportOCI, mock_path):
+    def setup(self, mock_path):
         mock_path.return_value = True
         with patch.dict('os.environ', {'HOME': '../data'}):
             self.oci_import = RootImportOCI(

--- a/test/unit/system/root_import/oci_test.py
+++ b/test/unit/system/root_import/oci_test.py
@@ -28,6 +28,10 @@ class TestRootImportOCI:
         assert self.oci_import.image_file == '/image.tar'
 
     @patch('os.path.exists')
+    def setup_method(self, cls, mock_path):
+        self.setup()
+
+    @patch('os.path.exists')
     def test_failed_init(self, mock_path):
         mock_path.return_value = False
         with raises(KiwiRootImportError):

--- a/test/unit/system/root_init_test.py
+++ b/test/unit/system/root_init_test.py
@@ -118,3 +118,6 @@ class TestRootInit:
 
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -29,7 +29,7 @@ class TestSystemSetup:
         self._caplog = caplog
 
     @patch('kiwi.system.setup.RuntimeConfig')
-    def setup(self, mock_SystemSetup, mock_RuntimeConfig):
+    def setup(self, mock_RuntimeConfig):
         Defaults.set_platform_name('x86_64')
         self.runtime_config = Mock()
         self.runtime_config.get_package_changes = Mock(

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -70,8 +70,15 @@ class TestSystemSetup:
             returncode=0
         )
 
+    @patch('kiwi.system.setup.RuntimeConfig')
+    def setup_method(self, cls, mock_RuntimeConfig):
+        self.setup()
+
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()
 
     def test_setup_ix86(self):
         Defaults.set_platform_name('i686')

--- a/test/unit/system/size_test.py
+++ b/test/unit/system/size_test.py
@@ -9,6 +9,9 @@ class TestSystemSize:
     def setup(self):
         self.size = SystemSize('directory')
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_customize_ext(self):
         self.size.accumulate_files = mock.Mock(
             return_value=10000

--- a/test/unit/system/uri_test.py
+++ b/test/unit/system/uri_test.py
@@ -36,6 +36,9 @@ class TestUri:
             return_value=self.runtime_config
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_is_remote_raises_style_error(self):
         uri = Uri('xxx', 'rpm-md')
         with raises(KiwiUriStyleUnknown):

--- a/test/unit/system/users_test.py
+++ b/test/unit/system/users_test.py
@@ -7,6 +7,9 @@ class TestUsers:
     def setup(self):
         self.users = Users('root_dir')
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.system.users.Command.run')
     def test_user_exists(self, mock_command):
         assert self.users.user_exists('user') is True

--- a/test/unit/tasks/base_test.py
+++ b/test/unit/tasks/base_test.py
@@ -29,8 +29,8 @@ class TestCliTask:
     @patch('kiwi.cli.Cli.get_global_args')
     @patch('kiwi.tasks.base.RuntimeConfig')
     def setup(
-        self, mock_CliTask, mock_runtime_config, mock_global_args,
-        mock_command_args, mock_load_command, mock_help_check, mock_color,
+        self, mock_runtime_config, mock_global_args, mock_command_args,
+        mock_load_command, mock_help_check, mock_color,
         mock_setlog, mock_setLogFlag, mock_setLogLevel
     ):
         Defaults.set_platform_name('x86_64')

--- a/test/unit/tasks/base_test.py
+++ b/test/unit/tasks/base_test.py
@@ -61,6 +61,22 @@ class TestCliTask:
         mock_color.assert_called_once_with()
         mock_runtime_config.assert_called_once_with()
 
+    @patch('kiwi.logger.Logger.setLogLevel')
+    @patch('kiwi.logger.Logger.setLogFlag')
+    @patch('kiwi.logger.Logger.set_logfile')
+    @patch('kiwi.logger.Logger.set_color_format')
+    @patch('kiwi.cli.Cli.show_and_exit_on_help_request')
+    @patch('kiwi.cli.Cli.load_command')
+    @patch('kiwi.cli.Cli.get_command_args')
+    @patch('kiwi.cli.Cli.get_global_args')
+    @patch('kiwi.tasks.base.RuntimeConfig')
+    def setup_method(
+        self, cls, mock_runtime_config, mock_global_args, mock_command_args,
+        mock_load_command, mock_help_check, mock_color,
+        mock_setlog, mock_setLogFlag, mock_setLogLevel
+    ):
+        self.setup()
+
     def test_quadruple_token(self):
         assert self.task.quadruple_token('a,b') == ['a', 'b', None, None]
 
@@ -85,3 +101,6 @@ class TestCliTask:
 
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()

--- a/test/unit/tasks/image_info_test.py
+++ b/test/unit/tasks/image_info_test.py
@@ -75,8 +75,14 @@ class TestImageInfoTask:
         )
         self.task = ImageInfoTask()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()
 
     def _init_command_args(self):
         self.task.command_args = {}

--- a/test/unit/tasks/image_resize_test.py
+++ b/test/unit/tasks/image_resize_test.py
@@ -51,8 +51,14 @@ class TestImageResizeTask:
 
         self.task = ImageResizeTask()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()
 
     def _init_command_args(self):
         self.task.command_args = {}

--- a/test/unit/tasks/result_bundle_test.py
+++ b/test/unit/tasks/result_bundle_test.py
@@ -55,8 +55,14 @@ class TestResultBundleTask:
         )
         self.task.runtime_config = runtime_config
 
+    def setup_method(self, cls):
+        self.setup()
+
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()
 
     def _init_command_args(self):
         self.task.command_args = {}

--- a/test/unit/tasks/result_list_test.py
+++ b/test/unit/tasks/result_list_test.py
@@ -22,8 +22,14 @@ class TestResultListTask:
         )
         self.task = ResultListTask()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()
 
     def _init_command_args(self):
         self.task.command_args = {}

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -75,8 +75,14 @@ class TestSystemBuildTask:
 
         self.task = SystemBuildTask()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()
 
     def _init_command_args(self):
         self.task.command_args = {}

--- a/test/unit/tasks/system_create_test.py
+++ b/test/unit/tasks/system_create_test.py
@@ -54,8 +54,14 @@ class TestSystemCreateTask:
 
         self.task = SystemCreateTask()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()
 
     def _init_command_args(self):
         self.task.command_args = {}

--- a/test/unit/tasks/system_prepare_test.py
+++ b/test/unit/tasks/system_prepare_test.py
@@ -68,8 +68,14 @@ class TestSystemPrepareTask:
         )
         self.task = SystemPrepareTask()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()
 
     def _init_command_args(self):
         self.task.command_args = {}

--- a/test/unit/tasks/system_update_test.py
+++ b/test/unit/tasks/system_update_test.py
@@ -30,8 +30,14 @@ class TestSystemUpdateTask:
         )
         self.task = SystemUpdateTask()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def teardown(self):
         sys.argv = argv_kiwi_tests
+
+    def teardown_method(self, cls):
+        self.teardown()
 
     def _init_command_args(self):
         self.task.command_args = {}

--- a/test/unit/utils/block_test.py
+++ b/test/unit/utils/block_test.py
@@ -7,6 +7,9 @@ class TestBlockID:
     def setup(self):
         self.blkid = BlockID('device')
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.utils.block.Command.run')
     def test_setup_with_uuid_format(self, mock_command):
         BlockID('UUID=uuid')

--- a/test/unit/utils/checksum_test.py
+++ b/test/unit/utils/checksum_test.py
@@ -26,6 +26,10 @@ class TestChecksum:
         mock_exists.return_value = True
         self.checksum = Checksum('some-file')
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     def test_checksum_file_not_found(self):
         with raises(KiwiFileNotFound):
             Checksum('some-file')

--- a/test/unit/utils/checksum_test.py
+++ b/test/unit/utils/checksum_test.py
@@ -12,7 +12,7 @@ from kiwi.exceptions import KiwiFileNotFound
 
 class TestChecksum:
     @patch('os.path.exists')
-    def setup(self, mock_Checksum, mock_exists):
+    def setup(self, mock_exists):
         self.ascii = encoding.getregentry().name
         read_results = [bytes(b''), bytes(b'data'), bytes(b''), bytes(b'data')]
 

--- a/test/unit/utils/codec_test.py
+++ b/test/unit/utils/codec_test.py
@@ -17,6 +17,9 @@ class TestCodec:
     def setup(self):
         self.literal = bytes(b'\xc3\xbc')
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.utils.codec.Codec._wrapped_decode')
     def test_decode_ascii_failure(self, mock_decode):
         msg = 'utf-8 compatible string'

--- a/test/unit/utils/compress_test.py
+++ b/test/unit/utils/compress_test.py
@@ -20,7 +20,7 @@ class TestCompress:
         self._caplog = caplog
 
     @patch('os.path.exists')
-    def setup(self, mock_Compress, mock_exists):
+    def setup(self, mock_exists):
         mock_exists.return_value = True
         self.compress = Compress('some-file', True)
 

--- a/test/unit/utils/compress_test.py
+++ b/test/unit/utils/compress_test.py
@@ -24,6 +24,10 @@ class TestCompress:
         mock_exists.return_value = True
         self.compress = Compress('some-file', True)
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
     def test_source_file_not_found(self):
         with raises(KiwiFileNotFound):
             Compress('some-file')

--- a/test/unit/utils/fstab_test.py
+++ b/test/unit/utils/fstab_test.py
@@ -15,6 +15,12 @@ class TestFstab(object):
 
     def setup(self):
         self.fstab = Fstab()
+        self.fstab.read('../data/fstab')
+
+    def setup_method(self, cls):
+        self.setup()
+
+    def test_read(self):
         with self._caplog.at_level(logging.WARNING):
             self.fstab.read('../data/fstab')
             assert format(

--- a/test/unit/utils/fstab_test.py
+++ b/test/unit/utils/fstab_test.py
@@ -13,11 +13,8 @@ class TestFstab(object):
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
-    def setup(self, mock_Fstab):
+    def setup(self):
         self.fstab = Fstab()
-        self.fstab.read('../data/fstab')
-
-    def test_read(self):
         with self._caplog.at_level(logging.WARNING):
             self.fstab.read('../data/fstab')
             assert format(

--- a/test/unit/utils/output_test.py
+++ b/test/unit/utils/output_test.py
@@ -20,6 +20,9 @@ class TestDataOutput:
         )
         self.out = DataOutput(test_data)
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('sys.stdout')
     def test_display(self, mock_stdout):
         self.out.display()

--- a/test/unit/utils/rpm_database_test.py
+++ b/test/unit/utils/rpm_database_test.py
@@ -11,6 +11,9 @@ class TestRpmDataBase:
         self.rpmdb.rpmdb_host = Mock()
         self.rpmdb.rpmdb_image = Mock()
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.utils.rpm_database.Path.which')
     def test_has_rpm(self, mock_Path_which):
         mock_Path_which.return_value = None

--- a/test/unit/utils/rpm_test.py
+++ b/test/unit/utils/rpm_test.py
@@ -18,6 +18,9 @@ class TestRpm:
             ]
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.utils.rpm.Command.run')
     def test_expand_query(self, mock_Command_run):
         self.rpm_host.expand_query('foo')

--- a/test/unit/utils/sync_test.py
+++ b/test/unit/utils/sync_test.py
@@ -15,6 +15,9 @@ class TestDataSync:
     def setup(self):
         self.sync = DataSync('source_dir', 'target_dir')
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.utils.sync.Command.run')
     @patch('kiwi.utils.sync.DataSync.target_supports_extended_attributes')
     @patch('os.chmod')

--- a/test/unit/utils/sysconfig_test.py
+++ b/test/unit/utils/sysconfig_test.py
@@ -9,6 +9,9 @@ class TestSysConfig:
     def setup(self):
         self.sysconfig = SysConfig('../data/sysconfig_example.txt')
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_get_item(self):
         assert self.sysconfig['name'] == ' "Marcus"'
         assert self.sysconfig.get('name') == ' "Marcus"'

--- a/test/unit/utils/temporary_test.py
+++ b/test/unit/utils/temporary_test.py
@@ -7,6 +7,9 @@ class TestTemporary:
     def setup(self):
         self.temporary = Temporary()
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.utils.temporary.NamedTemporaryFile')
     def test_new_file(self, mock_NamedTemporaryFile):
         self.temporary.new_file()

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -50,6 +50,10 @@ class TestVolumeManagerBase:
         ]
 
     @patch('os.path.exists')
+    def setup_method(self, cls, mock_path):
+        self.setup()
+
+    @patch('os.path.exists')
     def test_init_custom_args(self, mock_exists):
         mock_exists.return_value = True
         volume_manager = VolumeManagerBase(

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -11,7 +11,7 @@ from kiwi.exceptions import KiwiVolumeManagerSetupError
 
 class TestVolumeManagerBase:
     @patch('os.path.exists')
-    def setup(self, mock_VolumeManagerBase, mock_path):
+    def setup(self, mock_path):
         self.volume_type = namedtuple(
             'volume_type', [
                 'name',

--- a/test/unit/volume_manager/btrfs_test.py
+++ b/test/unit/volume_manager/btrfs_test.py
@@ -24,7 +24,7 @@ class TestVolumeManagerBtrfs:
         self._caplog = caplog
 
     @patch('os.path.exists')
-    def setup(self, mock_VolumeManagerBtrfs, mock_path):
+    def setup(self, mock_path):
         self.volumes = [
             volume_type(
                 name='LVRoot', size='freespace:100', realpath='/',

--- a/test/unit/volume_manager/btrfs_test.py
+++ b/test/unit/volume_manager/btrfs_test.py
@@ -61,6 +61,10 @@ class TestVolumeManagerBtrfs:
             self.device_map, 'root_dir', self.volumes
         )
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_path):
+        self.setup()
+
     def test_post_init(self):
         self.volume_manager.post_init({'some-arg': 'some-val'})
         assert self.volume_manager.custom_args['some-arg'] == 'some-val'

--- a/test/unit/volume_manager/lvm_test.py
+++ b/test/unit/volume_manager/lvm_test.py
@@ -19,7 +19,7 @@ class TestVolumeManagerLVM:
         self._caplog = caplog
 
     @patch('os.path.exists')
-    def setup(self, mock_VolumeManagerLVM, mock_path):
+    def setup(self, mock_path):
         self.volumes = [
             volume_type(
                 name='LVRoot', size='freespace:100', realpath='/',

--- a/test/unit/volume_manager/lvm_test.py
+++ b/test/unit/volume_manager/lvm_test.py
@@ -63,6 +63,10 @@ class TestVolumeManagerLVM:
         )
         assert self.volume_manager.mount_options == 'a,b,c'
 
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_path):
+        self.setup()
+
     def test_post_init_custom_args(self):
         self.volume_manager.post_init({'some-arg': 'some-val'})
         assert self.volume_manager.custom_args['some-arg'] == 'some-val'

--- a/test/unit/xml_description_test.py
+++ b/test/unit/xml_description_test.py
@@ -144,6 +144,9 @@ class TestSchema:
             test_xml_extension_invalid_file.name
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_load_schema_from_xml_content(self):
         schema = etree.parse('../../kiwi/schema/kiwi.rng')
         lookup = '{http://relaxng.org/ns/structure/1.0}attribute'

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -53,6 +53,9 @@ class TestXMLState:
         self.bootloader.get_console.return_value = 'some-console'
         self.bootloader.get_serial_line.return_value = 'some-serial'
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_get_description_section(self):
         description = self.state.get_description_section()
         assert description.author == 'Marcus'


### PR DESCRIPTION
**Support nose and xunit style tests**
    
The modifications in this commit allows the unit tests to run on both, pytest 6.x (nose test layout) and the new  pytest 7.x (xunit test layout). This Fixes #2072 in a  much nicer way. Thanks much to @smarlowucf
