### PR TITLE
Fix disk script caller environment

### DIFF
--- a/doc/source/concept_and_workflow/shell_scripts.rst
+++ b/doc/source/concept_and_workflow/shell_scripts.rst
@@ -54,7 +54,8 @@ disk.sh
   and not the root tree as with :file:`config.sh` and :file:`images.sh`.
   The script :file:`disk.sh` is usually used to apply changes at parts of
   the system that are not an element of the file based root tree such as
-  the partition table, the bootloader or filesystem attributes.
+  the partition table, the contents of the final initrd, the bootloader,
+  filesystem attributes and more.
 
 {kiwi} executes scripts via the operating system if their executable
 bit is set (in that case a shebang is mandatory) otherwise they will be

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -25,6 +25,7 @@ from typing import (
 import kiwi.defaults as defaults
 
 from kiwi.utils.temporary import Temporary
+from kiwi.system.mount import ImageSystem
 from kiwi.storage.disk import ptable_entry_type
 from kiwi.defaults import Defaults
 from kiwi.filesystem.base import FileSystemBase
@@ -481,12 +482,18 @@ class DiskBuilder:
         if self.system_setup.script_exists(
             defaults.POST_DISK_SYNC_SCRIPT
         ):
-            disk_system = SystemSetup(
-                self.xml_state, system.get_mountpoint()
+            image_system = ImageSystem(
+                device_map, self.root_dir,
+                system.get_volumes() if self.volume_manager_name else {}
             )
-            disk_system.import_description()
-            disk_system.call_disk_script()
-            disk_system.cleanup()
+            image_system.mount()
+            disk_system = SystemSetup(
+                self.xml_state, image_system.mountpoint()
+            )
+            try:
+                disk_system.call_disk_script()
+            finally:
+                image_system.umount()
 
         # install boot loader
         self._install_bootloader(device_map, disk, system)
@@ -1158,16 +1165,23 @@ class DiskBuilder:
                         self.xml_state.build_type.get_squashfscompression()
                 }
             )
+            exclude_list = self._get_exclude_list_for_root_data_sync(device_map)
+            # To allow running custom scripts in a read-only root
+            # it's required to keep the /image mountpoint directory
+            # such that it can be bind mounted from the unpacked
+            # root tree
+            exclude_list.remove('image')
+            exclude_list.append('image/*')
             squashed_root.create_on_file(
                 filename=squashed_root_file.name,
-                exclude=self._get_exclude_list_for_root_data_sync(device_map)
+                exclude=exclude_list
             )
             readonly_target = device_map['readonly'].get_device()
             readonly_target_bytesize = device_map['readonly'].get_byte_size(
                 readonly_target
             )
             log.info(
-                '--> Dumping rootfs file({0} bytes) -> to {1}({2} bytes)'.format(
+                '--> Dumping rootfs file({0} bytes) -> {1}({2} bytes)'.format(
                     os.path.getsize(squashed_root_file.name),
                     readonly_target, readonly_target_bytesize
                 )

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -378,23 +378,25 @@ class DiskBuilder:
             device_map['root'] = volume_manager.get_device().get('root')
             device_map['swap'] = volume_manager.get_device().get('swap')
         else:
-            log.info(
-                'Creating root(%s) filesystem on %s',
-                self.requested_filesystem, device_map['root'].get_device()
-            )
-            filesystem_custom_parameters = {
-                'mount_options': self.custom_root_mount_args,
-                'create_options': self.custom_root_creation_args
-            }
-            filesystem = FileSystem.new(
-                self.requested_filesystem, device_map['root'],
-                self.root_dir + '/',
-                filesystem_custom_parameters
-            )
-            filesystem.create_on_device(
-                label=self.disk_setup.get_root_label()
-            )
-            system = filesystem
+            if not self.root_filesystem_is_overlay or \
+               self.root_filesystem_has_write_partition is not False:
+                log.info(
+                    'Creating root(%s) filesystem on %s',
+                    self.requested_filesystem, device_map['root'].get_device()
+                )
+                filesystem_custom_parameters = {
+                    'mount_options': self.custom_root_mount_args,
+                    'create_options': self.custom_root_creation_args
+                }
+                filesystem = FileSystem.new(
+                    self.requested_filesystem, device_map['root'],
+                    self.root_dir + '/',
+                    filesystem_custom_parameters
+                )
+                filesystem.create_on_device(
+                    label=self.disk_setup.get_root_label()
+                )
+                system = filesystem
 
         # create swap on current root device if requested
         if self.swap_mbytes:

--- a/kiwi/mount_manager.py
+++ b/kiwi/mount_manager.py
@@ -50,6 +50,7 @@ class MountManager:
             ).new_dir()
             self.mountpoint = self.mountpoint_tempdir.name
         else:
+            Path.create(mountpoint)
             self.mountpoint = mountpoint
 
     def bind_mount(self) -> None:
@@ -59,6 +60,15 @@ class MountManager:
         if not self.is_mounted():
             Command.run(
                 ['mount', '-n', '--bind', self.device, self.mountpoint]
+            )
+
+    def tmpfs_mount(self) -> None:
+        """
+        tmpfs mount the device to the mountpoint
+        """
+        if not self.is_mounted():
+            Command.run(
+                ['mount', '-t', 'tmpfs', 'tmpfs', self.mountpoint]
             )
 
     def mount(self, options: List[str] = []) -> None:

--- a/kiwi/system/mount.py
+++ b/kiwi/system/mount.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2022 Marcus Schäfer.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+import logging
+from typing import (
+    List, Dict
+)
+
+# project
+from kiwi.path import Path
+from kiwi.defaults import Defaults
+from kiwi.mount_manager import MountManager
+
+log = logging.getLogger('kiwi')
+
+
+class ImageSystem:
+    """
+    **Access the target image from the block layer**
+    """
+    def __init__(
+        self, device_map: Dict, root_dir: str, volumes: Dict = {}
+    ) -> None:
+        """
+        Construct a new ImageSystem object
+
+        :param dict device_map: Block device map
+        :param str root_dir: Path to unpacked image root tree
+        :param list volumes: Optional list of filesystem volumes
+        """
+        self.arch = Defaults.get_platform_name()
+        self.device_map = device_map
+        self.root_dir = root_dir
+        self.volumes = volumes
+        self.mount_list: List[MountManager] = []
+
+    def mountpoint(self) -> str:
+        """
+        Return image root mountpoint
+
+        :return: mountpoint path or empty string
+
+        :rtype: str
+        """
+        mountpoint = ''
+        if self.mount_list:
+            mountpoint = self.mount_list[0].mountpoint
+        return mountpoint
+
+    def mount(self) -> None:
+        """
+        Mount image system from current block layers
+        """
+        # mount root boot and efi devices as they are present
+        (root_device, boot_device, efi_device) = self._setup_device_names()
+        root_mount = MountManager(
+            device=root_device
+        )
+        if 's390' in self.arch:
+            boot_mount = MountManager(
+                device=boot_device, mountpoint=os.path.join(
+                    root_mount.mountpoint, 'boot', 'zipl'
+                )
+            )
+        else:
+            boot_mount = MountManager(
+                device=boot_device, mountpoint=os.path.join(
+                    root_mount.mountpoint, 'boot'
+                )
+            )
+        if efi_device:
+            efi_mount = MountManager(
+                device=efi_device, mountpoint=os.path.join(
+                    root_mount.mountpoint, 'boot', 'efi'
+                )
+            )
+
+        self.mount_list.append(root_mount)
+        root_mount.mount()
+
+        if not root_mount.device == boot_mount.device:
+            self.mount_list.append(boot_mount)
+            boot_mount.mount()
+
+        if efi_device:
+            self.mount_list.append(efi_mount)
+            efi_mount.mount()
+
+        if self.volumes:
+            self._mount_volumes(root_mount.mountpoint)
+
+        # bind mount /image from unpacked root to get access to e.g scripts
+        image_mount = MountManager(
+            device=os.path.join(self.root_dir, 'image'),
+            mountpoint=os.path.join(
+                root_mount.mountpoint, 'image'
+            )
+        )
+        self.mount_list.append(image_mount)
+        image_mount.bind_mount()
+
+        # mount tmp as tmpfs
+        tmp_mount = MountManager(
+            device='tmpfs', mountpoint=os.path.join(
+                root_mount.mountpoint, 'tmp'
+            )
+        )
+        self.mount_list.append(tmp_mount)
+        tmp_mount.tmpfs_mount()
+
+        # mount var/tmp as tmpfs
+        var_tmp_mount = MountManager(
+            device='tmpfs', mountpoint=os.path.join(
+                root_mount.mountpoint, 'var', 'tmp'
+            )
+        )
+        self.mount_list.append(var_tmp_mount)
+        var_tmp_mount.tmpfs_mount()
+
+        # mount dev as bind
+        device_mount = MountManager(
+            device='/dev', mountpoint=os.path.join(
+                root_mount.mountpoint, 'dev'
+            )
+        )
+        self.mount_list.append(device_mount)
+        device_mount.bind_mount()
+
+        # mount proc as bind
+        proc_mount = MountManager(
+            device='/proc', mountpoint=os.path.join(
+                root_mount.mountpoint, 'proc'
+            )
+        )
+        self.mount_list.append(proc_mount)
+        proc_mount.bind_mount()
+
+    def umount(self) -> None:
+        """
+        Umount all elements of mount_list in reverse order
+        """
+        for mount in reversed(self.mount_list):
+            if mount.is_mounted():
+                mount.umount()
+
+    def _setup_device_names(self) -> tuple:
+        root_device = self.device_map['root'].get_device()
+        boot_device = root_device
+        efi_device = None
+        if 'boot' in self.device_map:
+            boot_device = self.device_map['boot'].get_device()
+        if 'readonly' in self.device_map:
+            root_device = self.device_map['readonly'].get_device()
+        if 'efi' in self.device_map:
+            efi_device = self.device_map['efi'].get_device()
+        return (root_device, boot_device, efi_device)
+
+    def _mount_volumes(self, mountpoint) -> None:
+        for volume_path in Path.sort_by_hierarchy(sorted(self.volumes.keys())):
+            volume_mount = MountManager(
+                device=self.volumes[volume_path]['volume_device'],
+                mountpoint=os.path.join(
+                    mountpoint, volume_path
+                )
+            )
+            self.mount_list.append(volume_mount)
+            volume_mount.mount(
+                options=[self.volumes[volume_path]['volume_options']]
+            )
+
+    def __del__(self):
+        log.info('Cleaning up %s instance', type(self).__name__)
+        self.umount()

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ exclude=xml_parse.py
 # we ignore warnings about quoting of escape sequences (W605)
 ignore = E501, W605
 # we allow a custom complexity level
-max-complexity = 21
+max-complexity = 23
 
 [doc8]
 max-line-length = 90

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -286,9 +286,11 @@ class TestDiskBuilder:
     @patch('random.randrange')
     @patch('kiwi.builder.disk.Command.run')
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
+    @patch('kiwi.builder.disk.ImageSystem')
     @patch('os.path.exists')
     def test_create_disk_standard_root_with_kiwi_initrd(
-        self, mock_path, mock_grub_dir, mock_command, mock_rand, mock_fs
+        self, mock_path, mock_ImageSystem, mock_grub_dir,
+        mock_command, mock_rand, mock_fs
     ):
         mock_path.return_value = True
         mock_rand.return_value = 15
@@ -415,8 +417,9 @@ class TestDiskBuilder:
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     @patch('os.path.exists')
     @patch('kiwi.builder.disk.SystemSetup')
+    @patch('kiwi.builder.disk.ImageSystem')
     def test_create_disk_standard_root_with_dracut_initrd(
-        self, mock_SystemSetup, mock_path, mock_grub_dir,
+        self, mock_ImageSystem, mock_SystemSetup, mock_path, mock_grub_dir,
         mock_command, mock_rand, mock_fs
     ):
         self.boot_image_task.get_boot_names.return_value = self.boot_names_type(
@@ -480,7 +483,6 @@ class TestDiskBuilder:
             call('pre_disk_sync.sh'),
             call('disk.sh')
         ]
-        disk_system.import_description.assert_called_once_with()
         disk_system.call_pre_disk_script.assert_called_once_with()
         disk_system.call_disk_script.assert_called_once_with()
         self.setup.call_edit_boot_config_script.assert_called_once_with(
@@ -593,9 +595,9 @@ class TestDiskBuilder:
         assert squashfs.create_on_file.call_args_list == [
             call(exclude=['var/cache/kiwi'], filename='kiwi-tempname'),
             call(exclude=[
-                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                '.profile', '.kconfig', 'run/*', 'tmp/*',
                 '.buildenv', 'var/cache/kiwi',
-                'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
+                'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*', 'image/*'
             ], filename='kiwi-tempname')
         ]
         self.disk.create_root_readonly_partition.assert_called_once_with(11)
@@ -789,9 +791,10 @@ class TestDiskBuilder:
     @patch('kiwi.builder.disk.VolumeManager.new')
     @patch('kiwi.builder.disk.Command.run')
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
+    @patch('kiwi.builder.disk.ImageSystem')
     @patch('os.path.exists')
     def test_create_disk_volume_managed_root(
-        self, mock_exists, mock_grub_dir, mock_command,
+        self, mock_exists, mock_ImageSystem, mock_grub_dir, mock_command,
         mock_volume_manager, mock_fs
     ):
         mock_exists.return_value = True

--- a/test/unit/system/mount_test.py
+++ b/test/unit/system/mount_test.py
@@ -1,0 +1,108 @@
+import os
+import logging
+from mock import (
+    patch, MagicMock, Mock, call
+)
+from pytest import fixture
+
+from kiwi.system.mount import ImageSystem
+from kiwi.storage.mapped_device import MappedDevice
+
+
+class TestImageSystem:
+    @fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self._caplog = caplog
+
+    @patch('os.path.exists')
+    def setup(self, mock_os_path_exists):
+        mock_os_path_exists.return_value = True
+        self.device_map = {
+            'root': MappedDevice('/dev/root-device', Mock()),
+            'readonly': MappedDevice('/dev/readonly-root-device', Mock()),
+            'boot': MappedDevice('/dev/boot-device', Mock()),
+            'efi': MappedDevice('/dev/efi-device', Mock()),
+        }
+        self.volumes = {
+            'name': {
+                'volume_options': 'a,b,c',
+                'volume_device': '/dev/vgroup/volume'
+            }
+        }
+        self.image_system = ImageSystem(
+            self.device_map, 'root_dir', self.volumes
+        )
+
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_os_path_exists):
+        self.setup()
+
+    def test_mountpoint(self):
+        some_mount = MagicMock()
+        self.image_system.mount_list.append(some_mount)
+        assert self.image_system.mountpoint() == some_mount.mountpoint
+
+    @patch('kiwi.system.mount.MountManager')
+    def test_mount(self, mock_MountManager):
+        self.image_system.mount()
+        root_mount_mountpoint = self.image_system.mount_list[0].mountpoint
+        assert mock_MountManager.call_args_list == [
+            call(device='/dev/readonly-root-device'),
+            call(
+                device='/dev/boot-device',
+                mountpoint=os.path.join(root_mount_mountpoint, 'boot')
+            ),
+            call(
+                device='/dev/efi-device',
+                mountpoint=os.path.join(root_mount_mountpoint, 'boot', 'efi')
+            ),
+            call(
+                device='/dev/vgroup/volume',
+                mountpoint=os.path.join(root_mount_mountpoint, 'name')
+            ),
+            call(
+                device='root_dir/image',
+                mountpoint=os.path.join(root_mount_mountpoint, 'image')
+            ),
+            call(
+                device='tmpfs',
+                mountpoint=os.path.join(root_mount_mountpoint, 'tmp')
+            ),
+            call(
+                device='tmpfs',
+                mountpoint=os.path.join(root_mount_mountpoint, 'var', 'tmp')
+            ),
+            call(
+                device='/dev',
+                mountpoint=os.path.join(root_mount_mountpoint, 'dev')
+            ),
+            call(
+                device='/proc',
+                mountpoint=os.path.join(root_mount_mountpoint, 'proc')
+            )
+        ]
+
+    @patch('kiwi.system.mount.MountManager')
+    def test_mount_s390(self, mock_MountManager):
+        self.image_system.arch = 's390x'
+        self.image_system.mount()
+        root_mount_mountpoint = self.image_system.mount_list[0].mountpoint
+        assert mock_MountManager.call_args_list[1] == call(
+            device='/dev/boot-device',
+            mountpoint=os.path.join(root_mount_mountpoint, 'boot', 'zipl')
+        )
+
+    def test_umount(self):
+        some_mount = MagicMock()
+        some_mount.is_mounted.return_value = True
+        self.image_system.mount_list.append(some_mount)
+        self.image_system.umount()
+        some_mount.umount.assert_called_once_with()
+
+    def test_destructor(self):
+        some_mount = MagicMock()
+        some_mount.is_mounted.return_value = True
+        self.image_system.mount_list.append(some_mount)
+        with self._caplog.at_level(logging.INFO):
+            self.image_system.__del__()
+        some_mount.umount.assert_called_once_with()


### PR DESCRIPTION
This patch has three parts

**Fixed disk.sh caller environment**

The documentation explains the disk.sh script to be called from inside of the image root as it exists on the block layer. The disk.sh script is therefore also called after the sync of the unpacked image root tree to the block layer. The implementation however, was only partially calling disk.sh from such an environment. In fact the environment was only the mountpoint of the root partition but this is not the complete system regarding layouts that uses extra partitions and/or volumes. This commit introduces the use of the new class ImageSystem and calls disk.sh in the way it was designed and documented.

**Added ImageSystem class**
    
The class responsibility is to provide access to the image root system from the block layer of the image scope

**Prevent superfluous filesystem creation***
    
In case of an overlayroot setup and the request for no extra write partition, it is not needed to create a filesystem for the write space which never gets synced to the image. I found this bug when writing the ImageSystem class and as it has a dependency to the unit test code I put it as part of the PR but as an extra commit



