### PR TITLE
Added overlayroot_verity_blocks attribute

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -572,6 +572,51 @@ overlayroot="true|false"
   will not have any effect because the write partition will be
   resized on first boot to the available disk space.
 
+overlayroot_verity_blocks="number|all"
+  For the `oem` type only, specifies to create a dm verity hash
+  from the number of given blocks (or all) placed at the end of the squashfs
+  compressed read-only root filesystem. For later verification of the device,
+  the credentials information produced by `veritysetup` from the
+  cryptsetup tools, is created as a file in `/boot/overlayroot.verity`
+  and is stored as such into the image by default. The verification
+  file contents looks like the following example:
+
+  .. code:: bash
+
+     Hash type:         1
+     Data blocks:       10
+     Data block size:   4096
+     Hash block size:   4096
+     Hash algorithm:    sha256
+     Salt:              -SECRET-
+     Root hash:         -SECRET-
+     PARTUUID:          56d4ec24-393b-4ef5-af6b-6a8e1130b2c6
+     Root hashoffset:   226885632
+     Superblock:        --no-superblock
+
+  For verification of the device using the above information the
+  following `veritysetup` call is required
+
+  .. code:: bash
+
+     veritysetup verify \
+         /dev/matching[PARTUUID] /dev/matching[PARTUUID] \
+         "Value of Root hash:" \
+         --debug \
+         --no-superblock \
+         --salt="Value of Salt:" \
+         --data-blocks="Value of Data Blocks:" \
+         --hash-offset="Value of Root hashoffset:"
+
+  .. note::
+
+     It is a responsibility of the author of the image description
+     how to handle the credentials file in the desired way. The
+     standard way of {kiwi} to place it in `/boot` is most probably
+     not appropriate. One option to handle the credentials data is
+     as part of a `disk.sh` script which would allow to access and
+     manage the information in a custom way.
+
 overlayroot_write_partition="true|false"
   For the `oem` type only, allows to specify if the extra read-write
   partition in an `overlayroot` setup should be created or not.

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -29,6 +29,7 @@ safe-posix-short-name = xsd:token {pattern = "[a-zA-Z0-9_\-\.]{1,32}"}
 locale-name = xsd:token {pattern = "(POSIX|[a-z]{2,3}_[A-Z]{2})(,[a-z]{2,3}_[A-Z]{2})*"}
 mac-address-type = xsd:token {pattern = "([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}"}
 size-type = xsd:token {pattern = "\d*|image"}
+blocks-type = xsd:token {pattern = "\d*|all"}
 volume-size-type = xsd:token {pattern = "(\d+|\d+M|\d+G|all)"}
 partition-size-type = xsd:token {pattern = "(\d+|\d+M|\d+G)"}
 vhd-tag-type = xsd:token {pattern = "[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}"}
@@ -1537,6 +1538,24 @@ div {
             sch:param [ name = "attr" value = "overlayroot" ]
             sch:param [ name = "types" value = "oem" ]
         ]
+    k.type.overlayroot_verity_blocks.attribute =
+        ## Specifies to create a dm verity hash from the number of
+        ## given blocks and placed at the end of the squashfs
+        ## compressed read-only root filesystem. If the verity hash
+        ## should be calculated from the complete file the value 'all'
+        ## can be specified. The verification credentials information
+        ## produced by veritysetup for later verification is stored as
+        ## a file in /boot/overlayroot.verity and is put as such
+        ## into the image by default. It is a responsibility of the
+        ## author of the image description how to handle the
+        ## credentials file in the desired way. One option to handle
+        ## the credentials data is as part of a disk.sh script which
+        ## would allow to access and manage the information.
+        attribute overlayroot_verity_blocks { blocks-type }
+        >> sch:pattern [ id = "overlayroot_verity_blocks" is-a = "image_type"
+            sch:param [ name = "attr" value = "overlayroot_verity_blocks" ]
+            sch:param [ name = "types" value = "oem" ]
+        ]
     k.type.overlayroot_write_partition.attribute =
         ## Specifies to create an extra read-write partition
         ## in combination with the overlayroot attribute on the
@@ -1968,6 +1987,7 @@ div {
         k.type.overlayroot.attribute? &
         k.type.overlayroot_write_partition.attribute? &
         k.type.overlayroot_readonly_partsize.attribute? &
+        k.type.overlayroot_verity_blocks.attribute? &
         k.type.primary.attribute? &
         k.type.ramonly.attribute? &
         k.type.rootfs_label.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -46,6 +46,11 @@
       <param name="pattern">\d*|image</param>
     </data>
   </define>
+  <define name="blocks-type">
+    <data type="token">
+      <param name="pattern">\d*|all</param>
+    </data>
+  </define>
   <define name="volume-size-type">
     <data type="token">
       <param name="pattern">(\d+|\d+M|\d+G|all)</param>
@@ -2238,6 +2243,27 @@ image type oem</a:documentation>
         <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
+    <define name="k.type.overlayroot_verity_blocks.attribute">
+      <attribute name="overlayroot_verity_blocks">
+        <a:documentation>Specifies to create a dm verity hash from the number of
+given blocks and placed at the end of the squashfs
+compressed read-only root filesystem. If the verity hash
+should be calculated from the complete file the value 'all'
+can be specified. The verification credentials information
+produced by veritysetup for later verification is stored as
+a file in /boot/overlayroot.verity and is put as such
+into the image by default. It is a responsibility of the
+author of the image description how to handle the
+credentials file in the desired way. One option to handle
+the credentials data is as part of a disk.sh script which
+would allow to access and manage the information.</a:documentation>
+        <ref name="blocks-type"/>
+      </attribute>
+      <sch:pattern id="overlayroot_verity_blocks" is-a="image_type">
+        <sch:param name="attr" value="overlayroot_verity_blocks"/>
+        <sch:param name="types" value="oem"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.overlayroot_write_partition.attribute">
       <attribute name="overlayroot_write_partition">
         <a:documentation>Specifies to create an extra read-write partition
@@ -2902,6 +2928,9 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.overlayroot_readonly_partsize.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.overlayroot_verity_blocks.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.primary.attribute"/>

--- a/kiwi/utils/veritysetup.py
+++ b/kiwi/utils/veritysetup.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2022 Marcus Schäfer.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+from typing import Optional
+
+# project
+from kiwi.command import Command
+from kiwi.utils.block import BlockID
+
+
+class VeritySetup:
+    """
+    **Create block level verification data on file or device**
+    """
+    def __init__(
+        self, image_filepath: str, data_blocks: Optional[int] = None
+    ) -> None:
+        """
+        Construct new VeritySetup
+
+        :param str image_filepath: block device node or filename
+        :param int data_blocks:
+            Number of blocks to verify, if not provided the whole
+            image_filepath is used
+        """
+        self.image_filepath = image_filepath
+        self.data_blocks = data_blocks
+        self.verity_hash_offset = os.path.getsize(self.image_filepath)
+        self.verity_call = None
+
+    def format(self) -> None:
+        self.verity_call = Command.run(
+            [
+                'veritysetup', 'format',
+                self.image_filepath, self.image_filepath,
+                '--no-superblock',
+                f'--hash-offset={self.verity_hash_offset}'
+            ] + (
+                [
+                    f'--data-blocks={self.data_blocks}'
+                ] if self.data_blocks else []
+            )
+        )
+
+    def store_credentials(
+        self, credentials_filepath: str, target_block_id: BlockID
+    ) -> None:
+        if self.verity_call:
+            partition_uuid = target_block_id.get_blkid('PARTUUID')
+            with open(credentials_filepath, 'w') as verity:
+                verity.write(self.verity_call.output.strip())
+                verity.write(os.linesep)
+                verity.write(
+                    f'PARTUUID: {partition_uuid}')
+                verity.write(os.linesep)
+                verity.write(
+                    f'Root hashoffset: {self.verity_hash_offset}')
+                verity.write(os.linesep)
+                verity.write('Superblock: --no-superblock')
+                verity.write(os.linesep)

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2718,7 +2718,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, overlayroot_verity_blocks=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2765,6 +2765,7 @@ class type_(GeneratedsSuper):
         self.overlayroot = _cast(bool, overlayroot)
         self.overlayroot_write_partition = _cast(bool, overlayroot_write_partition)
         self.overlayroot_readonly_partsize = _cast(int, overlayroot_readonly_partsize)
+        self.overlayroot_verity_blocks = _cast(None, overlayroot_verity_blocks)
         self.primary = _cast(bool, primary)
         self.ramonly = _cast(bool, ramonly)
         self.rootfs_label = _cast(None, rootfs_label)
@@ -2966,6 +2967,8 @@ class type_(GeneratedsSuper):
     def set_overlayroot_write_partition(self, overlayroot_write_partition): self.overlayroot_write_partition = overlayroot_write_partition
     def get_overlayroot_readonly_partsize(self): return self.overlayroot_readonly_partsize
     def set_overlayroot_readonly_partsize(self, overlayroot_readonly_partsize): self.overlayroot_readonly_partsize = overlayroot_readonly_partsize
+    def get_overlayroot_verity_blocks(self): return self.overlayroot_verity_blocks
+    def set_overlayroot_verity_blocks(self, overlayroot_verity_blocks): self.overlayroot_verity_blocks = overlayroot_verity_blocks
     def get_primary(self): return self.primary
     def set_primary(self, primary): self.primary = primary
     def get_ramonly(self): return self.ramonly
@@ -3004,6 +3007,13 @@ class type_(GeneratedsSuper):
     def set_disk_start_sector(self, disk_start_sector): self.disk_start_sector = disk_start_sector
     def get_bundle_format(self): return self.bundle_format
     def set_bundle_format(self, bundle_format): self.bundle_format = bundle_format
+    def validate_blocks_type(self, value):
+        # Validate type blocks-type, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_blocks_type_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_blocks_type_patterns_, ))
+    validate_blocks_type_patterns_ = [['^\\d*|all$']]
     def validate_partition_size_type(self, value):
         # Validate type partition-size-type, a restriction on xs:token.
         if value is not None and Validate_simpletypes_:
@@ -3204,6 +3214,9 @@ class type_(GeneratedsSuper):
         if self.overlayroot_readonly_partsize is not None and 'overlayroot_readonly_partsize' not in already_processed:
             already_processed.add('overlayroot_readonly_partsize')
             outfile.write(' overlayroot_readonly_partsize="%s"' % self.gds_format_integer(self.overlayroot_readonly_partsize, input_name='overlayroot_readonly_partsize'))
+        if self.overlayroot_verity_blocks is not None and 'overlayroot_verity_blocks' not in already_processed:
+            already_processed.add('overlayroot_verity_blocks')
+            outfile.write(' overlayroot_verity_blocks=%s' % (quote_attrib(self.overlayroot_verity_blocks), ))
         if self.primary is not None and 'primary' not in already_processed:
             already_processed.add('primary')
             outfile.write(' primary="%s"' % self.gds_format_boolean(self.primary, input_name='primary'))
@@ -3581,6 +3594,12 @@ class type_(GeneratedsSuper):
                 raise_parse_error(node, 'Bad integer attribute: %s' % exp)
             if self.overlayroot_readonly_partsize < 0:
                 raise_parse_error(node, 'Invalid NonNegativeInteger')
+        value = find_attr_value_('overlayroot_verity_blocks', node)
+        if value is not None and 'overlayroot_verity_blocks' not in already_processed:
+            already_processed.add('overlayroot_verity_blocks')
+            self.overlayroot_verity_blocks = value
+            self.overlayroot_verity_blocks = ' '.join(self.overlayroot_verity_blocks.split())
+            self.validate_blocks_type(self.overlayroot_verity_blocks)    # validate type blocks-type
         value = find_attr_value_('primary', node)
         if value is not None and 'primary' not in already_processed:
             already_processed.add('primary')

--- a/test/unit/utils/veritysetup_test.py
+++ b/test/unit/utils/veritysetup_test.py
@@ -1,0 +1,59 @@
+import io
+from mock import (
+    patch, Mock, MagicMock, call
+)
+
+from kiwi.utils.veritysetup import VeritySetup
+
+
+class TestVeritySetup:
+    @patch('os.path.getsize')
+    def setup(self, mock_os_path_getsize):
+        mock_os_path_getsize.return_value = 42
+        self.veritysetup = VeritySetup('image_file', data_blocks=10)
+        self.veritysetup_full = VeritySetup('image_file')
+
+    @patch('os.path.getsize')
+    def setup_method(self, cls, mock_os_path_getsize):
+        self.setup()
+
+    @patch('kiwi.utils.veritysetup.Command.run')
+    def test_format(self, mock_Command_run):
+        self.veritysetup.format()
+        mock_Command_run.assert_called_once_with(
+            [
+                'veritysetup', 'format', 'image_file', 'image_file',
+                '--no-superblock', '--hash-offset=42', '--data-blocks=10'
+            ]
+        )
+
+    @patch('kiwi.utils.veritysetup.Command.run')
+    def test_format_full(self, mock_Command_run):
+        self.veritysetup_full.format()
+        mock_Command_run.assert_called_once_with(
+            [
+                'veritysetup', 'format', 'image_file', 'image_file',
+                '--no-superblock', '--hash-offset=42'
+            ]
+        )
+
+    def test_store_credentials(self):
+        self.veritysetup.verity_call = Mock()
+        target_block_id = Mock()
+        target_block_id.get_blkid.return_value = 'uuid'
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            self.veritysetup.store_credentials(
+                'credentials_file', target_block_id
+            )
+        assert file_handle.write.call_args_list == [
+            call(self.veritysetup.verity_call.output.strip.return_value),
+            call('\n'),
+            call("PARTUUID: uuid"),
+            call('\n'),
+            call('Root hashoffset: 42'),
+            call('\n'),
+            call('Superblock: --no-superblock'),
+            call('\n')
+        ]


### PR DESCRIPTION
Given the following type setup

```xml
<type image="oem" overlayroot="true" overlayroot_verity_blocks="10" .../>
```

Setting the ```overlayroot_verity_blocks``` attribute to a number (or ```alll```) in an overlayroot configuration will create a dm verity hash from the number of given blocks (or all) placed at the end of the squashfs compressed read-only root filesystem. For later verification of the device, and without further image description settings, the credentials information produced by veritysetup from the cryptsetup tools, is created as a file in ```/boot/overlayroot.verity``` and is stored as such into the image by default.

The default behavior is considered insecure as it places the veritysetup credentials information to verify the device as
human readable file to /boot as shown above. How the root hash gets secured is in the responsibility of the author of the image description. One way to deal with the credentials is as part of a ```disk.sh``` script like in the following example:

```bash
if [ -e /boot/overlayroot.verity ];then
    rm -f /boot/overlayroot.verity
fi
```

Of course this is also not recommended as it will delete the credentials information forever. So this should just give an idea which hook in the image creation process can be used to handle the file

For completeness verification of the device can be done in the following way:

```bash
kpartx -a image-file.raw
veritysetup verify /dev/mapper/loop0pX /dev/mapper/loop0pX "root_hash_from_credentials_file" \
    --debug \
    --no-superblock \
    --salt "salt_hash_from_credentials_file" \
    --data-blocks 10 \
    --hash-offset "offset_from_credentials_file"
```