### PR TITLE
Fixed unconditional grub package requirement

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -187,7 +187,9 @@ Recommends:     gfxboot
 Requires:       grub2-efi-x64
 %endif
 %endif
+%if ! (0%{?debian} || 0%{?ubuntu})
 Requires:       grub2
+%endif
 %ifarch %arm aarch64
 %if 0%{?fedora} || 0%{?rhel}
 Requires:       uboot-tools


### PR DESCRIPTION
The grub2 package should only be required on 32/64bit
x86 architectures. Building on arm for Debian based
distros causes a dependency issue because there is no
grub package available


