### PR TITLE
Support extended partitions

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -394,6 +394,15 @@ efiparttable="msdos|gpt":
   table type to use. If not set defaults to the GPT partition
   table type
 
+dosparttable_extended_layout="true|false":
+  For oem disk images, specifies to make use of logical partitions
+  inside of an extended one. If set to true and if the msdos table type
+  is active, this will cause the fourth partition to be an
+  extended partition and all following partitions will be
+  placed as logical partitions inside of that extended
+  partition. This setting is useful if more than 4 primary
+  partitions needs to be created in an msdos table
+
 btrfs_quota_groups="true|false":
   Boolean parameter to activate filesystem quotas if
   the filesystem is `btrfs`. By default quotas are inactive.

--- a/kiwi/partitioner/__init__.py
+++ b/kiwi/partitioner/__init__.py
@@ -35,6 +35,7 @@ class Partitioner(metaclass=ABCMeta):
     :param string table_type: Table type name
     :param object storage_provider: Instance of class based on DeviceProvider
     :param int start_sector: sector number
+    :param bool extended_layout: support extended layout for msdos table
     """
     @abstractmethod
     def __init__(self) -> None:
@@ -43,7 +44,7 @@ class Partitioner(metaclass=ABCMeta):
     @staticmethod
     def new(
         table_type: str, storage_provider: object,
-        start_sector: int = None
+        start_sector: int = None, extended_layout: bool = False
     ):
         name_map = {
             'msdos': 'MsDos',
@@ -61,7 +62,7 @@ class Partitioner(metaclass=ABCMeta):
                 )
                 start_sector = None
             return partitioner.__dict__[module_name](
-                storage_provider, start_sector
+                storage_provider, start_sector, extended_layout
             )
         except Exception as issue:
             raise KiwiPartitionerSetupError(

--- a/kiwi/partitioner/__init__.py
+++ b/kiwi/partitioner/__init__.py
@@ -43,7 +43,7 @@ class Partitioner(metaclass=ABCMeta):
     @staticmethod
     def new(
         table_type: str, storage_provider: object,
-        start_sector: int=None  # noqa: E252
+        start_sector: int = None
     ):
         name_map = {
             'msdos': 'MsDos',

--- a/kiwi/partitioner/base.py
+++ b/kiwi/partitioner/base.py
@@ -15,25 +15,36 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+from typing import (
+    List, Dict, Union
+)
+
+# project
+from kiwi.storage.device_provider import DeviceProvider
 
 
 class PartitionerBase:
     """
     **Base class for partitioners**
-
-    :param object disk_provider: Instance of DeviceProvider
-    :param int start_sector: sector number
     """
-    def __init__(self, disk_provider, start_sector=None):
+    def __init__(
+        self, disk_provider: DeviceProvider, start_sector: int = None
+    ) -> None:
+        """
+        Base class constructor for partitioners
+
+        :param object disk_provider: Instance of DeviceProvider
+        :param int start_sector: sector number
+        """
         self.disk_device = disk_provider.get_device()
         self.partition_id = 0
         self.start_sector = start_sector
 
-        self.flag_map = None
+        self.flag_map: Dict[str, Union[bool, str, None]] = {}
 
         self.post_init()
 
-    def post_init(self):
+    def post_init(self) -> None:
         """
         Post initialization method
 
@@ -41,7 +52,7 @@ class PartitionerBase:
         """
         pass
 
-    def get_id(self):
+    def get_id(self) -> int:
         """
         Current partition number
 
@@ -53,7 +64,9 @@ class PartitionerBase:
         """
         return self.partition_id
 
-    def create(self, name, mbsize, type_name, flags=None):
+    def create(
+        self, name: str, mbsize: int, type_name: str, flags: List[str] = []
+    ):
         """
         Create partition
 
@@ -66,7 +79,7 @@ class PartitionerBase:
         """
         raise NotImplementedError
 
-    def set_flag(self, partition_id, flag_name):
+    def set_flag(self, partition_id: int, flag_name: str):
         """
         Set partition flag
 
@@ -93,7 +106,7 @@ class PartitionerBase:
         """
         raise NotImplementedError
 
-    def resize_table(self, entries=None):
+    def resize_table(self, entries: int = 0):
         """
         Resize partition table
 

--- a/kiwi/partitioner/base.py
+++ b/kiwi/partitioner/base.py
@@ -28,17 +28,25 @@ class PartitionerBase:
     **Base class for partitioners**
     """
     def __init__(
-        self, disk_provider: DeviceProvider, start_sector: int = None
+        self, disk_provider: DeviceProvider, start_sector: int = None,
+        extended_layout: bool = False
     ) -> None:
         """
         Base class constructor for partitioners
 
         :param object disk_provider: Instance of DeviceProvider
         :param int start_sector: sector number
+        :param bool extended_layout:
+            If set to true and on msdos table type when creating
+            more than 4 partitions, this will cause the fourth
+            partition to be an extended partition and all following
+            partitions will be placed as logical partitions inside
+            of that extended partition
         """
         self.disk_device = disk_provider.get_device()
         self.partition_id = 0
         self.start_sector = start_sector
+        self.extended_layout = extended_layout
 
         self.flag_map: Dict[str, Union[bool, str, None]] = {}
 

--- a/kiwi/partitioner/dasd.py
+++ b/kiwi/partitioner/dasd.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import logging
+from typing import List
 
 # project
 from kiwi.utils.temporary import Temporary
@@ -29,7 +30,7 @@ class PartitionerDasd(PartitionerBase):
     """
     **Implements DASD partition setup**
     """
-    def post_init(self):
+    def post_init(self) -> None:
         """
         Post initialization method
 
@@ -45,7 +46,9 @@ class PartitionerDasd(PartitionerBase):
             't.csm': None
         }
 
-    def create(self, name, mbsize, type_name, flags=None):
+    def create(
+        self, name: str, mbsize: int, type_name: str, flags: List[str] = None
+    ) -> None:
         """
         Create DASD partition
 
@@ -80,7 +83,7 @@ class PartitionerDasd(PartitionerBase):
             # that point.
             log.debug('potential fdasd errors were ignored')
 
-    def resize_table(self, entries=None):
+    def resize_table(self, entries: int = None) -> None:
         """
         Resize partition table
 

--- a/kiwi/partitioner/gpt.py
+++ b/kiwi/partitioner/gpt.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import logging
+from typing import List
 
 # project
 from kiwi.command import Command
@@ -32,7 +33,7 @@ class PartitionerGpt(PartitionerBase):
     """
     **Implements GPT partition setup**
     """
-    def post_init(self):
+    def post_init(self) -> None:
         """
         Post initialization method
 
@@ -49,7 +50,9 @@ class PartitionerGpt(PartitionerBase):
             't.prep': '4100'
         }
 
-    def create(self, name, mbsize, type_name, flags=None):
+    def create(
+        self, name: str, mbsize: int, type_name: str, flags: List[str] = None
+    ) -> None:
         """
         Create GPT partition
 
@@ -84,7 +87,7 @@ class PartitionerGpt(PartitionerBase):
             for flag_name in flags:
                 self.set_flag(self.partition_id, flag_name)
 
-    def set_flag(self, partition_id, flag_name):
+    def set_flag(self, partition_id: int, flag_name: str) -> None:
         """
         Set GPT partition flag
 
@@ -99,14 +102,19 @@ class PartitionerGpt(PartitionerBase):
             Command.run(
                 [
                     'sgdisk', '-t',
-                    ':'.join([format(partition_id), self.flag_map[flag_name]]),
+                    ':'.join(
+                        [
+                            format(partition_id),
+                            format(self.flag_map[flag_name])
+                        ]
+                    ),
                     self.disk_device
                 ]
             )
         else:
             log.warning('Flag %s ignored on GPT', flag_name)
 
-    def set_hybrid_mbr(self):
+    def set_hybrid_mbr(self) -> None:
         """
         Turn partition table into hybrid GPT/MBR table
         """
@@ -130,7 +138,7 @@ class PartitionerGpt(PartitionerBase):
             ['sgdisk', '-h', ':'.join(partition_ids), self.disk_device]
         )
 
-    def set_mbr(self):
+    def set_mbr(self) -> None:
         """
         Turn partition table into MBR (msdos table)
         """
@@ -150,7 +158,7 @@ class PartitionerGpt(PartitionerBase):
             ['sgdisk', '-m', ':'.join(partition_ids), self.disk_device]
         )
 
-    def resize_table(self, entries=128):
+    def resize_table(self, entries: int = 128) -> None:
         """
         Resize partition table
 

--- a/kiwi/partitioner/msdos.py
+++ b/kiwi/partitioner/msdos.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import logging
+from typing import List
 
 # project
 from kiwi.utils.temporary import Temporary
@@ -33,7 +34,7 @@ class PartitionerMsDos(PartitionerBase):
     """
     **Implement old style msdos partition setup**
     """
-    def post_init(self):
+    def post_init(self) -> None:
         """
         Post initialization method
 
@@ -50,7 +51,9 @@ class PartitionerMsDos(PartitionerBase):
             't.prep': '41'
         }
 
-    def create(self, name, mbsize, type_name, flags=None):
+    def create(
+        self, name: str, mbsize: int, type_name: str, flags: List[str] = None
+    ) -> None:
         """
         Create msdos partition
 
@@ -97,7 +100,7 @@ class PartitionerMsDos(PartitionerBase):
             for flag_name in flags:
                 self.set_flag(self.partition_id, flag_name)
 
-    def set_flag(self, partition_id, flag_name):
+    def set_flag(self, partition_id: int, flag_name: str) -> None:
         """
         Set msdos partition flag
 
@@ -126,7 +129,7 @@ class PartitionerMsDos(PartitionerBase):
         else:
             log.warning('Flag %s ignored on msdos', flag_name)
 
-    def resize_table(self, entries=None):
+    def resize_table(self, entries: int = None) -> None:
         """
         Resize partition table
 

--- a/kiwi/partitioner/msdos.py
+++ b/kiwi/partitioner/msdos.py
@@ -48,11 +48,12 @@ class PartitionerMsDos(PartitionerBase):
             't.raid': 'fd',
             't.efi': None,
             't.csm': None,
-            't.prep': '41'
+            't.prep': '41',
+            't.extended': '5'
         }
 
     def create(
-        self, name: str, mbsize: int, type_name: str, flags: List[str] = None
+        self, name: str, mbsize: int, type_name: str, flags: List[str] = []
     ) -> None:
         """
         Create msdos partition
@@ -62,43 +63,19 @@ class PartitionerMsDos(PartitionerBase):
         :param string type_name: partition type
         :param list flags: additional flags
         """
-        self.partition_id += 1
-        fdisk_input = Temporary().new_file()
-        if self.partition_id > 1:
-            # Undefined start sector value skips this for fdisk and
-            # use its default value
-            self.start_sector = None
-        with open(fdisk_input.name, 'w') as partition:
-            log.debug(
-                '%s: fdisk: n p %d cur_position +%sM w q',
-                name, self.partition_id, format(mbsize)
-            )
-            partition.write(
-                'n\np\n{0}\n{1}\n{2}\nw\nq\n'.format(
-                    self.partition_id,
-                    '' if not self.start_sector else self.start_sector,
-                    '' if mbsize == 'all_free' else '+{0}M'.format(mbsize)
-                )
-            )
-        bash_command = ' '.join(
-            ['cat', fdisk_input.name, '|', 'fdisk', self.disk_device]
-        )
-        try:
-            Command.run(
-                ['bash', '-c', bash_command]
-            )
-        except Exception:
-            # unfortunately fdisk reports that it can't read in the partition
-            # table which I consider a bug in fdisk. However the table was
-            # correctly created and therefore we continue. Problem is that we
-            # are not able to detect real errors with the fdisk operation at
-            # that point.
-            log.debug('potential fdisk errors were ignored')
-
-        self.set_flag(self.partition_id, type_name)
-        if flags:
-            for flag_name in flags:
-                self.set_flag(self.partition_id, flag_name)
+        if self.extended_layout:
+            if self.partition_id < 3:
+                # in primary boundary
+                self._create_primary(name, mbsize, type_name, flags)
+            elif self.partition_id == 3:
+                # at primary boundary, create extended + logical
+                self._create_extended(name)
+                self._create_logical(name, mbsize, type_name, flags)
+            elif self.partition_id > 3:
+                # in logical boundary
+                self._create_logical(name, mbsize, type_name, flags)
+        else:
+            self._create_primary(name, mbsize, type_name, flags)
 
     def set_flag(self, partition_id: int, flag_name: str) -> None:
         """
@@ -138,3 +115,93 @@ class PartitionerMsDos(PartitionerBase):
         :param int entries: unused
         """
         pass
+
+    def _create_primary(
+        self, name: str, mbsize: int, type_name: str, flags: List[str] = []
+    ) -> None:
+        """
+        Create primary msdos partition
+        """
+        self.partition_id += 1
+        fdisk_input = Temporary().new_file()
+        if self.partition_id > 1:
+            # Undefined start sector value skips this for fdisk and
+            # use its default value
+            self.start_sector = None
+        with open(fdisk_input.name, 'w') as partition:
+            log.debug(
+                '%s: fdisk: n p %d cur_position +%sM w q',
+                name, self.partition_id, format(mbsize)
+            )
+            partition.write(
+                'n\np\n{0}\n{1}\n{2}\nw\nq\n'.format(
+                    self.partition_id,
+                    '' if not self.start_sector else self.start_sector,
+                    '' if mbsize == 'all_free' else '+{0}M'.format(mbsize)
+                )
+            )
+        self._call_fdisk(fdisk_input.name)
+        self._set_all_flags(type_name, flags)
+
+    def _create_extended(self, name: str) -> None:
+        """
+        Create extended msdos partition
+        """
+        self.partition_id += 1
+        fdisk_input = Temporary().new_file()
+        with open(fdisk_input.name, 'w') as partition:
+            log.debug(
+                '%s: fdisk: n e %d cur_position +all_freeM w q',
+                name, self.partition_id
+            )
+            partition.write(
+                'n\ne\n{0}\n{1}\n{2}\nw\nq\n'.format(
+                    self.partition_id, '', ''
+                )
+            )
+        self._call_fdisk(fdisk_input.name)
+
+    def _create_logical(
+        self, name: str, mbsize: int, type_name: str, flags: List[str] = []
+    ) -> None:
+        """
+        Create logical msdos partition
+        """
+        self.partition_id += 1
+        fdisk_input = Temporary().new_file()
+        with open(fdisk_input.name, 'w') as partition:
+            log.debug(
+                '%s: fdisk: n %d cur_position +%sM w q',
+                name, self.partition_id, format(mbsize)
+            )
+            partition.write(
+                'n\n{0}\n{1}\n{2}\nw\nq\n'.format(
+                    self.partition_id,
+                    '',
+                    '' if mbsize == 'all_free' else '+{0}M'.format(mbsize)
+                )
+            )
+        self._call_fdisk(fdisk_input.name)
+        self._set_all_flags(type_name, flags)
+
+    def _set_all_flags(self, type_name: str, flags: List[str]) -> None:
+        self.set_flag(self.partition_id, type_name)
+        if flags:
+            for flag_name in flags:
+                self.set_flag(self.partition_id, flag_name)
+
+    def _call_fdisk(self, fdisk_config_file_path: str) -> None:
+        bash_command = ' '.join(
+            ['cat', fdisk_config_file_path, '|', 'fdisk', self.disk_device]
+        )
+        try:
+            Command.run(
+                ['bash', '-c', bash_command]
+            )
+        except Exception:
+            # unfortunately fdisk reports that it can't read in the partition
+            # table which I consider a bug in fdisk. However the table was
+            # correctly created and therefore we continue. Problem is that we
+            # are not able to detect real errors with the fdisk operation at
+            # that point.
+            log.debug('potential fdisk errors were ignored')

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1453,6 +1453,19 @@ div {
             sch:param [ name = "attr" value = "efipartsize" ]
             sch:param [ name = "types" value = "oem" ]
         ]
+    k.type.dosparttable_extended_layout.attribute =
+        ## Specify to make use of logical partitions inside of an
+        ## extended one. If set to true and if the msdos table type
+        ## is active, this will cause the fourth partition to be an
+        ## extended partition and all following partitions will be
+        ## placed as logical partitions inside of that extended
+        ## partition. This setting is useful if more than 4 primary
+        ## partitions needs to be created in an msdos table
+        attribute dosparttable_extended_layout { xsd:boolean }
+        >> sch:pattern [ id = "dosparttable_extended_layout" is-a = "image_type"
+            sch:param [ name = "attr" value = "dosparttable_extended_layout" ]
+            sch:param [ name = "types" value = "oem" ]
+        ]
     k.type.efiparttable.attribute =
         ## For images with an EFI firmware specifies the partition
         ## table type to use. If not set defaults to gpt partition 
@@ -1950,6 +1963,7 @@ div {
         k.type.bootpartsize.attribute? &
         k.type.efipartsize.attribute? &
         k.type.efiparttable.attribute? &
+        k.type.dosparttable_extended_layout.attribute? &
         k.type.bootprofile.attribute? &
         k.type.btrfs_quota_groups.attribute? &
         k.type.btrfs_root_is_snapshot.attribute? &
@@ -2244,8 +2258,8 @@ div {
         k.partition.size.attribute &
         k.partition.partition_name.attribute? &
         k.partition.partition_type.attribute? &
-        k.partition.mountpoint.attribute &
-        k.partition.filesystem.attribute
+        k.partition.mountpoint.attribute? &
+        k.partition.filesystem.attribute?
     k.partition =
         ## Specify custom partition in the partition table
         element partition {

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2119,6 +2119,22 @@ size is set to 20 MB</a:documentation>
         <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
+    <define name="k.type.dosparttable_extended_layout.attribute">
+      <attribute name="dosparttable_extended_layout">
+        <a:documentation>Specify to make use of logical partitions inside of an
+extended one. If set to true and if the msdos table type
+is active, this will cause the fourth partition to be an
+extended partition and all following partitions will be
+placed as logical partitions inside of that extended
+partition. This setting is useful if more than 4 primary
+partitions needs to be created in an msdos table</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="dosparttable_extended_layout" is-a="image_type">
+        <sch:param name="attr" value="dosparttable_extended_layout"/>
+        <sch:param name="types" value="oem"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.efiparttable.attribute">
       <attribute name="efiparttable">
         <a:documentation>For images with an EFI firmware specifies the partition
@@ -2821,6 +2837,9 @@ kiwi-ng result bundle ...</a:documentation>
           <ref name="k.type.efiparttable.attribute"/>
         </optional>
         <optional>
+          <ref name="k.type.dosparttable_extended_layout.attribute"/>
+        </optional>
+        <optional>
           <ref name="k.type.bootprofile.attribute"/>
         </optional>
         <optional>
@@ -3393,8 +3412,12 @@ Allowed values are: t.linux</a:documentation>
         <optional>
           <ref name="k.partition.partition_type.attribute"/>
         </optional>
-        <ref name="k.partition.mountpoint.attribute"/>
-        <ref name="k.partition.filesystem.attribute"/>
+        <optional>
+          <ref name="k.partition.mountpoint.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.partition.filesystem.attribute"/>
+        </optional>
       </interleave>
     </define>
     <define name="k.partition">

--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -46,15 +46,19 @@ log = logging.getLogger('kiwi')
 class Disk(DeviceProvider):
     """
     **Implements storage disk and partition table setup**
-
-    :param string table_type: Partition table type name
-    :param object storage_provider: Instance of class based on DeviceProvider
-    :param int start_sector: sector number
     """
     def __init__(
         self, table_type: str, storage_provider: DeviceProvider,
         start_sector: int = None
     ):
+        """
+        Construct a new Disk layout object
+
+        :param string table_type: Partition table type name
+        :param object storage_provider:
+            Instance of class based on DeviceProvider
+        :param int start_sector: sector number
+        """
         # bind the underlaying block device providing class instance
         # to this object (e.g loop) if present. This is done to guarantee
         # the correct destructor order when the device should be released.

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2718,7 +2718,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, overlayroot_verity_blocks=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, overlayroot_verity_blocks=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2728,6 +2728,7 @@ class type_(GeneratedsSuper):
         self.bootpartsize = _cast(int, bootpartsize)
         self.efipartsize = _cast(int, efipartsize)
         self.efiparttable = _cast(None, efiparttable)
+        self.dosparttable_extended_layout = _cast(bool, dosparttable_extended_layout)
         self.bootprofile = _cast(None, bootprofile)
         self.btrfs_quota_groups = _cast(bool, btrfs_quota_groups)
         self.btrfs_root_is_snapshot = _cast(bool, btrfs_root_is_snapshot)
@@ -2893,6 +2894,8 @@ class type_(GeneratedsSuper):
     def set_efipartsize(self, efipartsize): self.efipartsize = efipartsize
     def get_efiparttable(self): return self.efiparttable
     def set_efiparttable(self, efiparttable): self.efiparttable = efiparttable
+    def get_dosparttable_extended_layout(self): return self.dosparttable_extended_layout
+    def set_dosparttable_extended_layout(self, dosparttable_extended_layout): self.dosparttable_extended_layout = dosparttable_extended_layout
     def get_bootprofile(self): return self.bootprofile
     def set_bootprofile(self, bootprofile): self.bootprofile = bootprofile
     def get_btrfs_quota_groups(self): return self.btrfs_quota_groups
@@ -3103,6 +3106,9 @@ class type_(GeneratedsSuper):
         if self.efiparttable is not None and 'efiparttable' not in already_processed:
             already_processed.add('efiparttable')
             outfile.write(' efiparttable=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.efiparttable), input_name='efiparttable')), ))
+        if self.dosparttable_extended_layout is not None and 'dosparttable_extended_layout' not in already_processed:
+            already_processed.add('dosparttable_extended_layout')
+            outfile.write(' dosparttable_extended_layout="%s"' % self.gds_format_boolean(self.dosparttable_extended_layout, input_name='dosparttable_extended_layout'))
         if self.bootprofile is not None and 'bootprofile' not in already_processed:
             already_processed.add('bootprofile')
             outfile.write(' bootprofile=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bootprofile), input_name='bootprofile')), ))
@@ -3355,6 +3361,15 @@ class type_(GeneratedsSuper):
             already_processed.add('efiparttable')
             self.efiparttable = value
             self.efiparttable = ' '.join(self.efiparttable.split())
+        value = find_attr_value_('dosparttable_extended_layout', node)
+        if value is not None and 'dosparttable_extended_layout' not in already_processed:
+            already_processed.add('dosparttable_extended_layout')
+            if value in ('true', '1'):
+                self.dosparttable_extended_layout = True
+            elif value in ('false', '0'):
+                self.dosparttable_extended_layout = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('bootprofile', node)
         if value is not None and 'bootprofile' not in already_processed:
             already_processed.add('bootprofile')

--- a/test/unit/partitioner/init_test.py
+++ b/test/unit/partitioner/init_test.py
@@ -28,23 +28,23 @@ class TestPartitioner:
     def test_partitioner_gpt(self, mock_gpt):
         storage_provider = Mock()
         Partitioner.new('gpt', storage_provider)
-        mock_gpt.assert_called_once_with(storage_provider, None)
+        mock_gpt.assert_called_once_with(storage_provider, None, False)
 
     @patch('kiwi.partitioner.msdos.PartitionerMsDos')
     def test_partitioner_msdos(self, mock_dos):
         storage_provider = Mock()
         Partitioner.new('msdos', storage_provider)
-        mock_dos.assert_called_once_with(storage_provider, None)
+        mock_dos.assert_called_once_with(storage_provider, None, False)
 
     @patch('kiwi.partitioner.dasd.PartitionerDasd')
     def test_partitioner_dasd(self, mock_dasd):
         storage_provider = Mock()
         Partitioner.new('dasd', storage_provider)
-        mock_dasd.assert_called_once_with(storage_provider, None)
+        mock_dasd.assert_called_once_with(storage_provider, None, False)
 
     @patch('kiwi.partitioner.dasd.PartitionerDasd')
     def test_partitioner_dasd_with_custom_start_sector(self, mock_dasd):
         storage_provider = Mock()
         with self._caplog.at_level(logging.WARNING):
             Partitioner.new('dasd', storage_provider, 4096)
-            mock_dasd.assert_called_once_with(storage_provider, None)
+            mock_dasd.assert_called_once_with(storage_provider, None, False)


### PR DESCRIPTION
Add support for extended layout to msdos table
    
This commit adds the following new type attribute
    
```xml
<type ... dosparttable_extended_layout="true|false"/>
```
    
If set it specifies to make use of logical partitions inside of an extended one. Effective only on type configurations which uses the msdos table type, it will cause the fourth partition to be an extended partition and all following partitions will be placed as logical partitions inside of that extended partition. This setting is useful if more than 4 partitions needs to be created in a msdos table. In addition to the support for extended/logical partitions the the attributes ```mountpoint``` and ```filesystem``` in the ```<partitions>```  section becomes optional. This also allows to place partitions as placeholders not mounted into the system
