### PR TITLE
Support mount by PARTUUID

### DIFF
--- a/build-tests/x86/leap/kiwi-settings/kiwi-settings.spec
+++ b/build-tests/x86/leap/kiwi-settings/kiwi-settings.spec
@@ -1,0 +1,28 @@
+Name:           kiwi-settings
+Version:        1.1.1
+Release:        0
+License:        GPL-3.0-or-later
+%if "%{_vendor}" == "debbuild"
+Packager:       Marcus Schaefer <marcus.schaefer@gmail.com>
+%endif
+Summary:        KIWI - runtime config file
+Group:          System/Management
+Source:         %{name}-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+BuildArch:      noarch
+
+%description
+Provides a KIWI runtime config file suitable building
+the leap based integrations test
+
+%prep
+%setup -q
+
+%install
+install -D -m 644 kiwi-settings/kiwi.yml %{buildroot}/etc/kiwi.yml
+
+%files
+%defattr(-,root,root)
+%config /etc/kiwi.yml
+
+%changelog

--- a/build-tests/x86/leap/kiwi-settings/kiwi-settings/kiwi.yml
+++ b/build-tests/x86/leap/kiwi-settings/kiwi-settings/kiwi.yml
@@ -1,0 +1,3 @@
+runtime_checks:
+  - disable:
+      - check_dracut_module_for_disk_overlay_in_package_list

--- a/build-tests/x86/leap/test-image-embedded/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-embedded/appliance.kiwi
@@ -13,6 +13,7 @@
         <profile name="Kernel" description="Provides kernel for kvm boot"/>
         <profile name="System" description="Provides system for kvm boot"/>
         <profile name="SystemOverlayRoot" description="Provides system for kvm boot using a squashfs compressed root overlay"/>
+        <profile name="SystemFeatures" description="Provides simple disk system with embedded features configured"/>
     </profiles>
     <preferences>
         <version>1.0.1</version>
@@ -45,15 +46,31 @@
             <size unit="M">200</size>
         </type>
     </preferences>
+    <preferences profiles="SystemFeatures">
+        <!-- simple disk image testing features useful in embedded projects -->
+        <type image="oem" filesystem="ext4" firmware="efi" overlayroot="true" bootpartition="true" devicepersistency="by-partuuid" kernelcmdline="console=ttyS0">
+            <bootloader name="grub2" console="serial" timeout="10"/>
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+            <size unit="M">500</size>
+        </type>
+    </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
     <repository type="rpm-md">
         <source path="obsrepositories:/"/>
     </repository>
-    <packages type="bootstrap" profiles="SystemOverlayRoot">
-        <!-- this is stupid here, because no initrd, but to disable the runtime check we need an entry in /etc/kiwi.yml which requires a package to be added in the prjconf such that the obs worker actually consumes this information. The shortcut way is to install and delete later -->
+    <packages type="bootstrap" profiles="Kernel,System,SystemOverlayRoot">
+        <package name="kernel-kvmsmall"/>
+    </packages>
+    <packages type="bootstrap" profiles="SystemFeatures">
         <package name="dracut-kiwi-overlay"/>
+        <package name="grub2"/>
+        <package name="grub2-i386-pc"/>
+        <package name="grub2-x86_64-efi"/>
+        <package name="kernel-default"/>
     </packages>
     <packages type="bootstrap">
         <package name="patterns-openSUSE-base"/>
@@ -70,7 +87,6 @@
         <package name="bind-utils"/>
         <package name="dhcp-client"/>
         <package name="which"/>
-        <package name="kernel-kvmsmall"/>
         <package name="timezone"/>
         <package name="gawk"/>
         <package name="grep"/>
@@ -83,8 +99,5 @@
         <package name="ca-certificates"/>
         <package name="ca-certificates-mozilla"/>
         <package name="openSUSE-release"/>
-    </packages>
-    <packages type="uninstall" profiles="SystemOverlayRoot">
-        <package name="dracut-kiwi-overlay"/>
     </packages>
 </image>

--- a/dracut/modules.d/90kiwi-overlay/parse-kiwi-overlay.sh
+++ b/dracut/modules.d/90kiwi-overlay/parse-kiwi-overlay.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # overlay images are specified with
 # root=overlay:UUID=uuid
+# root=overlay:PARTUUID=partuuid
+# root=overlay:LABEL=label
 # root=overlay:nbd=ip:exportname
 # root=overlay:aoe=interface
 
@@ -21,6 +23,16 @@ case "${overlayroot}" in
         root="${root#overlay:}"
         root="${root//\//\\x2f}"
         root="block:/dev/disk/by-uuid/${root#UUID=}"
+    ;;
+    overlay:PARTUUID=*|PARTUUID=*) \
+        root="${root#overlay:}"
+        root="${root//\//\\x2f}"
+        root="block:/dev/disk/by-partuuid/${root#PARTUUID=}"
+    ;;
+    overlay:LABEL=*|LABEL=*) \
+        root="${root#overlay:}"
+        root="${root//\//\\x2f}"
+        root="block:/dev/disk/by-label/${root#LABEL=}"
     ;;
     overlay:nbd=*) \
         root="block:/dev/nbd0"

--- a/kiwi.yml
+++ b/kiwi.yml
@@ -138,3 +138,6 @@
 
 #      # validate options passed to cryptsetup via luksformat element
 #      - check_luksformat_options_valid
+
+#      # check devicepersistency compatible with partition table type
+#      - check_partuuid_persistency_type_used_with_mbr

--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -560,7 +560,12 @@ class BootLoaderConfigBase:
                 return root_search.group(1)
         if boot_device:
             block_operation = BlockID(boot_device)
-            blkid_type = 'LABEL' if persistency_type == 'by-label' else 'UUID'
+            if persistency_type == 'by-label':
+                blkid_type = 'LABEL'
+            elif persistency_type == 'by-partuuid':
+                blkid_type = 'PARTUUID'
+            else:
+                blkid_type = 'UUID'
             location = block_operation.get_blkid(blkid_type)
             if self.xml_state.build_type.get_overlayroot():
                 return f'root=overlay:{blkid_type}={location}'

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -645,6 +645,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         * GRUB_TERMINAL
         * GRUB_DISTRIBUTOR
         * GRUB_DISABLE_LINUX_UUID
+        * GRUB_DISABLE_LINUX_PARTUUID
+        * GRUB_ENABLE_LINUX_LABEL
         """
         grub_default_entries = {
             'GRUB_TIMEOUT': self.timeout,
@@ -655,7 +657,11 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             r'(^root=[^\s]+)|( root=[^\s]+)', '', self.cmdline
         ).strip()
         if self.persistency_type == 'by-label':
+            grub_default_entries['GRUB_ENABLE_LINUX_LABEL'] = 'true'
             grub_default_entries['GRUB_DISABLE_LINUX_UUID'] = 'true'
+        elif self.persistency_type == 'by-partuuid':
+            grub_default_entries['GRUB_DISABLE_LINUX_UUID'] = 'true'
+            grub_default_entries['GRUB_DISABLE_LINUX_PARTUUID'] = 'false'
         if self.displayname:
             grub_default_entries['GRUB_DISTRIBUTOR'] = '"{0}"'.format(
                 self.displayname

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1038,8 +1038,12 @@ class DiskBuilder:
                 ]
             )
         else:
-            blkid_type = 'LABEL' if self.persistency_type == 'by-label' \
-                else 'UUID'
+            if self.persistency_type == 'by-label':
+                blkid_type = 'LABEL'
+            elif self.persistency_type == 'by-partuuid':
+                blkid_type = 'PARTUUID'
+            else:
+                blkid_type = 'UUID'
             device_id = block_operation.get_blkid(blkid_type)
             fstab_entry = ' '.join(
                 [

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1515,7 +1515,7 @@ div {
     k.type.devicepersistency.attribute =
         ## Specifies which method to use in order to get persistent
         ## storage device names. By default by-uuid is used.
-        attribute devicepersistency { "by-uuid" | "by-label" }
+        attribute devicepersistency { "by-uuid" | "by-label" | "by-partuuid" }
     k.type.editbootconfig.attribute =
         ## Specifies the path to a script which is called right
         ## before the bootloader is installed. The script runs

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2208,6 +2208,7 @@ storage device names. By default by-uuid is used.</a:documentation>
         <choice>
           <value>by-uuid</value>
           <value>by-label</value>
+          <value>by-partuuid</value>
         </choice>
       </attribute>
     </define>

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -96,7 +96,8 @@ class CliTask:
             'check_syslinux_installed_if_isolinux_is_used': [],
             'check_image_type_unique': [],
             'check_include_references_unresolvable': [],
-            'check_luksformat_options_valid': []
+            'check_luksformat_options_valid': [],
+            'check_partuuid_persistency_type_used_with_mbr': []
         }
         self.checks_after_command_args: Dict[str, List[str]] = {
             'check_repositories_configured': [],

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -136,7 +136,7 @@
                 <oem-swapname>swap</oem-swapname>
             </oemconfig>
         </type>
-        <type image="iso" mediacheck="true" firmware="bios"/>
+        <type image="iso" mediacheck="true" firmware="bios" devicepersistency="by-partuuid"/>
     </preferences>
     <users>
         <user groups="root" pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>

--- a/test/unit/bootloader/config/base_test.py
+++ b/test/unit/bootloader/config/base_test.py
@@ -126,6 +126,36 @@ class TestBootLoaderConfigBase:
 
     @patch('kiwi.xml_parse.type_.get_initrd_system')
     @patch('kiwi.bootloader.config.base.BlockID')
+    def test_get_boot_cmdline_initrd_system_is_dracut_partuuid(
+        self, mock_BlockID, mock_initrd
+    ):
+        block_operation = Mock()
+        block_operation.get_blkid.return_value = 'uuid'
+        mock_BlockID.return_value = block_operation
+        mock_initrd.return_value = 'dracut'
+        self.bootloader.xml_state.build_type.set_devicepersistency(
+            'by-partuuid'
+        )
+        assert self.bootloader.get_boot_cmdline('uuid') == \
+            'splash root=PARTUUID=uuid'
+
+    @patch('kiwi.xml_parse.type_.get_initrd_system')
+    @patch('kiwi.bootloader.config.base.BlockID')
+    def test_get_boot_cmdline_initrd_system_is_dracut_label(
+        self, mock_BlockID, mock_initrd
+    ):
+        block_operation = Mock()
+        block_operation.get_blkid.return_value = 'label'
+        mock_BlockID.return_value = block_operation
+        mock_initrd.return_value = 'dracut'
+        self.bootloader.xml_state.build_type.set_devicepersistency(
+            'by-label'
+        )
+        assert self.bootloader.get_boot_cmdline('uuid') == \
+            'splash root=LABEL=label'
+
+    @patch('kiwi.xml_parse.type_.get_initrd_system')
+    @patch('kiwi.bootloader.config.base.BlockID')
     def test_get_boot_cmdline_initrd_system_is_dracut_with_overlay(
         self, mock_BlockID, mock_initrd
     ):

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -582,6 +582,7 @@ class TestBootLoaderConfigGrub2:
             call('GRUB_DISTRIBUTOR', '"Bob"'),
             call('GRUB_ENABLE_BLSCFG', 'true'),
             call('GRUB_ENABLE_CRYPTODISK', 'y'),
+            call('GRUB_ENABLE_LINUX_LABEL', 'true'),
             call('GRUB_GFXMODE', '800x600'),
             call(
                 'GRUB_SERIAL_COMMAND', '"serial --speed=38400"'
@@ -621,6 +622,48 @@ class TestBootLoaderConfigGrub2:
                 'GRUB_BACKGROUND',
                 '/boot/grub2/themes/openSUSE/background.png'
             ),
+            call('GRUB_DISABLE_LINUX_UUID', 'true'),
+            call('GRUB_DISTRIBUTOR', '"Bob"'),
+            call('GRUB_ENABLE_BLSCFG', 'true'),
+            call('GRUB_ENABLE_CRYPTODISK', 'y'),
+            call('GRUB_ENABLE_LINUX_LABEL', 'true'),
+            call('GRUB_GFXMODE', '800x600'),
+            call(
+                'GRUB_SERIAL_COMMAND', '"serial --speed=38400"'
+            ),
+            call('GRUB_TERMINAL', '"serial"'),
+            call('GRUB_THEME', '/boot/grub2/themes/openSUSE/theme.txt'),
+            call('GRUB_TIMEOUT', 10),
+            call('GRUB_TIMEOUT_STYLE', 'countdown'),
+            call('SUSE_BTRFS_SNAPSHOT_BOOTING', 'true')
+        ]
+
+    @patch('os.path.exists')
+    @patch('kiwi.bootloader.config.grub2.SysConfig')
+    @patch('kiwi.bootloader.config.grub2.Command.run')
+    def test_setup_default_grub_use_of_by_partuuid(
+        self, mock_Command_run, mock_sysconfig, mock_exists
+    ):
+        grep_grub_option = Mock()
+        grep_grub_option.returncode = 0
+        mock_Command_run.return_value = grep_grub_option
+        grub_default = MagicMock()
+        mock_sysconfig.return_value = grub_default
+        mock_exists.return_value = True
+        self.bootloader.terminal = 'serial'
+        self.bootloader.theme = 'openSUSE'
+        self.bootloader.displayname = 'Bob'
+        self.bootloader.cmdline = 'root=UUID=foo'
+        self.bootloader.persistency_type = 'by-partuuid'
+
+        self.bootloader._setup_default_grub()
+
+        assert grub_default.__setitem__.call_args_list == [
+            call(
+                'GRUB_BACKGROUND',
+                '/boot/grub2/themes/openSUSE/background.png'
+            ),
+            call('GRUB_DISABLE_LINUX_PARTUUID', 'false'),
             call('GRUB_DISABLE_LINUX_UUID', 'true'),
             call('GRUB_DISTRIBUTOR', '"Bob"'),
             call('GRUB_ENABLE_BLSCFG', 'true'),

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -808,12 +808,26 @@ class TestDiskBuilder:
         with patch('builtins.open'):
             self.disk_builder.create_disk()
 
+        self.disk.persistency_type = 'by-uuid'
         self.disk.create_custom_partitions.assert_called_once_with(
             self.disk_builder.custom_partitions
         )
-
         assert [
             call('UUID=blkid_result /var blkid_result_fs defaults 0 0')
+        ] in self.disk_builder.fstab.add_entry.call_args_list
+
+        self.disk_builder.persistency_type = 'by-partuuid'
+        with patch('builtins.open'):
+            self.disk_builder.create_disk()
+        assert [
+            call('PARTUUID=blkid_result /var blkid_result_fs defaults 0 0')
+        ] in self.disk_builder.fstab.add_entry.call_args_list
+
+        self.disk_builder.persistency_type = 'by-label'
+        with patch('builtins.open'):
+            self.disk_builder.create_disk()
+        assert [
+            call('LABEL=blkid_result /var blkid_result_fs defaults 0 0')
         ] in self.disk_builder.fstab.add_entry.call_args_list
 
     @patch('kiwi.builder.disk.FileSystem.new')

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -179,6 +179,14 @@ class TestRuntimeChecker:
         with raises(KiwiRuntimeError):
             self.runtime_checker.check_volume_setup_has_no_root_definition()
 
+    def test_check_partuuid_persistency_type_used_with_mbr(self):
+        xml_state = XMLState(
+            self.description.load(), ['vmxFlavour'], 'iso'
+        )
+        runtime_checker = RuntimeChecker(xml_state)
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_partuuid_persistency_type_used_with_mbr()
+
     @patch('kiwi.runtime_checker.CommandCapabilities.has_option_in_help')
     def test_check_luksformat_options_valid(self, mock_has_option_in_help):
         mock_has_option_in_help.return_value = False


### PR DESCRIPTION
In addition to by-label and by-uuid also support mounting
by PARTUUID. Please note kiwi also makes sure that the grub
generated config file uses the root=PARTUUID= notation and it's
not clear if grub-mkconfig will persist making use of it.
Nevertheless there are also systems which uses different
methods to boot and it makes sense to support partuuid
mappings as well


