### PR TITLE
Support additional names for docker containers

### DIFF
--- a/build-tests/arm/fedora/test-image-live/appliance.kiwi
+++ b/build-tests/arm/fedora/test-image-live/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-live">
+<image schemaversion="7.5" name="kiwi-test-image-live">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/arm/rawhide/test-image-live-disk/appliance.kiwi
+++ b/build-tests/arm/rawhide/test-image-live-disk/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.4" name="kiwi-test-image-live-disk">
+<image schemaversion="7.5" name="kiwi-test-image-live-disk">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/arm/tumbleweed/test-image-live-disk/appliance.kiwi
+++ b/build-tests/arm/tumbleweed/test-image-live-disk/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.4" name="kiwi-test-image-live-disk">
+<image schemaversion="7.5" name="kiwi-test-image-live-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/arm/tumbleweed/test-image-rpi-overlay/appliance.kiwi
+++ b/build-tests/arm/tumbleweed/test-image-rpi-overlay/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-rpi-overlay">
+<image schemaversion="7.5" name="kiwi-test-image-rpi-overlay">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/arm/tumbleweed/test-image-rpi/appliance.kiwi
+++ b/build-tests/arm/tumbleweed/test-image-rpi/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-rpi">
+<image schemaversion="7.5" name="kiwi-test-image-rpi">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/ppc/fedora/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/ppc/fedora/test-image-disk-simple/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-disk-simple">
+<image schemaversion="7.5" name="kiwi-test-image-disk-simple">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/ppc/sle15/test-image-disk/appliance.kiwi
+++ b/build-tests/ppc/sle15/test-image-disk/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.4" name="kiwi-test-image-disk">
+<image schemaversion="7.5" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/ppc/tumbleweed/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/ppc/tumbleweed/test-image-disk-simple/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-disk-simple">
+<image schemaversion="7.5" name="kiwi-test-image-disk-simple">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/ppc/tumbleweed/test-image-disk/appliance.kiwi
+++ b/build-tests/ppc/tumbleweed/test-image-disk/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.4" name="kiwi-test-image-disk">
+<image schemaversion="7.5" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/s390/sle15/test-image-disk/appliance.kiwi
+++ b/build-tests/s390/sle15/test-image-disk/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.4" name="kiwi-test-image-disk">
+<image schemaversion="7.5" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/s390/tumbleweed/test-image-disk/appliance.kiwi
+++ b/build-tests/s390/tumbleweed/test-image-disk/appliance.kiwi
@@ -2,7 +2,7 @@
 
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.4" name="kiwi-test-image-disk">
+<image schemaversion="7.5" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
+++ b/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.4" name="kiwi-test-image-live-disk-kis">
+<image schemaversion="7.5" name="kiwi-test-image-live-disk-kis">
     <description type="system">
         <author>David Cassany</author>
         <contact>dcassany@suse.com</contact>

--- a/build-tests/x86/centos/test-image-live-disk-v7/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-live-disk-v7/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.4" name="kiwi-test-image-live-disk-v7">
+<image schemaversion="7.5" name="kiwi-test-image-live-disk-v7">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/centos/test-image-live-disk-v8/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-live-disk-v8/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.4" name="kiwi-test-image-live-disk-v8">
+<image schemaversion="7.5" name="kiwi-test-image-live-disk-v8">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/centos/test-image-live-disk-v9/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-live-disk-v9/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.4" name="kiwi-test-image-live-disk-v9">
+<image schemaversion="7.5" name="kiwi-test-image-live-disk-v9">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>marcus.schaefer@gmail.com</contact>

--- a/build-tests/x86/debian/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/debian/test-image-live-disk/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.4" name="kiwi-test-image-live-disk">
+<image schemaversion="7.5" name="kiwi-test-image-live-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.4" name="kiwi-test-image-live-disk">
+<image schemaversion="7.5" name="kiwi-test-image-live-disk">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/fedora/test-image-microdnf/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-microdnf/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-microdnf">
+<image schemaversion="7.5" name="kiwi-test-image-microdnf">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-custom-partitions/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-custom-partitions/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-custom-partitions">
+<image schemaversion="7.5" name="kiwi-test-image-custom-partitions">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/leap/test-image-disk-ramdisk/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-disk-ramdisk/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-disk-ramdisk">
+<image schemaversion="7.5" name="kiwi-test-image-disk-ramdisk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-disk-simple/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-disk-simple" displayname="Simple Disk">
+<image schemaversion="7.5" name="kiwi-test-image-disk-simple" displayname="Simple Disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-disk/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-disk/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-disk">
+<image schemaversion="7.5" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-docker-derived/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-docker-derived/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-docker-derived">
+<image schemaversion="7.5" name="kiwi-test-image-docker-derived">
     <description type="system">
         <author>David Cassany</author>
         <contact>dcassany@suse.de</contact>

--- a/build-tests/x86/leap/test-image-docker/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-docker/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-docker">
+<image schemaversion="7.5" name="kiwi-test-image-docker">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-embedded/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-embedded/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.4" name="kiwi-test-image-embedded">
+<image schemaversion="7.5" name="kiwi-test-image-embedded">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-live/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-live/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-live">
+<image schemaversion="7.5" name="kiwi-test-image-live">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-luks/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-luks/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-luks">
+<image schemaversion="7.5" name="kiwi-test-image-luks">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-lvm/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-lvm/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-lvm">
+<image schemaversion="7.5" name="kiwi-test-image-lvm">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-overlayroot/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-overlayroot">
+<image schemaversion="7.5" name="kiwi-test-image-overlayroot">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-tbz/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-tbz/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-tbz">
+<image schemaversion="7.5" name="kiwi-test-image-tbz">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/leap/test-image-vagrant/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-vagrant/appliance.kiwi
@@ -4,7 +4,7 @@
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 <!-- OBS-ExclusiveArch: x86_64 -->
 
-<image schemaversion="7.4" name="kiwi-test-image-vagrant">
+<image schemaversion="7.5" name="kiwi-test-image-vagrant">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.4" name="kiwi-test-image-live-disk">
+<image schemaversion="7.5" name="kiwi-test-image-live-disk">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/rawhide/test-image-microdnf/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-microdnf/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-microdnf">
+<image schemaversion="7.5" name="kiwi-test-image-microdnf">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/sle15/test-image-disk/appliance.kiwi
+++ b/build-tests/x86/sle15/test-image-disk/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-disk">
+<image schemaversion="7.5" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-MicroOS/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-MicroOS/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-MicroOS">
+<image schemaversion="7.5" name="kiwi-test-image-MicroOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-azure/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-azure/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-azure">
+<image schemaversion="7.5" name="kiwi-test-image-azure">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/tumbleweed/test-image-bundle-format/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-bundle-format/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="test-image-bundle-format">
+<image schemaversion="7.5" name="test-image-bundle-format">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-custom-partitions/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-custom-partitions/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-custom-partitions">
+<image schemaversion="7.5" name="kiwi-test-image-custom-partitions">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/tumbleweed/test-image-disk-legacy/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-legacy/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-disk-legacy">
+<image schemaversion="7.5" name="kiwi-test-image-disk-legacy">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-disk-ramdisk/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-ramdisk/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-disk-ramdisk">
+<image schemaversion="7.5" name="kiwi-test-image-disk-ramdisk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-simple/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-disk-simple" displayname="Simple Disk">
+<image schemaversion="7.5" name="kiwi-test-image-disk-simple" displayname="Simple Disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-disk/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-disk">
+<image schemaversion="7.5" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-docker-derived/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-docker-derived/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-docker-derived">
+<image schemaversion="7.5" name="kiwi-test-image-docker-derived">
     <description type="system">
         <author>David Cassany</author>
         <contact>dcassany@suse.de</contact>
@@ -8,7 +8,7 @@
     </description>
     <preferences>
         <type image="docker" derived_from="obs://openSUSE:Containers:Tumbleweed/containers/opensuse/tumbleweed#latest">
-            <containerconfig name="builder" tag="1.0" additionaltags="latest"/>
+            <containerconfig name="builder" tag="1.0" additionalnames=":latest"/>
         </type>
         <version>1.0</version>
         <packagemanager>zypper</packagemanager>

--- a/build-tests/x86/tumbleweed/test-image-docker/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-docker/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-docker">
+<image schemaversion="7.5" name="kiwi-test-image-docker">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-ec2/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-ec2/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-ec2">
+<image schemaversion="7.5" name="kiwi-test-image-ec2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/tumbleweed/test-image-gce/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-gce/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-gce">
+<image schemaversion="7.5" name="kiwi-test-image-gce">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
@@ -4,7 +4,7 @@
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 <!-- OBS-ExclusiveArch: x86_64 -->
 
-<image schemaversion="7.4" name="kiwi-test-image-live">
+<image schemaversion="7.5" name="kiwi-test-image-live">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-luks">
+<image schemaversion="7.5" name="kiwi-test-image-luks">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-lvm/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-lvm/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-lvm">
+<image schemaversion="7.5" name="kiwi-test-image-lvm">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-orthos/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-orthos/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-orthos">
+<image schemaversion="7.5" name="kiwi-test-image-orthos">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-overlayroot">
+<image schemaversion="7.5" name="kiwi-test-image-overlayroot">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-partitions-and-volumes/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-partitions-and-volumes/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-partitions-and-volumes">
+<image schemaversion="7.5" name="kiwi-test-image-partitions-and-volumes">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>marcus.schaefer@gmail.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-pxe/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-pxe/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.4" name="kiwi-test-image-pxe">
+<image schemaversion="7.5" name="kiwi-test-image-pxe">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-qcow-openstack/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-qcow-openstack/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-qcow-openstack">
+<image schemaversion="7.5" name="kiwi-test-image-qcow-openstack">
     <description type="system">
         <author>KIWI Team</author>
         <contact>kiwi-images@googlegroups.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-raid/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-raid/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-raid" displayname="Raid Disk">
+<image schemaversion="7.5" name="kiwi-test-image-raid" displayname="Raid Disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-suse-on-dnf/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-suse-on-dnf/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-suse-on-dnf">
+<image schemaversion="7.5" name="kiwi-test-image-suse-on-dnf">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-tbz/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-tbz/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-tbz">
+<image schemaversion="7.5" name="kiwi-test-image-tbz">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-vagrant/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-vagrant/appliance.kiwi
@@ -4,7 +4,7 @@
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 <!-- OBS-ExclusiveArch: x86_64 -->
 
-<image schemaversion="7.4" name="kiwi-test-image-vagrant">
+<image schemaversion="7.5" name="kiwi-test-image-vagrant">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/tumbleweed/test-image-wsl/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-wsl/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-wsl">
+<image schemaversion="7.5" name="kiwi-test-image-wsl">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/ubuntu/test-image-docker/appliance.kiwi
+++ b/build-tests/x86/ubuntu/test-image-docker/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="kiwi-test-image-docker">
+<image schemaversion="7.5" name="kiwi-test-image-docker">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>marcus.schaefer@gmail.com</contact>

--- a/build-tests/x86/ubuntu/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/ubuntu/test-image-live-disk/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.4" name="kiwi-test-image-live-disk">
+<image schemaversion="7.5" name="kiwi-test-image-live-disk">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -41,7 +41,7 @@ class ContainerImageOCI:
         {
             'container_name': 'name',
             'container_tag': '1.0',
-            'additional_tags': ['current', 'foobar'],
+            'additional_names': ['current', 'foobar'],
             'entry_command': ['/bin/bash', '-x'],
             'entry_subcommand': ['ls', '-l'],
             'maintainer': 'tux',
@@ -142,12 +142,22 @@ class ContainerImageOCI:
         )
         additional_refs = []
         if self.archive_transport == 'docker-archive':
-            if 'additional_tags' in self.oci_config:
+            if 'additional_names' in self.oci_config:
                 additional_refs = []
-                for tag in self.oci_config['additional_tags']:
-                    additional_refs.append('{0}:{1}'.format(
-                        self.oci_config['container_name'], tag
-                    ))
+                for name in self.oci_config['additional_names']:
+                    name_parts = name.partition(':')
+                    if not name_parts[0]:
+                        additional_refs.append('{0}:{1}'.format(
+                            self.oci_config['container_name'], name_parts[2]
+                        ))
+                    elif not name_parts[2]:
+                        additional_refs.append('{0}:{1}'.format(
+                            name_parts[0], self.oci_config['container_tag']
+                        ))
+                    else:
+                        additional_refs.append('{0}:{1}'.format(
+                            name_parts[0], name_parts[2]
+                        ))
 
         oci.export_container_image(
             filename, self.archive_transport, image_ref, additional_refs

--- a/kiwi/oci_tools/base.py
+++ b/kiwi/oci_tools/base.py
@@ -69,7 +69,7 @@ class OCIBase:
         :param str filename: The resulting filename
         :param str transport: The archive format
         :param str image_ref: Image reference of the exported image
-        :param list additional_tags: List of additional references
+        :param list additional_names: List of additional references
         """
         raise NotImplementedError
 

--- a/kiwi/oci_tools/buildah.py
+++ b/kiwi/oci_tools/buildah.py
@@ -90,20 +90,19 @@ class OCIBuildah(OCIBase):
         )
 
     def export_container_image(
-        self, filename, transport, image_ref, additional_refs=None
+        self, filename, transport, image_ref, additional_names=None
     ):
         """
         Exports the working container to a container image archive
 
         :param str filename: The resulting filename
         :param str transport: The archive format
-        :param str image_name: Name of the exported image
-        :param str image_tag: Tag of the exported image
-        :param list additional_tags: List of additional references
+        :param str image_ref: Reference of the exported image
+        :param list additional_names: List of additional references
         """
         extra_tags_opt = []
-        if additional_refs:
-            for ref in additional_refs:
+        if additional_names:
+            for ref in additional_names:
                 extra_tags_opt.extend(['--additional-tag', ref])
 
         # make sure the target tar file does not exist

--- a/kiwi/oci_tools/umoci.py
+++ b/kiwi/oci_tools/umoci.py
@@ -62,7 +62,7 @@ class OCIUmoci(OCIBase):
         ])
 
     def export_container_image(
-        self, filename, transport, image_ref, additional_refs=None
+        self, filename, transport, image_ref, additional_names=None
     ):
         """
         Exports the working container to a container image archive
@@ -71,11 +71,11 @@ class OCIUmoci(OCIBase):
         :param str transport: The archive format
         :param str image_name: Name of the exported image
         :param str image_tag: Tag of the exported image
-        :param list additional_tags: List of additional references
+        :param list additional_names: List of additional references
         """
         extra_tags_opt = []
-        if additional_refs:
-            for ref in additional_refs:
+        if additional_names:
+            for ref in additional_names:
                 extra_tags_opt.extend(['--additional-tag', ref])
 
         # make sure the target tar file does not exist

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -352,7 +352,7 @@ class RuntimeChecker:
             --help').\n
             It is known to be present since v0.1.30
         ''')
-        if 'additional_tags' in self.xml_state.get_container_config():
+        if 'additional_names' in self.xml_state.get_container_config():
             if not CommandCapabilities.has_option_in_help(
                 'skopeo', '--additional-tag', ['copy', '--help'],
                 raise_on_error=False

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -64,7 +64,7 @@ div {
         attribute xsi:schemaLocation { xsd:anyURI }
     k.image.schemaversion.attribute =
         ## The allowed Schema version (fixed value)
-        attribute schemaversion { "7.4" }
+        attribute schemaversion { "7.5" }
     k.image.id =
         ## An identification number which is represented in a file
         ## named /etc/ImageID
@@ -2546,12 +2546,12 @@ div {
             sch:param [ name = "attr" value = "tag" ]
             sch:param [ name = "types" value = "docker oci" ]
         ]
-    k.containerconfig.additionaltags.attribute =
+    k.containerconfig.additionalnames.attribute =
         ## Specifies additional tags for the container using a comma
         ## separated values string
-        attribute additionaltags { text }
-        >> sch:pattern [ id = "additionaltags" is-a = "container_type"
-            sch:param [ name = "attr" value = "additionaltags" ]
+        attribute additionalnames { text }
+        >> sch:pattern [ id = "additionalnames" is-a = "container_type"
+            sch:param [ name = "attr" value = "additionalnames" ]
             sch:param [ name = "types" value = "docker oci" ]
         ]
     k.containerconfig.maintainer.attribute =
@@ -2578,7 +2578,7 @@ div {
     k.containerconfig.attlist =
         k.containerconfig.name.attribute &
         k.containerconfig.tag.attribute? &
-        k.containerconfig.additionaltags.attribute? &
+        k.containerconfig.additionalnames.attribute? &
         k.containerconfig.maintainer.attribute? &
         k.containerconfig.user.attribute? &
         k.containerconfig.workingdir.attribute?

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2547,8 +2547,11 @@ div {
             sch:param [ name = "types" value = "docker oci" ]
         ]
     k.containerconfig.additionalnames.attribute =
-        ## Specifies additional tags for the container using a comma
-        ## separated values string
+        ## Specifies additional names for the container using a comma
+        ## separated values string. It supports '<repo1>:<tag2>,<repo2:tag2>'
+        ## format. If any of the names does not include the repository or tag
+        ## in that case `name` or `tag` attribute values from containerconfig
+        ## will be used to build a complete image referrence.
         attribute additionalnames { text }
         >> sch:pattern [ id = "additionalnames" is-a = "container_type"
             sch:param [ name = "attr" value = "additionalnames" ]

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -140,7 +140,7 @@ second the location of the XSD Schema
     <define name="k.image.schemaversion.attribute">
       <attribute name="schemaversion">
         <a:documentation>The allowed Schema version (fixed value)</a:documentation>
-        <value>7.4</value>
+        <value>7.5</value>
       </attribute>
     </define>
     <define name="k.image.id">
@@ -3812,13 +3812,13 @@ image is imported via the docker load command</a:documentation>
         <sch:param name="types" value="docker oci"/>
       </sch:pattern>
     </define>
-    <define name="k.containerconfig.additionaltags.attribute">
-      <attribute name="additionaltags">
+    <define name="k.containerconfig.additionalnames.attribute">
+      <attribute name="additionalnames">
         <a:documentation>Specifies additional tags for the container using a comma
 separated values string</a:documentation>
       </attribute>
-      <sch:pattern id="additionaltags" is-a="container_type">
-        <sch:param name="attr" value="additionaltags"/>
+      <sch:pattern id="additionalnames" is-a="container_type">
+        <sch:param name="attr" value="additionalnames"/>
         <sch:param name="types" value="docker oci"/>
       </sch:pattern>
     </define>
@@ -3856,7 +3856,7 @@ separated values string</a:documentation>
           <ref name="k.containerconfig.tag.attribute"/>
         </optional>
         <optional>
-          <ref name="k.containerconfig.additionaltags.attribute"/>
+          <ref name="k.containerconfig.additionalnames.attribute"/>
         </optional>
         <optional>
           <ref name="k.containerconfig.maintainer.attribute"/>

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -3814,8 +3814,11 @@ image is imported via the docker load command</a:documentation>
     </define>
     <define name="k.containerconfig.additionalnames.attribute">
       <attribute name="additionalnames">
-        <a:documentation>Specifies additional tags for the container using a comma
-separated values string</a:documentation>
+        <a:documentation>Specifies additional names for the container using a comma
+separated values string. It supports '&lt;repo1&gt;:&lt;tag2&gt;,&lt;repo2:tag2&gt;'
+format. If any of the names does not include the repository or tag
+in that case `name` or `tag` attribute values from containerconfig
+will be used to build a complete image referrence.</a:documentation>
       </attribute>
       <sch:pattern id="additionalnames" is-a="container_type">
         <sch:param name="attr" value="additionalnames"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/ms/Project/kiwi/.tox/3.6/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/david/work/kiwi/.tox/3.6/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -5086,11 +5086,11 @@ class containerconfig(GeneratedsSuper):
     useful container information."""
     subclass = None
     superclass = None
-    def __init__(self, name=None, tag=None, additionaltags=None, maintainer=None, user=None, workingdir=None, entrypoint=None, subcommand=None, expose=None, volumes=None, environment=None, labels=None, history=None):
+    def __init__(self, name=None, tag=None, additionalnames=None, maintainer=None, user=None, workingdir=None, entrypoint=None, subcommand=None, expose=None, volumes=None, environment=None, labels=None, history=None):
         self.original_tagname_ = None
         self.name = _cast(None, name)
         self.tag = _cast(None, tag)
-        self.additionaltags = _cast(None, additionaltags)
+        self.additionalnames = _cast(None, additionalnames)
         self.maintainer = _cast(None, maintainer)
         self.user = _cast(None, user)
         self.workingdir = _cast(None, workingdir)
@@ -5172,8 +5172,8 @@ class containerconfig(GeneratedsSuper):
     def set_name(self, name): self.name = name
     def get_tag(self): return self.tag
     def set_tag(self, tag): self.tag = tag
-    def get_additionaltags(self): return self.additionaltags
-    def set_additionaltags(self, additionaltags): self.additionaltags = additionaltags
+    def get_additionalnames(self): return self.additionalnames
+    def set_additionalnames(self, additionalnames): self.additionalnames = additionalnames
     def get_maintainer(self): return self.maintainer
     def set_maintainer(self, maintainer): self.maintainer = maintainer
     def get_user(self): return self.user
@@ -5221,9 +5221,9 @@ class containerconfig(GeneratedsSuper):
         if self.tag is not None and 'tag' not in already_processed:
             already_processed.add('tag')
             outfile.write(' tag=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.tag), input_name='tag')), ))
-        if self.additionaltags is not None and 'additionaltags' not in already_processed:
-            already_processed.add('additionaltags')
-            outfile.write(' additionaltags=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.additionaltags), input_name='additionaltags')), ))
+        if self.additionalnames is not None and 'additionalnames' not in already_processed:
+            already_processed.add('additionalnames')
+            outfile.write(' additionalnames=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.additionalnames), input_name='additionalnames')), ))
         if self.maintainer is not None and 'maintainer' not in already_processed:
             already_processed.add('maintainer')
             outfile.write(' maintainer=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.maintainer), input_name='maintainer')), ))
@@ -5268,10 +5268,10 @@ class containerconfig(GeneratedsSuper):
         if value is not None and 'tag' not in already_processed:
             already_processed.add('tag')
             self.tag = value
-        value = find_attr_value_('additionaltags', node)
-        if value is not None and 'additionaltags' not in already_processed:
-            already_processed.add('additionaltags')
-            self.additionaltags = value
+        value = find_attr_value_('additionalnames', node)
+        if value is not None and 'additionalnames' not in already_processed:
+            already_processed.add('additionalnames')
+            self.additionalnames = value
         value = find_attr_value_('maintainer', node)
         if value is not None and 'maintainer' not in already_processed:
             already_processed.add('maintainer')

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/david/work/kiwi/.tox/3.6/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/david/work/kiwi/.tox/3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -2368,15 +2368,15 @@ class XMLState:
             maintainer = container_config_section.get_maintainer()
             user = container_config_section.get_user()
             workingdir = container_config_section.get_workingdir()
-            additional_tags = container_config_section.get_additionaltags()
+            additional_names = container_config_section.get_additionalnames()
             if name:
                 container_base['container_name'] = name
 
             if tag:
                 container_base['container_tag'] = tag
 
-            if additional_tags:
-                container_base['additional_tags'] = additional_tags.split(',')
+            if additional_names:
+                container_base['additional_names'] = additional_names.split(',')
 
             if maintainer:
                 container_base['maintainer'] = maintainer

--- a/kiwi/xsl/convert74to75.xsl
+++ b/kiwi/xsl/convert74to75.xsl
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv74to75">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv74to75"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>7.4</literal> to <literal>7.5</literal>.
+</para>
+<xsl:template match="image" mode="conv74to75">
+    <xsl:choose>
+        <!-- nothing to do if already at 7.5 -->
+        <xsl:when test="@schemaversion > 7.4">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="7.5">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv74to75"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+
+<!-- rename additionaltags attribute to additionalnames and add a colon before each tag -->
+<xsl:template match="containerconfig" mode="conv74to75">
+    <containerconfig>
+        <xsl:copy-of select="@*[not(local-name(.) = 'additionaltags')]"/>
+        <xsl:if test="@additionaltags">
+            <xsl:attribute name="additionalnames">
+                <xsl:call-template name="replace-all">
+                    <xsl:with-param name="text" select="concat(':',@additionaltags)" />
+                    <xsl:with-param name="replace" select="','" />
+                    <xsl:with-param name="by" select="',:'" />
+                </xsl:call-template>
+            </xsl:attribute>
+        </xsl:if>
+        <xsl:apply-templates  mode="conv74to75"/>
+    </containerconfig>
+</xsl:template>
+
+<!-- replace all ocurrences of a substring template -->
+<xsl:template name="replace-all" mode="conv74to75">
+    <xsl:param name="text" />
+    <xsl:param name="replace" />
+    <xsl:param name="by" />
+    <xsl:choose>
+        <xsl:when test="$text = '' or $replace = ''or not($replace)" >
+            <!-- Prevent this routine from hanging -->
+            <xsl:value-of select="$text" />
+        </xsl:when>
+        <xsl:when test="contains($text, $replace)">
+            <xsl:value-of select="substring-before($text,$replace)" />
+            <xsl:value-of select="$by" />
+            <xsl:call-template name="replace-all">
+                <xsl:with-param name="text" select="substring-after($text,$replace)" />
+                <xsl:with-param name="replace" select="$replace" />
+                <xsl:with-param name="by" select="$by" />
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="$text" />
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/kiwi/xsl/master.xsl
+++ b/kiwi/xsl/master.xsl
@@ -46,6 +46,7 @@
 <xsl:import href="convert71to72.xsl"/>
 <xsl:import href="convert72to73.xsl"/>
 <xsl:import href="convert73to74.xsl"/>
+<xsl:import href="convert74to75.xsl"/>
 <xsl:import href="pretty.xsl"/>
 
 <xsl:output encoding="utf-8"/>
@@ -215,8 +216,12 @@
         <xsl:apply-templates select="exslt:node-set($v73)" mode="conv73to74"/>
     </xsl:variable>
 
+    <xsl:variable name="v75">
+        <xsl:apply-templates select="exslt:node-set($v74)" mode="conv74to75"/>
+    </xsl:variable>
+
     <xsl:apply-templates
-        select="exslt:node-set($v74)" mode="pretty"
+        select="exslt:node-set($v75)" mode="pretty"
     />
 </xsl:template>
 

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -44,7 +44,7 @@
 
 Name:           python-kiwi
 Version:        %%VERSION
-Provides:       kiwi-schema = 7.4
+Provides:       kiwi-schema = 7.5
 Release:        0
 Url:            https://github.com/OSInside/kiwi
 Summary:        KIWI - Appliance Builder Next Generation

--- a/test/data/example_arm_disk_size_config.xml
+++ b/test/data/example_arm_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_btrfs_config.xml
+++ b/test/data/example_btrfs_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS" displayname="Bob">
+<image schemaversion="7.5" name="LimeJeOS" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -127,7 +127,7 @@
     </preferences>
     <preferences profiles="containerFlavour">
         <type image="docker">
-            <containerconfig name="container_name" maintainer="tux" user="root" workingdir="/root" tag="container_tag" additionaltags="current,foobar">
+            <containerconfig name="container_name" maintainer="tux" user="root" workingdir="/root" tag="container_tag" additionalnames="current,foobar">
                 <entrypoint execute="/bin/bash">
                     <argument name="-x"/>
                 </entrypoint>

--- a/test/data/example_config_target_dir.xml
+++ b/test/data/example_config_target_dir.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS" displayname="Bob">
+<image schemaversion="7.5" name="LimeJeOS" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>

--- a/test/data/example_config_target_dir.xml
+++ b/test/data/example_config_target_dir.xml
@@ -126,7 +126,7 @@
     </preferences>
     <preferences profiles="containerFlavour">
         <type image="docker">
-            <containerconfig name="container_name" maintainer="tux" user="root" workingdir="/root" tag="container_tag" additionaltags="current,foobar">
+            <containerconfig name="container_name" maintainer="tux" user="root" workingdir="/root" tag="container_tag" additionalnames="current,foobar">
                 <entrypoint execute="/bin/bash">
                     <argument name="-x"/>
                 </entrypoint>

--- a/test/data/example_disk_config.xml
+++ b/test/data/example_disk_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_config.xml
+++ b/test/data/example_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_empty_vol_config.xml
+++ b/test/data/example_disk_size_empty_vol_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_oem_volume_config.xml
+++ b/test/data/example_disk_size_oem_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_partition_too_small_config.xml
+++ b/test/data/example_disk_size_partition_too_small_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="TestPartitions">
+<image schemaversion="7.5" name="TestPartitions">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_partitions_config.xml
+++ b/test/data/example_disk_size_partitions_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="TestPartitions">
+<image schemaversion="7.5" name="TestPartitions">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_vol_root_config.xml
+++ b/test/data/example_disk_size_vol_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_volume_config.xml
+++ b/test/data/example_disk_size_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_volume_too_small_config.xml
+++ b/test/data/example_disk_size_volume_too_small_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="JeOS">
+<image schemaversion="7.5" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_dot_profile_config.xml
+++ b/test/data/example_dot_profile_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_include_config.xml
+++ b/test/data/example_include_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS">
+<image schemaversion="7.5" name="LimeJeOS">
     <description type="system">
         <author>Marcus</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_include_config_from_description_dir.xml
+++ b/test/data/example_include_config_from_description_dir.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS">
+<image schemaversion="7.5" name="LimeJeOS">
     <description type="system">
         <author>Marcus</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_include_config_missing_reference.xml
+++ b/test/data/example_include_config_missing_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="JeOS">
+<image schemaversion="7.5" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_custom_rootvol_config.xml
+++ b/test/data/example_lvm_custom_rootvol_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="custom-root-volume-setup">
+<image schemaversion="7.5" name="custom-root-volume-setup">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_default_config.xml
+++ b/test/data/example_lvm_default_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_config.xml
+++ b/test/data/example_lvm_no_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_full_usr_config.xml
+++ b/test/data/example_lvm_no_root_full_usr_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_preferred_config.xml
+++ b/test/data/example_lvm_preferred_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_multiple_users_config.xml
+++ b/test/data/example_multiple_users_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_default_type.xml
+++ b/test/data/example_no_default_type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_image_packages_config.xml
+++ b/test/data/example_no_image_packages_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_imageinclude_config.xml
+++ b/test/data/example_no_imageinclude_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_partitions_config.xml
+++ b/test/data/example_partitions_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="TestPartitions">
+<image schemaversion="7.5" name="TestPartitions">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_ppc_disk_size_config.xml
+++ b/test/data/example_ppc_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_pxe_config.xml
+++ b/test/data/example_pxe_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_boot_desc_not_found.xml
+++ b/test/data/example_runtime_checker_boot_desc_not_found.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="JeOS">
+<image schemaversion="7.5" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -71,7 +71,7 @@
     </preferences>
     <preferences profiles="docker">
         <type image="docker">
-            <containerconfig name="container_name" additionaltags="foo,bar"/>
+            <containerconfig name="container_name" additionalnames="foo,bar"/>
         </type>
     </preferences>
     <preferences profiles="ec2Flavour">

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>

--- a/test/data/example_runtime_checker_conflicting_types.xml
+++ b/test/data/example_runtime_checker_conflicting_types.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="TypeConflict">
+<image schemaversion="7.5" name="TypeConflict">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/test/data/example_runtime_checker_include_nested_reference.xml
+++ b/test/data/example_runtime_checker_include_nested_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="JeOS">
+<image schemaversion="7.5" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_no_boot_reference.xml
+++ b/test/data/example_runtime_checker_no_boot_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="JeOS">
+<image schemaversion="7.5" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_no_initrd_system_reference.xml
+++ b/test/data/example_runtime_checker_no_initrd_system_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="JeOS">
+<image schemaversion="7.5" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_this_path_config.xml
+++ b/test/data/example_this_path_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="JeOS">
+<image schemaversion="7.5" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/image_info/config.xml
+++ b/test/data/image_info/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="LimeJeOS" displayname="Bob">
+<image schemaversion="7.5" name="LimeJeOS" displayname="Bob">
     <description type="system">
         <author>Marcus</author>
         <contact>ms@suse.com</contact>

--- a/test/data/isoboot/example-distribution-no-delete-section/config.xml
+++ b/test/data/isoboot/example-distribution-no-delete-section/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="initrd-isoboot-suse-13.2">
+<image schemaversion="7.5" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/isoboot/example-distribution/config.xml
+++ b/test/data/isoboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="initrd-isoboot-suse-13.2">
+<image schemaversion="7.5" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/oemboot/example-distribution/config.xml
+++ b/test/data/oemboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.4" name="initrd-oemboot-suse-13.2">
+<image schemaversion="7.5" name="initrd-oemboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/unit/container/oci_test.py
+++ b/test/unit/container/oci_test.py
@@ -32,7 +32,7 @@ class TestContainerImageOCI:
         self.oci = ContainerImageOCI(
             'root_dir', 'docker-archive', {
                 'container_name': 'foo/bar',
-                'additional_tags': ['current', 'foobar']
+                'additional_names': [':current', 'name:foobar', 'newname']
             }
         )
 
@@ -49,7 +49,7 @@ class TestContainerImageOCI:
         custom_args = {
             'container_name': 'foo',
             'container_tag': '1.0',
-            'additional_tags': ['current', 'foobar'],
+            'additional_names': ['current', 'foobar'],
             'entry_command': ['/bin/bash', '-x'],
             'entry_subcommand': ['ls', '-l'],
             'maintainer': 'tux',
@@ -155,14 +155,14 @@ class TestContainerImageOCI:
         )
         mock_oci.repack.assert_called_once_with({
             'container_name': 'foo/bar',
-            'additional_tags': ['current', 'foobar'],
+            'additional_names': [':current', 'name:foobar', 'newname'],
             'container_tag': 'latest',
             'entry_subcommand': ['/bin/bash'],
             'history': {'created_by': 'KIWI {0}'.format(__version__)}
         })
         mock_oci.set_config.assert_called_once_with({
             'container_name': 'foo/bar',
-            'additional_tags': ['current', 'foobar'],
+            'additional_names': [':current', 'name:foobar', 'newname'],
             'container_tag': 'latest',
             'entry_subcommand': ['/bin/bash'],
             'history': {'created_by': 'KIWI {0}'.format(__version__)}
@@ -197,18 +197,18 @@ class TestContainerImageOCI:
         )
         mock_oci.repack.assert_called_once_with({
             'container_name': 'foo/bar',
-            'additional_tags': ['current', 'foobar'],
+            'additional_names': [':current', 'name:foobar', 'newname'],
             'container_tag': 'latest',
             'history': {'created_by': 'KIWI {0}'.format(__version__)}
         })
         mock_oci.set_config.assert_called_once_with({
             'container_name': 'foo/bar',
-            'additional_tags': ['current', 'foobar'],
+            'additional_names': [':current', 'name:foobar', 'newname'],
             'container_tag': 'latest',
             'history': {'created_by': 'KIWI {0}'.format(__version__)}
         })
         mock_oci.post_process.assert_called_once_with()
         mock_oci.export_container_image.assert_called_once_with(
             'result.tar', 'docker-archive', 'foo/bar:latest',
-            ['foo/bar:current', 'foo/bar:foobar']
+            ['foo/bar:current', 'name:foobar', 'newname:latest']
         )

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -845,7 +845,7 @@ class TestXMLState:
             'entry_subcommand': ['ls', '-l'],
             'container_name': 'container_name',
             'container_tag': 'container_tag',
-            'additional_tags': ['current', 'foobar'],
+            'additional_names': ['current', 'foobar'],
             'workingdir': '/root',
             'environment': {
                 'PATH': '/bin:/usr/bin:/home/user/bin',


### PR DESCRIPTION
Docker containers used to support the attribute `additionaltags` which was used to provide multiple tags for the same image. Since only tags were supported this commit renames the attribute to `additionalnames` and now supports tags and names witht he following syntax:

* `<name>:<tag>` -> adds a full docker image reference including name and tag
* `:<tag>` -> adds an additional tag while reusing the former name
* `<name>` -> adds an additional name while reusing the former tag

Fixes #2045

Signed-off-by: David Cassany <dcassany@suse.com>
