### PR TITLE
Move scope of veritysetup

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -586,45 +586,10 @@ overlayroot_verity_blocks="number|all"
   from the number of given blocks (or all) placed at the end of the squashfs
   compressed read-only root filesystem. For later verification of the device,
   the credentials information produced by `veritysetup` from the
-  cryptsetup tools, is created as a file in `/boot/overlayroot.verity`
-  and is stored as such into the image by default. The verification
-  file contents looks like the following example:
-
-  .. code:: bash
-
-     Hash type:         1
-     Data blocks:       10
-     Data block size:   4096
-     Hash block size:   4096
-     Hash algorithm:    sha256
-     Salt:              -SECRET-
-     Root hash:         -SECRET-
-     PARTUUID:          56d4ec24-393b-4ef5-af6b-6a8e1130b2c6
-     Root hashoffset:   226885632
-     Superblock:        --no-superblock
-
-  For verification of the device using the above information the
-  following `veritysetup` call is required
-
-  .. code:: bash
-
-     veritysetup verify \
-         /dev/matching[PARTUUID] /dev/matching[PARTUUID] \
-         "Value of Root hash:" \
-         --debug \
-         --no-superblock \
-         --salt="Value of Salt:" \
-         --data-blocks="Value of Data Blocks:" \
-         --hash-offset="Value of Root hashoffset:"
-
-  .. note::
-
-     It is a responsibility of the author of the image description
-     how to handle the credentials file in the desired way. The
-     standard way of {kiwi} to place it in `/boot` is most probably
-     not appropriate. One option to handle the credentials data is
-     as part of a `disk.sh` script which would allow to access and
-     manage the information in a custom way.
+  cryptsetup tools are needed. This data as of now is only printed
+  as debugging information to the build log file. A concept to
+  persistently store the verification metadata as part of the
+  partition(s) will be a next step.
 
 overlayroot_write_partition="true|false"
   For the `oem` type only, allows to specify if the extra read-write

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -25,7 +25,6 @@ from typing import (
 import kiwi.defaults as defaults
 
 from kiwi.utils.temporary import Temporary
-from kiwi.utils.veritysetup import VeritySetup
 from kiwi.system.mount import ImageSystem
 from kiwi.storage.disk import ptable_entry_type
 from kiwi.defaults import Defaults
@@ -1187,27 +1186,10 @@ class DiskBuilder:
             )
 
             if self.root_filesystem_verity_blocks:
-                veritysetup = VeritySetup(
-                    squashed_root_file.name,
+                squashed_root.create_verity_layer(
                     self.root_filesystem_verity_blocks if
                     self.root_filesystem_verity_blocks != 'all' else None
                 )
-                log.info(
-                    '--> Creating dm verity hash ({0} blocks)...'.format(
-                        self.root_filesystem_verity_blocks
-                    )
-                )
-                veritysetup.format()
-                if system_boot:
-                    veritysetup.store_credentials(
-                        '{0}/overlayroot.verity'.format(
-                            system_boot.get_mountpoint()
-                        ), BlockID(device_map['readonly'].get_device())
-                    )
-                else:
-                    log.warning(
-                        'No write space for veritysetup credentials available'
-                    )
 
             readonly_target = device_map['readonly'].get_device()
             readonly_target_bytesize = device_map['readonly'].get_byte_size(

--- a/kiwi/filesystem/base.py
+++ b/kiwi/filesystem/base.py
@@ -28,6 +28,7 @@ from kiwi.utils.sync import DataSync
 from kiwi.mount_manager import MountManager
 from kiwi.command import Command
 from kiwi.storage.device_provider import DeviceProvider
+from kiwi.utils.veritysetup import VeritySetup
 
 from kiwi.exceptions import (
     KiwiFileSystemSyncError
@@ -67,7 +68,7 @@ class FileSystemBase:
 
         # filesystems created without a block device stores the result
         # filesystem file name here
-        self.filename = None
+        self.filename = ''
 
         self.custom_args: Dict = {}
         self.post_init(custom_args)
@@ -172,6 +173,21 @@ class FileSystemBase:
         )
         data.sync_data(
             exclude=exclude, options=Defaults.get_sync_options()
+        )
+
+    def create_verity_layer(self, blocks: Optional[int] = None):
+        veritysetup = VeritySetup(
+            self.filename if self.filename else
+            self.device_provider.get_device(),
+            blocks
+        )
+        log.info(
+            '--> Creating dm verity hash ({0} blocks)...'.format(
+                blocks or 'all'
+            )
+        )
+        log.debug(
+            '--> dm verity metadata: {0}'.format(veritysetup.format())
         )
 
     def umount(self):

--- a/kiwi/filesystem/clicfs.py
+++ b/kiwi/filesystem/clicfs.py
@@ -62,6 +62,7 @@ class FileSystemClicFs(FileSystemBase):
         :param string label: unused
         :param list exclude: unused
         """
+        self.filename = filename
         container_dir = Temporary(prefix='kiwi_clicfs.').new_dir()
         clicfs_container_filesystem = container_dir.name + '/fsdata.ext4'
         loop_provider = LoopDevice(
@@ -83,7 +84,7 @@ class FileSystemClicFs(FileSystemBase):
         del filesystem
 
         Command.run(
-            ['mkclicfs', clicfs_container_filesystem, filename]
+            ['mkclicfs', clicfs_container_filesystem, self.filename]
         )
 
     def _get_container_filesystem_size_mbytes(self):

--- a/kiwi/filesystem/isofs.py
+++ b/kiwi/filesystem/isofs.py
@@ -43,6 +43,7 @@ class FileSystemIsoFs(FileSystemBase):
         :param string label: unused
         :param list exclude: unused
         """
+        self.filename = filename
         meta_data = self.custom_args['meta_data']
         efi_mode = meta_data.get('efi_mode')
         ofw_mode = meta_data.get('ofw_mode')
@@ -58,4 +59,4 @@ class FileSystemIsoFs(FileSystemBase):
         if efi_loader:
             iso_tool.add_efi_loader_parameters(efi_loader)
 
-        iso_tool.create_iso(filename)
+        iso_tool.create_iso(self.filename)

--- a/kiwi/filesystem/squashfs.py
+++ b/kiwi/filesystem/squashfs.py
@@ -40,6 +40,7 @@ class FileSystemSquashFs(FileSystemBase):
         :param string label: unused
         :param list exclude: list of exclude dirs/files
         """
+        self.filename = filename
         exclude_options = []
         compression = self.custom_args.get('compression')
         if compression is None or compression == 'xz':
@@ -71,6 +72,7 @@ class FileSystemSquashFs(FileSystemBase):
 
         Command.run(
             [
-                'mksquashfs', self.root_dir, filename, '-noappend', '-b', '1M'
+                'mksquashfs', self.root_dir, self.filename,
+                '-noappend', '-b', '1M'
             ] + self.custom_args['create_options'] + exclude_options
         )

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 from collections import namedtuple
+from typing import Optional
 import logging
 import os
 
@@ -23,6 +24,7 @@ import os
 from kiwi.utils.temporary import Temporary
 from kiwi.command import Command
 from kiwi.storage.device_provider import DeviceProvider
+from kiwi.utils.veritysetup import VeritySetup
 from kiwi.mount_manager import MountManager
 from kiwi.utils.sync import DataSync
 from kiwi.path import Path
@@ -344,6 +346,19 @@ class VolumeManagerBase(DeviceProvider):
             data.sync_data(
                 options=Defaults.get_sync_options(), exclude=exclude
             )
+
+    def create_verity_layer(self, blocks: Optional[int] = None):
+        veritysetup = VeritySetup(
+            self.device_provider_root.get_device(), blocks
+        )
+        log.info(
+            '--> Creating dm verity hash ({0} blocks)...'.format(
+                blocks or 'all'
+            )
+        )
+        log.debug(
+            '--> dm verity metadata: {0}'.format(veritysetup.format())
+        )
 
     def set_property_readonly_root(self):
         """

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -558,45 +558,8 @@ class TestDiskBuilder:
     @patch('kiwi.builder.disk.Temporary.new_file')
     @patch('random.randrange')
     @patch('kiwi.builder.disk.BlockID')
-    @patch('kiwi.builder.disk.VeritySetup')
-    def test_create_disk_standard_root_is_overlay_no_verity_write_space(
-        self, mock_VeritySetup, mock_BlockID, mock_rand, mock_temp,
-        mock_getsize, mock_exists, mock_grub_dir, mock_command,
-        mock_squashfs, mock_fs, mock_DeviceProvider
-    ):
-        block_operation = Mock()
-        block_operation.get_blkid.return_value = 'partuuid'
-        block_operation.get_filesystem.return_value = 'ext3'
-        mock_BlockID.return_value = block_operation
-        self.disk_builder.root_filesystem_is_overlay = True
-        self.disk_builder.root_filesystem_has_write_partition = False
-        self.disk_builder.root_filesystem_verity_blocks = 'all'
-        self.disk_builder.volume_manager_name = None
-        self.disk_builder.initrd_system = 'dracut'
-        self.disk.public_partition_id_map = self.id_map
-        self.disk.public_partition_id_map['kiwi_ROPart'] = 1
-        # no boot space doesn't allow to write verity credentials
-        del self.device_map['boot']
-        m_open = mock_open()
-        with patch('builtins.open', m_open, create=True):
-            with self._caplog.at_level(logging.WARNING):
-                self.disk_builder.create_disk()
-                assert 'No write space for veritysetup credentials available' \
-                    in self._caplog.text
-
-    @patch('kiwi.builder.disk.DeviceProvider')
-    @patch('kiwi.builder.disk.FileSystem.new')
-    @patch('kiwi.builder.disk.FileSystemSquashFs')
-    @patch('kiwi.builder.disk.Command.run')
-    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
-    @patch('os.path.exists')
-    @patch('os.path.getsize')
-    @patch('kiwi.builder.disk.Temporary.new_file')
-    @patch('random.randrange')
-    @patch('kiwi.builder.disk.BlockID')
-    @patch('kiwi.builder.disk.VeritySetup')
     def test_create_disk_standard_root_is_overlay(
-        self, mock_VeritySetup, mock_BlockID, mock_rand, mock_temp,
+        self, mock_BlockID, mock_rand, mock_temp,
         mock_getsize, mock_exists, mock_grub_dir, mock_command,
         mock_squashfs, mock_fs, mock_DeviceProvider
     ):
@@ -642,8 +605,8 @@ class TestDiskBuilder:
                 'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*', 'image/*'
             ], filename='kiwi-tempname')
         ]
+        squashfs.create_verity_layer.assert_called_once_with(10)
         self.disk.create_root_readonly_partition.assert_called_once_with(11)
-        mock_VeritySetup.return_value.format.assert_called_once_with()
         assert mock_command.call_args_list[2] == call(
             ['blockdev', '--getsize64', '/dev/readonly-root-device']
         )

--- a/test/unit/filesystem/base_test.py
+++ b/test/unit/filesystem/base_test.py
@@ -77,6 +77,11 @@ class TestFileSystemBase:
         filesystem_mount.mount.assert_called_once_with([])
         assert self.fsbase.get_mountpoint() == 'tmpdir'
 
+    @patch('kiwi.filesystem.base.VeritySetup')
+    def test_create_verity_layer(self, mock_VeritySetup):
+        self.fsbase.create_verity_layer()
+        mock_VeritySetup.return_value.format.assert_called_once_with()
+
     def test_umount(self):
         mount = mock.Mock()
         self.fsbase.filesystem_mount = mount

--- a/test/unit/utils/veritysetup_test.py
+++ b/test/unit/utils/veritysetup_test.py
@@ -1,4 +1,5 @@
 import io
+from textwrap import dedent
 from mock import (
     patch, Mock, MagicMock, call
 )
@@ -12,6 +13,16 @@ class TestVeritySetup:
         mock_os_path_getsize.return_value = 42
         self.veritysetup = VeritySetup('image_file', data_blocks=10)
         self.veritysetup_full = VeritySetup('image_file')
+        self.verity_dict = {
+            'UUID': '',
+            'Hashtype': '1',
+            'Datablocks': '10',
+            'Datablocksize': '4096',
+            'Hashblocksize': '4096',
+            'Hashalgorithm': 'sha256',
+            'Salt': 'fb074d1db50...',
+            'Roothash': 'e2728628377...'
+        }
 
     @patch('os.path.getsize')
     def setup_method(self, cls, mock_os_path_getsize):
@@ -29,7 +40,20 @@ class TestVeritySetup:
 
     @patch('kiwi.utils.veritysetup.Command.run')
     def test_format_full(self, mock_Command_run):
-        self.veritysetup_full.format()
+        verity_call = Mock()
+        verity_call.output = dedent('''\n
+            VERITY header information for mysquash.img
+            UUID:
+            Hash type:          1
+            Data blocks:        10
+            Data block size:    4096
+            Hash block size:    4096
+            Hash algorithm:     sha256
+            Salt:               fb074d1db50...
+            Root hash:          e2728628377...
+        ''')
+        mock_Command_run.return_value = verity_call
+        assert self.veritysetup_full.format() == self.verity_dict
         mock_Command_run.assert_called_once_with(
             [
                 'veritysetup', 'format', 'image_file', 'image_file',
@@ -39,6 +63,7 @@ class TestVeritySetup:
 
     def test_store_credentials(self):
         self.veritysetup.verity_call = Mock()
+        self.veritysetup.verity_dict = self.verity_dict
         target_block_id = Mock()
         target_block_id.get_blkid.return_value = 'uuid'
         with patch('builtins.open', create=True) as mock_open:
@@ -48,12 +73,27 @@ class TestVeritySetup:
                 'credentials_file', target_block_id
             )
         assert file_handle.write.call_args_list == [
-            call(self.veritysetup.verity_call.output.strip.return_value),
-            call('\n'),
-            call("PARTUUID: uuid"),
+            call('Datablocks: 10\n'),
+            call('Datablocksize: 4096\n'),
+            call('Hashalgorithm: sha256\n'),
+            call('Hashblocksize: 4096\n'),
+            call('Hashtype: 1\n'),
+            call('Roothash: e2728628377...\n'),
+            call('Salt: fb074d1db50...\n'),
+            call('UUID: \n'),
+            call('PARTUUID: uuid'),
             call('\n'),
             call('Root hashoffset: 42'),
             call('\n'),
             call('Superblock: --no-superblock'),
             call('\n')
         ]
+
+    @patch('kiwi.utils.veritysetup.BlockID')
+    def test_get_block_storage_filesystem(self, mock_BlockID):
+        block_id = Mock()
+        mock_BlockID.return_value = block_id
+        block_id.get_filesystem.return_value = 'ext3'
+        assert self.veritysetup.get_block_storage_filesystem() == 'ext3'
+        block_id.get_filesystem.side_effect = Exception
+        assert self.veritysetup.get_block_storage_filesystem() == ''

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -243,6 +243,11 @@ class TestVolumeManagerBase:
         )
         assert self.volume_manager.get_mountpoint() == 'mountpoint'
 
+    @patch('kiwi.volume_manager.base.VeritySetup')
+    def test_create_verity_layer(self, mock_VeritySetup):
+        self.volume_manager.create_verity_layer()
+        mock_VeritySetup.return_value.format.assert_called_once_with()
+
     @patch('kiwi.volume_manager.base.Temporary')
     def test_setup_mountpoint(self, mock_Temporary):
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'


### PR DESCRIPTION
veritysetup was called as part of the disk builder.
However the veritysetup should be a responsibility of
the classes which implements the sync_data method.
This allows to use the creation of a verity hash right
after sync as a feature to these classes and in a broader
scope


