### PR TITLE
Fix github action running obs service refresh

### DIFF
--- a/helper/update_obs_services.sh
+++ b/helper/update_obs_services.sh
@@ -14,6 +14,6 @@ while read -r build_test; do
     curl_target="${api_target}?project=${project}&package=${package}"
 
     echo "Updating Test: ${package} for: ${project}"
-    curl --fail-with-body -H "Authorization: Token ${api_token}" \
+    curl -H "Authorization: Token ${api_token}" \
         -X POST "${curl_target}"
 done < <(find build-tests -name "appliance.kiwi")


### PR DESCRIPTION
The curl command to send the POST request for running the
obs remote service uses the --fail-with-body option.
Unfortunately the ubuntu-latest container used to run the
action comes with a curl version that does not support the
option. Thus this commit removes the use of the option

