### PR TITLE
Don't bind mount /run during build time

### DIFF
--- a/kiwi/system/root_bind.py
+++ b/kiwi/system/root_bind.py
@@ -69,8 +69,7 @@ class RootBind:
             '/proc',
             '/dev',
             '/var/run/dbus',
-            '/sys',
-            '/run'
+            '/sys'
         ]
         # share the following directory with the host
         self.shared_location = '/' + Defaults.get_shared_cache_location()


### PR DESCRIPTION
In commit #9512318 a new bind mount of /run into the root tree
during build time was introduced. The bind mount was done because
in my tests running podman from config.sh it did not work without
/run bind mounted. However, it turned out that I was wrong because
along with the provided methods to prepare cgroups and a custom
runtime configuration method; setupContainerRuntime() it is not
needed to have /run bind mounted. Thus this commit deletes the
bind mount of /run and therefore Fixes #2067


