### PR TITLE
Add support for custom size in filesystem classes

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -35,7 +35,32 @@ from kiwi.version import (
 
 from kiwi.exceptions import KiwiBootLoaderGrubDataError
 
+shim_loader_type = NamedTuple(
+    'shim_loader_type', [
+        ('filename', str),
+        ('binaryname', str)
+    ]
+)
+
+grub_loader_type = NamedTuple(
+    'grub_loader_type', [
+        ('filename', str),
+        ('binaryname', str)
+    ]
+)
+
+unit_type = NamedTuple(
+    'unit_type', [
+        ('byte', str),
+        ('kb', str),
+        ('mb', str),
+        ('gb', str)
+    ]
+)
+
+
 # Default module variables
+UNIT = unit_type(byte='b', kb='k', mb='m', gb='g')
 POST_DISK_SYNC_SCRIPT = 'disk.sh'
 PRE_DISK_SYNC_SCRIPT = 'pre_disk_sync.sh'
 POST_BOOTSTRAP_SCRIPT = 'post_bootstrap.sh'
@@ -51,20 +76,6 @@ CUSTOM_RUNTIME_CONFIG_FILE = None
 PLATFORM_MACHINE = platform.machine()
 
 log = logging.getLogger('kiwi')
-
-shim_loader_type = NamedTuple(
-    'shim_loader_type', [
-        ('filename', str),
-        ('binaryname', str)
-    ]
-)
-
-grub_loader_type = NamedTuple(
-    'grub_loader_type', [
-        ('filename', str),
-        ('binaryname', str)
-    ]
-)
 
 
 class Defaults:

--- a/kiwi/filesystem/btrfs.py
+++ b/kiwi/filesystem/btrfs.py
@@ -16,6 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
+import kiwi.defaults as defaults
+
 from kiwi.command import Command
 from kiwi.filesystem.base import FileSystemBase
 
@@ -24,16 +26,32 @@ class FileSystemBtrfs(FileSystemBase):
     """
     **Implements creation of btrfs filesystem**
     """
-    def create_on_device(self, label: str = None):
+    def create_on_device(
+        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb
+    ):
         """
         Create btrfs filesystem on block device
 
-        :param string label: label name
+        :param str label: label name
+        :param int size:
+            size value, can also be counted from the end via -X
+            The value is interpreted in units of: unit
+        :param str unit:
+            unit name. Default unit is set to: defaults.UNIT.kb
         """
         device = self.device_provider.get_device()
         if label:
             self.custom_args['create_options'].append('-L')
             self.custom_args['create_options'].append(label)
+        if size:
+            self.custom_args['create_options'].append('--byte-count')
+            self.custom_args['create_options'].append(
+                self._fs_size(
+                    size=self._map_size(
+                        size, from_unit=unit, to_unit=defaults.UNIT.byte
+                    ), unit=defaults.UNIT.byte
+                )
+            )
         Command.run(
             ['mkfs.btrfs'] + self.custom_args['create_options'] + [device]
         )

--- a/kiwi/filesystem/ext2.py
+++ b/kiwi/filesystem/ext2.py
@@ -16,6 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 
 # project
+import kiwi.defaults as defaults
+
 from kiwi.filesystem.base import FileSystemBase
 from kiwi.command import Command
 
@@ -24,16 +26,31 @@ class FileSystemExt2(FileSystemBase):
     """
     **Implements creation of ext2 filesystem**
     """
-    def create_on_device(self, label: str = None):
+    def create_on_device(
+        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb
+    ):
         """
         Create ext2 filesystem on block device
 
-        :param string label: label name
+        :param str label: label name
+        :param int size:
+            size value, can also be counted from the end via -X
+            The value is interpreted in units of: unit
+        :param str unit:
+            unit name. Default unit is set to: defaults.UNIT.kb
         """
-        device = self.device_provider.get_device()
+        device_args = [self.device_provider.get_device()]
         if label:
             self.custom_args['create_options'].append('-L')
             self.custom_args['create_options'].append(label)
+        if size:
+            device_args.append(
+                self._fs_size(
+                    size=self._map_size(
+                        size, from_unit=unit, to_unit=defaults.UNIT.kb
+                    ), unit=defaults.UNIT.kb
+                )
+            )
         Command.run(
-            ['mkfs.ext2'] + self.custom_args['create_options'] + [device]
+            ['mkfs.ext2'] + self.custom_args['create_options'] + device_args
         )

--- a/kiwi/filesystem/ext3.py
+++ b/kiwi/filesystem/ext3.py
@@ -16,6 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 
 # project
+import kiwi.defaults as defaults
+
 from kiwi.filesystem.base import FileSystemBase
 from kiwi.command import Command
 
@@ -24,16 +26,31 @@ class FileSystemExt3(FileSystemBase):
     """
     **Implements creation of ext3 filesystem**
     """
-    def create_on_device(self, label: str = None):
+    def create_on_device(
+        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb
+    ):
         """
         Create ext3 filesystem on block device
 
-        :param string label: label name
+        :param str label: label name
+        :param int size:
+            size value, can also be counted from the end via -X
+            The value is interpreted in units of: unit
+        :param str unit:
+            unit name. Default unit is set to: defaults.UNIT.kb
         """
-        device = self.device_provider.get_device()
+        device_args = [self.device_provider.get_device()]
         if label:
             self.custom_args['create_options'].append('-L')
             self.custom_args['create_options'].append(label)
+        if size:
+            device_args.append(
+                self._fs_size(
+                    size=self._map_size(
+                        size, from_unit=unit, to_unit=defaults.UNIT.kb
+                    ), unit=defaults.UNIT.kb
+                )
+            )
         Command.run(
-            ['mkfs.ext3'] + self.custom_args['create_options'] + [device]
+            ['mkfs.ext3'] + self.custom_args['create_options'] + device_args
         )

--- a/kiwi/filesystem/ext4.py
+++ b/kiwi/filesystem/ext4.py
@@ -16,6 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 
 # project
+import kiwi.defaults as defaults
+
 from kiwi.filesystem.base import FileSystemBase
 from kiwi.command import Command
 
@@ -24,16 +26,31 @@ class FileSystemExt4(FileSystemBase):
     """
     **Implements creation of ext4 filesystem**
     """
-    def create_on_device(self, label: str = None):
+    def create_on_device(
+        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb
+    ):
         """
         Create ext4 filesystem on block device
 
-        :param string label: label name
+        :param str label: label name
+        :param int size:
+            size value, can also be counted from the end via -X
+            The value is interpreted in units of: unit
+        :param str unit:
+            unit name. Default unit is set to: defaults.UNIT.kb
         """
-        device = self.device_provider.get_device()
+        device_args = [self.device_provider.get_device()]
         if label:
             self.custom_args['create_options'].append('-L')
             self.custom_args['create_options'].append(label)
+        if size:
+            device_args.append(
+                self._fs_size(
+                    size=self._map_size(
+                        size, from_unit=unit, to_unit=defaults.UNIT.kb
+                    ), unit=defaults.UNIT.kb
+                )
+            )
         Command.run(
-            ['mkfs.ext4'] + self.custom_args['create_options'] + [device]
+            ['mkfs.ext4'] + self.custom_args['create_options'] + device_args
         )

--- a/kiwi/filesystem/fat16.py
+++ b/kiwi/filesystem/fat16.py
@@ -16,6 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 
 # project
+import kiwi.defaults as defaults
+
 from kiwi.filesystem.base import FileSystemBase
 from kiwi.command import Command
 
@@ -24,18 +26,33 @@ class FileSystemFat16(FileSystemBase):
     """
     **Implements creation of fat16 filesystem**
     """
-    def create_on_device(self, label: str = None):
+    def create_on_device(
+        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb
+    ):
         """
         Create fat16 filesystem on block device
 
-        :param string label: label name
+        :param str label: label name
+        :param int size:
+            size value, can also be counted from the end via -X
+            The value is interpreted in units of: unit
+        :param str unit:
+            unit name. Default unit is set to: defaults.UNIT.kb
         """
-        device = self.device_provider.get_device()
+        device_args = [self.device_provider.get_device()]
         if label:
             self.custom_args['create_options'].append('-n')
             self.custom_args['create_options'].append(label)
+        if size:
+            device_args.append(
+                self._fs_size(
+                    size=self._map_size(
+                        size, from_unit=unit, to_unit=defaults.UNIT.kb
+                    ), unit=defaults.UNIT.kb
+                )
+            )
         Command.run(
             [
                 'mkdosfs', '-F16', '-I'
-            ] + self.custom_args['create_options'] + [device]
+            ] + self.custom_args['create_options'] + device_args
         )

--- a/kiwi/filesystem/fat32.py
+++ b/kiwi/filesystem/fat32.py
@@ -16,26 +16,43 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 
 # project
+import kiwi.defaults as defaults
+
 from kiwi.filesystem.base import FileSystemBase
 from kiwi.command import Command
 
 
 class FileSystemFat32(FileSystemBase):
     """
-    **Implements creation of fat16 filesystem**
+    **Implements creation of fat32 filesystem**
     """
-    def create_on_device(self, label: str = None):
+    def create_on_device(
+        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb
+    ):
         """
         Create fat32 filesystem on block device
 
-        :param string label: label name
+        :param str label: label name
+        :param int size:
+            size value, can also be counted from the end via -X
+            The value is interpreted in units of: unit
+        :param str unit:
+            unit name. Default unit is set to: defaults.UNIT.kb
         """
-        device = self.device_provider.get_device()
+        device_args = [self.device_provider.get_device()]
         if label:
             self.custom_args['create_options'].append('-n')
             self.custom_args['create_options'].append(label)
+        if size:
+            device_args.append(
+                self._fs_size(
+                    size=self._map_size(
+                        size, from_unit=unit, to_unit=defaults.UNIT.kb
+                    ), unit=defaults.UNIT.kb
+                )
+            )
         Command.run(
             [
                 'mkdosfs', '-F32', '-I'
-            ] + self.custom_args['create_options'] + [device]
+            ] + self.custom_args['create_options'] + device_args
         )

--- a/kiwi/filesystem/swap.py
+++ b/kiwi/filesystem/swap.py
@@ -16,6 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 
 # project
+import kiwi.defaults as defaults
+
 from kiwi.filesystem.base import FileSystemBase
 from kiwi.command import Command
 
@@ -24,11 +26,15 @@ class FileSystemSwap(FileSystemBase):
     """
     **Implements creation of swap space**
     """
-    def create_on_device(self, label: str = None):
+    def create_on_device(
+        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb
+    ):
         """
         Create swap space on block device
 
         :param string label: label name
+        :param int size: unused
+        :param str unit: unused
         """
         device = self.device_provider.get_device()
         if label:

--- a/kiwi/filesystem/xfs.py
+++ b/kiwi/filesystem/xfs.py
@@ -16,6 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
+import kiwi.defaults as defaults
+
 from kiwi.filesystem.base import FileSystemBase
 from kiwi.command import Command
 
@@ -24,16 +26,35 @@ class FileSystemXfs(FileSystemBase):
     """
     **Implements creation of xfs filesystem**
     """
-    def create_on_device(self, label: str = None):
+    def create_on_device(
+        self, label: str = None, size: int = 0,
+        unit: str = defaults.UNIT.kb
+    ):
         """
         Create xfs filesystem on block device
 
-        :param string label: label name
+        :param str label: label name
+        :param int size:
+            size value, can also be counted from the end via -X
+            The value is interpreted in units of: unit
+        :param str unit:
+            unit name. Default unit is set to: defaults.UNIT.kb
         """
         device = self.device_provider.get_device()
         if label:
             self.custom_args['create_options'].append('-L')
             self.custom_args['create_options'].append(label)
+        if size:
+            self.custom_args['create_options'].append('-d')
+            self.custom_args['create_options'].append(
+                'size={0}k'.format(
+                    self._fs_size(
+                        size=self._map_size(
+                            size, from_unit=unit, to_unit=defaults.UNIT.kb
+                        ), unit=defaults.UNIT.kb
+                    )
+                )
+            )
         Command.run(
             ['mkfs.xfs', '-f'] + self.custom_args['create_options'] + [device]
         )

--- a/test/unit/filesystem/btrfs_test.py
+++ b/test/unit/filesystem/btrfs_test.py
@@ -24,7 +24,11 @@ class TestFileSystemBtrfs:
 
     @patch('kiwi.filesystem.btrfs.Command.run')
     def test_create_on_device(self, mock_command):
-        self.btrfs.create_on_device('label')
+        self.btrfs.create_on_device('label', 100)
         call = mock_command.call_args_list[0]
-        assert mock_command.call_args_list[0] == \
-            call(['mkfs.btrfs', '-L', 'label', '/dev/foo'])
+        assert mock_command.call_args_list[0] == call(
+            [
+                'mkfs.btrfs', '-L', 'label',
+                '--byte-count', '102400', '/dev/foo'
+            ]
+        )

--- a/test/unit/filesystem/ext2_test.py
+++ b/test/unit/filesystem/ext2_test.py
@@ -24,7 +24,7 @@ class TestFileSystemExt2:
 
     @patch('kiwi.filesystem.ext2.Command.run')
     def test_create_on_device(self, mock_command):
-        self.ext2.create_on_device('label')
+        self.ext2.create_on_device('label', 100)
         call = mock_command.call_args_list[0]
         assert mock_command.call_args_list[0] == \
-            call(['mkfs.ext2', '-L', 'label', '/dev/foo'])
+            call(['mkfs.ext2', '-L', 'label', '/dev/foo', '100'])

--- a/test/unit/filesystem/ext3_test.py
+++ b/test/unit/filesystem/ext3_test.py
@@ -24,7 +24,7 @@ class TestFileSystemExt3:
 
     @patch('kiwi.filesystem.ext3.Command.run')
     def test_create_on_device(self, mock_command):
-        self.ext3.create_on_device('label')
+        self.ext3.create_on_device('label', 100)
         call = mock_command.call_args_list[0]
         assert mock_command.call_args_list[0] == \
-            call(['mkfs.ext3', '-L', 'label', '/dev/foo'])
+            call(['mkfs.ext3', '-L', 'label', '/dev/foo', '100'])

--- a/test/unit/filesystem/ext4_test.py
+++ b/test/unit/filesystem/ext4_test.py
@@ -24,7 +24,7 @@ class TestFileSystemExt4:
 
     @patch('kiwi.filesystem.ext4.Command.run')
     def test_create_on_device(self, mock_command):
-        self.ext4.create_on_device('label')
+        self.ext4.create_on_device('label', 100)
         call = mock_command.call_args_list[0]
         assert mock_command.call_args_list[0] == \
-            call(['mkfs.ext4', '-L', 'label', '/dev/foo'])
+            call(['mkfs.ext4', '-L', 'label', '/dev/foo', '100'])

--- a/test/unit/filesystem/fat16_test.py
+++ b/test/unit/filesystem/fat16_test.py
@@ -24,7 +24,7 @@ class TestFileSystemFat16:
 
     @patch('kiwi.filesystem.fat16.Command.run')
     def test_create_on_device(self, mock_command):
-        self.fat16.create_on_device('label')
+        self.fat16.create_on_device('label', 100)
         call = mock_command.call_args_list[0]
         assert mock_command.call_args_list[0] == \
-            call(['mkdosfs', '-F16', '-I', '-n', 'label', '/dev/foo'])
+            call(['mkdosfs', '-F16', '-I', '-n', 'label', '/dev/foo', '100'])

--- a/test/unit/filesystem/fat32_test.py
+++ b/test/unit/filesystem/fat32_test.py
@@ -24,7 +24,7 @@ class TestFileSystemFat32:
 
     @patch('kiwi.filesystem.fat32.Command.run')
     def test_create_on_device(self, mock_command):
-        self.fat32.create_on_device('label')
+        self.fat32.create_on_device('label', 100)
         call = mock_command.call_args_list[0]
         assert mock_command.call_args_list[0] == \
-            call(['mkdosfs', '-F32', '-I', '-n', 'label', '/dev/foo'])
+            call(['mkdosfs', '-F32', '-I', '-n', 'label', '/dev/foo', '100'])

--- a/test/unit/filesystem/xfs_test.py
+++ b/test/unit/filesystem/xfs_test.py
@@ -24,7 +24,10 @@ class TestFileSystemXfs:
 
     @patch('kiwi.filesystem.xfs.Command.run')
     def test_create_on_device(self, mock_command):
-        self.xfs.create_on_device('label')
+        self.xfs.create_on_device('label', 100)
         call = mock_command.call_args_list[0]
-        assert mock_command.call_args_list[0] == \
-            call(['mkfs.xfs', '-f', '-L', 'label', '/dev/foo'])
+        assert mock_command.call_args_list[0] == call(
+            [
+                'mkfs.xfs', '-f', '-L', 'label', '-d', 'size=100k', '/dev/foo'
+            ]
+        )


### PR DESCRIPTION
Allow to create filesystems with an optional size parameter.
If no size is provided the filesystem gets as big as the device
which is the default and unchanged behavior. In addition a
size counting from the beginning (>0) as well as a size
counting from the end (<=0) can be provided.


