### PR TITLE
Added container build test for Fedora

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,6 @@ var/
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt

--- a/build-tests/x86/fedora/kiwi-settings/kiwi-settings.spec
+++ b/build-tests/x86/fedora/kiwi-settings/kiwi-settings.spec
@@ -1,0 +1,28 @@
+Name:           kiwi-settings
+Version:        1.1.1
+Release:        0
+License:        GPL-3.0-or-later
+%if "%{_vendor}" == "debbuild"
+Packager:       Marcus Schaefer <marcus.schaefer@gmail.com>
+%endif
+Summary:        KIWI - runtime config file
+Group:          System/Management
+Source:         %{name}-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+BuildArch:      noarch
+
+%description
+Provides a KIWI runtime config file suitable building
+the fedora based integrations test
+
+%prep
+%setup -q
+
+%install
+install -D -m 644 kiwi-settings/kiwi.yml %{buildroot}/etc/kiwi.yml
+
+%files
+%defattr(-,root,root)
+%config /etc/kiwi.yml
+
+%changelog

--- a/build-tests/x86/fedora/kiwi-settings/kiwi-settings/kiwi.yml
+++ b/build-tests/x86/fedora/kiwi-settings/kiwi-settings/kiwi.yml
@@ -1,0 +1,2 @@
+oci:
+  - archive_tool: buildah

--- a/build-tests/x86/fedora/test-image-docker/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-docker/appliance.kiwi
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="7.5" name="kiwi-test-image-docker">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>marcus.schaefer@gmail.com</contact>
+        <specification>docker test build</specification>
+    </description>
+    <preferences>
+        <version>1.34.0</version>
+        <packagemanager>dnf</packagemanager>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>false</rpm-check-signatures>
+        <locale>en_US</locale>
+        <keytable>us</keytable>
+        <timezone>UTC</timezone>
+        <type image="docker">
+            <containerconfig name="jeos"/>
+        </type>
+    </preferences>
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
+    </users>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
+    </repository>
+    <packages type="image">
+        <package name="selinux-policy-targeted"/>
+        <package name="dhclient"/>
+        <package name="glibc-all-langpacks"/>
+        <package name="vim"/>
+        <package name="tzdata"/>
+        <package name="NetworkManager"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="filesystem"/>
+        <package name="basesystem"/>
+        <package name="fedora-release"/>
+    </packages>
+</image>


### PR DESCRIPTION
Fedora systems uses buildah to create containers. There is
no integration test for kiwi which tests building containers
with buildah. This commit adds a build test to cover this
path. Related to Issue #2020


