### PR TITLE
Allow Btrfs and XFS as options for the boot partition filesystem

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -614,7 +614,7 @@ overlayroot_readonly_partsize="mbsize"
   If the value can be provided beforehand this also speeds
   up the build process significantly
 
-bootfilesystem="ext2|ext3|ext4|fat32|fat16":
+bootfilesystem="btrfs|ext2|ext3|ext4|xfs|fat32|fat16":
   If an extra boot partition is required this attribute
   specify which filesystem should be used for it. The
   type of the selected bootloader might overwrite this

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1631,7 +1631,7 @@ div {
         ## type of the bootloader might overwrite this setting
         ## e.g for the syslinux loader fat is required
         attribute bootfilesystem {
-            "ext2" | "ext3" | "ext4" | "fat32" | "fat16"
+            "btrfs" | "ext2" | "ext3" | "ext4" | "xfs" | "fat32" | "fat16"
         }
         >> sch:pattern [ id = "bootfilesystem" is-a = "image_type"
             sch:param [ name = "attr" value = "bootfilesystem" ]

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2361,9 +2361,11 @@ specify which filesystem should be used for it. The
 type of the bootloader might overwrite this setting
 e.g for the syslinux loader fat is required</a:documentation>
         <choice>
+          <value>btrfs</value>
           <value>ext2</value>
           <value>ext3</value>
           <value>ext4</value>
+          <value>xfs</value>
           <value>fat32</value>
           <value>fat16</value>
         </choice>


### PR DESCRIPTION
We already do this implicitly when we do not define this attribute
and request a boot partition, so let us explicitly offer these as
options too.
