### PR TITLE
Include /run subdirectories in container images

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -787,6 +787,11 @@ derived_from="string":
   The image created by {kiwi} will use the specified container as the
   base root to work on.
 
+ensure_empty_tmpdirs="true|false":
+  For OCI container images, specifies whether to ensure /run and /tmp
+  directories are empty in the container image created by Kiwi.
+  Default is true.
+
 publisher="string":
   For ISO images, specifies the publisher name of the ISO.
 

--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -55,6 +55,7 @@ class ContainerBuilder:
         self.requested_container_type = xml_state.get_build_type_name()
         self.base_image = None
         self.base_image_md5 = None
+        self.ensure_empty_tmpdirs = True
 
         self.container_config['xz_options'] = \
             self.custom_args.get('xz_options')
@@ -83,6 +84,9 @@ class ContainerBuilder:
                         self.base_image_md5
                     )
                 )
+
+        if xml_state.build_type.get_ensure_empty_tmpdirs() is False:
+            self.ensure_empty_tmpdirs = False
 
         self.system_setup = SystemSetup(
             xml_state=xml_state, root_dir=self.root_dir
@@ -140,7 +144,7 @@ class ContainerBuilder:
             self.requested_container_type, self.root_dir, self.container_config
         )
         self.filename = container_image.create(
-            self.filename, self.base_image
+            self.filename, self.base_image, self.ensure_empty_tmpdirs
         )
         Result.verify_image_size(
             self.runtime_config.get_max_size_constraint(),

--- a/kiwi/container/appx.py
+++ b/kiwi/container/appx.py
@@ -68,12 +68,13 @@ class ContainerImageAppx:
                 )
             )
 
-    def create(self, filename, base_image=None):
+    def create(self, filename, base_image=None, ensure_empty_tmpdirs=None):
         """
         Create WSL/Appx archive
 
         :param string filename: archive file name
         :param string base_image: not-supported
+        :param string ensure_empty_tmpdirs: not-supported
         """
         exclude_list = Defaults.\
             get_exclude_list_for_root_data_sync() + Defaults.\

--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -97,7 +97,7 @@ class ContainerImageOCI:
             self.oci_config['history']['created_by'] = \
                 Defaults.get_default_container_created_by()
 
-    def create(self, filename, base_image):
+    def create(self, filename, base_image, ensure_empty_tmpdirs=True):
         """
         Create compressed oci system container tar archive
 
@@ -105,7 +105,7 @@ class ContainerImageOCI:
         :param string base_image: archive used as a base image
         """
         exclude_list = Defaults.\
-            get_exclude_list_for_root_data_sync() + Defaults.\
+            get_exclude_list_for_root_data_sync(ensure_empty_tmpdirs) + Defaults.\
             get_exclude_list_from_custom_exclude_files(self.root_dir)
         exclude_list.append('dev/*')
         exclude_list.append('sys/*')

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -336,7 +336,7 @@ class Defaults:
         ]
 
     @staticmethod
-    def get_exclude_list_for_root_data_sync():
+    def get_exclude_list_for_root_data_sync(no_tmpdirs: bool = True):
         """
         Provides the list of files or folders that are created
         by KIWI for its own purposes. Those files should be not
@@ -347,7 +347,11 @@ class Defaults:
         :rtype: list
         """
         exclude_list = [
-            'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+            'image', '.profile', '.kconfig'
+        ]
+        if no_tmpdirs:
+            exclude_list += ['run/*', 'tmp/*']
+        exclude_list += [
             Defaults.get_buildservice_env_name(),
             Defaults.get_shared_cache_location()
         ]

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1967,6 +1967,14 @@ div {
             sch:param [ name = "attr" value = "derived_from" ]
             sch:param [ name = "types" value = "docker oci" ]
         ]
+    k.type.ensure_empty_tmpdirs.attribute =
+        ## Whether to ensure /run and /tmp directories are empty in the
+        ## container image created by Kiwi.  Default is true.
+        attribute ensure_empty_tmpdirs { xsd:boolean }
+        >> sch:pattern [ id = "ensure_empty_tmpdirs" is-a = "image_type"
+            sch:param [ name = "attr" value = "ensure_empty_tmpdirs" ]
+            sch:param [ name = "types" value = "docker oci" ]
+        ]
     k.type.publisher.attribute =
         ## Specifies the publisher name of the ISO.
         attribute publisher { text }
@@ -2067,6 +2075,7 @@ div {
         k.type.volid.attribute? &
         k.type.wwid_wait_timeout.attribute? &
         k.type.derived_from.attribute? &
+        k.type.ensure_empty_tmpdirs.attribute? &
         k.type.xen_server.attribute? &
         k.type.publisher.attribute? &
         k.type.disk_start_sector.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2826,6 +2826,17 @@ to work on.</a:documentation>
         <sch:param name="types" value="docker oci"/>
       </sch:pattern>
     </define>
+    <define name="k.type.ensure_empty_tmpdirs.attribute">
+      <attribute name="ensure_empty_tmpdirs">
+        <a:documentation>Whether to ensure /run and /tmp directories are empty in the
+container image created by Kiwi.  Default is true.</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="ensure_empty_tmpdirs" is-a="image_type">
+        <sch:param name="attr" value="ensure_empty_tmpdirs"/>
+        <sch:param name="types" value="docker oci"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.publisher.attribute">
       <attribute name="publisher">
         <a:documentation>Specifies the publisher name of the ISO.</a:documentation>
@@ -3062,6 +3073,9 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.derived_from.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.ensure_empty_tmpdirs.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.xen_server.attribute"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.29.24.
-# Python 3.6.15 (default, Sep 23 2021, 15:41:43) [GCC]
+# Python 3.8.12 (default, Aug 31 2021, 01:23:42) [GCC]
 #
 # Command line options:
 #   ('-f', '')
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/ms/Project/kiwi/.tox/3.6/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/tserong/src/github/OSInside/kiwi/.tox/3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -2798,7 +2798,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2864,6 +2864,7 @@ class type_(GeneratedsSuper):
         self.volid = _cast(None, volid)
         self.wwid_wait_timeout = _cast(int, wwid_wait_timeout)
         self.derived_from = _cast(None, derived_from)
+        self.ensure_empty_tmpdirs = _cast(bool, ensure_empty_tmpdirs)
         self.xen_server = _cast(bool, xen_server)
         self.publisher = _cast(None, publisher)
         self.disk_start_sector = _cast(int, disk_start_sector)
@@ -3097,6 +3098,8 @@ class type_(GeneratedsSuper):
     def set_wwid_wait_timeout(self, wwid_wait_timeout): self.wwid_wait_timeout = wwid_wait_timeout
     def get_derived_from(self): return self.derived_from
     def set_derived_from(self, derived_from): self.derived_from = derived_from
+    def get_ensure_empty_tmpdirs(self): return self.ensure_empty_tmpdirs
+    def set_ensure_empty_tmpdirs(self, ensure_empty_tmpdirs): self.ensure_empty_tmpdirs = ensure_empty_tmpdirs
     def get_xen_server(self): return self.xen_server
     def set_xen_server(self, xen_server): self.xen_server = xen_server
     def get_publisher(self): return self.publisher
@@ -3370,6 +3373,9 @@ class type_(GeneratedsSuper):
         if self.derived_from is not None and 'derived_from' not in already_processed:
             already_processed.add('derived_from')
             outfile.write(' derived_from=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.derived_from), input_name='derived_from')), ))
+        if self.ensure_empty_tmpdirs is not None and 'ensure_empty_tmpdirs' not in already_processed:
+            already_processed.add('ensure_empty_tmpdirs')
+            outfile.write(' ensure_empty_tmpdirs="%s"' % self.gds_format_boolean(self.ensure_empty_tmpdirs, input_name='ensure_empty_tmpdirs'))
         if self.xen_server is not None and 'xen_server' not in already_processed:
             already_processed.add('xen_server')
             outfile.write(' xen_server="%s"' % self.gds_format_boolean(self.xen_server, input_name='xen_server'))
@@ -3832,6 +3838,15 @@ class type_(GeneratedsSuper):
         if value is not None and 'derived_from' not in already_processed:
             already_processed.add('derived_from')
             self.derived_from = value
+        value = find_attr_value_('ensure_empty_tmpdirs', node)
+        if value is not None and 'ensure_empty_tmpdirs' not in already_processed:
+            already_processed.add('ensure_empty_tmpdirs')
+            if value in ('true', '1'):
+                self.ensure_empty_tmpdirs = True
+            elif value in ('false', '0'):
+                self.ensure_empty_tmpdirs = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('xen_server', node)
         if value is not None and 'xen_server' not in already_processed:
             already_processed.add('xen_server')

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -119,6 +119,17 @@ class TestDefaults:
                 '../data/root-dir'
             ) == []
 
+    def test_get_exclude_list_for_root_data_sync(self):
+        assert Defaults.get_exclude_list_for_root_data_sync() == [
+            'image', '.profile', '.kconfig',
+            'run/*', 'tmp/*',
+            '.buildenv', 'var/cache/kiwi'
+        ]
+        assert Defaults.get_exclude_list_for_root_data_sync(no_tmpdirs=False) == [
+            'image', '.profile', '.kconfig',
+            '.buildenv', 'var/cache/kiwi'
+        ]
+
     @patch('glob.iglob')
     def test_get_signed_grub_loader(self, mock_iglob):
         def iglob_no_matches(pattern):


### PR DESCRIPTION
Rather than excluding *everything* in /run, this commit ensures that the directory structure inside /run in the image root is preserved inside container images.  Files remain excluded (so we won't pick up transient pidfiles and such).  This change _only_ applies for container image builds.  All other build types remain unaffected (i.e. all other build types will still have an empty /run directory).

Fixes: https://github.com/OSInside/kiwi/issues/2093
Signed-off-by: Tim Serong <tserong@suse.com>