### PR TITLE
Allow luks format options

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -485,11 +485,15 @@ kernelcmdline="string":
   Additional kernel parameters passed to the kernel by the
   bootloader.
 
-luks="passphrase":
-  Supplying a value will trigger the encryption of the partitions
-  using the LUKS extension and using the provided string as the
-  password. Note that the password must be entered when booting the
-  appliance!
+luks="passphrase|file:///path/to/keyfile":
+  Supplying a value will trigger the encryption of the partition
+  serving the root filesystem using the LUKS extension. The supplied
+  value represents either the passphrase string or the location of
+  a key file if specified as `file://...` resource. When using
+  a key file it is in the responsibility of the user how
+  this key file is actually being used. By default any
+  distribution will just open an interactive dialog asking
+  for the credentials at boot time !
 
 target_blocksize="number":
   Specifies the image blocksize in bytes which has to
@@ -750,6 +754,33 @@ publisher="string":
 
 The following sections shows the supported child elements of the `type`
 element including references to their usage in a detailed type setup:
+
+.. _preferences-type-luksformat:
+
+<preferences><type><luksformat>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The `luksformat` element is used to specify additional luks options
+passed on to the `cryptsetup luksFormat` call. The element requires
+the attribute `luks` to be set in the `<type>` section referring to
+`luksformat`. Several custom settings related to the LUKS and LUKS2
+format features can be setup. For example, making the switch to `LUKS2`:
+
+.. code:: xml
+
+   <luksformat>
+     <option name="--type" value="luks2"/>
+   </luksformat>
+
+Or to enable additional device mapper layers and features,
+for example `dm_integrity`:
+
+.. code:: xml
+
+   <luksformat>
+     <option name="--type" value="luks2"/>
+     <option name="--cipher" value="aes-gcm-random"/>
+     <option name="--integrity" value="aead"/>
+   </luksformat>
 
 .. _preferences-type-bootloader:
 

--- a/doc/source/working_with_images/disk_setup_for_luks.rst
+++ b/doc/source/working_with_images/disk_setup_for_luks.rst
@@ -66,4 +66,9 @@ Update the {kiwi} image description as follows:
        The value for the `luks` attribute sets the master passphrase
        for the LUKS keyring. Therefore the XML description becomes
        security critical and should only be readable by trustworthy
-       people
+       people. Alternatively the credentials information can be
+       stored in a key file and referenced as:
+
+       .. code:: xml
+
+          <type luks="file:///path/to/keyfile"/>

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -114,7 +114,8 @@ class DiskBuilder:
         self.mdraid = xml_state.build_type.get_mdraid()
         self.hybrid_mbr = xml_state.build_type.get_gpt_hybrid_mbr()
         self.force_mbr = xml_state.build_type.get_force_mbr()
-        self.luks = xml_state.build_type.get_luks()
+        self.luks = xml_state.get_luks_credentials()
+        self.luks_format_options = xml_state.get_luks_format_options()
         self.luks_os = xml_state.build_type.get_luksOS()
         self.xen_server = xml_state.is_xen_server()
         self.requested_filesystem = xml_state.build_type.get_filesystem()
@@ -320,6 +321,7 @@ class DiskBuilder:
             luks_root.create_crypto_luks(
                 passphrase=self.luks,
                 os=self.luks_os,
+                options=self.luks_format_options,
                 keyfile=self.luks_boot_keyfile if luks_need_keyfile else ''
             )
             if luks_need_keyfile:

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -861,6 +861,25 @@ div {
 }
 
 #==========================================
+# common element <option>
+#
+div {
+    k.option.name.attribute =
+        attribute name { text }
+    k.option.value.attribute =
+        attribute value { text }
+    k.option.attlist =
+        k.option.name.attribute &
+        k.option.value.attribute?
+    k.option =
+        ## A commandline option specification
+        element option {
+            k.option.attlist,
+            empty
+        }
+}
+
+#==========================================
 # common element <package>
 #
 div {
@@ -1814,8 +1833,12 @@ div {
     k.type.luks.attribute =
         ## Setup cryptographic volume along with the given filesystem
         ## using the LUKS extension. The value of this attribute
-        ## represents the password string used to be able to
-        ## mount that filesystem while booting
+        ## represents either the password string or the location of
+        ## a key file if specified as file:// resource. When using
+        ## a key file it is in the responsibility of the user how
+        ## this key file is actually being used. By default any
+        ## distribution will just open an interactive dialog asking
+        ## for credentials at boot time.
         attribute luks { text }
         >> sch:pattern [ id = "luks" is-a = "image_type"
             sch:param [ name = "attr" value = "luks" ]
@@ -1827,7 +1850,7 @@ div {
         ## in order to create a format compatible to the specified
         ## distribution
         attribute luksOS {
-            "sle11"
+            "sle12"
         }
         >> sch:pattern [ id = "luksOS" is-a = "image_type"
             sch:param [ name = "attr" value = "luksOS" ]
@@ -2025,7 +2048,8 @@ div {
             k.systemdisk? &
             k.partitions? &
             k.vagrantconfig* &
-            k.installmedia?
+            k.installmedia? &
+            k.luksformat?
         }
 }
 
@@ -2735,6 +2759,29 @@ div {
         element partitions {
             k.partitions.attlist &
             k.partition+
+        }
+}
+
+#==========================================
+# main block: <luksformat>
+#
+div {
+    sch:pattern [
+        id = "luks_requirement"
+        sch:rule [
+            context = "luksformat"
+            sch:assert [
+                test = "../@luks"
+                "luks attribute must be set when using luksformat option(s)"
+            ]
+        ]
+    ]
+    k.luksformat.attlist = empty
+    k.luksformat =
+        ## luksFormat option settings
+        element luksformat {
+            k.luksformat.attlist &
+            k.option+
         }
 }
 

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1301,6 +1301,34 @@ the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
   </div>
   <!--
     ==========================================
+    common element <option>
+    
+  -->
+  <div>
+    <define name="k.option.name.attribute">
+      <attribute name="name"/>
+    </define>
+    <define name="k.option.value.attribute">
+      <attribute name="value"/>
+    </define>
+    <define name="k.option.attlist">
+      <interleave>
+        <ref name="k.option.name.attribute"/>
+        <optional>
+          <ref name="k.option.value.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="k.option">
+      <element name="option">
+        <a:documentation>A commandline option specification</a:documentation>
+        <ref name="k.option.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
     common element <package>
     
   -->
@@ -2633,8 +2661,12 @@ kernel command line options</a:documentation>
       <attribute name="luks">
         <a:documentation>Setup cryptographic volume along with the given filesystem
 using the LUKS extension. The value of this attribute
-represents the password string used to be able to
-mount that filesystem while booting</a:documentation>
+represents either the password string or the location of
+a key file if specified as file:// resource. When using
+a key file it is in the responsibility of the user how
+this key file is actually being used. By default any
+distribution will just open an interactive dialog asking
+for credentials at boot time.</a:documentation>
       </attribute>
       <sch:pattern id="luks" is-a="image_type">
         <sch:param name="attr" value="luks"/>
@@ -2647,7 +2679,7 @@ mount that filesystem while booting</a:documentation>
 and hash format options is passed to the cryptsetup call
 in order to create a format compatible to the specified
 distribution</a:documentation>
-        <value>sle11</value>
+        <value>sle12</value>
       </attribute>
       <sch:pattern id="luksOS" is-a="image_type">
         <sch:param name="attr" value="luksOS"/>
@@ -3035,6 +3067,9 @@ kiwi-ng result bundle ...</a:documentation>
           </zeroOrMore>
           <optional>
             <ref name="k.installmedia"/>
+          </optional>
+          <optional>
+            <ref name="k.luksformat"/>
           </optional>
         </interleave>
       </element>
@@ -4101,6 +4136,32 @@ of the storage device</a:documentation>
           <ref name="k.partitions.attlist"/>
           <oneOrMore>
             <ref name="k.partition"/>
+          </oneOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <luksformat>
+    
+  -->
+  <div>
+    <sch:pattern id="luks_requirement">
+      <sch:rule context="luksformat">
+        <sch:assert test="../@luks">luks attribute must be set when using luksformat option(s)</sch:assert>
+      </sch:rule>
+    </sch:pattern>
+    <define name="k.luksformat.attlist">
+      <empty/>
+    </define>
+    <define name="k.luksformat">
+      <element name="luksformat">
+        <a:documentation>luksFormat option settings</a:documentation>
+        <interleave>
+          <ref name="k.luksformat.attlist"/>
+          <oneOrMore>
+            <ref name="k.option"/>
           </oneOrMore>
         </interleave>
       </element>

--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -53,7 +53,7 @@ class DiskSetup:
         self.bootpart_mbytes = xml_state.build_type.get_bootpartsize()
         self.spare_part_mbytes = xml_state.get_build_type_spare_part_size()
         self.mdraid = xml_state.build_type.get_mdraid()
-        self.luks = xml_state.build_type.get_luks()
+        self.luks = xml_state.get_luks_credentials()
         self.volume_manager = xml_state.get_volume_management()
         self.bootloader = xml_state.get_build_type_bootloader_name()
         self.oemconfig = xml_state.get_build_type_oemconfig_section()

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -335,7 +335,7 @@ class Profile:
         self.dot_profile['kiwi_startsector'] = \
             self.xml_state.get_disk_start_sector()
         self.dot_profile['kiwi_luks_empty_passphrase'] = \
-            True if type_section.get_luks() == '' else False
+            self.xml_state.get_luks_credentials() == ''
 
     def _profile_names_to_profile(self):
         # kiwi_profiles

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -1762,6 +1762,86 @@ class product(GeneratedsSuper):
 # end class product
 
 
+class option(GeneratedsSuper):
+    """A commandline option specification"""
+    subclass = None
+    superclass = None
+    def __init__(self, name=None, value=None):
+        self.original_tagname_ = None
+        self.name = _cast(None, name)
+        self.value = _cast(None, value)
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, option)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if option.subclass:
+            return option.subclass(*args_, **kwargs_)
+        else:
+            return option(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_name(self): return self.name
+    def set_name(self, name): self.name = name
+    def get_value(self): return self.value
+    def set_value(self, value): self.value = value
+    def hasContent_(self):
+        if (
+
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', name_='option', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('option')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='option')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='option', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='option'):
+        if self.name is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
+        if self.value is not None and 'value' not in already_processed:
+            already_processed.add('value')
+            outfile.write(' value=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.value), input_name='value')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='option', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('name', node)
+        if value is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            self.name = value
+        value = find_attr_value_('value', node)
+        if value is not None and 'value' not in already_processed:
+            already_processed.add('value')
+            self.value = value
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        pass
+# end class option
+
+
 class package(GeneratedsSuper):
     """Name of an image Package"""
     subclass = None
@@ -2718,7 +2798,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2822,6 +2902,10 @@ class type_(GeneratedsSuper):
             self.installmedia = []
         else:
             self.installmedia = installmedia
+        if luksformat is None:
+            self.luksformat = []
+        else:
+            self.luksformat = luksformat
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -2878,6 +2962,11 @@ class type_(GeneratedsSuper):
     def add_installmedia(self, value): self.installmedia.append(value)
     def insert_installmedia_at(self, index, value): self.installmedia.insert(index, value)
     def replace_installmedia_at(self, index, value): self.installmedia[index] = value
+    def get_luksformat(self): return self.luksformat
+    def set_luksformat(self, luksformat): self.luksformat = luksformat
+    def add_luksformat(self, value): self.luksformat.append(value)
+    def insert_luksformat_at(self, index, value): self.luksformat.insert(index, value)
+    def replace_luksformat_at(self, index, value): self.luksformat[index] = value
     def get_boot(self): return self.boot
     def set_boot(self, boot): self.boot = boot
     def get_bootfilesystem(self): return self.bootfilesystem
@@ -3055,7 +3144,8 @@ class type_(GeneratedsSuper):
             self.systemdisk or
             self.partitions or
             self.vagrantconfig or
-            self.installmedia
+            self.installmedia or
+            self.luksformat
         ):
             return True
         else:
@@ -3303,6 +3393,8 @@ class type_(GeneratedsSuper):
             vagrantconfig_.export(outfile, level, namespaceprefix_, name_='vagrantconfig', pretty_print=pretty_print)
         for installmedia_ in self.installmedia:
             installmedia_.export(outfile, level, namespaceprefix_, name_='installmedia', pretty_print=pretty_print)
+        for luksformat_ in self.luksformat:
+            luksformat_.export(outfile, level, namespaceprefix_, name_='luksformat', pretty_print=pretty_print)
     def build(self, node):
         already_processed = set()
         self.buildAttributes(node, node.attrib, already_processed)
@@ -3784,6 +3876,11 @@ class type_(GeneratedsSuper):
             obj_.build(child_)
             self.installmedia.append(obj_)
             obj_.original_tagname_ = 'installmedia'
+        elif nodeName_ == 'luksformat':
+            obj_ = luksformat.factory()
+            obj_.build(child_)
+            self.luksformat.append(obj_)
+            obj_.original_tagname_ = 'luksformat'
 # end class type_
 
 
@@ -5945,6 +6042,87 @@ class partitions(GeneratedsSuper):
             self.partition.append(obj_)
             obj_.original_tagname_ = 'partition'
 # end class partitions
+
+
+class luksformat(GeneratedsSuper):
+    """luksFormat option settings"""
+    subclass = None
+    superclass = None
+    def __init__(self, option=None):
+        self.original_tagname_ = None
+        if option is None:
+            self.option = []
+        else:
+            self.option = option
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, luksformat)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if luksformat.subclass:
+            return luksformat.subclass(*args_, **kwargs_)
+        else:
+            return luksformat(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_option(self): return self.option
+    def set_option(self, option): self.option = option
+    def add_option(self, value): self.option.append(value)
+    def insert_option_at(self, index, value): self.option.insert(index, value)
+    def replace_option_at(self, index, value): self.option[index] = value
+    def hasContent_(self):
+        if (
+            self.option
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', name_='luksformat', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('luksformat')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='luksformat')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='luksformat', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='luksformat'):
+        pass
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='luksformat', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for option_ in self.option:
+            option_.export(outfile, level, namespaceprefix_, name_='option', pretty_print=pretty_print)
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        pass
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        if nodeName_ == 'option':
+            obj_ = option.factory()
+            obj_.build(child_)
+            self.option.append(obj_)
+            obj_.original_tagname_ = 'option'
+# end class luksformat
 
 
 class environment(GeneratedsSuper):
@@ -8584,9 +8762,11 @@ __all__ = [
     "k_source",
     "label",
     "labels",
+    "luksformat",
     "machine",
     "namedCollection",
     "oemconfig",
+    "option",
     "package",
     "packages",
     "partition",

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -58,7 +58,12 @@
         <type image="iso" firmware="efi"/>
     </preferences>
     <preferences profiles="vmxFlavour">
-        <type image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" fscreateoptions="-O ^has_journal" btrfs_root_is_snapshot="true" spare_part="200M" spare_part_fs_attributes="no-copy-on-write" xen_server="true" formatoptions="force_size,super=man" filesystem="ext4" installiso="true">
+        <type image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" fscreateoptions="-O ^has_journal" btrfs_root_is_snapshot="true" spare_part="200M" spare_part_fs_attributes="no-copy-on-write" xen_server="true" formatoptions="force_size,super=man" filesystem="ext4" installiso="true" luks="linux">
+            <luksformat>
+                <option name="--type" value="luks2"/>
+                <option name="--cipher" value="aes-gcm-random"/>
+                <option name="--integrity" value="aead"/>
+            </luksformat>
             <size unit="G" additive="true">1</size>
             <systemdisk name="mydisk"/>
             <machine memory="512" xen_loader="hvmloader">

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -768,7 +768,8 @@ class TestDiskBuilder:
             self.disk_builder.create_disk()
 
         self.luks_root.create_crypto_luks.assert_called_once_with(
-            passphrase='passphrase', os=None, keyfile='root_dir/.root.keyfile'
+            passphrase='passphrase', os=None,
+            options=[], keyfile='root_dir/.root.keyfile'
         )
         self.luks_root.create_crypttab.assert_called_once_with(
             'root_dir/etc/crypttab'


### PR DESCRIPTION
Added new luksformat element which allows to pass
along options to the luksFormat call. This allows users to
switch between LUKS and LUKS2 via e.g

```xml
<luksformat>
    <option name="--type" value="luks2"/>
</luksformat>
```

It also allows to pass along a set of options only available
to LUKS2, e.g

```xml
<luksformat>
    <option name="--cipher" value="aes-gcm-random"/>
    <option name="--integrity" value="aead"/>
</luksformat>
```

In addition to the new attribute the existing luks attribute
can also be specified to read credentials from a keyfile by
using the file:// source locator, e.g

```xml
<type ... luks="file:///path/to/a/keyfile"/>
```

This Fixes #1898