### PR TITLE
Add support for verity setup on standard rootfs

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -554,6 +554,16 @@ devicepersistency="by-uuid|by-label":
 squashfscompression="uncompressed|gzip|lzo|lz4|xz|zstd":
   Specifies the compression type for mksquashfs
 
+verity_blocks="number|all"
+  For the `oem` type only, specifies to create a dm verity hash
+  from the number of given blocks (or all) placed at the end of the
+  root filesystem For later verification of the device,
+  the credentials information produced by `veritysetup` from the
+  cryptsetup tools are needed. This data as of now is only printed
+  as debugging information to the build log file. A concept to
+  persistently store the verification metadata as part of the
+  partition(s) will be a next step.
+
 overlayroot="true|false"
   For the `oem` type only, specifies to use an `overlayfs` based root
   filesystem consisting out of a squashfs compressed read-only root
@@ -580,16 +590,6 @@ overlayroot="true|false"
   element is set to `true` an eventually given `<size>` element
   will not have any effect because the write partition will be
   resized on first boot to the available disk space.
-
-overlayroot_verity_blocks="number|all"
-  For the `oem` type only, specifies to create a dm verity hash
-  from the number of given blocks (or all) placed at the end of the squashfs
-  compressed read-only root filesystem. For later verification of the device,
-  the credentials information produced by `veritysetup` from the
-  cryptsetup tools are needed. This data as of now is only printed
-  as debugging information to the build log file. A concept to
-  persistently store the verification metadata as part of the
-  partition(s) will be a next step.
 
 overlayroot_write_partition="true|false"
   For the `oem` type only, allows to specify if the extra read-write

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -60,6 +60,8 @@ unit_type = NamedTuple(
 
 
 # Default module variables
+VERITY_DATA_BLOCKSIZE = 1024  # 1kb
+VERITY_HASH_BLOCKSIZE = 1024  # 1kb
 UNIT = unit_type(byte='b', kb='k', mb='m', gb='g')
 POST_DISK_SYNC_SCRIPT = 'disk.sh'
 PRE_DISK_SYNC_SCRIPT = 'pre_disk_sync.sh'

--- a/kiwi/filesystem/base.py
+++ b/kiwi/filesystem/base.py
@@ -110,7 +110,8 @@ class FileSystemBase:
             self.custom_args['fs_attributes'] = []
 
     def create_on_device(
-        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb
+        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb,
+        uuid: str = None
     ):
         """
         Create filesystem on block device
@@ -124,6 +125,7 @@ class FileSystemBase:
             The value is interpreted in units of: unit
         :param str unit:
             unit name. Default unit is set to: defaults.UNIT.kb
+        :param str uuid: UUID name
         """
         raise NotImplementedError
 
@@ -184,10 +186,12 @@ class FileSystemBase:
             exclude=exclude, options=Defaults.get_sync_options()
         )
 
-    def create_verity_layer(self, blocks: Optional[int] = None):
+    def create_verity_layer(
+        self, blocks: Optional[int] = None, filename: str = None
+    ):
+        on_file_name = filename or self.filename
         veritysetup = VeritySetup(
-            self.filename if self.filename else
-            self.device_provider.get_device(),
+            on_file_name or self.device_provider.get_device(),
             blocks
         )
         log.info(

--- a/kiwi/filesystem/btrfs.py
+++ b/kiwi/filesystem/btrfs.py
@@ -27,7 +27,8 @@ class FileSystemBtrfs(FileSystemBase):
     **Implements creation of btrfs filesystem**
     """
     def create_on_device(
-        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb
+        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb,
+        uuid: str = None
     ):
         """
         Create btrfs filesystem on block device
@@ -38,11 +39,15 @@ class FileSystemBtrfs(FileSystemBase):
             The value is interpreted in units of: unit
         :param str unit:
             unit name. Default unit is set to: defaults.UNIT.kb
+        :param str uuid: UUID name
         """
         device = self.device_provider.get_device()
         if label:
             self.custom_args['create_options'].append('-L')
             self.custom_args['create_options'].append(label)
+        if uuid:
+            self.custom_args['create_options'].append('-U')
+            self.custom_args['create_options'].append(uuid)
         if size:
             self.custom_args['create_options'].append('--byte-count')
             self.custom_args['create_options'].append(

--- a/kiwi/filesystem/ext2.py
+++ b/kiwi/filesystem/ext2.py
@@ -27,7 +27,8 @@ class FileSystemExt2(FileSystemBase):
     **Implements creation of ext2 filesystem**
     """
     def create_on_device(
-        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb
+        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb,
+        uuid: str = None
     ):
         """
         Create ext2 filesystem on block device
@@ -38,11 +39,15 @@ class FileSystemExt2(FileSystemBase):
             The value is interpreted in units of: unit
         :param str unit:
             unit name. Default unit is set to: defaults.UNIT.kb
+        :param str uuid: UUID name
         """
         device_args = [self.device_provider.get_device()]
         if label:
             self.custom_args['create_options'].append('-L')
             self.custom_args['create_options'].append(label)
+        if uuid:
+            self.custom_args['create_options'].append('-U')
+            self.custom_args['create_options'].append(uuid)
         if size:
             device_args.append(
                 self._fs_size(

--- a/kiwi/filesystem/ext3.py
+++ b/kiwi/filesystem/ext3.py
@@ -27,7 +27,8 @@ class FileSystemExt3(FileSystemBase):
     **Implements creation of ext3 filesystem**
     """
     def create_on_device(
-        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb
+        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb,
+        uuid: str = None
     ):
         """
         Create ext3 filesystem on block device
@@ -38,11 +39,15 @@ class FileSystemExt3(FileSystemBase):
             The value is interpreted in units of: unit
         :param str unit:
             unit name. Default unit is set to: defaults.UNIT.kb
+        :param str uuid: UUID name
         """
         device_args = [self.device_provider.get_device()]
         if label:
             self.custom_args['create_options'].append('-L')
             self.custom_args['create_options'].append(label)
+        if uuid:
+            self.custom_args['create_options'].append('-U')
+            self.custom_args['create_options'].append(uuid)
         if size:
             device_args.append(
                 self._fs_size(

--- a/kiwi/filesystem/ext4.py
+++ b/kiwi/filesystem/ext4.py
@@ -27,7 +27,8 @@ class FileSystemExt4(FileSystemBase):
     **Implements creation of ext4 filesystem**
     """
     def create_on_device(
-        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb
+        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb,
+        uuid: str = None
     ):
         """
         Create ext4 filesystem on block device
@@ -38,11 +39,15 @@ class FileSystemExt4(FileSystemBase):
             The value is interpreted in units of: unit
         :param str unit:
             unit name. Default unit is set to: defaults.UNIT.kb
+        :param str uuid: UUID name
         """
         device_args = [self.device_provider.get_device()]
         if label:
             self.custom_args['create_options'].append('-L')
             self.custom_args['create_options'].append(label)
+        if uuid:
+            self.custom_args['create_options'].append('-U')
+            self.custom_args['create_options'].append(uuid)
         if size:
             device_args.append(
                 self._fs_size(

--- a/kiwi/filesystem/fat16.py
+++ b/kiwi/filesystem/fat16.py
@@ -27,7 +27,8 @@ class FileSystemFat16(FileSystemBase):
     **Implements creation of fat16 filesystem**
     """
     def create_on_device(
-        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb
+        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb,
+        uuid: str = None
     ):
         """
         Create fat16 filesystem on block device
@@ -38,11 +39,15 @@ class FileSystemFat16(FileSystemBase):
             The value is interpreted in units of: unit
         :param str unit:
             unit name. Default unit is set to: defaults.UNIT.kb
+        :param str uuid: Volume Label, there is no real UUID on fat
         """
         device_args = [self.device_provider.get_device()]
         if label:
             self.custom_args['create_options'].append('-n')
             self.custom_args['create_options'].append(label)
+        if uuid:
+            self.custom_args['create_options'].append('-i')
+            self.custom_args['create_options'].append(uuid)
         if size:
             device_args.append(
                 self._fs_size(

--- a/kiwi/filesystem/fat32.py
+++ b/kiwi/filesystem/fat32.py
@@ -27,7 +27,8 @@ class FileSystemFat32(FileSystemBase):
     **Implements creation of fat32 filesystem**
     """
     def create_on_device(
-        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb
+        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb,
+        uuid: str = None
     ):
         """
         Create fat32 filesystem on block device
@@ -38,11 +39,15 @@ class FileSystemFat32(FileSystemBase):
             The value is interpreted in units of: unit
         :param str unit:
             unit name. Default unit is set to: defaults.UNIT.kb
+        :param str uuid: Volume Label, there is no real UUID on fat
         """
         device_args = [self.device_provider.get_device()]
         if label:
             self.custom_args['create_options'].append('-n')
             self.custom_args['create_options'].append(label)
+        if uuid:
+            self.custom_args['create_options'].append('-i')
+            self.custom_args['create_options'].append(uuid)
         if size:
             device_args.append(
                 self._fs_size(

--- a/kiwi/filesystem/swap.py
+++ b/kiwi/filesystem/swap.py
@@ -27,7 +27,8 @@ class FileSystemSwap(FileSystemBase):
     **Implements creation of swap space**
     """
     def create_on_device(
-        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb
+        self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb,
+        uuid: str = None
     ):
         """
         Create swap space on block device
@@ -35,6 +36,7 @@ class FileSystemSwap(FileSystemBase):
         :param string label: label name
         :param int size: unused
         :param str unit: unused
+        :param str uuid: unused
         """
         device = self.device_provider.get_device()
         if label:

--- a/kiwi/filesystem/xfs.py
+++ b/kiwi/filesystem/xfs.py
@@ -28,7 +28,7 @@ class FileSystemXfs(FileSystemBase):
     """
     def create_on_device(
         self, label: str = None, size: int = 0,
-        unit: str = defaults.UNIT.kb
+        unit: str = defaults.UNIT.kb, uuid: str = None
     ):
         """
         Create xfs filesystem on block device
@@ -39,11 +39,15 @@ class FileSystemXfs(FileSystemBase):
             The value is interpreted in units of: unit
         :param str unit:
             unit name. Default unit is set to: defaults.UNIT.kb
+        :param str uuid: UUID name
         """
         device = self.device_provider.get_device()
         if label:
             self.custom_args['create_options'].append('-L')
             self.custom_args['create_options'].append(label)
+        if uuid:
+            self.custom_args['create_options'].append('-m')
+            self.custom_args['create_options'].append(f'uuid={uuid}')
         if size:
             self.custom_args['create_options'].append('-d')
             self.custom_args['create_options'].append(

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -28,8 +28,8 @@ safe-posix-name = xsd:token {pattern = "[a-zA-Z0-9_\-\.]+"}
 safe-posix-short-name = xsd:token {pattern = "[a-zA-Z0-9_\-\.]{1,32}"}
 locale-name = xsd:token {pattern = "(POSIX|[a-z]{2,3}_[A-Z]{2})(,[a-z]{2,3}_[A-Z]{2})*"}
 mac-address-type = xsd:token {pattern = "([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}"}
-size-type = xsd:token {pattern = "\d*|image"}
-blocks-type = xsd:token {pattern = "\d*|all"}
+size-type = xsd:token {pattern = "(\d*|image)"}
+blocks-type = xsd:token {pattern = "(\d*|all)"}
 volume-size-type = xsd:token {pattern = "(\d+|\d+M|\d+G|all)"}
 partition-size-type = xsd:token {pattern = "(\d+|\d+M|\d+G)"}
 vhd-tag-type = xsd:token {pattern = "[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}"}
@@ -1540,6 +1540,16 @@ div {
             sch:param [ name = "attr" value = "squashfscompression" ]
             sch:param [ name = "types" value = "oem pxe kis iso" ]
         ]
+    k.type.verity_blocks.attribute =
+        ## Specifies to create a dm verity hash from the number of
+        ## given blocks and placed at the end of the root filesystem
+        ## If the verity hash should be calculated from the complete
+        ## file the value 'all' can be specified.
+        attribute verity_blocks { blocks-type }
+        >> sch:pattern [ id = "verity_blocks" is-a = "image_type"
+            sch:param [ name = "attr" value = "verity_blocks" ]
+            sch:param [ name = "types" value = "oem" ]
+        ]
     k.type.overlayroot.attribute =
         ## Specifies to use an overlay root system consisting
         ## out of a squashfs compressed read-only root system
@@ -1549,17 +1559,6 @@ div {
         attribute overlayroot { xsd:boolean }
         >> sch:pattern [ id = "overlayroot" is-a = "image_type"
             sch:param [ name = "attr" value = "overlayroot" ]
-            sch:param [ name = "types" value = "oem" ]
-        ]
-    k.type.overlayroot_verity_blocks.attribute =
-        ## Specifies to create a dm verity hash from the number of
-        ## given blocks and placed at the end of the squashfs
-        ## compressed read-only root filesystem. If the verity hash
-        ## should be calculated from the complete file the value 'all'
-        ## can be specified.
-        attribute overlayroot_verity_blocks { blocks-type }
-        >> sch:pattern [ id = "overlayroot_verity_blocks" is-a = "image_type"
-            sch:param [ name = "attr" value = "overlayroot_verity_blocks" ]
             sch:param [ name = "types" value = "oem" ]
         ]
     k.type.overlayroot_write_partition.attribute =
@@ -1994,7 +1993,7 @@ div {
         k.type.overlayroot.attribute? &
         k.type.overlayroot_write_partition.attribute? &
         k.type.overlayroot_readonly_partsize.attribute? &
-        k.type.overlayroot_verity_blocks.attribute? &
+        k.type.verity_blocks.attribute? &
         k.type.primary.attribute? &
         k.type.ramonly.attribute? &
         k.type.rootfs_label.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -43,12 +43,12 @@
   </define>
   <define name="size-type">
     <data type="token">
-      <param name="pattern">\d*|image</param>
+      <param name="pattern">(\d*|image)</param>
     </data>
   </define>
   <define name="blocks-type">
     <data type="token">
-      <param name="pattern">\d*|all</param>
+      <param name="pattern">(\d*|all)</param>
     </data>
   </define>
   <define name="volume-size-type">
@@ -2245,6 +2245,19 @@ structure</a:documentation>
         <sch:param name="types" value="oem pxe kis iso"/>
       </sch:pattern>
     </define>
+    <define name="k.type.verity_blocks.attribute">
+      <attribute name="verity_blocks">
+        <a:documentation>Specifies to create a dm verity hash from the number of
+given blocks and placed at the end of the root filesystem
+If the verity hash should be calculated from the complete
+file the value 'all' can be specified.</a:documentation>
+        <ref name="blocks-type"/>
+      </attribute>
+      <sch:pattern id="verity_blocks" is-a="image_type">
+        <sch:param name="attr" value="verity_blocks"/>
+        <sch:param name="types" value="oem"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.overlayroot.attribute">
       <attribute name="overlayroot">
         <a:documentation>Specifies to use an overlay root system consisting
@@ -2256,20 +2269,6 @@ image type oem</a:documentation>
       </attribute>
       <sch:pattern id="overlayroot" is-a="image_type">
         <sch:param name="attr" value="overlayroot"/>
-        <sch:param name="types" value="oem"/>
-      </sch:pattern>
-    </define>
-    <define name="k.type.overlayroot_verity_blocks.attribute">
-      <attribute name="overlayroot_verity_blocks">
-        <a:documentation>Specifies to create a dm verity hash from the number of
-given blocks and placed at the end of the squashfs
-compressed read-only root filesystem. If the verity hash
-should be calculated from the complete file the value 'all'
-can be specified.</a:documentation>
-        <ref name="blocks-type"/>
-      </attribute>
-      <sch:pattern id="overlayroot_verity_blocks" is-a="image_type">
-        <sch:param name="attr" value="overlayroot_verity_blocks"/>
         <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
@@ -2944,7 +2943,7 @@ kiwi-ng result bundle ...</a:documentation>
           <ref name="k.type.overlayroot_readonly_partsize.attribute"/>
         </optional>
         <optional>
-          <ref name="k.type.overlayroot_verity_blocks.attribute"/>
+          <ref name="k.type.verity_blocks.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.primary.attribute"/>

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -24,7 +24,6 @@ import os
 from kiwi.utils.temporary import Temporary
 from kiwi.command import Command
 from kiwi.storage.device_provider import DeviceProvider
-from kiwi.utils.veritysetup import VeritySetup
 from kiwi.mount_manager import MountManager
 from kiwi.utils.sync import DataSync
 from kiwi.path import Path
@@ -347,18 +346,13 @@ class VolumeManagerBase(DeviceProvider):
                 options=Defaults.get_sync_options(), exclude=exclude
             )
 
-    def create_verity_layer(self, blocks: Optional[int] = None):
-        veritysetup = VeritySetup(
-            self.device_provider_root.get_device(), blocks
-        )
-        log.info(
-            '--> Creating dm verity hash ({0} blocks)...'.format(
-                blocks or 'all'
-            )
-        )
-        log.debug(
-            '--> dm verity metadata: {0}'.format(veritysetup.format())
-        )
+    def create_verity_layer(
+        self, blocks: Optional[int] = None, filename: str = None
+    ):
+        """
+        veritysetup on LVM devices is not supported
+        """
+        raise NotImplementedError
 
     def set_property_readonly_root(self):
         """

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/david/work/kiwi/.tox/3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/ms/Project/kiwi/.tox/3.6/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -2718,7 +2718,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, overlayroot_verity_blocks=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2766,7 +2766,7 @@ class type_(GeneratedsSuper):
         self.overlayroot = _cast(bool, overlayroot)
         self.overlayroot_write_partition = _cast(bool, overlayroot_write_partition)
         self.overlayroot_readonly_partsize = _cast(int, overlayroot_readonly_partsize)
-        self.overlayroot_verity_blocks = _cast(None, overlayroot_verity_blocks)
+        self.verity_blocks = _cast(None, verity_blocks)
         self.primary = _cast(bool, primary)
         self.ramonly = _cast(bool, ramonly)
         self.rootfs_label = _cast(None, rootfs_label)
@@ -2970,8 +2970,8 @@ class type_(GeneratedsSuper):
     def set_overlayroot_write_partition(self, overlayroot_write_partition): self.overlayroot_write_partition = overlayroot_write_partition
     def get_overlayroot_readonly_partsize(self): return self.overlayroot_readonly_partsize
     def set_overlayroot_readonly_partsize(self, overlayroot_readonly_partsize): self.overlayroot_readonly_partsize = overlayroot_readonly_partsize
-    def get_overlayroot_verity_blocks(self): return self.overlayroot_verity_blocks
-    def set_overlayroot_verity_blocks(self, overlayroot_verity_blocks): self.overlayroot_verity_blocks = overlayroot_verity_blocks
+    def get_verity_blocks(self): return self.verity_blocks
+    def set_verity_blocks(self, verity_blocks): self.verity_blocks = verity_blocks
     def get_primary(self): return self.primary
     def set_primary(self, primary): self.primary = primary
     def get_ramonly(self): return self.ramonly
@@ -3016,7 +3016,7 @@ class type_(GeneratedsSuper):
             if not self.gds_validate_simple_patterns(
                     self.validate_blocks_type_patterns_, value):
                 warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_blocks_type_patterns_, ))
-    validate_blocks_type_patterns_ = [['^\\d*|all$']]
+    validate_blocks_type_patterns_ = [['^(\\d*|all)$']]
     def validate_partition_size_type(self, value):
         # Validate type partition-size-type, a restriction on xs:token.
         if value is not None and Validate_simpletypes_:
@@ -3220,9 +3220,9 @@ class type_(GeneratedsSuper):
         if self.overlayroot_readonly_partsize is not None and 'overlayroot_readonly_partsize' not in already_processed:
             already_processed.add('overlayroot_readonly_partsize')
             outfile.write(' overlayroot_readonly_partsize="%s"' % self.gds_format_integer(self.overlayroot_readonly_partsize, input_name='overlayroot_readonly_partsize'))
-        if self.overlayroot_verity_blocks is not None and 'overlayroot_verity_blocks' not in already_processed:
-            already_processed.add('overlayroot_verity_blocks')
-            outfile.write(' overlayroot_verity_blocks=%s' % (quote_attrib(self.overlayroot_verity_blocks), ))
+        if self.verity_blocks is not None and 'verity_blocks' not in already_processed:
+            already_processed.add('verity_blocks')
+            outfile.write(' verity_blocks=%s' % (quote_attrib(self.verity_blocks), ))
         if self.primary is not None and 'primary' not in already_processed:
             already_processed.add('primary')
             outfile.write(' primary="%s"' % self.gds_format_boolean(self.primary, input_name='primary'))
@@ -3609,12 +3609,12 @@ class type_(GeneratedsSuper):
                 raise_parse_error(node, 'Bad integer attribute: %s' % exp)
             if self.overlayroot_readonly_partsize < 0:
                 raise_parse_error(node, 'Invalid NonNegativeInteger')
-        value = find_attr_value_('overlayroot_verity_blocks', node)
-        if value is not None and 'overlayroot_verity_blocks' not in already_processed:
-            already_processed.add('overlayroot_verity_blocks')
-            self.overlayroot_verity_blocks = value
-            self.overlayroot_verity_blocks = ' '.join(self.overlayroot_verity_blocks.split())
-            self.validate_blocks_type(self.overlayroot_verity_blocks)    # validate type blocks-type
+        value = find_attr_value_('verity_blocks', node)
+        if value is not None and 'verity_blocks' not in already_processed:
+            already_processed.add('verity_blocks')
+            self.verity_blocks = value
+            self.verity_blocks = ' '.join(self.verity_blocks.split())
+            self.validate_blocks_type(self.verity_blocks)    # validate type blocks-type
         value = find_attr_value_('primary', node)
         if value is not None and 'primary' not in already_processed:
             already_processed.add('primary')

--- a/test/unit/filesystem/btrfs_test.py
+++ b/test/unit/filesystem/btrfs_test.py
@@ -24,11 +24,11 @@ class TestFileSystemBtrfs:
 
     @patch('kiwi.filesystem.btrfs.Command.run')
     def test_create_on_device(self, mock_command):
-        self.btrfs.create_on_device('label', 100)
+        self.btrfs.create_on_device('label', 100, uuid='uuid')
         call = mock_command.call_args_list[0]
         assert mock_command.call_args_list[0] == call(
             [
-                'mkfs.btrfs', '-L', 'label',
+                'mkfs.btrfs', '-L', 'label', '-U', 'uuid',
                 '--byte-count', '102400', '/dev/foo'
             ]
         )

--- a/test/unit/filesystem/ext2_test.py
+++ b/test/unit/filesystem/ext2_test.py
@@ -24,7 +24,7 @@ class TestFileSystemExt2:
 
     @patch('kiwi.filesystem.ext2.Command.run')
     def test_create_on_device(self, mock_command):
-        self.ext2.create_on_device('label', 100)
+        self.ext2.create_on_device('label', 100, uuid='uuid')
         call = mock_command.call_args_list[0]
         assert mock_command.call_args_list[0] == \
-            call(['mkfs.ext2', '-L', 'label', '/dev/foo', '100'])
+            call(['mkfs.ext2', '-L', 'label', '-U', 'uuid', '/dev/foo', '100'])

--- a/test/unit/filesystem/ext3_test.py
+++ b/test/unit/filesystem/ext3_test.py
@@ -24,7 +24,7 @@ class TestFileSystemExt3:
 
     @patch('kiwi.filesystem.ext3.Command.run')
     def test_create_on_device(self, mock_command):
-        self.ext3.create_on_device('label', 100)
+        self.ext3.create_on_device('label', 100, uuid='uuid')
         call = mock_command.call_args_list[0]
         assert mock_command.call_args_list[0] == \
-            call(['mkfs.ext3', '-L', 'label', '/dev/foo', '100'])
+            call(['mkfs.ext3', '-L', 'label', '-U', 'uuid', '/dev/foo', '100'])

--- a/test/unit/filesystem/ext4_test.py
+++ b/test/unit/filesystem/ext4_test.py
@@ -24,7 +24,7 @@ class TestFileSystemExt4:
 
     @patch('kiwi.filesystem.ext4.Command.run')
     def test_create_on_device(self, mock_command):
-        self.ext4.create_on_device('label', 100)
+        self.ext4.create_on_device('label', 100, uuid='uuid')
         call = mock_command.call_args_list[0]
         assert mock_command.call_args_list[0] == \
-            call(['mkfs.ext4', '-L', 'label', '/dev/foo', '100'])
+            call(['mkfs.ext4', '-L', 'label', '-U', 'uuid', '/dev/foo', '100'])

--- a/test/unit/filesystem/fat16_test.py
+++ b/test/unit/filesystem/fat16_test.py
@@ -24,7 +24,11 @@ class TestFileSystemFat16:
 
     @patch('kiwi.filesystem.fat16.Command.run')
     def test_create_on_device(self, mock_command):
-        self.fat16.create_on_device('label', 100)
+        self.fat16.create_on_device('label', 100, uuid='uuid')
         call = mock_command.call_args_list[0]
-        assert mock_command.call_args_list[0] == \
-            call(['mkdosfs', '-F16', '-I', '-n', 'label', '/dev/foo', '100'])
+        assert mock_command.call_args_list[0] == call(
+            [
+                'mkdosfs', '-F16', '-I', '-n', 'label',
+                '-i', 'uuid', '/dev/foo', '100'
+            ]
+        )

--- a/test/unit/filesystem/fat32_test.py
+++ b/test/unit/filesystem/fat32_test.py
@@ -24,7 +24,11 @@ class TestFileSystemFat32:
 
     @patch('kiwi.filesystem.fat32.Command.run')
     def test_create_on_device(self, mock_command):
-        self.fat32.create_on_device('label', 100)
+        self.fat32.create_on_device('label', 100, uuid='uuid')
         call = mock_command.call_args_list[0]
-        assert mock_command.call_args_list[0] == \
-            call(['mkdosfs', '-F32', '-I', '-n', 'label', '/dev/foo', '100'])
+        assert mock_command.call_args_list[0] == call(
+            [
+                'mkdosfs', '-F32', '-I', '-n', 'label',
+                '-i', 'uuid', '/dev/foo', '100'
+            ]
+        )

--- a/test/unit/filesystem/xfs_test.py
+++ b/test/unit/filesystem/xfs_test.py
@@ -24,10 +24,11 @@ class TestFileSystemXfs:
 
     @patch('kiwi.filesystem.xfs.Command.run')
     def test_create_on_device(self, mock_command):
-        self.xfs.create_on_device('label', 100)
+        self.xfs.create_on_device('label', 100, uuid='uuid')
         call = mock_command.call_args_list[0]
         assert mock_command.call_args_list[0] == call(
             [
-                'mkfs.xfs', '-f', '-L', 'label', '-d', 'size=100k', '/dev/foo'
+                'mkfs.xfs', '-f', '-L', 'label',
+                '-m', 'uuid=uuid', '-d', 'size=100k', '/dev/foo'
             ]
         )

--- a/test/unit/utils/veritysetup_test.py
+++ b/test/unit/utils/veritysetup_test.py
@@ -34,7 +34,28 @@ class TestVeritySetup:
         mock_Command_run.assert_called_once_with(
             [
                 'veritysetup', 'format', 'image_file', 'image_file',
-                '--no-superblock', '--hash-offset=42', '--data-blocks=10'
+                '--no-superblock', '--hash-offset=42',
+                '--hash-block-size=1024', '--data-blocks=10',
+                '--data-block-size=1024',
+            ]
+        )
+
+    @patch('kiwi.utils.veritysetup.Command.run')
+    @patch('kiwi.utils.veritysetup.Temporary.new_file')
+    @patch('os.path.getsize')
+    def test_get_hash_byte_size(
+        self, mock_os_path_getsize, mock_Temporary_new_file, mock_Command_run
+    ):
+        tempfile = Mock()
+        tempfile.name = 'tempfile'
+        mock_Temporary_new_file.return_value = tempfile
+        assert self.veritysetup.get_hash_byte_size() == \
+            mock_os_path_getsize.return_value
+        mock_Command_run.assert_called_once_with(
+            [
+                'veritysetup', 'format', 'image_file', 'tempfile',
+                '--no-superblock', '--hash-block-size=1024', '--data-blocks=10',
+                '--data-block-size=1024',
             ]
         )
 
@@ -57,7 +78,7 @@ class TestVeritySetup:
         mock_Command_run.assert_called_once_with(
             [
                 'veritysetup', 'format', 'image_file', 'image_file',
-                '--no-superblock', '--hash-offset=42'
+                '--no-superblock', '--hash-offset=42', '--hash-block-size=1024'
             ]
         )
 

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -243,10 +243,9 @@ class TestVolumeManagerBase:
         )
         assert self.volume_manager.get_mountpoint() == 'mountpoint'
 
-    @patch('kiwi.volume_manager.base.VeritySetup')
-    def test_create_verity_layer(self, mock_VeritySetup):
-        self.volume_manager.create_verity_layer()
-        mock_VeritySetup.return_value.format.assert_called_once_with()
+    def test_create_verity_layer(self):
+        with raises(NotImplementedError):
+            self.volume_manager.create_verity_layer()
 
     @patch('kiwi.volume_manager.base.Temporary')
     def test_setup_mountpoint(self, mock_Temporary):


### PR DESCRIPTION
So far the verity support was only available with the overlayroot layout and the read-only squashfs root. This commit adds a new attribute: ```verity_blocks="number|all"``` which allows to create the verity setup also on the standard root partition

In addition to the change it was needed to extend the Filesystem API with an additional optional paramter to allow setup of the filesystem UUID. Having the opportunity to set the UUID at filesystem creation is generally useful and with regards to this particular change it became also required

