### PR TITLE
Added create_verification_metadata method

### DIFF
--- a/kiwi.yml
+++ b/kiwi.yml
@@ -12,8 +12,8 @@
 
 # Setup access to security keys
 #credentials:
-#  # Specify private key used for signing operations
-#  - rootfs_signing_key_file: /path/to/private.pem
+#  # Specify private key(s) used for signing operations
+#  - verification_metadata_signing_key_file: /path/to/private.pem
 
 # Setup access options for the Open BuildService
 #obs:

--- a/kiwi.yml
+++ b/kiwi.yml
@@ -10,6 +10,11 @@
 # to your needs
 #
 
+# Setup access to security keys
+#credentials:
+#  # Specify private key used for signing operations
+#  - rootfs_signing_key_file: /path/to/private.pem
+
 # Setup access options for the Open BuildService
 #obs:
 #  # Specify the URL of the Open BuildService download server

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -60,8 +60,10 @@ unit_type = NamedTuple(
 
 
 # Default module variables
-VERITY_DATA_BLOCKSIZE = 1024  # 1kb
-VERITY_HASH_BLOCKSIZE = 1024  # 1kb
+VERITY_DATA_BLOCKSIZE = 4096  # 4kb
+VERITY_HASH_BLOCKSIZE = 4096  # 4kb
+VERIFICATION_METADATA_FORMAT_VERSION = '1'
+VERIFICATION_METADATA_OFFSET = 4096  # 4kb
 UNIT = unit_type(byte='b', kb='k', mb='m', gb='g')
 POST_DISK_SYNC_SCRIPT = 'disk.sh'
 PRE_DISK_SYNC_SCRIPT = 'pre_disk_sync.sh'

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -835,3 +835,16 @@ class KiwiPartitionTooSmallError(KiwiError):
     Exception raised if the specified partition size is smaller
     than the required bytes to store the data
     """
+
+
+class KiwiCredentialsError(KiwiError):
+    """
+    Exception raised if required credentials information is missing
+    """
+
+
+class KiwiOffsetError(KiwiError):
+    """
+    Exception raised if the offset for a seek operation does not
+    match the expected data to write
+    """

--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -74,6 +74,25 @@ class RuntimeConfig:
                 with open(config_file, 'r') as config:
                     RUNTIME_CONFIG = yaml.safe_load(config) or {}
 
+    def get_credentials_signing_key_file(self):
+        """
+        Return rootfs signing key file, used for signature creation
+        of rootfs verification metadata:
+
+        credentials:
+          - rootfs_signing_key_file: ...
+
+        There is no default value for this setting available
+
+        :return: file path name or ''
+
+        :rtype: str
+        """
+        signing_key_file = self._get_attribute(
+            element='credentials', attribute='rootfs_signing_key_file'
+        )
+        return signing_key_file if signing_key_file else ''
+
     def get_obs_download_server_url(self):
         """
         Return URL of buildservice download server in:

--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -74,13 +74,13 @@ class RuntimeConfig:
                 with open(config_file, 'r') as config:
                     RUNTIME_CONFIG = yaml.safe_load(config) or {}
 
-    def get_credentials_signing_key_file(self):
+    def get_credentials_verification_metadata_signing_key_file(self):
         """
-        Return rootfs signing key file, used for signature creation
-        of rootfs verification metadata:
+        Return verification metadata signing key file, used for
+        signature creation of rootfs verification metadata:
 
         credentials:
-          - rootfs_signing_key_file: ...
+          - verification_metadata_signing_key_file: ...
 
         There is no default value for this setting available
 
@@ -89,7 +89,8 @@ class RuntimeConfig:
         :rtype: str
         """
         signing_key_file = self._get_attribute(
-            element='credentials', attribute='rootfs_signing_key_file'
+            element='credentials',
+            attribute='verification_metadata_signing_key_file'
         )
         return signing_key_file if signing_key_file else ''
 

--- a/kiwi/utils/veritysetup.py
+++ b/kiwi/utils/veritysetup.py
@@ -192,12 +192,17 @@ class VeritySetup:
                 metadata_format_version, filesystem, filesystem_mode
             )
 
+            hash_start_block = int(
+                self.verity_hash_offset / int(
+                    self.verity_dict['Hashblocksize']
+                )
+            )
             dm_verity_credentials = '{0} {1} {2} {3} {4} {5} {6} {7}'.format(
                 self.verity_dict['Hashtype'],
                 self.verity_dict['Datablocksize'],
                 self.verity_dict['Hashblocksize'],
                 self.verity_dict['Datablocks'],
-                int(self.verity_hash_offset / defaults.VERITY_HASH_BLOCKSIZE),
+                hash_start_block,
                 self.verity_dict['Hashalgorithm'],
                 self.verity_dict['Roothash'],
                 self.verity_dict['Salt']
@@ -220,15 +225,17 @@ class VeritySetup:
         following section:
 
         credentials:
-          - rootfs_signing_key_file: /path/to/pkey
+          - verification_metadata_signing_key_file: /path/to/pkey
         """
         if self.verification_metadata_file:
             runtime_config = RuntimeConfig()
-            signing_key_file = \
-                runtime_config.get_credentials_signing_key_file()
+            signing_key_file = runtime_config.\
+                get_credentials_verification_metadata_signing_key_file()
             if not signing_key_file:
                 raise KiwiCredentialsError(
-                    'No rootfs_signing_key_file configured in runtime config'
+                    '{0} not configured in runtime config'.format(
+                        'verification_metadata_signing_key_file'
+                    )
                 )
             signature_file = Temporary().new_file()
             Command.run(

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -354,6 +354,12 @@ class VolumeManagerBase(DeviceProvider):
         """
         raise NotImplementedError
 
+    def create_verification_metadata(self, device_node: str = '') -> None:
+        """
+        Write verification block on LVM devices is not supported
+        """
+        raise NotImplementedError
+
     def set_property_readonly_root(self):
         """
         Implements setup of read-only root property

--- a/test/unit/filesystem/base_test.py
+++ b/test/unit/filesystem/base_test.py
@@ -87,6 +87,16 @@ class TestFileSystemBase:
         self.fsbase.create_verity_layer()
         mock_VeritySetup.return_value.format.assert_called_once_with()
 
+    def test_create_verification_metadata(self):
+        veritysetup = mock.Mock()
+        self.fsbase.veritysetup = veritysetup
+        self.fsbase.create_verification_metadata('/some/device')
+        veritysetup.create_verity_verification_metadata.assert_called_once_with()
+        veritysetup.sign_verification_metadata.assert_called_once_with()
+        veritysetup.write_verification_metadata.assert_called_once_with(
+            '/some/device'
+        )
+
     def test_umount(self):
         mount = mock.Mock()
         self.fsbase.filesystem_mount = mount

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -93,6 +93,7 @@ class TestRuntimeConfig:
         assert runtime_config.get_iso_tool_category() == 'xorriso'
         assert runtime_config.get_oci_archive_tool() == 'umoci'
         assert runtime_config.get_package_changes() is False
+        assert runtime_config.get_credentials_signing_key_file() == ''
 
     def test_config_sections_invalid(self):
         with patch.dict('os.environ', {'HOME': '../data/kiwi_config/invalid'}):

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -93,7 +93,8 @@ class TestRuntimeConfig:
         assert runtime_config.get_iso_tool_category() == 'xorriso'
         assert runtime_config.get_oci_archive_tool() == 'umoci'
         assert runtime_config.get_package_changes() is False
-        assert runtime_config.get_credentials_signing_key_file() == ''
+        assert runtime_config.\
+            get_credentials_verification_metadata_signing_key_file() == ''
 
     def test_config_sections_invalid(self):
         with patch.dict('os.environ', {'HOME': '../data/kiwi_config/invalid'}):

--- a/test/unit/utils/veritysetup_test.py
+++ b/test/unit/utils/veritysetup_test.py
@@ -180,9 +180,10 @@ class TestVeritySetup:
         metadata_file.name = 'metadata_file'
         self.veritysetup.verification_metadata_file = metadata_file
         runtime_config = Mock()
-        runtime_config.get_credentials_signing_key_file = Mock(
-            return_value=None
-        )
+        runtime_config.\
+            get_credentials_verification_metadata_signing_key_file = Mock(
+                return_value=None
+            )
         mock_RuntimeConfig.return_value = runtime_config
         with raises(KiwiCredentialsError):
             self.veritysetup.sign_verification_metadata()
@@ -200,9 +201,10 @@ class TestVeritySetup:
         metadata_file.name = 'metadata_file'
         self.veritysetup.verification_metadata_file = metadata_file
         runtime_config = Mock()
-        runtime_config.get_credentials_signing_key_file = Mock(
-            return_value='signing_key_file'
-        )
+        runtime_config.\
+            get_credentials_verification_metadata_signing_key_file = Mock(
+                return_value='signing_key_file'
+            )
         mock_RuntimeConfig.return_value = runtime_config
         with patch('builtins.open', create=True) as mock_open:
             mock_open.return_value = MagicMock(spec=io.IOBase)

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -247,6 +247,10 @@ class TestVolumeManagerBase:
         with raises(NotImplementedError):
             self.volume_manager.create_verity_layer()
 
+    def test_create_verification_metadata(self):
+        with raises(NotImplementedError):
+            self.volume_manager.create_verification_metadata('/some/device')
+
     @patch('kiwi.volume_manager.base.Temporary')
     def test_setup_mountpoint(self, mock_Temporary):
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'


### PR DESCRIPTION
Along with creating a filesystem including device mapper features like dm_verity (see verity_blocks) or dm_crypt/dm_integrity (see luks) there is always the question where to store the metadata information required to setup the device map. This can include information about blocksizes, offset addresses and more. The create_verification_metadata() method allows to write a signed custom data block of a documented format at the end of the given block special which stores this type of information such that tools at boot time gets the opportunity to read this information. In this commit only information connected to the dm_verity feature activated via the verity_blocks attribute will be part of the verification block. With future changes other data might be added

