### PR TITLE
Add embed verity metadata attribute

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -575,6 +575,37 @@ verity_blocks="number|all"
   persistently store the verification metadata as part of the
   partition(s) will be a next step.
 
+embed_verity_metadata="true|false"
+  For the `oem` type only, and in combination with the `verity_blocks`
+  attribute, specifies to write a binary block at the end of the
+  partition serving the root filesystem, containing information
+  for `dm_verity` verification in the following format:
+
+  .. code:: bash
+
+     |header|0xFF|dm_verity_credentials|0xFF|0x0|
+
+  header:
+    Is a string of the following information separated by spaces
+
+    * **version**: currently set to `1`
+    * **fstype**: name of `filesystem` attribute
+    * **access**: either `ro` or `rw` depending on the filesystem capabilities
+    * `verity`: fixed identifier value
+
+  dm_verity_credentials:
+    Is a string of the following information separated by spaces
+
+    * **hash_type**: hash type name as returned by `veritysetup`
+    * **data_blksize**: data blocksize as returned by `veritysetup`
+    * **hash_blksize**: hash blocksize as returned by `veritysetup`
+    * **data_blocks**: number of data blocks as returned by `veritysetup`
+    * **hash_start_block**:
+      hash start block as required by the kernel to construct the device map
+    * **algorithm**: hash algorithm as returned by `veritysetup`
+    * **root_hash**: root hash as returned by `veritysetup`
+    * **salt**: salt hash as returned by `veritysetup`
+
 overlayroot="true|false"
   For the `oem` type only, specifies to use an `overlayfs` based root
   filesystem consisting out of a squashfs compressed read-only root

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -97,6 +97,8 @@ class DiskBuilder:
             xml_state.build_type.get_overlayroot_readonly_partsize()
         self.root_filesystem_verity_blocks = \
             xml_state.build_type.get_verity_blocks()
+        self.root_filesystem_embed_verity_metadata = \
+            xml_state.build_type.get_embed_verity_metadata()
         self.dosparttable_extended_layout = \
             xml_state.build_type.get_dosparttable_extended_layout()
         self.custom_root_mount_args = xml_state.get_fs_mount_option_list()
@@ -1211,6 +1213,10 @@ class DiskBuilder:
                     'of=%s' % readonly_target
                 ]
             )
+            if self.root_filesystem_embed_verity_metadata:
+                squashed_root.create_verification_metadata(
+                    readonly_target
+                )
         elif self.root_filesystem_verity_blocks:
             root_target = device_map['root'].get_device()
             root_target_bytesize = device_map['root'].get_byte_size(
@@ -1221,6 +1227,8 @@ class DiskBuilder:
                 self.root_filesystem_verity_blocks if
                 self.root_filesystem_verity_blocks != 'all' else None
             ).get_hash_byte_size()
+            if self.root_filesystem_embed_verity_metadata:
+                verity_root_file_bytes -= defaults.VERIFICATION_METADATA_OFFSET
             verity_root_file = Temporary().new_file()
             loop_provider = LoopDevice(
                 verity_root_file.name,
@@ -1263,6 +1271,10 @@ class DiskBuilder:
                     'of=%s' % root_target
                 ]
             )
+            if self.root_filesystem_embed_verity_metadata:
+                filesystem.create_verification_metadata(
+                    root_target
+                )
         else:
             system.sync_data(
                 self._get_exclude_list_for_root_data_sync(device_map)

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1321,6 +1321,17 @@ div {
             ]
         ]
     ]
+    sch:pattern [
+        abstract = "true"
+        id = "image_verity_requirement"
+        sch:rule [
+            context = "type[@embed_verity_metadata]"
+            sch:assert [
+                test = "@$attr"
+                "$attr attribute must be set for embed_verity_metadata"
+            ]
+        ]
+    ]
     k.type.boot.attribute =
         ## Specifies the path of the boot image (initrd) description
         ## provided with KIWI
@@ -1568,6 +1579,20 @@ div {
         >> sch:pattern [ id = "verity_blocks" is-a = "image_type"
             sch:param [ name = "attr" value = "verity_blocks" ]
             sch:param [ name = "types" value = "oem" ]
+        ]
+    k.type.embed_verity_metadata.attribute =
+        ## In combination with the verity_blocks attribute, embed
+        ## a verification metadata block at the end of the partition
+        ## serving the root filesystem
+        attribute embed_verity_metadata { xsd:boolean }
+        >> sch:pattern [
+            id = "embed_verity_metadata" is-a = "image_type"
+            sch:param [ name = "attr" value = "embed_verity_metadata" ]
+            sch:param [ name = "types" value = "oem" ]
+        ]
+        >> sch:pattern [
+            id = "verity_blocks_mandatory" is-a = "image_verity_requirement"
+            sch:param [ name = "attr" value = "verity_blocks" ]
         ]
     k.type.overlayroot.attribute =
         ## Specifies to use an overlay root system consisting
@@ -2026,6 +2051,7 @@ div {
         k.type.overlayroot_write_partition.attribute? &
         k.type.overlayroot_readonly_partsize.attribute? &
         k.type.verity_blocks.attribute? &
+        k.type.embed_verity_metadata.attribute? &
         k.type.primary.attribute? &
         k.type.ramonly.attribute? &
         k.type.rootfs_label.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1950,6 +1950,11 @@ volume management system</a:documentation>
         <sch:assert test="oemconfig/oem-resize[contains(text(), 'false')]">$attr attribute also needs the setting: &lt;oem-resize&gt;false&lt;/oem-resize&gt; in the &lt;oemconfig&gt; section of the selected &lt;type&gt;</sch:assert>
       </sch:rule>
     </sch:pattern>
+    <sch:pattern abstract="true" id="image_verity_requirement">
+      <sch:rule context="type[@embed_verity_metadata]">
+        <sch:assert test="@$attr">$attr attribute must be set for embed_verity_metadata</sch:assert>
+      </sch:rule>
+    </sch:pattern>
     <define name="k.type.boot.attribute">
       <attribute name="boot">
         <a:documentation>Specifies the path of the boot image (initrd) description
@@ -2284,6 +2289,21 @@ file the value 'all' can be specified.</a:documentation>
       <sch:pattern id="verity_blocks" is-a="image_type">
         <sch:param name="attr" value="verity_blocks"/>
         <sch:param name="types" value="oem"/>
+      </sch:pattern>
+    </define>
+    <define name="k.type.embed_verity_metadata.attribute">
+      <attribute name="embed_verity_metadata">
+        <a:documentation>In combination with the verity_blocks attribute, embed
+a verification metadata block at the end of the partition
+serving the root filesystem</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="embed_verity_metadata" is-a="image_type">
+        <sch:param name="attr" value="embed_verity_metadata"/>
+        <sch:param name="types" value="oem"/>
+      </sch:pattern>
+      <sch:pattern id="verity_blocks_mandatory" is-a="image_verity_requirement">
+        <sch:param name="attr" value="verity_blocks"/>
       </sch:pattern>
     </define>
     <define name="k.type.overlayroot.attribute">
@@ -2993,6 +3013,9 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.verity_blocks.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.embed_verity_metadata.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.primary.attribute"/>

--- a/kiwi/utils/block.py
+++ b/kiwi/utils/block.py
@@ -82,6 +82,7 @@ class BlockID:
         :rtype: str
         """
         blkid_result = Command.run(
-            ['blkid', self.device, '-s', id_type, '-o', 'value']
+            ['blkid', self.device, '-s', id_type, '-o', 'value'],
+            raise_on_error=False
         )
-        return blkid_result.output.strip(os.linesep)
+        return blkid_result.output.strip(os.linesep) if blkid_result else ''

--- a/kiwi/utils/veritysetup.py
+++ b/kiwi/utils/veritysetup.py
@@ -269,13 +269,9 @@ class VeritySetup:
             instance of BlockID of the target storage device
         """
         if self.verity_dict:
-            partition_uuid = target_block_id.get_blkid('PARTUUID')
             with open(credentials_filepath, 'w') as verity:
                 for key in sorted(self.verity_dict.keys()):
                     verity.write(f'{key}: {self.verity_dict[key]}{os.linesep}')
-                verity.write(
-                    f'PARTUUID: {partition_uuid}')
-                verity.write(os.linesep)
                 verity.write(
                     f'Root hashoffset: {self.verity_hash_offset}')
                 verity.write(os.linesep)

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2798,7 +2798,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2848,6 +2848,7 @@ class type_(GeneratedsSuper):
         self.overlayroot_write_partition = _cast(bool, overlayroot_write_partition)
         self.overlayroot_readonly_partsize = _cast(int, overlayroot_readonly_partsize)
         self.verity_blocks = _cast(None, verity_blocks)
+        self.embed_verity_metadata = _cast(bool, embed_verity_metadata)
         self.primary = _cast(bool, primary)
         self.ramonly = _cast(bool, ramonly)
         self.rootfs_label = _cast(None, rootfs_label)
@@ -3064,6 +3065,8 @@ class type_(GeneratedsSuper):
     def set_overlayroot_readonly_partsize(self, overlayroot_readonly_partsize): self.overlayroot_readonly_partsize = overlayroot_readonly_partsize
     def get_verity_blocks(self): return self.verity_blocks
     def set_verity_blocks(self, verity_blocks): self.verity_blocks = verity_blocks
+    def get_embed_verity_metadata(self): return self.embed_verity_metadata
+    def set_embed_verity_metadata(self, embed_verity_metadata): self.embed_verity_metadata = embed_verity_metadata
     def get_primary(self): return self.primary
     def set_primary(self, primary): self.primary = primary
     def get_ramonly(self): return self.ramonly
@@ -3319,6 +3322,9 @@ class type_(GeneratedsSuper):
         if self.verity_blocks is not None and 'verity_blocks' not in already_processed:
             already_processed.add('verity_blocks')
             outfile.write(' verity_blocks=%s' % (quote_attrib(self.verity_blocks), ))
+        if self.embed_verity_metadata is not None and 'embed_verity_metadata' not in already_processed:
+            already_processed.add('embed_verity_metadata')
+            outfile.write(' embed_verity_metadata="%s"' % self.gds_format_boolean(self.embed_verity_metadata, input_name='embed_verity_metadata'))
         if self.primary is not None and 'primary' not in already_processed:
             already_processed.add('primary')
             outfile.write(' primary="%s"' % self.gds_format_boolean(self.primary, input_name='primary'))
@@ -3718,6 +3724,15 @@ class type_(GeneratedsSuper):
             self.verity_blocks = value
             self.verity_blocks = ' '.join(self.verity_blocks.split())
             self.validate_blocks_type(self.verity_blocks)    # validate type blocks-type
+        value = find_attr_value_('embed_verity_metadata', node)
+        if value is not None and 'embed_verity_metadata' not in already_processed:
+            already_processed.add('embed_verity_metadata')
+            if value in ('true', '1'):
+                self.embed_verity_metadata = True
+            elif value in ('false', '0'):
+                self.embed_verity_metadata = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('primary', node)
         if value is not None and 'primary' not in already_processed:
             already_processed.add('primary')

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -439,6 +439,7 @@ class TestDiskBuilder:
         filesystem = Mock()
         mock_fs.return_value = filesystem
         self.disk_builder.root_filesystem_verity_blocks = 10
+        self.disk_builder.root_filesystem_embed_verity_metadata = True
         self.disk_builder.root_filesystem_is_overlay = False
         self.disk_builder.volume_manager_name = None
         self.disk_builder.initrd_system = 'dracut'
@@ -562,6 +563,9 @@ class TestDiskBuilder:
         assert self.boot_image_task.write_system_config_file.call_args_list == \
             []
         filesystem.create_verity_layer.assert_called_once_with(10, 'tempfile')
+        filesystem.create_verification_metadata.assert_called_once_with(
+            '/dev/root-device'
+        )
 
     @patch('kiwi.builder.disk.DeviceProvider')
     @patch('kiwi.builder.disk.FileSystem.new')
@@ -586,6 +590,7 @@ class TestDiskBuilder:
         self.disk_builder.root_filesystem_is_overlay = True
         self.disk_builder.root_filesystem_has_write_partition = False
         self.disk_builder.root_filesystem_verity_blocks = 10
+        self.disk_builder.root_filesystem_embed_verity_metadata = True
         self.disk_builder.volume_manager_name = None
         squashfs = Mock()
         mock_squashfs.return_value = squashfs
@@ -621,6 +626,9 @@ class TestDiskBuilder:
             ], filename='kiwi-tempname')
         ]
         squashfs.create_verity_layer.assert_called_once_with(10)
+        squashfs.create_verification_metadata.assert_called_once_with(
+            '/dev/readonly-root-device'
+        )
         self.disk.create_root_readonly_partition.assert_called_once_with(11)
         assert mock_command.call_args_list[2] == call(
             ['blockdev', '--getsize64', '/dev/readonly-root-device']

--- a/test/unit/utils/block_test.py
+++ b/test/unit/utils/block_test.py
@@ -21,7 +21,8 @@ class TestBlockID:
     def test_get_blkid(self, mock_command):
         self.blkid.get_blkid('LABEL')
         mock_command.assert_called_once_with(
-            ['blkid', 'device', '-s', 'LABEL', '-o', 'value']
+            ['blkid', 'device', '-s', 'LABEL', '-o', 'value'],
+            raise_on_error=False
         )
 
     @patch('kiwi.utils.block.BlockID.get_blkid')

--- a/test/unit/utils/veritysetup_test.py
+++ b/test/unit/utils/veritysetup_test.py
@@ -110,8 +110,6 @@ class TestVeritySetup:
             call('Roothash: e2728628377...\n'),
             call('Salt: fb074d1db50...\n'),
             call('UUID: \n'),
-            call('PARTUUID: uuid'),
-            call('\n'),
             call('Root hashoffset: 4096'),
             call('\n'),
             call('Superblock: --no-superblock'),


### PR DESCRIPTION
This change is three fold

**Added embed_verity_metadata attribute**
    
Specifies to write a binary block at the end of the partition serving the root filesystem, containing information for dm_verity verification and to construct the device map. This is actually the final step to just activate the code changes done in #2100 
and related

**Make blkid call more robust**
    
Do not raise if blkid is not able to read the requested ID. It is expected that the methods of the BlockID class either returns a value or none but do not raise and cause the complete process to terminate. I found this when running several tests were I did not expect the process to fail but just to return an empty value

**Update contents of store_credentials result file**
    
The method added information about the PARTUUID as useful information. However, PARTUUID's are not supported by all partition tables. The Linux generated artificial values from the disk identifier are not wanted in this scope. As the information is not mandatory it's better to not  provide it at all and avoid confusion to users. This change is related to #2082 which let me understand how disk and part UUID are generated if the actual partition table does not support them.



