### PR TITLE
Fixed parsing of veritysetup output

### DIFF
--- a/kiwi/utils/veritysetup.py
+++ b/kiwi/utils/veritysetup.py
@@ -88,7 +88,10 @@ class VeritySetup:
         )
         for line in verity_call.output.split(os.linesep):
             try:
-                (key, value) = line.replace(' ', '').split(':', 2)
+                # strip out any space, tabs, newlines
+                line = ''.join(line.split())
+                # split out key:value based data
+                (key, value) = line.split(':', 2)
                 self.verity_dict[key] = value
             except ValueError:
                 # ignore any occurrence for which split failed

--- a/test/unit/utils/veritysetup_test.py
+++ b/test/unit/utils/veritysetup_test.py
@@ -72,9 +72,9 @@ class TestVeritySetup:
         verity_call.output = dedent('''\n
             VERITY header information for mysquash.img
             UUID:
-            Hash type:          1
+            Hash type:			1
             Data blocks:        10
-            Data block size:    4096
+            Data block size:	4096
             Hash block size:    4096
             Hash algorithm:     sha256
             Salt:               fb074d1db50...


### PR DESCRIPTION
veritysetup uses tabs to align values. The way kiwi parsed
the values did not strip out the tabs and later on keeps
them in the verification metadata block. The unit test
did not catch this because the mock output used for
veritysetup did not contain tabs. This commit fixes the
test to catch this condition and also fixes the code to
handle all space characters (tabs, space, newlines) in
a safe way


