### PR TITLE
Ensure BootloaderConfig resources are cleaned first

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1322,14 +1322,15 @@ class DiskBuilder:
 
         if self.bootloader != 'custom':
             # create bootloader config prior bootloader installation
-            self.bootloader_config.setup_disk_image_config(
-                boot_options=custom_install_arguments
-            )
-            if 's390' in self.arch:
-                self.bootloader_config.write()
-
-            # cleanup bootloader config resources taken prior to next steps
-            del self.bootloader_config
+            try:
+                self.bootloader_config.setup_disk_image_config(
+                    boot_options=custom_install_arguments
+                )
+                if 's390' in self.arch:
+                    self.bootloader_config.write()
+            finally:
+                # cleanup bootloader config resources taken prior to next steps
+                del self.bootloader_config
 
             log.debug(
                 "custom arguments for bootloader installation %s",


### PR DESCRIPTION
This commit wraps the manual BootloaderConfig instance cleanup in
disk builder into a try/finally scope. This way if KIWI is aborted
or fails within this scope the BootloaderConfig is cleaned up first.

Signed-off-by: David Cassany <dcassany@suse.com>