### PR TITLE
Added set_uuid() method to FileSystem API

### DIFF
--- a/kiwi/filesystem/base.py
+++ b/kiwi/filesystem/base.py
@@ -110,6 +110,19 @@ class FileSystemBase:
         if not self.custom_args.get('fs_attributes'):
             self.custom_args['fs_attributes'] = []
 
+    def set_uuid(self):
+        """
+        Create new random filesystem UUID
+
+        Implement in specialized filesystem class for filesystems which
+        supports the concept of an UUID and allows to change it
+        """
+        log.warning(
+            'Instance {0} has no support for setting a new UUID label'.format(
+                type(self).__name__
+            )
+        )
+
     def create_on_device(
         self, label: str = None, size: int = 0, unit: str = defaults.UNIT.kb,
         uuid: str = None

--- a/kiwi/filesystem/btrfs.py
+++ b/kiwi/filesystem/btrfs.py
@@ -60,3 +60,12 @@ class FileSystemBtrfs(FileSystemBase):
         Command.run(
             ['mkfs.btrfs'] + self.custom_args['create_options'] + [device]
         )
+
+    def set_uuid(self):
+        """
+        Create new random filesystem UUID
+        """
+        device = self.device_provider.get_device()
+        Command.run(
+            ['btrfstune', '-u', device]
+        )

--- a/kiwi/filesystem/ext2.py
+++ b/kiwi/filesystem/ext2.py
@@ -59,3 +59,15 @@ class FileSystemExt2(FileSystemBase):
         Command.run(
             ['mkfs.ext2'] + self.custom_args['create_options'] + device_args
         )
+
+    def set_uuid(self):
+        """
+        Create new random filesystem UUID
+        """
+        device = self.device_provider.get_device()
+        Command.run(
+            ['e2fsck', '-y', '-f', device], raise_on_error=False
+        )
+        Command.run(
+            ['tune2fs', '-f', '-U', 'random', device]
+        )

--- a/kiwi/filesystem/ext3.py
+++ b/kiwi/filesystem/ext3.py
@@ -59,3 +59,15 @@ class FileSystemExt3(FileSystemBase):
         Command.run(
             ['mkfs.ext3'] + self.custom_args['create_options'] + device_args
         )
+
+    def set_uuid(self):
+        """
+        Create new random filesystem UUID
+        """
+        device = self.device_provider.get_device()
+        Command.run(
+            ['e2fsck', '-y', '-f', device], raise_on_error=False
+        )
+        Command.run(
+            ['tune2fs', '-f', '-U', 'random', device]
+        )

--- a/kiwi/filesystem/ext4.py
+++ b/kiwi/filesystem/ext4.py
@@ -59,3 +59,15 @@ class FileSystemExt4(FileSystemBase):
         Command.run(
             ['mkfs.ext4'] + self.custom_args['create_options'] + device_args
         )
+
+    def set_uuid(self):
+        """
+        Create new random filesystem UUID
+        """
+        device = self.device_provider.get_device()
+        Command.run(
+            ['e2fsck', '-y', '-f', device], raise_on_error=False
+        )
+        Command.run(
+            ['tune2fs', '-f', '-U', 'random', device]
+        )

--- a/kiwi/filesystem/fat16.py
+++ b/kiwi/filesystem/fat16.py
@@ -61,3 +61,12 @@ class FileSystemFat16(FileSystemBase):
                 'mkdosfs', '-F16', '-I'
             ] + self.custom_args['create_options'] + device_args
         )
+
+    def set_uuid(self):
+        """
+        Create new random filesystem UUID
+        """
+        device = self.device_provider.get_device()
+        Command.run(
+            ['mlabel', '-n', '-i', device, '::']
+        )

--- a/kiwi/filesystem/fat32.py
+++ b/kiwi/filesystem/fat32.py
@@ -61,3 +61,12 @@ class FileSystemFat32(FileSystemBase):
                 'mkdosfs', '-F32', '-I'
             ] + self.custom_args['create_options'] + device_args
         )
+
+    def set_uuid(self):
+        """
+        Create new random filesystem UUID
+        """
+        device = self.device_provider.get_device()
+        Command.run(
+            ['mlabel', '-n', '-i', device, '::']
+        )

--- a/kiwi/filesystem/xfs.py
+++ b/kiwi/filesystem/xfs.py
@@ -62,3 +62,12 @@ class FileSystemXfs(FileSystemBase):
         Command.run(
             ['mkfs.xfs', '-f'] + self.custom_args['create_options'] + [device]
         )
+
+    def set_uuid(self):
+        """
+        Create new random filesystem UUID
+        """
+        device = self.device_provider.get_device()
+        Command.run(
+            ['xfs_admin', '-U', 'generate', device]
+        )

--- a/test/unit/filesystem/base_test.py
+++ b/test/unit/filesystem/base_test.py
@@ -1,5 +1,8 @@
+import logging
 from mock import patch
-from pytest import raises
+from pytest import (
+    raises, fixture
+)
 import mock
 
 import kiwi.defaults as defaults
@@ -10,6 +13,10 @@ from kiwi.exceptions import KiwiFileSystemSyncError
 
 
 class TestFileSystemBase:
+    @fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self._caplog = caplog
+
     def setup(self):
         provider = mock.Mock()
         provider.get_device = mock.Mock(
@@ -116,6 +123,10 @@ class TestFileSystemBase:
         assert self.fsbase._fs_size(-1024, unit=defaults.UNIT.mb) == '0'
         # size of 1073741824b - 1g must be zero
         assert self.fsbase._fs_size(-1, unit=defaults.UNIT.gb) == '0'
+
+    def test_set_uuid(self):
+        with self._caplog.at_level(logging.WARNING):
+            self.fsbase.set_uuid()
 
     def test_destructor_valid_mountpoint(self):
         self.fsbase.filesystem_mount = mock.Mock()

--- a/test/unit/filesystem/btrfs_test.py
+++ b/test/unit/filesystem/btrfs_test.py
@@ -32,3 +32,10 @@ class TestFileSystemBtrfs:
                 '--byte-count', '102400', '/dev/foo'
             ]
         )
+
+    @patch('kiwi.filesystem.btrfs.Command.run')
+    def test_set_uuid(self, mock_command):
+        self.btrfs.set_uuid()
+        mock_command.assert_called_once_with(
+            ['btrfstune', '-u', '/dev/foo']
+        )

--- a/test/unit/filesystem/ext2_test.py
+++ b/test/unit/filesystem/ext2_test.py
@@ -1,4 +1,6 @@
-from mock import patch
+from mock import (
+    patch, call
+)
 
 import mock
 
@@ -28,3 +30,11 @@ class TestFileSystemExt2:
         call = mock_command.call_args_list[0]
         assert mock_command.call_args_list[0] == \
             call(['mkfs.ext2', '-L', 'label', '-U', 'uuid', '/dev/foo', '100'])
+
+    @patch('kiwi.filesystem.ext2.Command.run')
+    def test_set_uuid(self, mock_command):
+        self.ext2.set_uuid()
+        assert mock_command.call_args_list == [
+            call(['e2fsck', '-y', '-f', '/dev/foo'], raise_on_error=False),
+            call(['tune2fs', '-f', '-U', 'random', '/dev/foo'])
+        ]

--- a/test/unit/filesystem/ext3_test.py
+++ b/test/unit/filesystem/ext3_test.py
@@ -1,4 +1,6 @@
-from mock import patch
+from mock import (
+    patch, call
+)
 
 import mock
 
@@ -28,3 +30,11 @@ class TestFileSystemExt3:
         call = mock_command.call_args_list[0]
         assert mock_command.call_args_list[0] == \
             call(['mkfs.ext3', '-L', 'label', '-U', 'uuid', '/dev/foo', '100'])
+
+    @patch('kiwi.filesystem.ext3.Command.run')
+    def test_set_uuid(self, mock_command):
+        self.ext3.set_uuid()
+        assert mock_command.call_args_list == [
+            call(['e2fsck', '-y', '-f', '/dev/foo'], raise_on_error=False),
+            call(['tune2fs', '-f', '-U', 'random', '/dev/foo'])
+        ]

--- a/test/unit/filesystem/ext4_test.py
+++ b/test/unit/filesystem/ext4_test.py
@@ -1,4 +1,6 @@
-from mock import patch
+from mock import (
+    patch, call
+)
 
 import mock
 
@@ -28,3 +30,11 @@ class TestFileSystemExt4:
         call = mock_command.call_args_list[0]
         assert mock_command.call_args_list[0] == \
             call(['mkfs.ext4', '-L', 'label', '-U', 'uuid', '/dev/foo', '100'])
+
+    @patch('kiwi.filesystem.ext4.Command.run')
+    def test_set_uuid(self, mock_command):
+        self.ext4.set_uuid()
+        assert mock_command.call_args_list == [
+            call(['e2fsck', '-y', '-f', '/dev/foo'], raise_on_error=False),
+            call(['tune2fs', '-f', '-U', 'random', '/dev/foo'])
+        ]

--- a/test/unit/filesystem/fat16_test.py
+++ b/test/unit/filesystem/fat16_test.py
@@ -32,3 +32,10 @@ class TestFileSystemFat16:
                 '-i', 'uuid', '/dev/foo', '100'
             ]
         )
+
+    @patch('kiwi.filesystem.fat16.Command.run')
+    def test_set_uuid(self, mock_command):
+        self.fat16.set_uuid()
+        mock_command.assert_called_once_with(
+            ['mlabel', '-n', '-i', '/dev/foo', '::']
+        )

--- a/test/unit/filesystem/fat32_test.py
+++ b/test/unit/filesystem/fat32_test.py
@@ -32,3 +32,10 @@ class TestFileSystemFat32:
                 '-i', 'uuid', '/dev/foo', '100'
             ]
         )
+
+    @patch('kiwi.filesystem.fat32.Command.run')
+    def test_set_uuid(self, mock_command):
+        self.fat32.set_uuid()
+        mock_command.assert_called_once_with(
+            ['mlabel', '-n', '-i', '/dev/foo', '::']
+        )

--- a/test/unit/filesystem/xfs_test.py
+++ b/test/unit/filesystem/xfs_test.py
@@ -32,3 +32,10 @@ class TestFileSystemXfs:
                 '-m', 'uuid=uuid', '-d', 'size=100k', '/dev/foo'
             ]
         )
+
+    @patch('kiwi.filesystem.xfs.Command.run')
+    def test_set_uuid(self, mock_command):
+        self.xfs.set_uuid()
+        mock_command.assert_called_once_with(
+            ['xfs_admin', '-U', 'generate', '/dev/foo']
+        )


### PR DESCRIPTION
Allow to set a custom UUID not only at creation time of
a filesystem but also at a later point in time in an
already existing filesystem


