### PR TITLE
Fixed overlay root dracut module

### DIFF
--- a/dracut/modules.d/90kiwi-overlay/kiwi-overlay-root.sh
+++ b/dracut/modules.d/90kiwi-overlay/kiwi-overlay-root.sh
@@ -40,12 +40,12 @@ function initGlobalDevices {
     else
         write_partition="$1"
         root_disk=$(
-            lsblk -p -n -r -s -o NAME,TYPE "${write_partition}" |\
-            grep disk | cut -f1 -d ' '
+            lsblk -p -n -r -s -o NAME,TYPE "${write_partition}" \
+                | grep disk | cut -f1 -d ' '
         )
         read_only_partition=$(
-            lsblk -p -r --fs -o NAME,FSTYPE "${root_disk}" |\
-            grep squashfs | head -n 1 | cut -f1 -d ' '
+            lsblk -p -r --fs -o NAME,FSTYPE "${root_disk}" \
+                | grep squashfs | head -n 1 | cut -f1 -d ' '
         )
     fi
 }

--- a/dracut/modules.d/90kiwi-overlay/kiwi-overlay-root.sh
+++ b/dracut/modules.d/90kiwi-overlay/kiwi-overlay-root.sh
@@ -45,7 +45,7 @@ function initGlobalDevices {
         )
         read_only_partition=$(
             lsblk -p -r --fs -o NAME,FSTYPE "${root_disk}" |\
-            grep squashfs | cut -f1 -d ' '
+            grep squashfs | head -n 1 | cut -f1 -d ' '
         )
     fi
 }


### PR DESCRIPTION
make sure there is always only one selection for the
readonly root partition

