### PR TITLE
Added new CloneDevice class

### DIFF
--- a/doc/source/api/kiwi.storage.rst
+++ b/doc/source/api/kiwi.storage.rst
@@ -54,6 +54,14 @@ Submodules
     :undoc-members:
     :show-inheritance:
 
+`kiwi.storage.clone_device` Module
+----------------------------------
+
+.. automodule:: kiwi.storage.clone_device
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 `kiwi.storage.setup` Module
 ---------------------------
 

--- a/kiwi/storage/clone_device.py
+++ b/kiwi/storage/clone_device.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2022 Marcus Schäfer.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import uuid
+from typing import List
+
+from kiwi.storage.device_provider import DeviceProvider
+from kiwi.storage.mapped_device import MappedDevice
+from kiwi.filesystem import FileSystem
+from kiwi.command import Command
+from kiwi.utils.block import BlockID
+from kiwi.defaults import Defaults
+
+from kiwi.exceptions import KiwiRaidSetupError
+
+
+class CloneDevice(DeviceProvider):
+    """
+    **Implements device cloning**
+    """
+    def __init__(self, source_provider: DeviceProvider, root_dir: str):
+        """
+        Construct a new CloneDevice layout object
+
+        :param object source_provider:
+            Instance of class based on DeviceProvider
+        :param str root_dir:
+            Path to image root directory
+        """
+        self.source_provider = source_provider
+        self.root_dir = root_dir
+
+    def clone(self, target_devices: List[DeviceProvider]):
+        """
+        Clone source device to target device(s)
+
+        :param list target_devices:
+            List of target DeviceProvider instances
+        """
+        for target_device in target_devices:
+            Command.run(
+                [
+                    'dd',
+                    'if={0}'.format(self.source_provider.get_device()),
+                    'of={0}'.format(target_device.get_device())
+                ]
+            )
+            clone_id = BlockID(target_device.get_device())
+            target_filesystem = clone_id.get_filesystem()
+
+            if target_filesystem in Defaults.get_filesystem_image_types():
+                # Simple filesystem clones needs to be unique on the UUID
+                # to avoid conflicts on the running system
+                FileSystem.new(
+                    target_filesystem, target_device
+                ).set_uuid()
+            elif target_filesystem == 'LVM2_member':
+                # Volume Group clones requires to be unique on the vgroup
+                # name to avoid conflicts on the running system
+                Command.run(
+                    ['vgimportclone', target_device.get_device()]
+                )
+            elif target_filesystem == 'crypto_LUKS':
+                # Device mapper clones based on the LUKS header needs to be
+                # unique in the LUKS UUID to avoid conflicts on the running
+                # system
+                Command.run(
+                    [
+                        'cryptsetup', '-q', 'luksUUID',
+                        target_device.get_device(), '--uuid',
+                        format(uuid.uuid4())
+                    ]
+                )
+            elif target_filesystem == 'linux_raid_member':
+                # Device mapper clones based on the RAID superblock needs
+                # to be unique in the UUID stored in the raid superblock
+                # to avoid conflicts on the running system
+                try:
+                    mdadm_conf = f'{self.root_dir}/etc/mdadm.conf'
+                    with open(mdadm_conf) as mdadm:
+                        raid_config = mdadm.readline().split(' ')
+                    md_device = raid_config[1]
+                    md_name = raid_config[3].split('=')[1]
+                    Command.run(
+                        ['mdadm', '--stop', md_device]
+                    )
+                    Command.run(
+                        [
+                            'mdadm', '--assemble', '--update=uuid', '--name',
+                            md_name, md_device, target_device.get_device()
+                        ]
+                    )
+                    FileSystem.new(
+                        BlockID(md_device).get_filesystem(),
+                        MappedDevice(md_device, target_device)
+                    ).set_uuid()
+                    Command.run(
+                        ['mdadm', '--stop', md_device]
+                    )
+                    Command.run(
+                        [
+                            'mdadm', '--assemble', md_device,
+                            self.source_provider.get_device()
+                        ]
+                    )
+                except Exception as issue:
+                    raise KiwiRaidSetupError(
+                        f'Failed to update mdraid UUID: {issue}'
+                    )

--- a/test/unit/storage/clone_device_test.py
+++ b/test/unit/storage/clone_device_test.py
@@ -1,0 +1,139 @@
+import io
+from mock import (
+    patch, call, MagicMock, Mock
+)
+from pytest import raises
+
+from kiwi.storage.clone_device import CloneDevice
+
+from kiwi.exceptions import KiwiRaidSetupError
+
+
+class TestCloneDevice:
+    def setup(self):
+        self.storage_device = Mock()
+        self.storage_device.get_device = Mock(
+            return_value='/dev/source-device'
+        )
+        self.target_device = Mock()
+        self.target_device.get_device = Mock(
+            return_value='/dev/target-device'
+        )
+        self.clone_id = Mock()
+        self.clone_device = CloneDevice(
+            self.storage_device, 'root_dir'
+        )
+
+    @patch('kiwi.storage.clone_device.Command.run')
+    @patch('kiwi.storage.clone_device.BlockID')
+    @patch('kiwi.storage.clone_device.FileSystem.new')
+    def test_clone_filesystem(
+        self, mock_FileSystem_new, mock_BlockID, mock_Command_run
+    ):
+        self.clone_id.get_filesystem.return_value = 'ext3'
+        mock_BlockID.return_value = self.clone_id
+
+        self.clone_device.clone([self.target_device])
+
+        mock_Command_run.assert_called_once_with(
+            ['dd', 'if=/dev/source-device', 'of=/dev/target-device']
+        )
+        mock_FileSystem_new.assert_called_once_with(
+            'ext3', self.target_device
+        )
+        mock_FileSystem_new.return_value.set_uuid.assert_called_once_with()
+
+    @patch('kiwi.storage.clone_device.Command.run')
+    @patch('kiwi.storage.clone_device.BlockID')
+    def test_clone_lvm(self, mock_BlockID, mock_Command_run):
+        self.clone_id.get_filesystem.return_value = 'LVM2_member'
+        mock_BlockID.return_value = self.clone_id
+
+        self.clone_device.clone([self.target_device])
+
+        assert mock_Command_run.call_args_list == [
+            call(
+                ['dd', 'if=/dev/source-device', 'of=/dev/target-device']
+            ),
+            call(
+                ['vgimportclone', '/dev/target-device']
+            )
+        ]
+
+    @patch('kiwi.storage.clone_device.Command.run')
+    @patch('kiwi.storage.clone_device.BlockID')
+    @patch('uuid.uuid4')
+    def test_clone_luks(self, mock_uuid4, mock_BlockID, mock_Command_run):
+        self.clone_id.get_filesystem.return_value = 'crypto_LUKS'
+        mock_BlockID.return_value = self.clone_id
+        mock_uuid4.return_value = 'some-UUID'
+
+        self.clone_device.clone([self.target_device])
+
+        assert mock_Command_run.call_args_list == [
+            call(
+                ['dd', 'if=/dev/source-device', 'of=/dev/target-device']
+            ),
+            call(
+                [
+                    'cryptsetup', '-q', 'luksUUID',
+                    '/dev/target-device', '--uuid', 'some-UUID'
+                ]
+            )
+        ]
+
+    @patch('kiwi.storage.clone_device.Command.run')
+    @patch('kiwi.storage.clone_device.BlockID')
+    @patch('kiwi.storage.clone_device.FileSystem.new')
+    @patch('kiwi.storage.clone_device.MappedDevice')
+    def test_clone_raid(
+        self, mock_MappedDevice, mock_FileSystem_new,
+        mock_BlockID, mock_Command_run
+    ):
+        self.clone_id.get_filesystem.return_value = 'linux_raid_member'
+        mock_BlockID.return_value = self.clone_id
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            file_handle.readline.return_value = \
+                'ARRAY /dev/md0 metadata=1.2 name=asterix:0 UUID=...'
+
+            self.clone_device.clone([self.target_device])
+
+            mock_open.assert_called_once_with('root_dir/etc/mdadm.conf')
+
+        mock_FileSystem_new.assert_called_once_with(
+            mock_BlockID.return_value.get_filesystem.return_value,
+            mock_MappedDevice.return_value
+        )
+        mock_FileSystem_new.return_value.set_uuid.assert_called_once_with()
+        assert mock_Command_run.call_args_list == [
+            call(
+                ['dd', 'if=/dev/source-device', 'of=/dev/target-device']
+            ),
+            call(
+                ['mdadm', '--stop', '/dev/md0']
+            ),
+            call(
+                [
+                    'mdadm', '--assemble', '--update=uuid',
+                    '--name', 'asterix:0', '/dev/md0', '/dev/target-device'
+                ]
+            ),
+            call(
+                ['mdadm', '--stop', '/dev/md0']
+            ),
+            call(
+                ['mdadm', '--assemble', '/dev/md0', '/dev/source-device']
+            )
+        ]
+
+    @patch('kiwi.storage.clone_device.Command.run')
+    @patch('kiwi.storage.clone_device.BlockID')
+    def test_clone_raid_raises(self, mock_BlockID, mock_Command_run):
+        self.clone_id.get_filesystem.return_value = 'linux_raid_member'
+        mock_BlockID.return_value = self.clone_id
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.side_effect = Exception
+            with raises(KiwiRaidSetupError):
+                self.clone_device.clone([self.target_device])


### PR DESCRIPTION
Added CloneDevice class to the storage interface. The class allows to create clone(s) from a given source block device into a list of target block devices. The target block devices are clones of the source but prevents device naming conflicts for unique identifiers like the UUID. This is required to still allow to boot from images containing device clones and needs to be
handled by tools that might work on top of the cloned devices.

