### PR TITLE
Be less strict in boot link to itself

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -255,8 +255,10 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 'rm', '-f', 'boot', '&&',
                 'ln', '-s', '.', 'boot'
             ]
+            # not every filesystem supports symlinks, and the link is optional
+            # therefore don't fail in case the link cannot be created
             Command.run(
-                ['bash', '-c', ' '.join(bash_command)]
+                ['bash', '-c', ' '.join(bash_command)], raise_on_error=False
             )
 
         # Patch the written grub config file to actually work:

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -893,7 +893,7 @@ class TestBootLoaderConfigGrub2:
                     [
                         'bash', '-c',
                         'cd root_mount_point/boot && rm -f boot && ln -s . boot'
-                    ]
+                    ], raise_on_error=False
                 )
             ]
             mock_copy_grub_config_to_efi_path.assert_called_once_with(


### PR DESCRIPTION
As part of the grub setup a link named ```boot``` inside of ```/boot``` is created pointing to itself ```boot -> .``` The reason is to allow the bootloader config to find its files referenced as ```/boot/something``` independently if /boot is placed into an extra partition. However if an extra boot partition is used and a filesystem which does not support symlinks, e.g fat, that symlink creation should not lead to an error in the image build process as it is considered an optional safe link and not a mandatory pre-requisite

