### PR TITLE
Add support for part clones to the Disk interface

### DIFF
--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -169,7 +169,7 @@ class Disk(DeviceProvider):
         :param str mbsize: partition size string
         :param int clone: create [clone] cop(y/ies) of the root partition
         """
-        (mbsize, mbsize_clone) = self._parse_size(mbsize)
+        (mbsize, mbsize_clone) = Disk._parse_size(mbsize)
         if clone:
             self._create_clones('root', clone, 't.linux', mbsize_clone)
         self.partitioner.create('p.lxroot', mbsize, 't.linux')
@@ -189,7 +189,7 @@ class Disk(DeviceProvider):
         :param str mbsize: partition size string
         :param int clone: create [clone] cop(y/ies) of the lvm roo partition
         """
-        (mbsize, mbsize_clone) = self._parse_size(mbsize)
+        (mbsize, mbsize_clone) = Disk._parse_size(mbsize)
         if clone:
             self._create_clones('root', clone, 't.lvm', mbsize_clone)
         self.partitioner.create('p.lxlvm', mbsize, 't.lvm')
@@ -207,7 +207,7 @@ class Disk(DeviceProvider):
         :param str mbsize: partition size string
         :param int clone: create [clone] cop(y/ies) of the raid root partition
         """
-        (mbsize, mbsize_clone) = self._parse_size(mbsize)
+        (mbsize, mbsize_clone) = Disk._parse_size(mbsize)
         if clone:
             self._create_clones('root', clone, 't.raid', mbsize_clone)
         self.partitioner.create('p.lxraid', mbsize, 't.raid')
@@ -227,7 +227,7 @@ class Disk(DeviceProvider):
         :param str mbsize: partition size string
         :param int clone: create [clone] cop(y/ies) of the ro root partition
         """
-        (mbsize, mbsize_clone) = self._parse_size(mbsize)
+        (mbsize, mbsize_clone) = Disk._parse_size(mbsize)
         if clone:
             self._create_clones('root', clone, 't.linux', mbsize_clone)
         self.partitioner.create('p.lxreadonly', mbsize, 't.linux')
@@ -243,7 +243,7 @@ class Disk(DeviceProvider):
         :param str mbsize: partition size string
         :param int clone: create [clone] cop(y/ies) of the boot partition
         """
-        (mbsize, mbsize_clone) = self._parse_size(mbsize)
+        (mbsize, mbsize_clone) = Disk._parse_size(mbsize)
         if clone:
             self._create_clones('boot', clone, 't.linux', mbsize_clone)
         self.partitioner.create('p.lxboot', mbsize, 't.linux')
@@ -258,7 +258,7 @@ class Disk(DeviceProvider):
 
         :param str mbsize: partition size string
         """
-        (mbsize, _) = self._parse_size(mbsize)
+        (mbsize, _) = Disk._parse_size(mbsize)
         self.partitioner.create('p.prep', mbsize, 't.prep')
         self._add_to_map('prep')
         self._add_to_public_id_map('kiwi_PrepPart')
@@ -271,7 +271,7 @@ class Disk(DeviceProvider):
 
         :param str mbsize: partition size string
         """
-        (mbsize, _) = self._parse_size(mbsize)
+        (mbsize, _) = Disk._parse_size(mbsize)
         self.partitioner.create('p.spare', mbsize, 't.linux')
         self._add_to_map('spare')
         self._add_to_public_id_map('kiwi_SparePart')
@@ -284,7 +284,7 @@ class Disk(DeviceProvider):
 
         :param str mbsize: partition size string
         """
-        (mbsize, _) = self._parse_size(mbsize)
+        (mbsize, _) = Disk._parse_size(mbsize)
         self.partitioner.create('p.swap', mbsize, 't.swap')
         self._add_to_map('swap')
         self._add_to_public_id_map('kiwi_SwapPart')
@@ -297,7 +297,7 @@ class Disk(DeviceProvider):
 
         :param str mbsize: partition size string
         """
-        (mbsize, _) = self._parse_size(mbsize)
+        (mbsize, _) = Disk._parse_size(mbsize)
         self.partitioner.create('p.legacy', mbsize, 't.csm')
         self._add_to_map('efi_csm')
         self._add_to_public_id_map('kiwi_BiosGrub')
@@ -310,7 +310,7 @@ class Disk(DeviceProvider):
 
         :param str mbsize: partition size string
         """
-        (mbsize, _) = self._parse_size(mbsize)
+        (mbsize, _) = Disk._parse_size(mbsize)
         self.partitioner.create('p.UEFI', mbsize, 't.efi')
         self._add_to_map('efi')
         self._add_to_public_id_map('kiwi_EfiPart')
@@ -431,7 +431,8 @@ class Disk(DeviceProvider):
             self._add_to_map(f'{name}clone{clone_id}')
             self._add_to_public_id_map(f'kiwi_{name}PartClone{clone_id}')
 
-    def _parse_size(self, value: str) -> Tuple[str, str]:
+    @staticmethod
+    def _parse_size(value: str) -> Tuple[str, str]:
         """
         parse size value. This can be one of the following
 

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1418,6 +1418,7 @@ class XMLState:
                 {
                     'NAME': ptable_entry_type(
                         mbsize=int,
+                        clone=int,
                         partition_name=str,
                         partition_type=str,
                         mountpoint=str,
@@ -1436,6 +1437,11 @@ class XMLState:
             partition_name = partition.get_partition_name() or f'p.lx{name}'
             partitions[name] = ptable_entry_type(
                 mbsize=self._to_mega_byte(partition.get_size()),
+                # There is currently no clone attribute in the <partition>
+                # element. This will be added on completion of the partition
+                # clone feature. The internal API structure however, already
+                # knows about the capability
+                clone=0,
                 partition_name=partition_name,
                 partition_type=partition.get_partition_type() or 't.linux',
                 mountpoint=partition.get_mountpoint(),

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -803,6 +803,7 @@ class TestDiskBuilder:
         self.disk_builder.custom_partitions = {
             'var': ptable_entry_type(
                 mbsize=100,
+                clone=0,
                 partition_name='p.lxvar',
                 partition_type='t.linux',
                 mountpoint='/var',

--- a/test/unit/storage/disk_test.py
+++ b/test/unit/storage/disk_test.py
@@ -53,90 +53,99 @@ class TestDisk:
         self.storage_provider.is_loop.called_once_with()
 
     def test_create_root_partition(self):
-        self.disk.create_root_partition(100)
-        self.partitioner.create.assert_called_once_with(
-            'p.lxroot', 100, 't.linux'
-        )
+        self.disk.create_root_partition('100', 1)
+        assert self.partitioner.create.call_args_list == [
+            call('p.lxrootclone1', '100', 't.linux'),
+            call('p.lxroot', '100', 't.linux')
+        ]
 
     def test_create_root_which_is_also_boot_partition(self):
-        self.disk.create_root_partition(200)
+        self.disk.create_root_partition('200')
         self.partitioner.create.assert_called_once_with(
-            'p.lxroot', 200, 't.linux'
+            'p.lxroot', '200', 't.linux'
         )
         assert self.disk.public_partition_id_map['kiwi_RootPart'] == 1
         assert self.disk.public_partition_id_map['kiwi_BootPart'] == 1
 
     def test_create_root_which_is_also_read_write_partition(self):
         self.disk.public_partition_id_map['kiwi_ROPart'] = 1
-        self.disk.create_root_partition(200)
+        self.disk.create_root_partition('200')
         self.partitioner.create.assert_called_once_with(
-            'p.lxroot', 200, 't.linux'
+            'p.lxroot', '200', 't.linux'
         )
         assert self.disk.public_partition_id_map['kiwi_RootPart'] == 1
         assert self.disk.public_partition_id_map['kiwi_RWPart'] == 1
 
     def test_create_root_lvm_partition(self):
-        self.disk.create_root_lvm_partition(100)
-        self.partitioner.create.assert_called_once_with(
-            'p.lxlvm', 100, 't.lvm'
-        )
+        self.disk.create_root_lvm_partition('100', 1)
+        assert self.partitioner.create.call_args_list == [
+            call('p.lxrootclone1', '100', 't.lvm'),
+            call('p.lxlvm', '100', 't.lvm')
+        ]
+        assert self.disk.public_partition_id_map['kiwi_rootPartClone1'] == 1
         assert self.disk.public_partition_id_map['kiwi_RootPart'] == 1
 
     def test_create_root_raid_partition(self):
-        self.disk.create_root_raid_partition(100)
-        self.partitioner.create.assert_called_once_with(
-            'p.lxraid', 100, 't.raid'
-        )
+        self.disk.create_root_raid_partition('100', 1)
+        assert self.partitioner.create.call_args_list == [
+            call('p.lxrootclone1', '100', 't.raid'),
+            call('p.lxraid', '100', 't.raid')
+        ]
+        assert self.disk.public_partition_id_map['kiwi_rootPartClone1'] == 1
         assert self.disk.public_partition_id_map['kiwi_RootPart'] == 1
         assert self.disk.public_partition_id_map['kiwi_RaidPart'] == 1
 
     def test_create_root_readonly_partition(self):
-        self.disk.create_root_readonly_partition(100)
-        self.partitioner.create.assert_called_once_with(
-            'p.lxreadonly', 100, 't.linux'
-        )
+        self.disk.create_root_readonly_partition('100', 1)
+        assert self.partitioner.create.call_args_list == [
+            call('p.lxrootclone1', '100', 't.linux'),
+            call('p.lxreadonly', '100', 't.linux')
+        ]
+        assert self.disk.public_partition_id_map['kiwi_rootPartClone1'] == 1
         assert self.disk.public_partition_id_map['kiwi_ROPart'] == 1
 
     def test_create_boot_partition(self):
-        self.disk.create_boot_partition(100)
-        self.partitioner.create.assert_called_once_with(
-            'p.lxboot', 100, 't.linux'
-        )
+        self.disk.create_boot_partition('100', 1)
+        assert self.partitioner.create.call_args_list == [
+            call('p.lxbootclone1', '100', 't.linux'),
+            call('p.lxboot', '100', 't.linux')
+        ]
+        assert self.disk.public_partition_id_map['kiwi_bootPartClone1'] == 1
         assert self.disk.public_partition_id_map['kiwi_BootPart'] == 1
 
     def test_create_efi_csm_partition(self):
-        self.disk.create_efi_csm_partition(100)
+        self.disk.create_efi_csm_partition('100')
         self.partitioner.create.assert_called_once_with(
-            'p.legacy', 100, 't.csm'
+            'p.legacy', '100', 't.csm'
         )
         assert self.disk.public_partition_id_map['kiwi_BiosGrub'] == 1
 
     def test_create_efi_partition(self):
-        self.disk.create_efi_partition(100)
+        self.disk.create_efi_partition('100')
         self.partitioner.create.assert_called_once_with(
-            'p.UEFI', 100, 't.efi'
+            'p.UEFI', '100', 't.efi'
         )
         assert self.disk.public_partition_id_map['kiwi_EfiPart'] == 1
 
     def test_create_spare_partition(self):
-        self.disk.create_spare_partition(42)
+        self.disk.create_spare_partition('42')
         self.partitioner.create.assert_called_once_with(
-            'p.spare', 42, 't.linux'
+            'p.spare', '42', 't.linux'
         )
         assert self.disk.public_partition_id_map['kiwi_SparePart'] == 1
 
     def test_create_swap_partition(self):
-        self.disk.create_swap_partition(42)
+        self.disk.create_swap_partition('42')
         self.partitioner.create.assert_called_once_with(
-            'p.swap', 42, 't.swap'
+            'p.swap', '42', 't.swap'
         )
         assert self.disk.public_partition_id_map['kiwi_SwapPart'] == 1
 
     @patch('kiwi.storage.disk.Command.run')
     def test_create_prep_partition(self, mock_command):
-        self.disk.create_prep_partition(8)
+        self.disk.create_prep_partition('8')
         self.partitioner.create.assert_called_once_with(
-            'p.prep', 8, 't.prep'
+            'p.prep', '8', 't.prep'
         )
         assert self.disk.public_partition_id_map['kiwi_PrepPart'] == 1
 
@@ -144,7 +153,8 @@ class TestDisk:
     def test_create_custom_partitions(self, mock_command):
         table_entries = {
             'var': ptable_entry_type(
-                mbsize=100,
+                mbsize='100',
+                clone=2,
                 partition_name='p.lxvar',
                 partition_type='t.linux',
                 mountpoint='/var',
@@ -152,15 +162,20 @@ class TestDisk:
             )
         }
         self.disk.create_custom_partitions(table_entries)
-        self.partitioner.create.assert_called_once_with(
-            'p.lxvar', 100, 't.linux'
-        )
+        assert self.partitioner.create.call_args_list == [
+            call('p.lxvarclone1', '100', 't.linux'),
+            call('p.lxvarclone2', '100', 't.linux'),
+            call('p.lxvar', '100', 't.linux')
+        ]
+        assert self.disk.public_partition_id_map['kiwi_varPartClone1'] == 1
+        assert self.disk.public_partition_id_map['kiwi_varPartClone2'] == 1
         assert self.disk.public_partition_id_map['kiwi_VarPart'] == 1
 
     def test_create_custom_partitions_reserved_name(self):
         table_entries = {
             'root': ptable_entry_type(
-                mbsize=100,
+                mbsize='100',
+                clone=0,
                 partition_name='p.lxroot',
                 partition_type='t.linux',
                 mountpoint='/',
@@ -172,14 +187,14 @@ class TestDisk:
 
     @patch('kiwi.storage.disk.Command.run')
     def test_device_map_efi_partition(self, mock_command):
-        self.disk.create_efi_partition(100)
+        self.disk.create_efi_partition('100')
         self.disk.map_partitions()
         assert self.disk.partition_map == {'efi': '/dev/mapper/loop0p1'}
         self.disk.is_mapped = False
 
     @patch('kiwi.storage.disk.Command.run')
     def test_device_map_prep_partition(self, mock_command):
-        self.disk.create_prep_partition(8)
+        self.disk.create_prep_partition('8')
         self.disk.map_partitions()
         assert self.disk.partition_map == {'prep': '/dev/mapper/loop0p1'}
         self.disk.is_mapped = False
@@ -190,7 +205,7 @@ class TestDisk:
         self.storage_provider.get_device = mock.Mock(
             return_value='/dev/sda'
         )
-        self.disk.create_efi_partition(100)
+        self.disk.create_efi_partition('100')
         self.disk.map_partitions()
         assert self.disk.partition_map == {'efi': '/dev/sda1'}
         self.disk.is_mapped = False
@@ -201,27 +216,27 @@ class TestDisk:
         self.storage_provider.get_device = mock.Mock(
             return_value='/dev/c0d0'
         )
-        self.disk.create_efi_partition(100)
+        self.disk.create_efi_partition('100')
         self.disk.map_partitions()
         assert self.disk.partition_map == {'efi': '/dev/c0d0p1'}
         self.disk.is_mapped = False
 
     @patch('kiwi.storage.disk.Command.run')
     def test_activate_boot_partition_is_boot_partition(self, mock_command):
-        self.disk.create_boot_partition(100)
-        self.disk.create_root_partition(100)
+        self.disk.create_boot_partition('100')
+        self.disk.create_root_partition('100')
         self.disk.activate_boot_partition()
         self.partitioner.set_flag(1, 'f.active')
 
     @patch('kiwi.storage.disk.Command.run')
     def test_activate_boot_partition_is_root_partition(self, mock_command):
-        self.disk.create_root_partition(100)
+        self.disk.create_root_partition('100')
         self.disk.activate_boot_partition()
         self.partitioner.set_flag(1, 'f.active')
 
     @patch('kiwi.storage.disk.Command.run')
     def test_activate_boot_partition_is_prep_partition(self, mock_command):
-        self.disk.create_prep_partition(8)
+        self.disk.create_prep_partition('8')
         self.disk.activate_boot_partition()
         self.partitioner.set_flag(1, 'f.active')
 
@@ -300,3 +315,13 @@ class TestDisk:
     def test_create_mbr(self):
         self.disk.create_mbr()
         self.partitioner.set_mbr.assert_called_once_with()
+
+    def test_parse_size(self):
+        (size, _) = self.disk._parse_size('100')
+        assert size == '100'
+        (size, clone_size) = self.disk._parse_size('all_free')
+        assert size == 'all_free'
+        assert clone_size == 'all_free'
+        (size, clone_size) = self.disk._parse_size('clone:100:all_free')
+        assert size == '100'
+        assert clone_size == 'all_free'

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -330,6 +330,7 @@ class TestXMLState:
         assert state.get_partitions() == {
             'var': ptable_entry_type(
                 mbsize=100,
+                clone=0,
                 partition_name='p.lxvar',
                 partition_type='t.linux',
                 mountpoint='/var',


### PR DESCRIPTION
The Disk class provides methods to create partition(s) and map names according to its scope and independent of the actual partition tools. For example: ```create_root_partition()``` This commit adds an additional optional clone parameter to all methods for which we want to allow partition clones


