### PR TITLE
Fix vagrant sshd config file

### DIFF
--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -586,7 +586,7 @@ function baseVagrantSetup {
     chown -R vagrant:vagrant /home/vagrant/
 
     # apply recommended ssh settings for vagrant boxes
-    SSHD_CONFIG=/etc/ssh/sshd_config.d/99-vagrant.conf
+    SSHD_CONFIG=/etc/ssh/sshd_config.d/00-vagrant.conf
     if [[ ! -d "$(dirname ${SSHD_CONFIG})" ]]; then
         SSHD_CONFIG=/etc/ssh/sshd_config
         # prepend the settings, so that they take precedence

--- a/test/scripts/conftest.py
+++ b/test/scripts/conftest.py
@@ -8,27 +8,49 @@ FUNCTIONS_COPY_CONTAINERFILE = """COPY kiwi/config/functions.sh /bin/functions.s
 CONTAINERS = [
     DerivedContainer(base=url, containerfile=FUNCTIONS_COPY_CONTAINERFILE)
     for url in [
+        "registry.opensuse.org/opensuse/leap:15.4",
         "registry.opensuse.org/opensuse/leap:15.3",
         "registry.opensuse.org/opensuse/leap:15.2",
         "registry.opensuse.org/opensuse/tumbleweed:latest",
+        "registry.suse.com/suse/sle15:15.4",
         "registry.suse.com/suse/sle15:15.3",
         "registry.suse.com/suse/sle15:15.2",
         "registry.suse.com/suse/sle15:15.1",
         "registry.suse.com/suse/sles12sp5:latest",
         "quay.io/centos/centos:stream8",
+        "quay.io/centos/centos:stream9",
     ]
 ]
 
 (
+    LEAP_15_4,
     LEAP_15_3,
     LEAP_15_2,
     TUMBLEWEED,
+    SLE_15_SP4,
     SLE_15_SP3,
     SLE_15_SP2,
     SLE_15_SP1,
     SLE_12_SP5,
     CENTOS_STREAM_8,
+    CENTOS_STREAM_9,
 ) = CONTAINERS
+
+
+CONTAINERS_WITH_ZYPPER = [
+    LEAP_15_4,
+    LEAP_15_3,
+    LEAP_15_2,
+    TUMBLEWEED,
+    SLE_15_SP4,
+    SLE_15_SP3,
+]
+
+
+CONTAINERS_WITH_YUM = [
+    CENTOS_STREAM_8,
+    CENTOS_STREAM_9,
+]
 
 
 def pytest_generate_tests(metafunc):

--- a/test/scripts/test_baseVagrantSetup.py
+++ b/test/scripts/test_baseVagrantSetup.py
@@ -1,21 +1,17 @@
 from pytest_container.container import DerivedContainer
 from .conftest import (
-    CENTOS_STREAM_8,
-    LEAP_15_2,
-    LEAP_15_3,
-    TUMBLEWEED,
+    CONTAINERS_WITH_YUM,
+    CONTAINERS_WITH_ZYPPER,
 )
 import pytest
 
 
-VAGRANT_SETUP_CONTAINERFILE = (
-    r"""RUN groupadd vagrant && useradd -g vagrant vagrant
+VAGRANT_SETUP_CONTAINERFILE = r"""RUN groupadd vagrant && useradd -g vagrant vagrant
 RUN echo $'#!/bin/bash \n\
 printf "%s " "$@" >> /systemctl_params \n\
 echo >> /systemctl_params \n\
 '> /usr/bin/systemctl && chmod +x /usr/bin/systemctl
 """
-)
 
 ZYPPER_IN_CMD_CONTAINERFILE = (
     """RUN zypper -n in openssh sudo && /usr/sbin/sshd-gen-keys-start
@@ -25,16 +21,17 @@ ZYPPER_IN_CMD_CONTAINERFILE = (
 
 @pytest.mark.parametrize(
     "container_per_test",
-    (
-        DerivedContainer(base=TUMBLEWEED, containerfile=ZYPPER_IN_CMD_CONTAINERFILE),
-        DerivedContainer(base=LEAP_15_2, containerfile=ZYPPER_IN_CMD_CONTAINERFILE),
-        DerivedContainer(base=LEAP_15_3, containerfile=ZYPPER_IN_CMD_CONTAINERFILE),
+    [
+        DerivedContainer(base=cont, containerfile=ZYPPER_IN_CMD_CONTAINERFILE)
+        for cont in CONTAINERS_WITH_ZYPPER
+    ] + [
         DerivedContainer(
-            base=CENTOS_STREAM_8,
+            base=cont,
             containerfile="""RUN yum -y install openssh-server sudo && /usr/libexec/openssh/sshd-keygen ed25519
 """ + VAGRANT_SETUP_CONTAINERFILE,
-        ),
-    ),
+        )
+        for cont in CONTAINERS_WITH_YUM
+    ],
     indirect=["container_per_test"],
 )
 def test_configures_system_for_vagrant(container_per_test):
@@ -59,9 +56,9 @@ def test_configures_system_for_vagrant(container_per_test):
     assert "vagrant insecure public key" in authorized_keys.content_string
 
     # check the sshd config
-    sshd_config = container_per_test.connection.run_expect([0], "sshd -T")
-    assert "UseDNS no".lower() in sshd_config.stdout
-    assert "GSSAPIAuthentication no".lower() in sshd_config.stdout
+    sshd_config = container_per_test.connection.run_expect([0], "sshd -T").stdout
+    assert "UseDNS no".lower() in sshd_config
+    assert "GSSAPIAuthentication no".lower() in sshd_config
 
     # check that the shared /vagrant folder is present and has the correct permissions
     vagrant_shared_dir = container_per_test.connection.file("/vagrant")

--- a/test/scripts/test_suseSetupProduct.py
+++ b/test/scripts/test_suseSetupProduct.py
@@ -3,10 +3,12 @@ import pytest
 from .conftest import (
     LEAP_15_2,
     LEAP_15_3,
+    LEAP_15_4,
     SLE_12_SP5,
     SLE_15_SP1,
     SLE_15_SP2,
     SLE_15_SP3,
+    SLE_15_SP4,
     TUMBLEWEED,
 )
 
@@ -30,6 +32,8 @@ def test_does_nothing_when_product_correct(auto_container_per_test):
         (TUMBLEWEED, "openSUSE.prod"),
         (LEAP_15_2, "openSUSE.prod"),
         (LEAP_15_3, "Leap.prod"),
+        (LEAP_15_4, "Leap.prod"),
+        (SLE_15_SP4, "SLES.prod"),
         (SLE_15_SP3, "SLES.prod"),
         (SLE_15_SP2, "SLES.prod"),
         (SLE_15_SP1, "SLES.prod"),


### PR DESCRIPTION
Changes proposed in this pull request:
* Add Leap 15.4, SLE 15 SP4 & CentOS Stream 9 to the scripts tests
* Change the custom vagrant config file to `00-vagrant.conf`, If it is called `99-vagrant.conf`, then anything "before" that, like
`50-redhat.conf` takes precedence and overrides our custom settings.