### PR TITLE
Changed LUKS type 'luks' to 'luks1'

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
@@ -16,7 +16,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="uefi" luks="linux" luks_version="luks" bootpartition="false">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="uefi" luks="linux" luks_version="luks1" bootpartition="false">
             <luksformat>
                 <option name="--cipher" value="aes-xts-plain64"/>
                 <option name="--key-size" value="256"/>

--- a/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
@@ -16,7 +16,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="uefi" luks="linux" luks_version="luks1" bootpartition="false">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="uefi" luks="linux" luks_version="luks" bootpartition="false">
             <luksformat>
                 <option name="--cipher" value="aes-xts-plain64"/>
                 <option name="--key-size" value="256"/>

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -497,10 +497,11 @@ luks="passphrase|file:///path/to/keyfile":
 
 luks_version="luks|luks1|luks2":
   Specify which `LUKS` version should be used. If not set and by
-  default `luks` is used. The specification of the `LUKS` version
-  allows using a different set of `luksformat` options. To
-  investigate the differences between the two please consult the
-  `cryptsetup` manual page.
+  default `luks` is used. The interpretation of the default depends
+  on the distribution and could result in either 'luks1' or 'luks2'.
+  The specification of the `LUKS` version allows using a different
+  set of `luksformat` options. To investigate the differences between
+  the two please consult the `cryptsetup` manual page.
 
 target_blocksize="number":
   Specifies the image blocksize in bytes which has to

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -495,9 +495,9 @@ luks="passphrase|file:///path/to/keyfile":
   distribution will just open an interactive dialog asking
   for the credentials at boot time !
 
-luks_version="luks|luks2":
+luks_version="luks1|luks2":
   Specify which `LUKS` version should be used. If not set and by
-  default `luks` is used. The specification of the `LUKS` version
+  default `luks1` is used. The specification of the `LUKS` version
   allows using a different set of `luksformat` options. To
   investigate the differences between the two please consult the
   `cryptsetup` manual page.

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -495,9 +495,9 @@ luks="passphrase|file:///path/to/keyfile":
   distribution will just open an interactive dialog asking
   for the credentials at boot time !
 
-luks_version="luks1|luks2":
+luks_version="luks|luks1|luks2":
   Specify which `LUKS` version should be used. If not set and by
-  default `luks1` is used. The specification of the `LUKS` version
+  default `luks` is used. The specification of the `LUKS` version
   allows using a different set of `luksformat` options. To
   investigate the differences between the two please consult the
   `cryptsetup` manual page.

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1890,9 +1890,9 @@ div {
             sch:param [ name = "types" value = "oem iso pxe kis" ]
         ]
     k.type.luks_version.attribute =
-        ## Specify LUKS version. This can be either set to "luks"
-        ## or "luks2". By default "luks" is used.
-        attribute luks_version { "luks" | "luks2" }
+        ## Specify LUKS version. This can be either set to "luks1"
+        ## or "luks2". By default "luks1" is used.
+        attribute luks_version { "luks1" | "luks2" }
         >> sch:pattern [ id = "luksversion" is-a = "image_type"
             sch:param [ name = "attr" value = "luksversion" ]
             sch:param [ name = "types" value = "oem iso pxe kis" ]

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1890,9 +1890,9 @@ div {
             sch:param [ name = "types" value = "oem iso pxe kis" ]
         ]
     k.type.luks_version.attribute =
-        ## Specify LUKS version. This can be either set to "luks1"
-        ## or "luks2". By default "luks1" is used.
-        attribute luks_version { "luks1" | "luks2" }
+        ## Specify LUKS version. This can be either set to "luks", "luks1"
+        ## or "luks2". By default "luks" is used.
+        attribute luks_version { "luks" | "luks1" | "luks2" }
         >> sch:pattern [ id = "luksversion" is-a = "image_type"
             sch:param [ name = "attr" value = "luksversion" ]
             sch:param [ name = "types" value = "oem iso pxe kis" ]

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2711,10 +2711,11 @@ kernel command line options</a:documentation>
     </define>
     <define name="k.type.luks_version.attribute">
       <attribute name="luks_version">
-        <a:documentation>Specify LUKS version. This can be either set to "luks"
+        <a:documentation>Specify LUKS version. This can be either set to "luks", "luks1"
 or "luks2". By default "luks" is used.</a:documentation>
         <choice>
           <value>luks</value>
+          <value>luks1</value>
           <value>luks2</value>
         </choice>
       </attribute>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.29.24.
-# Python 3.6.15 (default, Sep 23 2021, 15:41:43) [GCC]
+# Python 3.10.4 (main, Apr  2 2022, 09:04:19) [GCC 11.2.0]
 #
 # Command line options:
 #   ('-f', '')
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/ms/Project/kiwi/.tox/3.6/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /mnt/storage/kiwi/.tox/3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi


### PR DESCRIPTION
The default cryptsetup `--type luks` apparently has a different meaning on different distributions. On Debian creating a volume with `--type luks` creates a luks2 volume. With this change the type is defined more explicitly and allows creating a LUKS1 volume on Debian. This way /boot can also be encrypted and unlocked with GRUB.

