### PR TITLE
Add support for partition cloning

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -485,6 +485,20 @@ kernelcmdline="string":
   Additional kernel parameters passed to the kernel by the
   bootloader.
 
+root_clone="number"
+  For oem disk images, this attribute allows to create `number`
+  clone(s) of the root partition, with `number` >= 1. A clone partition
+  is content wise an exact byte for byte copy of the origin root partition.
+  However, to avoid conflicts at boot time the UUID of any
+  cloned partition will be made unique. In the sequence of partitions,
+  the clone(s) will always be created first followed by the
+  partition considered the origin. The origin partition is the
+  one that will be referenced and used by the system.
+  Also see :ref:`clone_partitions`
+
+boot_clone="number"
+  Same as `root_clone` but applied to the boot partition if present
+
 luks="passphrase|file:///path/to/keyfile":
   Supplying a value will trigger the encryption of the partition
   serving the root filesystem using the LUKS extension. The supplied

--- a/doc/source/working_with_images.rst
+++ b/doc/source/working_with_images.rst
@@ -23,6 +23,7 @@ Working with Images
 
    working_with_images/custom_partitions
    working_with_images/custom_volumes
+   working_with_images/clone_partitions
 
    working_with_images/setup_network_bootserver
    working_with_images/legacy_netboot_root_filesystem

--- a/doc/source/working_with_images/clone_partitions.rst
+++ b/doc/source/working_with_images/clone_partitions.rst
@@ -1,0 +1,128 @@
+.. _clone_partitions:
+
+Partition Clones
+================
+
+.. sidebar:: Abstract
+
+   This page provides details about the partition clone feature
+   and its use cases
+
+{kiwi} allows to create block level clones of certain partitions
+used in the image. Clones can be created from the `root`, `boot`
+and any other partition listed in the `<partitions>` element.
+
+A partition clone is a simple byte dump from one
+block storage device to another. However, this would cause conflicts
+during boot of the system because all unique identifiers like
+the UUID of a filesystem will no longer be unique. The clone
+feature of {kiwi} takes care of this part and re-creates the
+relevant unique identifiers per cloned partition. {kiwi} allows
+this also for complex partitions like LVM, LUKS or RAID.
+
+The partition clone(s) will always appear first in the partition table,
+followed by the origin partition. The origin partition is the one
+whose identifier will be referenced and used by the system. By default
+no cloned partition will be mounted or used by the system at boot time.
+
+Let's take a look at the following example:
+
+.. code:: xml
+
+   <type image="oem" root_clone="1" boot_clone="1" firmware="uefi" filesystem="xfs" bootpartition="true" bootfilesystem="ext4">
+       <partitions>
+           <partition name="home" size="10" mountpoint="/home" filesystem="ext3" clone="2"/>
+       </partitions>
+   </type>
+
+With the above setup {kiwi} will create a disk image that
+contains the following partition table:
+
+.. code::
+
+   Number  Start (sector)    End (sector)  Size       Code  Name
+      1            2048            6143   2.0 MiB     EF02  p.legacy
+      2            6144           47103   20.0 MiB    EF00  p.UEFI
+      3           47104          661503   300.0 MiB   8300  p.lxbootclone1
+      4          661504         1275903   300.0 MiB   8300  p.lxboot
+      5         1275904         1296383   10.0 MiB    8300  p.lxhomeclone1
+      6         1296384         1316863   10.0 MiB    8300  p.lxhomeclone2
+      7         1316864         1337343   10.0 MiB    8300  p.lxhome
+      8         1337344         3864575   1.2 GiB     8300  p.lxrootclone1
+      9         3864576         6287326   1.2 GiB     8300  p.lxroot
+
+When booting the system only the origin partitions `p.lxboot`, `p.lxroot`
+and `p.lxhome` will be mounted and visible in e.g. :file:`/etc/fstab`,
+the bootloader or the initrd. Thus partition clones are present as a data
+source but are not relevant for the operating system from a functional
+perspective.
+
+As shown in the above example there is one clone request for root and boot
+and a two clone requests for the home partition. {kiwi} does not sanity-
+check the provided number of clones (e.g. whether your partition table
+can hold that many partitions).
+
+.. warning::
+
+   There is a limit how many partitions a partition table can hold.
+   This also limits how many clones can be created.
+
+Use Case
+--------
+
+Potential use cases for which a clone of one or more partitions
+is useful include among others:
+
+Factory Resets:
+  Creating an image with the option to rollback to the
+  state of the system at deployment time can be very helpful
+  for disaster recovery
+
+System Updates with Rollbacks e.g A/B:
+  Creating an image which holds extra space allowing to rollback
+  modified data can make a system more robust. For example
+  in a simple A/B update concept, partition A would get updated
+  but would flip to B if A is considered broken after applying the
+  update.
+
+.. note::
+
+   Most probably any use case based on partition clones requires
+   additional software to manage them. {kiwi} provides the
+   option to create the clone layout but it does not provide
+   the software to implement the actual use case for which the
+   partition clones are needed.
+
+Developers writing applications based on a clone layout created
+with {kiwi} can leverage the metadata file :file:`/config.partids`.
+This file is created at build time and contains the mapping between
+the partition `name` and the actual partition number in the partition
+table. For partition clones, the following naming convention applies:
+
+.. code::
+
+   kiwi_(name)PartClone(id)="(partition_number)"
+
+The `(name)` is either taken from the `name` attribute
+of the `<partition>` element or it is a fixed name assigned by {kiwi}.
+There are the following reserved partition names for which cloning
+is supported:
+
+* root
+* readonly
+* boot
+
+For the mentioned example this will result in the
+following :file:`/config.partids`:
+
+.. code::
+
+   kiwi_BiosGrub="1"
+   kiwi_EfiPart="2"
+   kiwi_bootPartClone1="3"
+   kiwi_BootPart="4"
+   kiwi_homePartClone1="5"
+   kiwi_homePartClone2="6"
+   kiwi_HomePart="7"
+   kiwi_rootPartClone1="8"
+   kiwi_RootPart="9"

--- a/doc/source/working_with_images/custom_partitions.rst
+++ b/doc/source/working_with_images/custom_partitions.rst
@@ -71,6 +71,16 @@ filesystem="btrfs|ext2|ext3|ext4|squashfs|xfs
   Mandatory filesystem configuration to create one of the supported
   filesystems on the partition.
 
+clone="number"
+  Optional setting to indicate that this partition should be
+  cloned `number` of times. A clone partition is content wise an
+  exact byte for byte copy of the origin. However, to avoid conflicts at boot
+  time the UUID of any cloned partition will be made unique. In the
+  sequence of partitions, the clone(s) will always be created first
+  followed by the partition considered the origin. The origin
+  partition is the one that will be referenced and used by the
+  system
+
 Despite the customization options of the partition table shown above
 there are the following limitations:
 

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -29,6 +29,7 @@ safe-posix-short-name = xsd:token {pattern = "[a-zA-Z0-9_\-\.]{1,32}"}
 locale-name = xsd:token {pattern = "(POSIX|[a-z]{2,3}_[A-Z]{2})(,[a-z]{2,3}_[A-Z]{2})*"}
 mac-address-type = xsd:token {pattern = "([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}"}
 size-type = xsd:token {pattern = "(\d*|image)"}
+number-type = xsd:token {pattern = "\d+"}
 blocks-type = xsd:token {pattern = "(\d*|all)"}
 volume-size-type = xsd:token {pattern = "(\d+|\d+M|\d+G|all)"}
 partition-size-type = xsd:token {pattern = "(\d+|\d+M|\d+G)"}
@@ -2049,6 +2050,25 @@ div {
             sch:param [ name = "attr" value = "disk_start_sector" ]
             sch:param [ name = "types" value = "oem" ]
         ]
+    k.type.root_clone.attribute =
+        ## Clone root partition N times
+        attribute root_clone { number-type }
+        >> sch:pattern [ id = "root_clone" is-a = "image_type"
+            sch:param [ name = "attr" value = "root_clone" ]
+            sch:param [ name = "types" value = "oem" ]
+        ]
+    k.type.boot_clone.attribute =
+        ## Clone boot partition N times. If no boot partition is
+        ## used, the attribute has no effect. The use of a boot
+        ## partition can be enforced through the bootpartition
+        ## attribute or is implicitly activated according to the
+        ## combination of type settings that makes the use of an
+        ## extra boot partition a requirement
+        attribute boot_clone { number-type }
+        >> sch:pattern [ id = "boot_clone" is-a = "image_type"
+            sch:param [ name = "attr" value = "boot_clone" ]
+            sch:param [ name = "types" value = "oem" ]
+        ]
     k.type.bundle_format.attribute =
         ## Specifies the bundle format pattern
         ## The format string can contain placeholders for the
@@ -2141,6 +2161,8 @@ div {
         k.type.xen_server.attribute? &
         k.type.publisher.attribute? &
         k.type.disk_start_sector.attribute? &
+        k.type.root_clone.attribute? &
+        k.type.boot_clone.attribute? &
         k.type.bundle_format.attribute?
     k.type =
         ## The Image Type of the Logical Extend
@@ -2375,13 +2397,17 @@ div {
         attribute filesystem {
             "btrfs" | "ext2" | "ext3" | "ext4" | "squashfs" | "xfs"
         }
+    k.partition.clone.attribute =
+        ## Clone this partition N times
+        attribute clone { number-type }
     k.partition.attlist =
         k.partition.name.attribute &
         k.partition.size.attribute &
         k.partition.partition_name.attribute? &
         k.partition.partition_type.attribute? &
         k.partition.mountpoint.attribute? &
-        k.partition.filesystem.attribute?
+        k.partition.filesystem.attribute? &
+        k.partition.clone.attribute?
     k.partition =
         ## Specify custom partition in the partition table
         element partition {

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -46,6 +46,11 @@
       <param name="pattern">(\d*|image)</param>
     </data>
   </define>
+  <define name="number-type">
+    <data type="token">
+      <param name="pattern">\d+</param>
+    </data>
+  </define>
   <define name="blocks-type">
     <data type="token">
       <param name="pattern">(\d*|all)</param>
@@ -2918,6 +2923,31 @@ default.</a:documentation>
         <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
+    <define name="k.type.root_clone.attribute">
+      <attribute name="root_clone">
+        <a:documentation>Clone root partition N times</a:documentation>
+        <ref name="number-type"/>
+      </attribute>
+      <sch:pattern id="root_clone" is-a="image_type">
+        <sch:param name="attr" value="root_clone"/>
+        <sch:param name="types" value="oem"/>
+      </sch:pattern>
+    </define>
+    <define name="k.type.boot_clone.attribute">
+      <attribute name="boot_clone">
+        <a:documentation>Clone boot partition N times. If no boot partition is
+used, the attribute has no effect. The use of a boot
+partition can be enforced through the bootpartition
+attribute or is implicitly activated according to the
+combination of type settings that makes the use of an
+extra boot partition a requirement</a:documentation>
+        <ref name="number-type"/>
+      </attribute>
+      <sch:pattern id="boot_clone" is-a="image_type">
+        <sch:param name="attr" value="boot_clone"/>
+        <sch:param name="types" value="oem"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.bundle_format.attribute">
       <attribute name="bundle_format">
         <a:documentation>Specifies the bundle format pattern
@@ -3155,6 +3185,12 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.disk_start_sector.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.root_clone.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.boot_clone.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.bundle_format.attribute"/>
@@ -3556,6 +3592,12 @@ Allowed values are: t.linux</a:documentation>
         </choice>
       </attribute>
     </define>
+    <define name="k.partition.clone.attribute">
+      <attribute name="clone">
+        <a:documentation>Clone this partition N times</a:documentation>
+        <ref name="number-type"/>
+      </attribute>
+    </define>
     <define name="k.partition.attlist">
       <interleave>
         <ref name="k.partition.name.attribute"/>
@@ -3571,6 +3613,9 @@ Allowed values are: t.linux</a:documentation>
         </optional>
         <optional>
           <ref name="k.partition.filesystem.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.partition.clone.attribute"/>
         </optional>
       </interleave>
     </define>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.29.24.
-# Python 3.10.4 (main, Apr  2 2022, 09:04:19) [GCC 11.2.0]
+# Python 3.6.15 (default, Sep 23 2021, 15:41:43) [GCC]
 #
 # Command line options:
 #   ('-f', '')
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /mnt/storage/kiwi/.tox/3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/ms/Project/kiwi/.tox/3.6/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -2798,7 +2798,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2872,6 +2872,8 @@ class type_(GeneratedsSuper):
         self.xen_server = _cast(bool, xen_server)
         self.publisher = _cast(None, publisher)
         self.disk_start_sector = _cast(int, disk_start_sector)
+        self.root_clone = _cast(None, root_clone)
+        self.boot_clone = _cast(None, boot_clone)
         self.bundle_format = _cast(None, bundle_format)
         if bootloader is None:
             self.bootloader = []
@@ -3118,6 +3120,10 @@ class type_(GeneratedsSuper):
     def set_publisher(self, publisher): self.publisher = publisher
     def get_disk_start_sector(self): return self.disk_start_sector
     def set_disk_start_sector(self, disk_start_sector): self.disk_start_sector = disk_start_sector
+    def get_root_clone(self): return self.root_clone
+    def set_root_clone(self, root_clone): self.root_clone = root_clone
+    def get_boot_clone(self): return self.boot_clone
+    def set_boot_clone(self, boot_clone): self.boot_clone = boot_clone
     def get_bundle_format(self): return self.bundle_format
     def set_bundle_format(self, bundle_format): self.bundle_format = bundle_format
     def validate_blocks_type(self, value):
@@ -3155,6 +3161,13 @@ class type_(GeneratedsSuper):
                     self.validate_safe_posix_short_name_patterns_, value):
                 warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_safe_posix_short_name_patterns_, ))
     validate_safe_posix_short_name_patterns_ = [['^[a-zA-Z0-9_\\-\\.]{1,32}$']]
+    def validate_number_type(self, value):
+        # Validate type number-type, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_number_type_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_number_type_patterns_, ))
+    validate_number_type_patterns_ = [['^\\d+$']]
     def hasContent_(self):
         if (
             self.bootloader or
@@ -3409,6 +3422,12 @@ class type_(GeneratedsSuper):
         if self.disk_start_sector is not None and 'disk_start_sector' not in already_processed:
             already_processed.add('disk_start_sector')
             outfile.write(' disk_start_sector="%s"' % self.gds_format_integer(self.disk_start_sector, input_name='disk_start_sector'))
+        if self.root_clone is not None and 'root_clone' not in already_processed:
+            already_processed.add('root_clone')
+            outfile.write(' root_clone=%s' % (quote_attrib(self.root_clone), ))
+        if self.boot_clone is not None and 'boot_clone' not in already_processed:
+            already_processed.add('boot_clone')
+            outfile.write(' boot_clone=%s' % (quote_attrib(self.boot_clone), ))
         if self.bundle_format is not None and 'bundle_format' not in already_processed:
             already_processed.add('bundle_format')
             outfile.write(' bundle_format=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bundle_format), input_name='bundle_format')), ))
@@ -3917,6 +3936,18 @@ class type_(GeneratedsSuper):
                 self.disk_start_sector = int(value)
             except ValueError as exp:
                 raise_parse_error(node, 'Bad integer attribute: %s' % exp)
+        value = find_attr_value_('root_clone', node)
+        if value is not None and 'root_clone' not in already_processed:
+            already_processed.add('root_clone')
+            self.root_clone = value
+            self.root_clone = ' '.join(self.root_clone.split())
+            self.validate_number_type(self.root_clone)    # validate type number-type
+        value = find_attr_value_('boot_clone', node)
+        if value is not None and 'boot_clone' not in already_processed:
+            already_processed.add('boot_clone')
+            self.boot_clone = value
+            self.boot_clone = ' '.join(self.boot_clone.split())
+            self.validate_number_type(self.boot_clone)    # validate type number-type
         value = find_attr_value_('bundle_format', node)
         if value is not None and 'bundle_format' not in already_processed:
             already_processed.add('bundle_format')
@@ -4447,7 +4478,7 @@ class partition(GeneratedsSuper):
     """Specify custom partition in the partition table"""
     subclass = None
     superclass = None
-    def __init__(self, name=None, size=None, partition_name=None, partition_type=None, mountpoint=None, filesystem=None):
+    def __init__(self, name=None, size=None, partition_name=None, partition_type=None, mountpoint=None, filesystem=None, clone=None):
         self.original_tagname_ = None
         self.name = _cast(None, name)
         self.size = _cast(None, size)
@@ -4455,6 +4486,7 @@ class partition(GeneratedsSuper):
         self.partition_type = _cast(None, partition_type)
         self.mountpoint = _cast(None, mountpoint)
         self.filesystem = _cast(None, filesystem)
+        self.clone = _cast(None, clone)
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -4478,6 +4510,8 @@ class partition(GeneratedsSuper):
     def set_mountpoint(self, mountpoint): self.mountpoint = mountpoint
     def get_filesystem(self): return self.filesystem
     def set_filesystem(self, filesystem): self.filesystem = filesystem
+    def get_clone(self): return self.clone
+    def set_clone(self, clone): self.clone = clone
     def validate_partition_size_type(self, value):
         # Validate type partition-size-type, a restriction on xs:token.
         if value is not None and Validate_simpletypes_:
@@ -4492,6 +4526,13 @@ class partition(GeneratedsSuper):
                     self.validate_safe_posix_short_name_patterns_, value):
                 warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_safe_posix_short_name_patterns_, ))
     validate_safe_posix_short_name_patterns_ = [['^[a-zA-Z0-9_\\-\\.]{1,32}$']]
+    def validate_number_type(self, value):
+        # Validate type number-type, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_number_type_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_number_type_patterns_, ))
+    validate_number_type_patterns_ = [['^\\d+$']]
     def hasContent_(self):
         if (
 
@@ -4538,6 +4579,9 @@ class partition(GeneratedsSuper):
         if self.filesystem is not None and 'filesystem' not in already_processed:
             already_processed.add('filesystem')
             outfile.write(' filesystem=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.filesystem), input_name='filesystem')), ))
+        if self.clone is not None and 'clone' not in already_processed:
+            already_processed.add('clone')
+            outfile.write(' clone=%s' % (quote_attrib(self.clone), ))
     def exportChildren(self, outfile, level, namespaceprefix_='', name_='partition', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node):
@@ -4578,6 +4622,12 @@ class partition(GeneratedsSuper):
             already_processed.add('filesystem')
             self.filesystem = value
             self.filesystem = ' '.join(self.filesystem.split())
+        value = find_attr_value_('clone', node)
+        if value is not None and 'clone' not in already_processed:
+            already_processed.add('clone')
+            self.clone = value
+            self.clone = ' '.join(self.clone.split())
+            self.validate_number_type(self.clone)    # validate type number-type
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class partition

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1437,11 +1437,7 @@ class XMLState:
             partition_name = partition.get_partition_name() or f'p.lx{name}'
             partitions[name] = ptable_entry_type(
                 mbsize=self._to_mega_byte(partition.get_size()),
-                # There is currently no clone attribute in the <partition>
-                # element. This will be added on completion of the partition
-                # clone feature. The internal API structure however, already
-                # knows about the capability
-                clone=0,
+                clone=int(partition.get_clone()) if partition.get_clone() else 0,
                 partition_name=partition_name,
                 partition_type=partition.get_partition_type() or 't.linux',
                 mountpoint=partition.get_mountpoint(),


### PR DESCRIPTION
Support creating block level clones of certain partitions
used in the image. Clones can be created from the root, boot
and any partition listed in the ```<partitions>``` element.


