### PR TITLE
Fixed runtime check

### DIFF
--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -886,8 +886,10 @@ class RuntimeChecker:
 
             <package name="{0}"/>
         ''')
+        initrd_system = self.xml_state.get_initrd_system()
         required_dracut_package = 'dracut-kiwi-overlay'
-        if self.xml_state.build_type.get_overlayroot():
+        if initrd_system == 'dracut' and \
+           self.xml_state.build_type.get_overlayroot():
             package_names = \
                 self.xml_state.get_bootstrap_packages() + \
                 self.xml_state.get_system_packages()


### PR DESCRIPTION
Fixed check_dracut_module_for_disk_overlay_in_package_list. The
check complains if the dracut-kiwi-overlay module is not installed
but overlay support was requested. This is correct but should only
be done if the selected initrd system is dracut.

