### PR TITLE
Follow up fix for isolinux-config

### DIFF
--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -232,7 +232,7 @@ class InstallImageBuilder:
             self.boot_image_task.boot_root_directory, self.media_dir.name,
             bootloader_config.get_boot_theme()
         )
-        if not self.firmware.efi_mode():
+        if self.firmware.bios_mode():
             Iso(self.media_dir.name).setup_isolinux_boot_path()
         bootloader_config.write_meta_data()
         bootloader_config.setup_install_image_config(

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -167,7 +167,7 @@ class LiveImageBuilder:
             self.boot_image.boot_root_directory, self.media_dir.name,
             bootloader_config.get_boot_theme()
         )
-        if not self.firmware.efi_mode():
+        if self.firmware.bios_mode():
             Iso(self.media_dir.name).setup_isolinux_boot_path()
         bootloader_config.write_meta_data()
         bootloader_config.setup_live_image_config(

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -155,6 +155,8 @@ class TestInstallImageBuilder:
         mock_BootLoaderConfig.return_value = bootloader_config
         mock_Temporary.side_effect = side_effect
 
+        self.firmware.bios_mode.return_value = False
+
         m_open = mock_open()
         with patch('builtins.open', m_open, create=True):
             self.install_image.create_install_iso()
@@ -261,6 +263,7 @@ class TestInstallImageBuilder:
         mock_BootLoaderConfig.reset_mock()
         tmp_names = [temp_esp_file, temp_squashfs, temp_media_dir]
         self.firmware.efi_mode.return_value = None
+        self.firmware.bios_mode.return_value = True
 
         with patch('builtins.open', m_open, create=True):
             self.install_image.create_install_iso()
@@ -278,6 +281,7 @@ class TestInstallImageBuilder:
     def test_create_install_iso_no_kernel_found(
         self, mock_command, mock_Temporary, mock_setup_media_loader_directory
     ):
+        self.firmware.bios_mode.return_value = False
         self.kernel.get_kernel.return_value = False
         with patch('builtins.open'):
             with raises(KiwiInstallBootImageError):
@@ -289,6 +293,7 @@ class TestInstallImageBuilder:
     def test_create_install_iso_no_hypervisor_found(
         self, mock_command, mock_Temporary, mock_setup_media_loader_directory
     ):
+        self.firmware.bios_mode.return_value = False
         self.kernel.get_xen_hypervisor.return_value = False
         with patch('builtins.open'):
             with raises(KiwiInstallBootImageError):
@@ -301,6 +306,7 @@ class TestInstallImageBuilder:
     def test_create_install_pxe_no_kernel_found(
         self, mock_compress, mock_md5, mock_command, mock_Temporary
     ):
+        self.firmware.bios_mode.return_value = False
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         self.kernel.get_kernel.return_value = False
         with patch('builtins.open'):
@@ -316,6 +322,7 @@ class TestInstallImageBuilder:
         self, mock_symlink, mock_compress, mock_md5, mock_command,
         mock_Temporary
     ):
+        self.firmware.bios_mode.return_value = False
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         self.kernel.get_xen_hypervisor.return_value = False
         with patch('builtins.open'):

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -185,6 +185,7 @@ class TestLiveImageBuilder:
         self.setup.export_package_verification.return_value = '.verified'
         self.setup.export_package_list.return_value = '.packages'
 
+        self.firmware.bios_mode.return_value = False
         self.live_image.create()
 
         self.setup.import_cdroot_files.assert_called_once_with('temp_media_dir')
@@ -327,6 +328,7 @@ class TestLiveImageBuilder:
         )
 
         self.firmware.efi_mode.return_value = None
+        self.firmware.bios_mode.return_value = True
         tmpdir_name = [temp_squashfs, temp_media_dir]
         kiwi.builder.live.BootLoaderConfig.new.reset_mock()
         self.live_image.create()
@@ -343,6 +345,7 @@ class TestLiveImageBuilder:
         self, mock_shutil, mock_Temporary,
         mock_setup_media_loader_directory
     ):
+        self.firmware.bios_mode.return_value = False
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         self.kernel.get_kernel.return_value = False
         with raises(KiwiLiveBootImageError):
@@ -355,6 +358,7 @@ class TestLiveImageBuilder:
         self, mock_shutil, mock_Temporary,
         mock_setup_media_loader_directory
     ):
+        self.firmware.bios_mode.return_value = False
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         self.kernel.get_xen_hypervisor.return_value = False
         with raises(KiwiLiveBootImageError):
@@ -368,6 +372,7 @@ class TestLiveImageBuilder:
         self, mock_exists, mock_shutil, mock_Temporary,
         mock_setup_media_loader_directory
     ):
+        self.firmware.bios_mode.return_value = False
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         mock_exists.return_value = False
         with raises(KiwiLiveBootImageError):


### PR DESCRIPTION
isolinux-config is called to update the search path inside
of the isolinux binary. isolinux/syslinux is exclusive to
the ix86 architecture and to BIOS firmware. Therefore the
condition to actually call it should reflect this.

