### PR TITLE
Allow more repo params to be set on the cmdline

### DIFF
--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -18,8 +18,8 @@ SYNOPSIS
        [--clear-cache]
        [--ignore-repos]
        [--ignore-repos-used-for-build]
-       [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>]
-       [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>...]
+       [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>]
+       [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>...]
        [--add-package=<name>...]
        [--add-bootstrap-package=<name>...]
        [--delete-package=<name>...]
@@ -62,7 +62,7 @@ OPTIONS
   specify package to add(install). The option can be specified
   multiple times
 
---add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>
+--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>
 
   Add a new repository to the existing repository setup in the XML
   description. This option can be specified multiple times.
@@ -110,7 +110,7 @@ OPTIONS
   configurations which has the imageonly attribute set to true
   will not be ignored.
 
---set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>
+--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>
 
   Overwrite the first repository entry in the XML description with the
   provided information:
@@ -148,6 +148,23 @@ OPTIONS
 
     Set to either **true** or **false** to specify if this repository
     should validate the package signatures.
+
+  - **{signing_keys}**
+
+    List of signing_keys enclosed in curly brackets and delimited by a colon
+
+  - **components**
+
+    Component list for debian based repos as string delimited by a space
+
+  - **distribution**
+
+    Main distribution name for debian based repos
+
+  - **repo_gpgcheck**
+
+    Set to either **true** or **false** to specify if this repository
+    should validate the repository signature.
 
 --set-container-derived-from=<uri>
 

--- a/doc/source/commands/system_prepare.rst
+++ b/doc/source/commands/system_prepare.rst
@@ -16,8 +16,8 @@ SYNOPSIS
        [--clear-cache]
        [--ignore-repos]
        [--ignore-repos-used-for-build]
-       [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>]
-       [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>...]
+       [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>]
+       [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>...]
        [--add-package=<name>...]
        [--add-bootstrap-package=<name>...]
        [--delete-package=<name>...]
@@ -62,7 +62,7 @@ OPTIONS
   specify package to add(install). The option can be specified
   multiple times
 
---add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>
+--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>
 
   Add a new repository to the existing repository setup in the XML
   description. This option can be specified multiple times.
@@ -111,7 +111,7 @@ OPTIONS
 
   Path to create the new root system.
 
---set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>
+--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>
 
   Overwrite the first repository entry in the XML description with the
   provided information:
@@ -149,6 +149,23 @@ OPTIONS
 
     Set to either **true** or **false** to specify if this repository
     should validate the package signatures.
+
+    - **{signing_keys}**
+
+    List of signing_keys enclosed in curly brackets and delimited by a colon
+
+  - **components**
+
+    Component list for debian based repos as string delimited by a space
+
+  - **distribution**
+
+    Main distribution name for debian based repos
+
+  - **repo_gpgcheck**
+
+    Set to either **true** or **false** to specify if this repository
+    should validate the repository signature.
 
 --set-container-derived-from=<uri>
 

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -184,7 +184,9 @@ class CliTask:
 
         self.runtime_checker = RuntimeChecker(self.xml_state)
 
-    def quadruple_token(self, option: str) -> List[Union[bool, str, None]]:
+    def quadruple_token(
+        self, option: str
+    ) -> List[Union[bool, str, List[str], None]]:
         """
         Helper method for commandline options of the form --option a,b,c,d
 
@@ -199,9 +201,12 @@ class CliTask:
         """
         return self._ntuple_token(option, 4)
 
-    def sextuple_token(self, option: str) -> List[Union[bool, str, None]]:
+    def tentuple_token(
+        self, option: str
+    ) -> List[Union[bool, str, List[str], None]]:
         """
-        Helper method for commandline options of the form --option a,b,c,d,e,f
+        Helper method for commandline options of the
+        form --option a,b,c,d,e,f,g,h,i,j
 
         Make sure to provide a common result for option values which
         separates the information in a comma separated list of values
@@ -212,7 +217,7 @@ class CliTask:
 
         :rtype: list
         """
-        return self._ntuple_token(option, 6)
+        return self._ntuple_token(option, 10)
 
     def run_checks(self, checks: Dict[str, List[str]]) -> None:
         """
@@ -230,18 +235,20 @@ class CliTask:
             }.items():
                 attrgetter(method)(self.runtime_checker)(*args)
 
-    def _pop_token(self, tokens: List[str]) -> Union[bool, str]:
+    def _pop_token(self, tokens: List[str]) -> Union[bool, str, List[str]]:
         token = tokens.pop(0)
         if len(token) > 0 and token == 'true':
             return True
         elif len(token) > 0 and token == 'false':
             return False
+        elif len(token) > 0 and token.startswith('{'):
+            return token.replace('{', '').replace('}', '').split(':')
         else:
             return token
 
     def _ntuple_token(
         self, option: str, tuple_count: int
-    ) -> List[Union[bool, str, None]]:
+    ) -> List[Union[bool, str, List[str], None]]:
         """
         Helper method for commandline options of the form --option a,b,c,d,e,f
 

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -22,8 +22,8 @@ usage: kiwi-ng system build -h | --help
            [--clear-cache]
            [--ignore-repos]
            [--ignore-repos-used-for-build]
-           [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>]
-           [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>...]
+           [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>]
+           [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>...]
            [--add-package=<name>...]
            [--add-bootstrap-package=<name>...]
            [--delete-package=<name>...]
@@ -45,9 +45,13 @@ options:
         install the given package name as part of the early bootstrap process
     --add-package=<name>
         install the given package name
-    --add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>
-        add repository with given source, type, alias, priority,
-        the imageinclude flag and the package_gpgcheck flag
+    --add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>
+        add repository with given source, type, alias,
+        priority, imageinclude(true|false), package_gpgcheck(true|false),
+        list of signing_keys enclosed in curly brackets delimited by a colon,
+        component list for debian based repos as string delimited by a space,
+        main distribution name for debian based repos and
+        repo_gpgcheck(true|false)
     --allow-existing-root
         allow to use an existing root directory from an earlier
         build attempt. Use with caution this could cause an inconsistent
@@ -79,9 +83,13 @@ options:
         add a container label in the container configuration metadata. It
         overwrites the label with the provided key-value pair in case it was
         already defined in the XML description
-    --set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>
+    --set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>
         overwrite the first XML listed repository source, type, alias,
-        priority, the imageinclude flag and the package_gpgcheck flag
+        priority, imageinclude(true|false), package_gpgcheck(true|false),
+        list of signing_keys enclosed in curly brackets delimited by a colon,
+        component list for debian based repos as string delimited by a space,
+        main distribution name for debian based repos and
+        repo_gpgcheck(true|false)
     --signing-key=<key-file>
         includes the key-file as a trusted key for package manager validations
     --target-dir=<directory>
@@ -156,13 +164,13 @@ class SystemBuildTask(CliTask):
 
         if self.command_args['--set-repo']:
             self.xml_state.set_repository(
-                *self.sextuple_token(self.command_args['--set-repo'])
+                *self._get_repo_parameters(self.command_args['--set-repo'])
             )
 
         if self.command_args['--add-repo']:
             for add_repo in self.command_args['--add-repo']:
                 self.xml_state.add_repository(
-                    *self.sextuple_token(add_repo)
+                    *self._get_repo_parameters(add_repo)
                 )
 
         if self.command_args['--set-container-tag']:
@@ -301,3 +309,11 @@ class SystemBuildTask(CliTask):
         else:
             return False
         return self.manual
+
+    def _get_repo_parameters(self, tokens):
+        parameters = self.tentuple_token(tokens)
+        signing_keys_index = 6
+        if not parameters[signing_keys_index]:
+            # make sure to pass empty list for signing_keys param
+            parameters[signing_keys_index] = []
+        return parameters

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1796,7 +1796,9 @@ class XMLState:
     def set_repository(
         self, repo_source: str, repo_type: str, repo_alias: str,
         repo_prio: str, repo_imageinclude: bool = False,
-        repo_package_gpgcheck: Optional[bool] = None
+        repo_package_gpgcheck: Optional[bool] = None,
+        repo_signing_keys: List[str] = [], components: str = None,
+        distribution: str = None, repo_gpgcheck: Optional[bool] = None
     ) -> None:
         """
         Overwrite repository data of the first repository
@@ -1807,6 +1809,10 @@ class XMLState:
         :param str repo_prio: priority number, package manager specific
         :param bool repo_imageinclude: setup repository inside of the image
         :param bool repo_package_gpgcheck: enable/disable package gpg checks
+        :param list repo_signing_keys: list of signing key file names
+        :param str components: component names for debian repos
+        :param str distribution: base distribution name for debian repos
+        :param bool repo_gpgcheck: enable/disable repo gpg checks
         """
         repository_sections = self.get_repository_sections()
         if repository_sections:
@@ -1823,12 +1829,23 @@ class XMLState:
                 repository.set_imageinclude(repo_imageinclude)
             if repo_package_gpgcheck is not None:
                 repository.set_package_gpgcheck(repo_package_gpgcheck)
+            if repo_signing_keys:
+                repository.get_source().set_signing(
+                    [xml_parse.signing(key=k) for k in repo_signing_keys]
+                )
+            if components:
+                repository.set_components(components)
+            if distribution:
+                repository.set_distribution(distribution)
+            if repo_gpgcheck is not None:
+                repository.set_repository_gpgcheck(repo_gpgcheck)
 
     def add_repository(
         self, repo_source: str, repo_type: str, repo_alias: str = None,
         repo_prio: str = '', repo_imageinclude: bool = False,
         repo_package_gpgcheck: Optional[bool] = None,
-        repo_signing_keys: List[str] = []
+        repo_signing_keys: List[str] = [], components: str = None,
+        distribution: str = None, repo_gpgcheck: Optional[bool] = None
     ) -> None:
         """
         Add a new repository section at the end of the list
@@ -1839,6 +1856,10 @@ class XMLState:
         :param str repo_prio: priority number, package manager specific
         :param bool repo_imageinclude: setup repository inside of the image
         :param bool repo_package_gpgcheck: enable/disable package gpg checks
+        :param list repo_signing_keys: list of signing key file names
+        :param str components: component names for debian repos
+        :param str distribution: base distribution name for debian repos
+        :param bool repo_gpgcheck: enable/disable repo gpg checks
         """
         priority_number: Optional[int] = None
         try:
@@ -1858,7 +1879,10 @@ class XMLState:
                     ]
                 ),
                 imageinclude=repo_imageinclude,
-                package_gpgcheck=repo_package_gpgcheck
+                package_gpgcheck=repo_package_gpgcheck,
+                repository_gpgcheck=repo_gpgcheck,
+                components=components,
+                distribution=distribution
             )
         )
 

--- a/test/unit/tasks/base_test.py
+++ b/test/unit/tasks/base_test.py
@@ -80,6 +80,18 @@ class TestCliTask:
     def test_quadruple_token(self):
         assert self.task.quadruple_token('a,b') == ['a', 'b', None, None]
 
+    def test_tentuple_token(self):
+        assert self.task.tentuple_token(
+            'a,b,,d,e,f,{1:2:3},x y z,jammy,false'
+        ) == [
+            'a', 'b', '', 'd', 'e', 'f', ['1', '2', '3'], 'x y z',
+            'jammy', False
+        ]
+        assert self.task.tentuple_token('a,b,,d,e,f,{1:2:3}') == [
+            'a', 'b', '', 'd', 'e', 'f', ['1', '2', '3'],
+            None, None, None
+        ]
+
     @patch('kiwi.tasks.base.RuntimeChecker')
     def test_load_xml_description(self, mock_runtime_checker):
         self.task.load_xml_description('../data/description')

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -285,7 +285,8 @@ class TestSystemBuildTask:
         self.task.command_args['--set-repo'] = 'http://example.com,yast2,alias'
         self.task.process()
         mock_set_repo.assert_called_once_with(
-            'http://example.com', 'yast2', 'alias', None, None, None
+            'http://example.com', 'yast2', 'alias',
+            None, None, None, [], None, None, None
         )
 
     @patch('kiwi.xml_state.XMLState.add_repository')
@@ -299,7 +300,8 @@ class TestSystemBuildTask:
         ]
         self.task.process()
         mock_add_repo.assert_called_once_with(
-            'http://example.com', 'yast2', 'alias', '99', False, True
+            'http://example.com', 'yast2', 'alias', '99',
+            False, True, [], None, None, None
         )
 
     def test_process_system_build_help(self):

--- a/test/unit/tasks/system_prepare_test.py
+++ b/test/unit/tasks/system_prepare_test.py
@@ -274,7 +274,8 @@ class TestSystemPrepareTask:
         self.task.command_args['--set-repo'] = 'http://example.com,yast2,alias'
         self.task.process()
         mock_state.assert_called_once_with(
-            'http://example.com', 'yast2', 'alias', None, None, None
+            'http://example.com', 'yast2', 'alias',
+            None, None, None, [], None, None, None
         )
 
     @patch('kiwi.xml_state.XMLState.add_repository')
@@ -285,7 +286,8 @@ class TestSystemPrepareTask:
         ]
         self.task.process()
         mock_state.assert_called_once_with(
-            'http://example.com', 'yast2', 'alias', '99', True, None
+            'http://example.com', 'yast2', 'alias', '99',
+            True, None, [], None, None, None
         )
 
     def test_process_system_prepare_help(self):

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -202,7 +202,10 @@ class TestXMLState:
         assert self.state.get_bootstrap_collection_type() == 'onlyRequired'
 
     def test_set_repository(self):
-        self.state.set_repository('repo', 'type', 'alias', 1, True, False)
+        self.state.set_repository(
+            'repo', 'type', 'alias', 1, True, False, ['key_a', 'key_b'],
+            'main universe', 'jammy', False
+        )
         assert self.state.xml_data.get_repository()[0].get_source().get_path() \
             == 'repo'
         assert self.state.xml_data.get_repository()[0].get_type() == 'type'
@@ -212,9 +215,22 @@ class TestXMLState:
             .get_imageinclude() is True
         assert self.state.xml_data.get_repository()[0] \
             .get_package_gpgcheck() is False
+        assert self.state.xml_data.get_repository()[0] \
+            .get_source().get_signing()[0].get_key() == 'key_a'
+        assert self.state.xml_data.get_repository()[0] \
+            .get_source().get_signing()[1].get_key() == 'key_b'
+        assert self.state.xml_data.get_repository()[0].get_components() \
+            == 'main universe'
+        assert self.state.xml_data.get_repository()[0].get_distribution() \
+            == 'jammy'
+        assert self.state.xml_data.get_repository()[0] \
+            .get_repository_gpgcheck() is False
 
     def test_add_repository(self):
-        self.state.add_repository('repo', 'type', 'alias', 1, True)
+        self.state.add_repository(
+            'repo', 'type', 'alias', 1, True, None, ['key_a', 'key_b'],
+            'main universe', 'jammy', False
+        )
         assert self.state.xml_data.get_repository()[3].get_source().get_path() \
             == 'repo'
         assert self.state.xml_data.get_repository()[3].get_type() == 'type'
@@ -222,6 +238,16 @@ class TestXMLState:
         assert self.state.xml_data.get_repository()[3].get_priority() == 1
         assert self.state.xml_data.get_repository()[3] \
             .get_imageinclude() is True
+        assert self.state.xml_data.get_repository()[3] \
+            .get_source().get_signing()[0].get_key() == 'key_a'
+        assert self.state.xml_data.get_repository()[3] \
+            .get_source().get_signing()[1].get_key() == 'key_b'
+        assert self.state.xml_data.get_repository()[3].get_components() \
+            == 'main universe'
+        assert self.state.xml_data.get_repository()[3].get_distribution() \
+            == 'jammy'
+        assert self.state.xml_data.get_repository()[3] \
+            .get_repository_gpgcheck() is False
 
     def test_add_repository_with_empty_values(self):
         self.state.add_repository('repo', 'type', '', '', True)


### PR DESCRIPTION
The repository parameters for ```signing keys```, the ```component``` list the main ```distribution``` name for debian repositories and the ```repository_gpgcheck``` could not be set via the commandline options ```--add-repo```  and/or ```--set-repo```. This commit adds support for them and also updates the manual page accordingly
