### PR TITLE
Subformats should also not be compressed when encryption is enabled

### DIFF
--- a/kiwi.yml
+++ b/kiwi.yml
@@ -28,7 +28,13 @@
 # Setup behaviour of the kiwi result bundle command
 #bundle:
 #  # Specify if the bundle tarball should contain compressed results.
-#  # Note: already compressed result information will not be touched
+#  # Note: Already compressed result information will not be touched.
+#  # Build results that generate an encrypted filesystem, i.e.
+#  # luks setup, will not be compressed. The intention for result compression
+#  # is to produce a smaller representation of the original. Encrypted data
+#  # generally grows when an attempt is made to compress the data. This is
+#  # due to the nature of compression algorithms. Therefore this setting is
+#  # ignored when encryption is enabled.
 #  - compress: false
 #  # Specify if the image build result and bundle should contain
 #  # a .changes file. The .changes file contains the package changelog

--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -91,6 +91,7 @@ class FileSystemBuilder:
         self.filesystems_no_device_node = [
             'squashfs'
         ]
+        self.luks = xml_state.get_luks_credentials()
         self.result = Result(xml_state)
         self.runtime_config = RuntimeConfig()
 
@@ -128,13 +129,14 @@ class FileSystemBuilder:
         )
         if self.bundle_format:
             self.result.add_bundle_format(self.bundle_format)
+        compression = self.runtime_config.get_bundle_compression(default=True)
+        if self.luks is not None:
+            compression = False
         self.result.add(
             key='filesystem_image',
             filename=self.filename,
             use_for_bundle=True,
-            compress=self.runtime_config.get_bundle_compression(
-                default=True
-            ),
+            compress=compression,
             shasum=True
         )
         self.result.add(

--- a/kiwi/storage/subformat/base.py
+++ b/kiwi/storage/subformat/base.py
@@ -185,15 +185,16 @@ class DiskFormatBase:
 
         :param object result: Instance of Result
         """
+        compression = self.runtime_config.get_bundle_compression(default=True)
+        if self.xml_state.get_luks_credentials() is not None:
+            compression = False
         result.add(
             key='disk_format_image',
             filename=self.get_target_file_path_for_format(
                 self.image_format
             ),
             use_for_bundle=True,
-            compress=self.runtime_config.get_bundle_compression(
-                default=True
-            ),
+            compress=compression,
             shasum=True
         )
 

--- a/kiwi/storage/subformat/vhdfixed.py
+++ b/kiwi/storage/subformat/vhdfixed.py
@@ -79,15 +79,16 @@ class DiskFormatVhdFixed(DiskFormatBase):
 
         :param object result: Instance of Result
         """
+        compression = self.runtime_config.get_bundle_compression(default=True)
+        if self.xml_state.get_luks_credentials() is not None:
+            compression = False
         result.add(
             key='disk_format_image',
             filename=self.get_target_file_path_for_format(
                 self.image_format
             ),
             use_for_bundle=True,
-            compress=self.runtime_config.get_bundle_compression(
-                default=True
-            ),
+            compress=compression,
             shasum=True
         )
 

--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -68,13 +68,14 @@ class DiskFormatVmdk(DiskFormatBase):
 
         :param object result: Instance of Result
         """
+        compression = self.runtime_config.get_bundle_compression(default=True)
+        if self.xml_state.get_luks_credentials() is not None:
+            compression = False
         result.add(
             key='disk_format_image',
             filename=self.get_target_file_path_for_format('vmdk'),
             use_for_bundle=True,
-            compress=self.runtime_config.get_bundle_compression(
-                default=True
-            ),
+            compress=compression,
             shasum=True
         )
         result.add(

--- a/test/unit/storage/subformat/base_test.py
+++ b/test/unit/storage/subformat/base_test.py
@@ -27,6 +27,9 @@ class TestDiskFormatBase:
         self.xml_state.get_image_version = Mock(
             return_value='1.2.3'
         )
+        self.xml_state.get_luks_credentials = Mock(
+            return_value=None
+        )
         self.runtime_config = Mock()
         self.runtime_config.get_bundle_compression.return_value = True
         kiwi.storage.subformat.base.RuntimeConfig = Mock(
@@ -71,7 +74,7 @@ class TestDiskFormatBase:
         assert self.disk_format.get_target_file_path_for_format('vhd') == \
             'target_dir/some-disk-image.x86_64-1.2.3.vhd'
 
-    def test_store_to_result(self):
+    def test_store_to_result_default(self):
         result = Mock()
         self.disk_format.image_format = 'qcow2'
         self.disk_format.store_to_result(result)
@@ -82,6 +85,20 @@ class TestDiskFormatBase:
             shasum=True,
             use_for_bundle=True
         )
+
+    def test_store_to_result_with_luks(self):
+        result = Mock()
+        self.xml_state.get_luks_credentials = Mock(return_value='foo')
+        self.disk_format.image_format = 'qcow2'
+        self.disk_format.store_to_result(result)
+        result.add.assert_called_once_with(
+            compress=False,
+            filename='target_dir/some-disk-image.x86_64-1.2.3.qcow2',
+            key='disk_format_image',
+            shasum=True,
+            use_for_bundle=True
+        )
+        self.xml_state.get_luks_credentials = Mock(return_value=None)
 
     @patch('os.path.getsize')
     def test_resize_raw_disk_raises_on_shrink_disk(self, mock_getsize):

--- a/test/unit/storage/subformat/vhdfixed_test.py
+++ b/test/unit/storage/subformat/vhdfixed_test.py
@@ -25,6 +25,9 @@ class TestDiskFormatVhdFixed:
         self.xml_state.get_image_version = Mock(
             return_value='1.2.3'
         )
+        self.xml_state.get_luks_credentials = Mock(
+            return_value=None
+        )
         self.runtime_config = Mock()
         self.runtime_config.get_bundle_compression.return_value = True
         kiwi.storage.subformat.base.RuntimeConfig = Mock(
@@ -89,7 +92,7 @@ class TestDiskFormatVhdFixed:
             call(65536, 0), call(0, 2)
         ]
 
-    def test_store_to_result(self):
+    def test_store_to_result_default(self):
         result = Mock()
         self.disk_format.store_to_result(result)
         result.add.assert_called_once_with(
@@ -99,3 +102,16 @@ class TestDiskFormatVhdFixed:
             shasum=True,
             use_for_bundle=True
         )
+
+    def test_store_to_result_with_luks(self):
+        result = Mock()
+        self.xml_state.get_luks_credentials = Mock(return_value='foo')
+        self.disk_format.store_to_result(result)
+        result.add.assert_called_once_with(
+            compress=False,
+            filename='target_dir/some-disk-image.x86_64-1.2.3.vhdfixed',
+            key='disk_format_image',
+            shasum=True,
+            use_for_bundle=True
+        )
+        self.xml_state.get_luks_credentials = Mock(return_value=None)


### PR DESCRIPTION
This is a follow on change to bdba953. When the filesystem is encrypted the
resulting image should not be compressed.

Fixes # .

Changes proposed in this pull request:
*
* Do not compress encrypted formats
