### PR TITLE
Add support for prebuilt bootstrap package for apt

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -420,6 +420,15 @@ btrfs_root_is_readonly_snapshot="true|false":
   effective if `btrfs_root_is_snapshot` is also set to true. By default the
   root filesystem snapshot is writable.
 
+bootstrap_package="package_name":
+  For use with the `apt` packagemanager only. Specifies the name
+  of a bootstrap package which provides a bootstrap tarball
+  in :file:`/var/lib/bootstrap/PACKAGE_NAME.ARCH.tar.xz`.
+  The tarball will be unpacked and used as the bootstrap
+  rootfs to begin with. This allows for an alternative bootstrap
+  method preventing the use of `debootstrap`. For further details
+  see :ref:`debootstrap_alternative`.
+
 compressed="true|false":
   Specifies whether the image output file should be
   compressed or not. This option is only used for filesystem only images or

--- a/doc/source/working_with_images.rst
+++ b/doc/source/working_with_images.rst
@@ -35,3 +35,4 @@ Working with Images
    working_with_images/build_with_profiles
    working_with_images/build_in_buildservice
    working_with_images/use_suse_media
+   working_with_images/build_without_debootstrap

--- a/doc/source/working_with_images/build_without_debootstrap.rst
+++ b/doc/source/working_with_images/build_without_debootstrap.rst
@@ -1,0 +1,113 @@
+.. _debootstrap_alternative:
+
+Circumvent debootstrap
+======================
+
+.. sidebar:: Abstract
+
+   This page provides information how to build Debian based
+   images with `apt` but without using `debootstrap` to bootstrap
+   the image root tree
+
+When building Debian based images {kiwi} uses two tools to
+create the image root tree. First it calls `debootstrap` to
+initialize a minimal root tree and next it chroot's into that
+tree to complete the installation via `apt`. The reason why it
+is done that way is because `apt` does not(yet) support to
+install packages into an empty root directory like it is done
+with all other packagemanager interfaces implemented in {kiwi}.
+
+The use of `debootstrap` comes along with some prerequisites
+and limitations:
+
+* It can only use one repository to bootstrap from
+* It can only use an official archive repo
+* It has its own dependency resolver different from apt
+
+If one ore more of this properties turns into an issue, {kiwi}
+allows for an alternative process which is based on a prebuilt
+bootstrap-root archive provided as a package.
+
+To make use of a `bootstrap_package`, the name of that package
+needs to be referenced in the {kiwi} description as follows:
+
+.. code:: xml
+
+   <packages type="bootstrap" bootstrap_package="bootstrap-root">
+       <package name="a"/>
+       <package name="b"/>
+   </packages>
+
+The boostrap process now changes in a way that the provided
+bootstrap_package `bootstrap-root` will be installed on the build
+host machine. Next {kiwi} searches for a tar archive file
+:file:`/var/lib/bootstrap/bootstrap-root.ARCH.tar.xz`,
+where `ARCH` is the name of the host architecture e.g `x86_64`.
+If found the archive gets unpacked and serves as the bootstrap
+root tree to begin with. The optionally provided additional
+bootstrap packages, `a` and `b` in this example will be installed
+like system packages via `chroot` and `apt`. Usually no additional
+bootstrap packages are needed as they could all be handled as
+system packages.
+
+How to Create a bootstrap_package
+---------------------------------
+
+Changing the setup in {kiwi} to use a `bootstrap_package` rather
+then letting `debootstrap` do the job comes with the task to create
+that package providing the bootstrap root tree. There are more than
+one way to do this. The following procedure is just one example and
+requires some background knowledge about the Open Build Service
+`OBS <https://build.opensuse.org>`__ and its {kiwi} integration.
+
+1. Create an OBS project and repository setup that matches your image target
+2. Create an image build package
+
+   .. code:: bash
+
+      osc mkpac bootstrap-root
+
+3. Create the following :file:`appliance.kiwi` file
+
+   .. code:: xml
+
+      <image schemaversion="7.4" name="bootstrap-root">
+          <description type="system">
+              <author>The Author</author>
+              <contact>author@example.com</contact>
+              <specification>prebuilt bootstrap rootfs for ...</specification>
+          </description>
+
+          <preferences>
+              <version>1.0.1</version>
+              <packagemanager>apt</packagemanager>
+              <type image="tbz"/>
+          </preferences>
+
+          <repository type="rpm-md">
+              <source path="obsrepositories:/"/>
+          </repository>
+
+          <packages type="image">
+              <!-- packages included so OBS adds it as a build dependency, however this is installed by debootstrap -->
+              <package name="mawk"/>
+          </packages>
+
+          <packages type="bootstrap">
+              <!-- bootstrap done via debootstrap -->
+          </packages>
+      </image>
+
+   .. code:: bash
+
+      osc add appliance.kiwi
+      osc ci
+
+4. Package the image build results into a debian package
+
+   In step 3. the bootstrap root tarball was created but not yet
+   packaged. A debian package is needed such that it can be
+   referenced with the `bootstrap_package` attribute and the repository
+   providing it. The simplest way to package the `bootstrap-root` tarball
+   is to create another package in OBS and use the tarball file as
+   its source.

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -116,7 +116,7 @@ class PackageManagerBase:
         raise NotImplementedError
 
     def process_install_requests_bootstrap(
-        self, root_bind: RootBind = None
+        self, root_bind: RootBind = None, bootstrap_package: str = None
     ) -> command_call_type:
         """
         Process package install requests for bootstrap phase (no chroot)

--- a/kiwi/package_manager/dnf.py
+++ b/kiwi/package_manager/dnf.py
@@ -135,12 +135,13 @@ class PackageManagerDnf(PackageManagerBase):
             )
 
     def process_install_requests_bootstrap(
-        self, root_bind: RootBind = None
+        self, root_bind: RootBind = None, bootstrap_package: str = None
     ) -> command_call_type:
         """
         Process package install requests for bootstrap phase (no chroot)
 
         :param object root_bind: unused
+        :param str bootstrap_package: unused
 
         :return: process results in command type
 

--- a/kiwi/package_manager/microdnf.py
+++ b/kiwi/package_manager/microdnf.py
@@ -154,12 +154,13 @@ class PackageManagerMicroDnf(PackageManagerBase):
             )
 
     def process_install_requests_bootstrap(
-        self, root_bind: RootBind = None
+        self, root_bind: RootBind = None, bootstrap_package: str = None
     ) -> command_call_type:
         """
         Process package install requests for bootstrap phase (no chroot)
 
         :param object root_bind: unused
+        :param str bootstrap_package: unused
 
         :return: process results in command type
 

--- a/kiwi/package_manager/pacman.py
+++ b/kiwi/package_manager/pacman.py
@@ -111,12 +111,13 @@ class PackageManagerPacman(PackageManagerBase):
         pass
 
     def process_install_requests_bootstrap(
-        self, root_bind: RootBind = None
+        self, root_bind: RootBind = None, bootstrap_package: str = None
     ) -> command_call_type:
         """
         Process package install requests for bootstrap phase (no chroot)
 
         :param object root_bind: unused
+        :param str bootstrap_package: unused
 
         :return: process results in command type
 

--- a/kiwi/package_manager/zypper.py
+++ b/kiwi/package_manager/zypper.py
@@ -113,12 +113,13 @@ class PackageManagerZypper(PackageManagerBase):
         pass
 
     def process_install_requests_bootstrap(
-        self, root_bind: RootBind = None
+        self, root_bind: RootBind = None, bootstrap_package: str = None
     ) -> command_call_type:
         """
         Process package install requests for bootstrap phase (no chroot)
 
         :param object root_bind: unused
+        :param str bootstrap_package: unused
 
         :return: process results in command type
 

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -3271,6 +3271,18 @@ div {
 # main block: <packages>
 #
 div {
+    sch:pattern [
+        abstract = "true"
+        id = "packages_type"
+        sch:rule [
+            context = "packages[@$attr]"
+            sch:assert [
+                test = "contains('$types', @type)"
+                "$attr attribute is only available for the following "
+                "packages type(s): $types"
+            ]
+        ]
+    ]
     k.packages.type.attribute =
         ## Specifies package collection type. `bootstrap` packages
         ## gets installed in the very first phase of an image build
@@ -3291,10 +3303,34 @@ div {
         attribute patternType {
             "onlyRequired" | "plusRecommended"
         }
+    k.packages.bootstrap_package.attribute =
+        ## Specify bootstrap package providing a bootstrap tarball
+        ## in /var/cache/kiwi/bootstrap/PACKAGE_NAME.ARCH.tar.xz
+        ## The tarball will be unpacked and used as the bootstrap
+        ## rootfs to begin with. The feature is currently only
+        ## available with the apt package manager to allow an
+        ## alternative bootstrap method for debootstrap
+        attribute bootstrap_package { text }
+        >> sch:pattern [ id = "bootstrap_package" is-a = "packages_type"
+            sch:param [ name = "attr" value = "bootstrap_package" ]
+            sch:param [ name = "types" value = "bootstrap" ]
+        ]
+        sch:pattern [
+            id = "bootstrap_package_validation"
+            sch:rule [
+                context = "packages"
+                sch:assert [
+                    test = "../preferences/packagemanager[text()='apt'] or not(@bootstrap_package)"
+                    "bootstrap_package attribute only available for "
+                    "the apt packagemanager"
+                ]
+            ]
+        ]
     k.packages.attlist =
         k.packages.type.attribute &
         k.packages.profiles.attribute? &
-        k.packages.patternType.attribute?
+        k.packages.patternType.attribute? &
+        k.packages.bootstrap_package.attribute?
     k.packages =
         ## Specifies Packages/Patterns Used in Different Stages
         element packages {

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -4929,6 +4929,11 @@ running the image.</a:documentation>
     
   -->
   <div>
+    <sch:pattern abstract="true" id="packages_type">
+      <sch:rule context="packages[@$attr]">
+        <sch:assert test="contains('$types', @type)">$attr attribute is only available for the following packages type(s): $types</sch:assert>
+      </sch:rule>
+    </sch:pattern>
     <define name="k.packages.type.attribute">
       <attribute name="type">
         <a:documentation>Specifies package collection type. `bootstrap` packages
@@ -4965,6 +4970,25 @@ or plusRecommended</a:documentation>
         </choice>
       </attribute>
     </define>
+    <define name="k.packages.bootstrap_package.attribute">
+      <attribute name="bootstrap_package">
+        <a:documentation>Specify bootstrap package providing a bootstrap tarball
+in /var/cache/kiwi/bootstrap/PACKAGE_NAME.ARCH.tar.xz
+The tarball will be unpacked and used as the bootstrap
+rootfs to begin with. The feature is currently only
+available with the apt package manager to allow an
+alternative bootstrap method for debootstrap</a:documentation>
+      </attribute>
+      <sch:pattern id="bootstrap_package" is-a="packages_type">
+        <sch:param name="attr" value="bootstrap_package"/>
+        <sch:param name="types" value="bootstrap"/>
+      </sch:pattern>
+    </define>
+    <sch:pattern id="bootstrap_package_validation">
+      <sch:rule context="packages">
+        <sch:assert test="../preferences/packagemanager[text()='apt'] or not(@bootstrap_package)">bootstrap_package attribute only available for the apt packagemanager</sch:assert>
+      </sch:rule>
+    </sch:pattern>
     <define name="k.packages.attlist">
       <interleave>
         <ref name="k.packages.type.attribute"/>
@@ -4973,6 +4997,9 @@ or plusRecommended</a:documentation>
         </optional>
         <optional>
           <ref name="k.packages.patternType.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.packages.bootstrap_package.attribute"/>
         </optional>
       </interleave>
     </define>

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -250,8 +250,9 @@ class SystemPrepare:
             self.xml_state.get_collection_modules()
         )
         process = CommandProcess(
-            command=manager.process_install_requests_bootstrap(self.root_bind),
-            log_topic='bootstrap'
+            command=manager.process_install_requests_bootstrap(
+                self.root_bind, self.xml_state.get_bootstrap_package_name()
+            ), log_topic='bootstrap'
         )
         try:
             process.poll_show_progress(

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -8049,11 +8049,12 @@ class packages(GeneratedsSuper):
     """Specifies Packages/Patterns Used in Different Stages"""
     subclass = None
     superclass = None
-    def __init__(self, type_=None, profiles=None, patternType=None, archive=None, ignore=None, namedCollection=None, collectionModule=None, product=None, package=None):
+    def __init__(self, type_=None, profiles=None, patternType=None, bootstrap_package=None, archive=None, ignore=None, namedCollection=None, collectionModule=None, product=None, package=None):
         self.original_tagname_ = None
         self.type_ = _cast(None, type_)
         self.profiles = _cast(None, profiles)
         self.patternType = _cast(None, patternType)
+        self.bootstrap_package = _cast(None, bootstrap_package)
         if archive is None:
             self.archive = []
         else:
@@ -8125,6 +8126,8 @@ class packages(GeneratedsSuper):
     def set_profiles(self, profiles): self.profiles = profiles
     def get_patternType(self): return self.patternType
     def set_patternType(self, patternType): self.patternType = patternType
+    def get_bootstrap_package(self): return self.bootstrap_package
+    def set_bootstrap_package(self, bootstrap_package): self.bootstrap_package = bootstrap_package
     def hasContent_(self):
         if (
             self.archive or
@@ -8168,6 +8171,9 @@ class packages(GeneratedsSuper):
         if self.patternType is not None and 'patternType' not in already_processed:
             already_processed.add('patternType')
             outfile.write(' patternType=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.patternType), input_name='patternType')), ))
+        if self.bootstrap_package is not None and 'bootstrap_package' not in already_processed:
+            already_processed.add('bootstrap_package')
+            outfile.write(' bootstrap_package=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bootstrap_package), input_name='bootstrap_package')), ))
     def exportChildren(self, outfile, level, namespaceprefix_='', name_='packages', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -8207,6 +8213,10 @@ class packages(GeneratedsSuper):
             already_processed.add('patternType')
             self.patternType = value
             self.patternType = ' '.join(self.patternType.split())
+        value = find_attr_value_('bootstrap_package', node)
+        if value is not None and 'bootstrap_package' not in already_processed:
+            already_processed.add('bootstrap_package')
+            self.bootstrap_package = value
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         if nodeName_ == 'archive':
             obj_ = archive.factory()

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -579,6 +579,24 @@ class XMLState:
                     result.append(package.get_name().strip())
         return sorted(result)
 
+    def get_bootstrap_package_name(self) -> str:
+        """
+        bootstrap_package name from type="bootstrap" packages section
+
+        :return: bootstrap_package name
+
+        :rtype: str
+        """
+        typed_packages_sections = self.get_packages_sections(
+            ['bootstrap', self.get_build_type_name()]
+        )
+        bootstrap_package = ''
+        for packages in typed_packages_sections:
+            bootstrap_package = packages.get_bootstrap_package()
+            if bootstrap_package:
+                break
+        return bootstrap_package
+
     def get_collection_type(self, section_type: str = 'image') -> str:
         """
         Collection type from packages sections matching given section

--- a/test/data/example_apt_config.xml
+++ b/test/data/example_apt_config.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="7.5" name="apt-testing">
+    <description type="system">
+        <author>Bob</author>
+        <contact>user@example.com</contact>
+        <specification>
+            Testing various configuration for apt packagemanager
+        </specification>
+    </description>
+    <preferences>
+        <version>1.13.2</version>
+        <packagemanager>apt</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <type image="tbz"/>
+    </preferences>
+    <repository priority="42" sourcetype="baseurl">
+        <source path="iso:///image/CDs/dvd.iso">
+            <signing key="file:key_a"/>
+        </source>
+    </repository>
+    <packages type="image">
+        <package name="foo"/>
+    </packages>
+    <packages type="bootstrap" bootstrap_package="bootstrap-me">
+        <package name="filesystem"/>
+    </packages>
+</image>

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -304,7 +304,7 @@ class TestSystemPrepare:
             {'disable': ['mod_c'], 'enable': ['mod_a:stream', 'mod_b']}
         )
         self.manager.process_install_requests_bootstrap.assert_called_once_with(
-            self.system.root_bind
+            self.system.root_bind, None
         )
         mock_tar.assert_called_once_with(
             '{0}/bootstrap.tgz'.format(self.description_dir)

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -35,6 +35,12 @@ class TestXMLState:
         self.state = XMLState(
             self.description.load()
         )
+        apt_description = XMLDescription(
+            '../data/example_apt_config.xml'
+        )
+        self.apt_state = XMLState(
+            apt_description.load()
+        )
         boot_description = XMLDescription(
             '../data/isoboot/example-distribution/config.xml'
         )
@@ -1090,3 +1096,6 @@ class TestXMLState:
             '--cipher', 'aes-gcm-random',
             '--integrity', 'aead'
         ]
+
+    def test_get_bootstrap_package_name(self):
+        assert self.apt_state.get_bootstrap_package_name() == 'bootstrap-me'


### PR DESCRIPTION
When using the apt packagemanager kiwi required the use of debootstrap to create the initial rootfs. This works as long as there is always a main distribution repository available which follows the structure of the official debian mirrors. However if such a main distribution is not present or an alternative layout like e.g OBS repos is used, debootstrap will refuse to work. To allow for an alternative and without the dependency to debootstrap kiwi supports using a prebuilt bootstrap package providing the mini rootfs to serve as the bootstrap result. As all other package managers properly supports installation into an empty new root, this feature was only added when using the apt packagemanager

