### PR TITLE
Add support for group id in users setting

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -1472,11 +1472,13 @@ Additionally, the following optional attributes can be specified:
 home="path":
   The path to the user's home directory
 
-groups="group_a,group_b":
+groups="group_a,group_b,group_c:id":
   A comma separated list of UNIX groups. The first element of the
   list is used as the user's primary group. The remaining elements are
   appended to the user's supplementary groups. When no groups are assigned
-  then the system's default primary group will be used.
+  then the system's default primary group will be used. If a group should
+  be of a specific group id, it can be appended to the name separated by
+  a colon
 
 id="number":
   The numeric user id of this account.

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -1478,7 +1478,18 @@ groups="group_a,group_b,group_c:id":
   appended to the user's supplementary groups. When no groups are assigned
   then the system's default primary group will be used. If a group should
   be of a specific group id, it can be appended to the name separated by
-  a colon
+  a colon.
+
+  .. note::
+
+     Group ID's can only be set for groups that does not yet exist at
+     the time when {kiwi} creates them. A check is made if the desired
+     group is already present and if it exists the user will become a
+     member of that group but any given group ID from the {kiwi}
+     configuration will **not** be taken into account. Usually all
+     standard system groups are affected by this behavior because they
+     are provided by the OS itself. Thus it's by intention not possible
+     to overwrite the group ID of an existing group. 
 
 id="number":
   The numeric user id of this account.

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -34,7 +34,7 @@ blocks-type = xsd:token {pattern = "(\d*|all)"}
 volume-size-type = xsd:token {pattern = "(\d+|\d+M|\d+G|all)"}
 partition-size-type = xsd:token {pattern = "(\d+|\d+M|\d+G)"}
 vhd-tag-type = xsd:token {pattern = "[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}"}
-groups-list = xsd:token {pattern = "[a-zA-Z0-9_\-\.]+(,[a-zA-Z0-9_\-\.]+)*"}
+groups-list = xsd:token {pattern = "[a-zA-Z0-9_\-\.:]+(,[a-zA-Z0-9_\-\.:]+)*"}
 arch-name = xsd:token {pattern = "(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x))*"}
 portnum-type = xsd:token {pattern = "(\d+|\d+/(udp|tcp))"}
 grub_console = xsd:token {pattern = "(console|gfxterm|serial)( (console|gfxterm|serial))*"}
@@ -2190,8 +2190,8 @@ div {
         ## The user ID for this user
         attribute id { xsd:nonNegativeInteger }
     k.user.groups.attribute =
-        ## The list of groups that he user belongs to. The
-        ## frist item in the list is used as the login group.
+        ## The list of groups that the user belongs to. The
+        ## first item in the list is used as the login group.
         ## If 'groups' is not present a default group is assigned
         ## to the user according to he specifing toolchain behaviour.
         attribute groups { groups-list }

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -73,7 +73,7 @@
   </define>
   <define name="groups-list">
     <data type="token">
-      <param name="pattern">[a-zA-Z0-9_\-\.]+(,[a-zA-Z0-9_\-\.]+)*</param>
+      <param name="pattern">[a-zA-Z0-9_\-\.:]+(,[a-zA-Z0-9_\-\.:]+)*</param>
     </data>
   </define>
   <define name="arch-name">
@@ -3253,8 +3253,8 @@ kiwi-ng result bundle ...</a:documentation>
     </define>
     <define name="k.user.groups.attribute">
       <attribute name="groups">
-        <a:documentation>The list of groups that he user belongs to. The
-frist item in the list is used as the login group.
+        <a:documentation>The list of groups that the user belongs to. The
+first item in the list is used as the login group.
 If 'groups' is not present a default group is assigned
 to the user according to he specifing toolchain behaviour.</a:documentation>
         <ref name="groups-list"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -4053,7 +4053,7 @@ class user(GeneratedsSuper):
             if not self.gds_validate_simple_patterns(
                     self.validate_groups_list_patterns_, value):
                 warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_groups_list_patterns_, ))
-    validate_groups_list_patterns_ = [['^[a-zA-Z0-9_\\-\\.]+(,[a-zA-Z0-9_\\-\\.]+)*$']]
+    validate_groups_list_patterns_ = [['^[a-zA-Z0-9_\\-\\.:]+(,[a-zA-Z0-9_\\-\\.:]+)*$']]
     def hasContent_(self):
         if (
 

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1284,13 +1284,14 @@ class XMLState:
 
         return users_list
 
-    def get_user_groups(self, user_name) -> List:
+    def get_user_groups(self, user_name) -> List[str]:
         """
         List of group names matching specified user
 
-        Each entry in the list is the name of a group that the specified
-        user belongs to. The first item in the list is the login or primary
-        group. The list will be empty if no groups are specified in the
+        Each entry in the list is the name of a group and optionally its
+        group ID separated by a colon, that the specified user belongs to.
+        The first item in the list is the login or primary group. The
+        list will be empty if no groups are specified in the
         description file.
 
         :return: groups data for the given user

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -169,7 +169,7 @@
     <users>
         <user pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>
         <user groups="users" pwdformat="plain" password="mypwd" home="/home/tux" name="tux"/>
-        <user groups="kiwi,admin,users" pwdformat="plain" password="mypwd" name="kiwi"/>
+        <user groups="kiwi,admin:42,users" pwdformat="plain" password="mypwd" name="kiwi"/>
     </users>
     <repository priority="42" sourcetype="baseurl">
         <source path="iso:///image/CDs/dvd.iso">

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -507,7 +507,7 @@ class TestSystemSetup:
         calls = [
             call('users', []),
             call('kiwi', []),
-            call('admin', [])
+            call('admin', ['-g', '42'])
         ]
         users.group_add.assert_has_calls(calls)
 


### PR DESCRIPTION
Allow to specify the group id in the groups list a user should belong to. The group id can be placed as part of the group name separated by a colon like in the following example:

```xml
<users>
    <user groups="kiwi,admin:42,users" password="..." name="kiwi"/>
</users>
```

Please note kiwi checks if the provided group already exists and only creates a group if it is not already present in the system. As default groups are usually provided by the OS itself including its preferred group id, you will intentionally not be able to overwrite group id for existing groups.

This Fixes #2064

