### PR TITLE
Added --target-arch for image info

### DIFF
--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -19,6 +19,7 @@
 usage: kiwi-ng -h | --help
        kiwi-ng [--profile=<name>...]
                [--temp-dir=<directory>]
+               [--target-arch=<name>]
                [--type=<build_type>]
                [--logfile=<filename>]
                [--debug]
@@ -92,7 +93,7 @@ global options for services: image, system
         configuration elements. If not specified kiwi searches for
         a file named config.xml or a file matching *.kiwi
 
-global options for services: system
+global options for services: image, system
     --target-arch=<name>
         set the image architecture. By default the host architecture is
         used as the image architecture. If the specified architecture name

--- a/kiwi/solver/sat.py
+++ b/kiwi/solver/sat.py
@@ -65,6 +65,10 @@ class Sat:
             'deb-x86_64': {
                 'pool_dist': self.solv.Pool.DISTTYPE_DEB,
                 'arch': 'amd64'
+            },
+            'deb-aarch64': {
+                'pool_dist': self.solv.Pool.DISTTYPE_DEB,
+                'arch': 'arm64'
             }
         }
         dist_type = dist_types.get(f'{dist}-{arch}')


### PR DESCRIPTION
Allow cross arch dependency solving

For example

```
user@host_some_arch:
> kiwi-ng --target-arch aarch64 image info --description /path/to/image_description --resolve-package-list
```

