### PR TITLE
Correct setfiles relabeling

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -544,6 +544,11 @@ target_removable="true|false":
   of the target machine. By default the target disk is
   expected to be non-removable
 
+selinux_policy.attribute="targeted|mls|minimum":
+  The `selinux_policy` attribute sets the SELinux policy to use.
+  `targeted` policy is the default policy. Only change this option
+  if you want to use the `mls` or `minimum` policy.
+
 spare_part="number":
   Request a spare partition right before the root partition
   of the requested size. The attribute takes a size value

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1419,6 +1419,12 @@ div {
             sch:param [ name = "attr" value = "target_removable" ]
             sch:param [ name = "types" value = "oem" ]
         ]
+    k.type.selinux_policy.attribute =
+        ## On systems using selinux use the given policy.
+        ## by default 'targeted' is used
+        attribute selinux_policy {
+            "targeted" | "mls" | "minimum"
+        }
     k.type.spare_part.attribute =
         ## Request a spare partition right before the root partition
         ## of the requested size. The attribute takes a size value
@@ -2152,6 +2158,7 @@ div {
         k.type.spare_part_is_last.attribute? &
         k.type.target_blocksize.attribute? &
         k.type.target_removable.attribute? &
+        k.type.selinux_policy.attribute? &
         k.type.vga.attribute? &
         k.type.vhdfixedtag.attribute? &
         k.type.volid.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2062,6 +2062,17 @@ expected to be non-removable</a:documentation>
         <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
+    <define name="k.type.selinux_policy.attribute">
+      <attribute name="selinux_policy">
+        <a:documentation>On systems using selinux use the given policy.
+by default 'targeted' is used</a:documentation>
+        <choice>
+          <value>targeted</value>
+          <value>mls</value>
+          <value>minimum</value>
+        </choice>
+      </attribute>
+    </define>
     <define name="k.type.spare_part.attribute">
       <attribute name="spare_part">
         <a:documentation>Request a spare partition right before the root partition
@@ -3158,6 +3169,9 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.target_removable.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.selinux_policy.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.vga.attribute"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2798,7 +2798,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2863,6 +2863,7 @@ class type_(GeneratedsSuper):
         self.spare_part_is_last = _cast(bool, spare_part_is_last)
         self.target_blocksize = _cast(int, target_blocksize)
         self.target_removable = _cast(bool, target_removable)
+        self.selinux_policy = _cast(None, selinux_policy)
         self.vga = _cast(None, vga)
         self.vhdfixedtag = _cast(None, vhdfixedtag)
         self.volid = _cast(None, volid)
@@ -3102,6 +3103,8 @@ class type_(GeneratedsSuper):
     def set_target_blocksize(self, target_blocksize): self.target_blocksize = target_blocksize
     def get_target_removable(self): return self.target_removable
     def set_target_removable(self, target_removable): self.target_removable = target_removable
+    def get_selinux_policy(self): return self.selinux_policy
+    def set_selinux_policy(self, selinux_policy): self.selinux_policy = selinux_policy
     def get_vga(self): return self.vga
     def set_vga(self, vga): self.vga = vga
     def get_vhdfixedtag(self): return self.vhdfixedtag
@@ -3395,6 +3398,9 @@ class type_(GeneratedsSuper):
         if self.target_removable is not None and 'target_removable' not in already_processed:
             already_processed.add('target_removable')
             outfile.write(' target_removable="%s"' % self.gds_format_boolean(self.target_removable, input_name='target_removable'))
+        if self.selinux_policy is not None and 'selinux_policy' not in already_processed:
+            already_processed.add('selinux_policy')
+            outfile.write(' selinux_policy=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.selinux_policy), input_name='selinux_policy')), ))
         if self.vga is not None and 'vga' not in already_processed:
             already_processed.add('vga')
             outfile.write(' vga=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.vga), input_name='vga')), ))
@@ -3878,6 +3884,11 @@ class type_(GeneratedsSuper):
                 self.target_removable = False
             else:
                 raise_parse_error(node, 'Bad boolean attribute')
+        value = find_attr_value_('selinux_policy', node)
+        if value is not None and 'selinux_policy' not in already_processed:
+            already_processed.add('selinux_policy')
+            self.selinux_policy = value
+            self.selinux_policy = ' '.join(self.selinux_policy.split())
         value = find_attr_value_('vga', node)
         if value is not None and 'vga' not in already_processed:
             already_processed.add('vga')


### PR DESCRIPTION
This change was inspired by a change done on Fedora's livecd-tools
from here: livecd-tools/livecd-tools#236. The patch corrects issues
with the setfiles SELinux relabel command. The issues become apparent
when the host and guest policies differ. Thus it becomes required
to explicitly set the policy to decouple from eventual unwanted
host settings.

