### PR TITLE
Fixed handling of signing_keys in cmdline options

### DIFF
--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -151,7 +151,9 @@ OPTIONS
 
   - **{signing_keys}**
 
-    List of signing_keys enclosed in curly brackets and delimited by a colon
+    List of signing_keys enclosed in curly brackets and delimited by 
+    semicolon. The reference to a signing key must be provided as URI
+    format
 
   - **components**
 

--- a/doc/source/commands/system_prepare.rst
+++ b/doc/source/commands/system_prepare.rst
@@ -152,7 +152,9 @@ OPTIONS
 
     - **{signing_keys}**
 
-    List of signing_keys enclosed in curly brackets and delimited by a colon
+    List of signing_keys enclosed in curly brackets and delimited by
+    semicolon. The reference to a signing key must be provided as URI
+    format
 
   - **components**
 

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -242,7 +242,7 @@ class CliTask:
         elif len(token) > 0 and token == 'false':
             return False
         elif len(token) > 0 and token.startswith('{'):
-            return token.replace('{', '').replace('}', '').split(':')
+            return token.replace('{', '').replace('}', '').split(';')
         else:
             return token
 

--- a/test/unit/tasks/base_test.py
+++ b/test/unit/tasks/base_test.py
@@ -82,12 +82,12 @@ class TestCliTask:
 
     def test_tentuple_token(self):
         assert self.task.tentuple_token(
-            'a,b,,d,e,f,{1:2:3},x y z,jammy,false'
+            'a,b,,d,e,f,{1;2;3},x y z,jammy,false'
         ) == [
             'a', 'b', '', 'd', 'e', 'f', ['1', '2', '3'], 'x y z',
             'jammy', False
         ]
-        assert self.task.tentuple_token('a,b,,d,e,f,{1:2:3}') == [
+        assert self.task.tentuple_token('a,b,,d,e,f,{1;2;3}') == [
             'a', 'b', '', 'd', 'e', 'f', ['1', '2', '3'],
             None, None, None
         ]


### PR DESCRIPTION
When passing signing_keys with the --add-repo|--set-repo
commandline options the delimiter to separate the single
key information is a colon(:). However, this is stupid when
kiwi expects the signing key to be references as an URI
format like file://... Therefore this patch changes the
delimiter from colon(:) to semicolon(;)

