### PR TITLE
Fix helper method to detect dracut outfile format

### DIFF
--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -461,11 +461,15 @@ class BootImageBase:
             'dracut', root_dir=self.boot_root_directory, access_mode=os.X_OK
         )
         if dracut_tool:
-            outfile_expression = r'outfile="/boot/(init.*\$kernel.*)"'
+            outfile_expression = r'outfile=".*/boot/(init.*kernel.*)"'
             with open(dracut_tool) as dracut:
                 matches = re.findall(outfile_expression, dracut.read())
                 if matches:
-                    return matches[0].replace('$kernel', '{kernel_version}')
+                    return matches[0].replace(
+                        '$kernel', '{kernel_version}'
+                    ).replace(
+                        '${kernel}', '{kernel_version}'
+                    )
         return None
 
     def _get_boot_image_output_file_format_from_existing_file(

--- a/test/unit/boot/image/base_test.py
+++ b/test/unit/boot/image/base_test.py
@@ -178,6 +178,11 @@ class TestBootImageBase:
                 kernel_name='kernel_name',
                 initrd_name='initrd-kernel_version'
             )
+            file_handle.read.return_value = 'outfile="/boot/initrd-${kernel}"'
+            assert self.boot_image.get_boot_names() == self.boot_names_type(
+                kernel_name='kernel_name',
+                initrd_name='initrd-kernel_version'
+            )
 
     def test_noop_methods(self):
         self.boot_image.include_module('module')


### PR DESCRIPTION
The method _get_boot_image_output_file_format_from_dracut_code
is used in kiwi to match parts of the dracut code for the used
output file format. Beginning with dracut-056 the code part
checked has changed syntactically such that the match did
no longer work. This commit increases the scope of the match
and replace pattern and Fixes #2149


