### PR TITLE
Prefer file based syscall in kexec when possible

### DIFF
--- a/dracut/modules.d/99kiwi-dump-reboot/kiwi-dump-reboot-system.sh
+++ b/dracut/modules.d/99kiwi-dump-reboot/kiwi-dump-reboot-system.sh
@@ -50,7 +50,17 @@ function boot_installed_system {
     if getargbool 0 rd.kiwi.debug; then
         boot_options="${boot_options} rd.kiwi.debug"
     fi
-    kexec -l /run/install/boot/*/loader/linux \
+    kexec_options=""
+    if kexec --help | grep -q kexec-syscall-auto;then
+        # try file based syscall first and fall back to kexec_load
+        # syscall if not present. On systems using kexec that does
+        # provide --kexec-syscall-auto the assumption is made that
+        # neither kexec nor the kernel supports file based syscall
+        # and thus no syscall selection is made
+        kexec_options="${kexec_options} --kexec-syscall-auto"
+    fi
+    kexec "${kexec_options}" \
+        --load /run/install/boot/*/loader/linux \
         --initrd /run/install/initrd.system_image \
         --command-line "${boot_options}"
     if ! kexec -e; then


### PR DESCRIPTION
Use file based syscall in kexec if available. This is needed to
support boot on an secure boot enabled system and is in general
more reliable to boot into the system on real hardware platforms


