### PR TITLE
Fix btrfs volume mounting

### DIFF
--- a/kiwi/system/mount.py
+++ b/kiwi/system/mount.py
@@ -175,7 +175,7 @@ class ImageSystem:
             volume_mount = MountManager(
                 device=self.volumes[volume_path]['volume_device'],
                 mountpoint=os.path.join(
-                    mountpoint, volume_path
+                    mountpoint, os.path.relpath(volume_path, '/')
                 )
             )
             self.mount_list.append(volume_mount)


### PR DESCRIPTION
If the second argument of os.path.join is an absolute directory, the
result would be that directory. The intention is to produce a
subdirectory of the mountpoint though. So pass a relative path.

Without the fix, kiwi would try to e.g mount the /var subvolume of
the image over the /var of the host, screwing everthing up of course
:-)