### PR TITLE
Fix btrfs volume mounting

### DIFF
--- a/kiwi/system/mount.py
+++ b/kiwi/system/mount.py
@@ -167,7 +167,7 @@ class ImageSystem:
             volume_mount = MountManager(
                 device=self.volumes[volume_path]['volume_device'],
                 mountpoint=os.path.join(
-                    mountpoint, os.path.relpath(volume_path, '/')
+                    mountpoint, volume_path.lstrip(os.sep)
                 )
             )
             self.mount_list.append(volume_mount)

--- a/kiwi/system/mount.py
+++ b/kiwi/system/mount.py
@@ -132,23 +132,15 @@ class ImageSystem:
         self.mount_list.append(var_tmp_mount)
         var_tmp_mount.tmpfs_mount()
 
-        # mount dev as bind
-        device_mount = MountManager(
-            device='/dev', mountpoint=os.path.join(
-                root_mount.mountpoint, 'dev'
+        # mount kernel interfaces as bind
+        for location in ('proc', 'sys', 'dev'):
+            shared_mount = MountManager(
+                device=os.path.join('/', location), mountpoint=os.path.join(
+                    root_mount.mountpoint, location
+                )
             )
-        )
-        self.mount_list.append(device_mount)
-        device_mount.bind_mount()
-
-        # mount proc as bind
-        proc_mount = MountManager(
-            device='/proc', mountpoint=os.path.join(
-                root_mount.mountpoint, 'proc'
-            )
-        )
-        self.mount_list.append(proc_mount)
-        proc_mount.bind_mount()
+            self.mount_list.append(shared_mount)
+            shared_mount.bind_mount()
 
     def umount(self) -> None:
         """

--- a/kiwi/system/mount.py
+++ b/kiwi/system/mount.py
@@ -175,7 +175,7 @@ class ImageSystem:
             volume_mount = MountManager(
                 device=self.volumes[volume_path]['volume_device'],
                 mountpoint=os.path.join(
-                    mountpoint, volume_path
+                    mountpoint, os.path.relpath(volume_path, '/')
                 )
             )
             self.mount_list.append(volume_mount)

--- a/test/unit/system/mount_test.py
+++ b/test/unit/system/mount_test.py
@@ -73,12 +73,16 @@ class TestImageSystem:
                 mountpoint=os.path.join(root_mount_mountpoint, 'var', 'tmp')
             ),
             call(
-                device='/dev',
-                mountpoint=os.path.join(root_mount_mountpoint, 'dev')
-            ),
-            call(
                 device='/proc',
                 mountpoint=os.path.join(root_mount_mountpoint, 'proc')
+            ),
+            call(
+                device='/sys',
+                mountpoint=os.path.join(root_mount_mountpoint, 'sys')
+            ),
+            call(
+                device='/dev',
+                mountpoint=os.path.join(root_mount_mountpoint, 'dev')
             )
         ]
 


### PR DESCRIPTION
If the second argument of os.path.join is an absolute directory, the
result would be that directory. The intention is to produce a
subdirectory of the mountpoint though. So pass a relative path.

