### PR TITLE
Support squashfs in custom partitions

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -745,9 +745,33 @@ class DiskBuilder:
                             device_map[map_name],
                             f'{self.root_dir}{ptable_entry.mountpoint}/'
                         )
-                        filesystem.create_on_device(
-                            label=map_name.upper()
-                        )
+                        if ptable_entry.filesystem == 'squashfs':
+                            squashed_root_file = Temporary().new_file()
+                            filesystem.create_on_file(
+                                filename=squashed_root_file.name,
+                                exclude=[Defaults.get_shared_cache_location()]
+                            )
+                            readonly_target = device_map[map_name].get_device()
+                            readonly_target_bytesize = device_map[map_name].get_byte_size(
+                                readonly_target
+                            )
+                            log.info(
+                                '--> Dumping {0!r} file({1} bytes) -> {2}({3} bytes)'.format(
+                                    map_name, os.path.getsize(squashed_root_file.name),
+                                    readonly_target, readonly_target_bytesize
+                                )
+                            )
+                            Command.run(
+                                [
+                                    'dd',
+                                    'if=%s' % squashed_root_file.name,
+                                    'of=%s' % readonly_target
+                                ]
+                            )
+                        else:
+                            filesystem.create_on_device(
+                                label=map_name.upper()
+                            )
                         filesystem_dict[map_name] = filesystem
         return filesystem_dict
 
@@ -1113,16 +1137,20 @@ class DiskBuilder:
         if not options:
             options = ['defaults']
         block_operation = BlockID(device)
+        filesystem = block_operation.get_filesystem()
         if self.volume_manager_name and self.volume_manager_name == 'lvm' \
            and (mount_point == '/' or mount_point == 'swap'):
             fstab_entry = ' '.join(
                 [
                     device, mount_point,
-                    block_operation.get_filesystem(), ','.join(options), check
+                    filesystem, ','.join(options), check
                 ]
             )
         else:
-            if self.persistency_type == 'by-label':
+            if filesystem == 'squashfs':
+                # squashfs does not provide a label or uuid
+                blkid_type = 'PARTUUID'
+            elif self.persistency_type == 'by-label':
                 blkid_type = 'LABEL'
             elif self.persistency_type == 'by-partuuid':
                 blkid_type = 'PARTUUID'
@@ -1132,7 +1160,7 @@ class DiskBuilder:
             fstab_entry = ' '.join(
                 [
                     blkid_type + '=' + device_id, mount_point,
-                    block_operation.get_filesystem(), ','.join(options), check
+                    filesystem, ','.join(options), check
                 ]
             )
         self.fstab.add_entry(fstab_entry)
@@ -1243,10 +1271,11 @@ class DiskBuilder:
         for map_name in sorted(system_custom_parts.keys()):
             system_custom_part = system_custom_parts[map_name]
             log.info('--> Syncing custom partition(s) data')
-            system_custom_part.sync_data()
+            if not system_custom_part.filename:
+                system_custom_part.sync_data()
             if device_map.get(f'{map_name}clone1'):
                 log.info(
-                    f'--> Dumping {map_name} clone data at extra partition'
+                    f'--> Dumping {map_name!r} clone data at extra partition'
                 )
                 system_custom_part_clone = CloneDevice(
                     system_custom_part.device_provider, self.root_dir

--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -310,11 +310,17 @@ class DiskSetup:
         data_partition_mbytes = self._calculate_partition_mbytes()
         for map_name in sorted(self.custom_partitions.keys()):
             partition_mount_path = self.custom_partitions[map_name].mountpoint
+            partition_filesystem = self.custom_partitions[map_name].filesystem
             partition_clone = self.custom_partitions[map_name].clone
             if partition_mount_path:
                 partition_mbsize = self.custom_partitions[map_name].mbsize
-                disk_add_mbytes = int(partition_mbsize) - \
-                    data_partition_mbytes.partition[partition_mount_path]
+                if partition_filesystem == 'squashfs':
+                    # cannot predict compressed size prior compressing
+                    # use size as configured
+                    disk_add_mbytes = int(partition_mbsize)
+                else:
+                    disk_add_mbytes = int(partition_mbsize) - \
+                        data_partition_mbytes.partition[partition_mount_path]
                 if disk_add_mbytes > 0:
                     if partition_clone:
                         partition_clone += 1

--- a/test/data/example_disk_size_partitions_config.xml
+++ b/test/data/example_disk_size_partitions_config.xml
@@ -15,6 +15,7 @@
             <partitions>
                 <partition name="var" size="100" mountpoint="/var" filesystem="ext3"/>
                 <partition name="var/tmp" size="500" mountpoint="/var/tmp" filesystem="xfs"/>
+                <partition name="tmp" size="100" mountpoint="/tmp" filesystem="squashfs"/>
             </partitions>
         </type>
     </preferences>

--- a/test/unit/storage/setup_test.py
+++ b/test/unit/storage/setup_test.py
@@ -217,7 +217,7 @@ class TestDiskSetup:
     @patch('os.path.exists')
     def test_get_disksize_mbytes_partitions(self, mock_exists):
         mock_exists.side_effect = lambda path: path != 'root_dir/var/tmp'
-        assert self.setup_partitions.get_disksize_mbytes() == 632
+        assert self.setup_partitions.get_disksize_mbytes() == 732
 
     @patch('os.path.exists')
     def test_get_disksize_mbytes_clones(self, mock_exists):
@@ -232,7 +232,7 @@ class TestDiskSetup:
         )
         assert self.setup_partitions.get_disksize_mbytes(
             root_clone=1, boot_clone=1
-        ) == 742
+        ) == 842
 
     @patch('os.path.exists')
     def test_get_disksize_mbytes_oem_volumes(self, mock_exists):


### PR DESCRIPTION
When using squashfs in a custom partitions setup like the following:

```xml
<partitions>
    <partition ... filesystem="squashfs"/>
</partitions>
```

The build fails because the filesystem needs to be created using the ```create_on_file()``` API and not the ```create_on_device()``` API. In addition the size estimation is bogus when using squashfs and cannot be pre-calculated because we only know how much space the filesystem really needs after mksquashfs as worked on the data and the compression. Thus this commit also relaxes the required size check in case of squashfs. Last but not least a squashfs filesystem does not provide label or UUID and can only be referenced by the PARTUUID it gets dumped on or by the native unix device node. As the unix node is a loop during build time of the image and meaningless this commit also forces by-partuuid mapping in fstab when mounting the squashfs based device.

