### PR TITLE
github: Refresh issue template to cover more operating scenarios

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,6 +5,9 @@
 ## Steps to reproduce the behaviour
 
 ## OS and Software information
-+ KIWI version: 
-+ Operating system: 
-+ OBS version: 
+
+* KIWI version: 
+* Operating system host version: 
+* Operating system target version: 
+* Open Build Service version (N/A if not using OBS): 
+* Koji version (N/A if not using Koji): 


### PR DESCRIPTION
KIWI is often used for cross-distribution image builds, so we
should ask for that information when appropriate.

Additionally, clarify "OBS" as "Open Build Service" to disambiguate.

Finally, add a line about Koji since Koji can run kiwi to build
images now.