### PR TITLE
Fixed custom disk start sector setup

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -146,6 +146,7 @@ class DiskBuilder:
         self.disk_resize_requested = \
             xml_state.get_oemconfig_oem_resize()
         self.swap_mbytes = xml_state.get_oemconfig_swap_mbytes()
+        self.disk_start_sector = xml_state.get_disk_start_sector()
         self.disk_setup = DiskSetup(
             xml_state, root_dir
         )
@@ -276,7 +277,7 @@ class DiskBuilder:
 
         disk = Disk(
             self.firmware.get_partition_table_type(), loop_provider,
-            self.xml_state.get_disk_start_sector(),
+            self.disk_start_sector,
             extended_layout=bool(self.dosparttable_extended_layout)
         )
 
@@ -986,6 +987,10 @@ class DiskBuilder:
         if self.firmware.ofw_mode():
             log.info('--> setting active flag to primary PReP partition')
             disk.activate_boot_partition()
+
+        if not self.firmware.efi_mode() and self.disk_start_sector:
+            log.info(f'--> setting start sector to: {self.disk_start_sector}')
+            disk.set_start_sector(self.disk_start_sector)
 
         if self.firmware.efi_mode():
             if self.force_mbr:

--- a/kiwi/partitioner/base.py
+++ b/kiwi/partitioner/base.py
@@ -114,6 +114,16 @@ class PartitionerBase:
         """
         raise NotImplementedError
 
+    def set_start_sector(self, start_sector: int):
+        """
+        Set start sector of first partition as configured
+
+        :param int start_sector: unused
+
+        Does nothing by default
+        """
+        pass
+
     def resize_table(self, entries: int = 0):
         """
         Resize partition table

--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -348,6 +348,14 @@ class Disk(DeviceProvider):
         """
         self.partitioner.set_mbr()
 
+    def set_start_sector(self, start_sector: int):
+        """
+        Set start sector
+
+        Note: only effective on DOS tables
+        """
+        self.partitioner.set_start_sector(start_sector)
+
     def wipe(self):
         """
         Zap (destroy) any GPT and MBR data structures if present

--- a/kiwi/utils/block.py
+++ b/kiwi/utils/block.py
@@ -71,6 +71,23 @@ class BlockID:
         """
         return self.get_blkid('TYPE')
 
+    def get_partition_count(self) -> int:
+        """
+        Retrieve number of partitions from block device
+
+        :return: A number
+
+        :rtype: int
+        """
+        partition_count = 0
+        lsblk_result = Command.run(
+            ['lsblk', '-r', '-o', 'NAME,TYPE', self.device]
+        )
+        for line in lsblk_result.output.strip().split(os.linesep):
+            if line.strip().endswith('part'):
+                partition_count += 1
+        return partition_count
+
     def get_blkid(self, id_type):
         """
         Retrieve information for specified metadata ID from block device

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -1129,6 +1129,26 @@ class TestDiskBuilder:
 
         self.disk.create_mbr.assert_called_once_with()
 
+    @patch('kiwi.builder.disk.FileSystem.new')
+    @patch('kiwi.builder.disk.Command.run')
+    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
+    def test_create_disk_custom_start_sector_requested(
+        self, mock_grub_dir, mock_command, mock_fs
+    ):
+        filesystem = Mock()
+        mock_fs.return_value = filesystem
+        self.disk_builder.volume_manager_name = None
+        self.disk_builder.install_media = False
+        self.disk_builder.disk_start_sector = 4096
+        self.firmware.efi_mode = Mock(
+            return_value=None
+        )
+
+        with patch('builtins.open'):
+            self.disk_builder.create_disk()
+
+        self.disk.set_start_sector.assert_called_once_with(4096)
+
     def test_create(self):
         result = Mock()
         create_disk = Mock(return_value=result)

--- a/test/unit/partitioner/base_test.py
+++ b/test/unit/partitioner/base_test.py
@@ -37,3 +37,6 @@ class TestPartitionerBase:
     def test_resize_table(self):
         with raises(NotImplementedError):
             self.partitioner.resize_table()
+
+    def test_set_start_sector(self):
+        assert self.partitioner.set_start_sector(4096) is None

--- a/test/unit/storage/disk_test.py
+++ b/test/unit/storage/disk_test.py
@@ -316,6 +316,10 @@ class TestDisk:
         self.disk.create_mbr()
         self.partitioner.set_mbr.assert_called_once_with()
 
+    def test_set_start_sector(self):
+        self.disk.set_start_sector(4096)
+        self.partitioner.set_start_sector.assert_called_once_with(4096)
+
     def test_parse_size(self):
         (size, _) = self.disk._parse_size('100')
         assert size == '100'

--- a/test/unit/utils/block_test.py
+++ b/test/unit/utils/block_test.py
@@ -1,4 +1,6 @@
-from mock import patch
+from mock import (
+    Mock, patch
+)
 
 from kiwi.utils.block import BlockID
 
@@ -39,3 +41,10 @@ class TestBlockID:
     def test_get_uuid(self, mock_get_blkid):
         self.blkid.get_uuid()
         mock_get_blkid.assert_called_once_with('UUID')
+
+    @patch('kiwi.utils.block.Command.run')
+    def test_get_partition_count(self, mock_Command_run):
+        lsblk_call = Mock()
+        lsblk_call.output = "NAME TYPE\nsda disk\nsda4 part \nsda3 part"
+        mock_Command_run.return_value = lsblk_call
+        assert self.blkid.get_partition_count() == 2


### PR DESCRIPTION
The attribute

```xml
<type ... disk_start_sector="..."/>
```

allows to specify a custom start sector for the first partition of the disk. On GPT tables everything works nicely, on DOS tables the used tools fdisk/sfdisk are not able to manage the start/end values of subsequent partitions if the first partition doesn't start with the tooling default. This patch allows to set the start sector after the partition table has been created
