### PR TITLE
Fix race condition in runtime_config_test

### DIFF
--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -30,8 +30,8 @@ class TestRuntimeConfig:
             with raises(KiwiRuntimeConfigFormatError):
                 runtime_config._get_attribute('foo', 'bar')
 
+    @patch('kiwi.defaults.CUSTOM_RUNTIME_CONFIG_FILE', 'some-config-file')
     def test_init_raises_custom_config_file_not_found(self):
-        Defaults.set_custom_runtime_config_file('some-config-file')
         with patch('os.path.isfile', return_value=False):
             with raises(KiwiRuntimeConfigFileError):
                 RuntimeConfig(reread=True)


### PR DESCRIPTION
This commit instead of setting the global variable of the runtime config
file patches it. This is relevant if running unit tests in parallel,
where global variables are shared if not patched.

Signed-off-by: David Cassany <dcassany@suse.com>
