### PR TITLE
Fix mocking of grub2-install (fix #2124)

### DIFF
--- a/kiwi/bootloader/install/grub2.py
+++ b/kiwi/bootloader/install/grub2.py
@@ -335,28 +335,32 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
         if os.access(root_path, os.W_OK):
             grub2_install = ''.join(
                 [
-                    root_path, '/usr/sbin/',
+                    '/usr/sbin/',
                     self._get_grub2_install_tool_name(root_path)
                 ]
             )
             grub2_install_backup = ''.join(
                 [grub2_install, '.orig']
             )
-            grub2_install_noop = ''.join(
-                [root_path, '/bin/true']
+            grub2_install_noop = '/bin/true'
+            Command.run(
+                [
+                    'chroot', root_path,
+                    'cp', '-p', grub2_install, grub2_install_backup
+                ]
             )
             Command.run(
-                ['cp', '-p', grub2_install, grub2_install_backup]
-            )
-            Command.run(
-                ['cp', grub2_install_noop, grub2_install]
+                [
+                    'chroot', root_path,
+                    'cp', grub2_install_noop, grub2_install
+                ]
             )
 
     def _enable_grub2_install(self, root_path):
         if os.access(root_path, os.W_OK):
             grub2_install = ''.join(
                 [
-                    root_path, '/usr/sbin/',
+                    '/usr/sbin/',
                     self._get_grub2_install_tool_name(root_path)
                 ]
             )
@@ -365,7 +369,10 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
             )
             if os.path.exists(grub2_install_backup):
                 Command.run(
-                    ['mv', grub2_install_backup, grub2_install]
+                    [
+                        'chroot', root_path,
+                        'mv', grub2_install_backup, grub2_install
+                    ]
                 )
 
     def _get_grub2_install_tool_name(self, root_path):

--- a/test/unit/bootloader/install/grub2_test.py
+++ b/test/unit/bootloader/install/grub2_test.py
@@ -377,19 +377,22 @@ class TestBootLoaderInstallGrub2:
 
         assert mock_command.call_args_list == [
             call([
-                'cp', '-p', 'tmp_root/usr/sbin/grub2-install',
-                'tmp_root/usr/sbin/grub2-install.orig'
+                'chroot', 'tmp_root',
+                'cp', '-p', '/usr/sbin/grub2-install',
+                '/usr/sbin/grub2-install.orig'
             ]),
             call([
-                'cp', 'tmp_root/bin/true', 'tmp_root/usr/sbin/grub2-install'
+                'chroot', 'tmp_root',
+                'cp', '/bin/true', '/usr/sbin/grub2-install'
             ]),
             call([
                 'chroot', 'tmp_root', 'shim-install', '--removable',
                 '/dev/some-device'
             ]),
             call([
-                'mv', 'tmp_root/usr/sbin/grub2-install.orig',
-                'tmp_root/usr/sbin/grub2-install'
+                'chroot', 'tmp_root',
+                'mv', '/usr/sbin/grub2-install.orig',
+                '/usr/sbin/grub2-install'
             ])
         ]
         self.root_mount.mount.assert_called_once_with()


### PR DESCRIPTION
/bin/true was being used from the host machine instead of
the chroot

Fixes #2124  .
