### PR TITLE
Support custom size for embedded EFI FAT image

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-disk-legacy/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-legacy/appliance.kiwi
@@ -16,7 +16,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" initrd_system="kiwi" boot="oemboot/suse-tumbleweed" kernelcmdline="console=ttyS0" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true" installboot="install">
+        <type image="oem" filesystem="btrfs" initrd_system="kiwi" boot="oemboot/suse-tumbleweed" kernelcmdline="console=ttyS0" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true" installboot="install" efifatimagesize="50">
             <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-unattended>true</oem-unattended>

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -389,6 +389,11 @@ efipartsize="nonNegativeInteger":
   specifies the size in MB. If not set the EFI partition
   size is set to 20 MB
 
+efifatimagesize="nonNegativeInteger":
+  For ISO images (live and install) the EFI boot requires
+  an embedded FAT image. This attribute specifies the size
+  in MB. If not set the FAT image size is set to 20 MB
+
 efiparttable="msdos|gpt":
   For images with an EFI firmware specifies the partition
   table type to use. If not set defaults to the GPT partition

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -852,8 +852,11 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         Creates a EFI system partition image at the given path.
         Must be called after setup_install_boot_images and write.
         """
+        fat_image_mbsize = int(
+            self.xml_state.build_type.get_efifatimagesize() or 20
+        )
         Command.run(
-            ['qemu-img', 'create', path, '20M']
+            ['qemu-img', 'create', path, f'{fat_image_mbsize}M']
         )
         Command.run(
             ['mkdosfs', '-n', 'BOOT', path]

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1501,6 +1501,15 @@ div {
             sch:param [ name = "attr" value = "efipartsize" ]
             sch:param [ name = "types" value = "oem" ]
         ]
+    k.type.efifatimagesize.attribute =
+        ## For ISO images (live and install) the EFI boot requires
+        ## an embedded FAT image. This attribute specifies the size
+        ## in MB. If not set the min efifatimage size is set to 20 MB
+        attribute efifatimagesize { xsd:nonNegativeInteger }
+        >> sch:pattern [ id = "efifatimagesize" is-a = "image_type"
+            sch:param [ name = "attr" value = "efifatimagesize" ]
+            sch:param [ name = "types" value = "oem" ]
+        ]
     k.type.dosparttable_extended_layout.attribute =
         ## Specify to make use of logical partitions inside of an
         ## extended one. If set to true and if the msdos table type
@@ -2102,6 +2111,7 @@ div {
         k.type.bootpartition.attribute? &
         k.type.bootpartsize.attribute? &
         k.type.efipartsize.attribute? &
+        k.type.efifatimagesize.attribute? &
         k.type.efiparttable.attribute? &
         k.type.dosparttable_extended_layout.attribute? &
         k.type.bootprofile.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2173,6 +2173,18 @@ size is set to 20 MB</a:documentation>
         <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
+    <define name="k.type.efifatimagesize.attribute">
+      <attribute name="efifatimagesize">
+        <a:documentation>For ISO images (live and install) the EFI boot requires
+an embedded FAT image. This attribute specifies the size
+in MB. If not set the min efifatimage size is set to 20 MB</a:documentation>
+        <data type="nonNegativeInteger"/>
+      </attribute>
+      <sch:pattern id="efifatimagesize" is-a="image_type">
+        <sch:param name="attr" value="efifatimagesize"/>
+        <sch:param name="types" value="oem"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.dosparttable_extended_layout.attribute">
       <attribute name="dosparttable_extended_layout">
         <a:documentation>Specify to make use of logical partitions inside of an
@@ -3003,6 +3015,9 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.efipartsize.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.efifatimagesize.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.efiparttable.attribute"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2798,7 +2798,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2807,6 +2807,7 @@ class type_(GeneratedsSuper):
         self.bootpartition = _cast(bool, bootpartition)
         self.bootpartsize = _cast(int, bootpartsize)
         self.efipartsize = _cast(int, efipartsize)
+        self.efifatimagesize = _cast(int, efifatimagesize)
         self.efiparttable = _cast(None, efiparttable)
         self.dosparttable_extended_layout = _cast(bool, dosparttable_extended_layout)
         self.bootprofile = _cast(None, bootprofile)
@@ -2991,6 +2992,8 @@ class type_(GeneratedsSuper):
     def set_bootpartsize(self, bootpartsize): self.bootpartsize = bootpartsize
     def get_efipartsize(self): return self.efipartsize
     def set_efipartsize(self, efipartsize): self.efipartsize = efipartsize
+    def get_efifatimagesize(self): return self.efifatimagesize
+    def set_efifatimagesize(self, efifatimagesize): self.efifatimagesize = efifatimagesize
     def get_efiparttable(self): return self.efiparttable
     def set_efiparttable(self, efiparttable): self.efiparttable = efiparttable
     def get_dosparttable_extended_layout(self): return self.dosparttable_extended_layout
@@ -3230,6 +3233,9 @@ class type_(GeneratedsSuper):
         if self.efipartsize is not None and 'efipartsize' not in already_processed:
             already_processed.add('efipartsize')
             outfile.write(' efipartsize="%s"' % self.gds_format_integer(self.efipartsize, input_name='efipartsize'))
+        if self.efifatimagesize is not None and 'efifatimagesize' not in already_processed:
+            already_processed.add('efifatimagesize')
+            outfile.write(' efifatimagesize="%s"' % self.gds_format_integer(self.efifatimagesize, input_name='efifatimagesize'))
         if self.efiparttable is not None and 'efiparttable' not in already_processed:
             already_processed.add('efiparttable')
             outfile.write(' efiparttable=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.efiparttable), input_name='efiparttable')), ))
@@ -3514,6 +3520,15 @@ class type_(GeneratedsSuper):
             except ValueError as exp:
                 raise_parse_error(node, 'Bad integer attribute: %s' % exp)
             if self.efipartsize < 0:
+                raise_parse_error(node, 'Invalid NonNegativeInteger')
+        value = find_attr_value_('efifatimagesize', node)
+        if value is not None and 'efifatimagesize' not in already_processed:
+            already_processed.add('efifatimagesize')
+            try:
+                self.efifatimagesize = int(value)
+            except ValueError as exp:
+                raise_parse_error(node, 'Bad integer attribute: %s' % exp)
+            if self.efifatimagesize < 0:
                 raise_parse_error(node, 'Invalid NonNegativeInteger')
         value = find_attr_value_('efiparttable', node)
         if value is not None and 'efiparttable' not in already_processed:


### PR DESCRIPTION
For ISO images (live and install) the EFI boot requires an embedded
FAT image. As of now a fixed size of 20M was used which leads to a
problem if the EFI image or the initrd or the kernel is bigger than
20M. With the new attribute:

```
efifatimagesize="nonNegativeInteger"
```

we can now set a different value for the FAT image. Please note the
value must be aligned to the also customizable efipartsize value
which allows to configure the size of the EFI partition


