### PR TITLE
Fixed kexec options setup in kiwi-dump-reboot

### DIFF
--- a/dracut/modules.d/99kiwi-dump-reboot/kiwi-dump-reboot-system.sh
+++ b/dracut/modules.d/99kiwi-dump-reboot/kiwi-dump-reboot-system.sh
@@ -59,6 +59,8 @@ function boot_installed_system {
         # and thus no syscall selection is made
         kexec_options="${kexec_options} --kexec-syscall-auto"
     fi
+    # shellcheck disable=SC2116,SC2086
+    kexec_options=$(echo ${kexec_options}) # strip spaces
     kexec "${kexec_options}" \
         --load /run/install/boot/*/loader/linux \
         --initrd /run/install/initrd.system_image \


### PR DESCRIPTION
The dracut module 99kiwi-dump-reboot creates an options
list for kexec. Under certain conditions the options
list can contain multiple spaces which leads to an error
when calling kexec. This commit makes sure to trim
white spaces. This Fixes #2178


