### PR TITLE
Support URIs with credentials in solver plugin

### DIFF
--- a/kiwi/solver/repository/base.py
+++ b/kiwi/solver/repository/base.py
@@ -23,6 +23,7 @@ from lxml import etree
 import random
 import glob
 import os
+import re
 
 # project
 import kiwi.defaults as defaults
@@ -43,8 +44,19 @@ class SolverRepositoryBase:
     """
     def __init__(self, uri, user=None, secret=None):
         self.uri = uri
-        self.user = user
-        self.secret = secret
+        # check if the URI string contains credentials and
+        # extract/trim them from the uri object. The urlparse
+        # class does not recognize this information as a valid
+        # URI and throws an exception
+        secret_format = re.match(r'^(.*)://(.*):(.*)@(.*)', uri.uri)
+        if secret_format:
+            self.user = secret_format.group(2)
+            self.secret = secret_format.group(3)
+            self.uri.uri = \
+                f'{secret_format.group(1)}://{secret_format.group(4)}'
+        else:
+            self.user = user
+            self.secret = secret
         self.repository_metadata_dirs = []
         self.repository_solvable_dir = None
 

--- a/test/unit/solver/repository/base_test.py
+++ b/test/unit/solver/repository/base_test.py
@@ -17,10 +17,19 @@ from kiwi.exceptions import KiwiUriOpenError
 class TestSolverRepositoryBase:
     def setup(self):
         self.uri = mock.Mock()
+        self.uri.uri = 'http://example.org/some/path'
         self.solver = SolverRepositoryBase(self.uri)
 
     def setup_method(self, cls):
         self.setup()
+
+    def test_uri_has_credentials(self):
+        self.uri = mock.Mock()
+        self.uri.uri = 'http://user:pass@example.org/some/path'
+        self.solver = SolverRepositoryBase(self.uri)
+        assert self.solver.user == 'user'
+        assert self.solver.secret == 'pass'
+        assert self.solver.uri.uri == 'http://example.org/some/path'
 
     @patch.object(SolverRepositoryBase, '_get_repomd_xml')
     @patch.object(SolverRepositoryBase, '_get_deb_packages')

--- a/test/unit/solver/repository/deb_test.py
+++ b/test/unit/solver/repository/deb_test.py
@@ -8,6 +8,7 @@ from kiwi.solver.repository.base import SolverRepositoryBase
 class TestSolverRepositoryDeb:
     def setup(self):
         self.uri = Mock()
+        self.uri.uri = 'http://example.org/some/path'
         self.solver = SolverRepositoryDeb(self.uri)
 
     def setup_method(self, cls):

--- a/test/unit/solver/repository/rpm_dir_test.py
+++ b/test/unit/solver/repository/rpm_dir_test.py
@@ -12,6 +12,7 @@ from kiwi.exceptions import KiwiRpmDirNotRemoteError
 class TestSolverRepositoryRpmDir:
     def setup(self):
         self.uri = Mock()
+        self.uri.uri = 'http://example.org/some/path'
         self.solver = SolverRepositoryRpmDir(self.uri)
 
     def setup_method(self, cls):

--- a/test/unit/solver/repository/rpm_md_test.py
+++ b/test/unit/solver/repository/rpm_md_test.py
@@ -12,6 +12,7 @@ class TestSolverRepositoryRpmMd:
     def setup(self):
         self.xml_data = etree.parse('../data/repomd.xml')
         self.uri = mock.Mock()
+        self.uri.uri = 'http://example.org/some/path'
         self.solver = SolverRepositoryRpmMd(self.uri)
 
     def setup_method(self, cls):

--- a/test/unit/solver/repository/suse_test.py
+++ b/test/unit/solver/repository/suse_test.py
@@ -12,6 +12,7 @@ class TestSolverRepositorySUSE:
     def setup(self):
         self.xml_data = etree.parse('../data/repomd.xml')
         self.uri = mock.Mock()
+        self.uri.uri = 'http://example.org/some/path'
         self.solver = SolverRepositorySUSE(self.uri)
 
     def setup_method(self, cls):

--- a/test/unit/tasks/image_info_test.py
+++ b/test/unit/tasks/image_info_test.py
@@ -122,6 +122,9 @@ class TestImageInfoTask:
     def test_process_image_info_resolve_package_list(
         self, mock_get_repo_type, mock_uri, mock_solver_repo_new, mock_out
     ):
+        uri = Mock()
+        uri.uri = 'http://example.org/some/path'
+        mock_uri.return_value = uri
         mock_get_repo_type.return_value = 'apt-deb'
         self.solver.set_dist_type.return_value = {
             'arch': 'amd64'


### PR DESCRIPTION
check if the URI string contains credentials and extract/trim them from the uri object. The urlparse class does not recognize this information as a valid URI and throws an exception

