### PR TITLE
Further Prevent Race Conditions for re-part/fsck

### DIFF
--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -240,7 +240,11 @@ setup_debug
 # More details: https://github.com/SUSE/kiwi/issues/1034
 
 # make sure we unmask the fsck service
-trap unmask_fsck_root_service EXIT
+trap "
+until [ -e \"${root_device}\" ]; do
+     sleep .5
+done
+unmask_fsck_root_service" EXIT
 
 mask_fsck_root_service
 

--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -240,11 +240,11 @@ setup_debug
 # More details: https://github.com/SUSE/kiwi/issues/1034
 
 # make sure we unmask the fsck service
-trap "
+trap '
 until [ -e ${root_device} ]; do
      sleep .5
 done
-unmask_fsck_root_service" EXIT
+unmask_fsck_root_service' EXIT
 
 mask_fsck_root_service
 

--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -241,7 +241,7 @@ setup_debug
 
 # make sure we unmask the fsck service
 trap '
-until [ -e ${root_device} ]; do
+until [ -e "${root_device}" ]; do
      sleep .5
 done
 unmask_fsck_root_service' EXIT

--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -241,7 +241,7 @@ setup_debug
 
 # make sure we unmask the fsck service
 trap "
-until [ -e '${root_device}' ]; do
+until [ -e ${root_device} ]; do
      sleep .5
 done
 unmask_fsck_root_service" EXIT

--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -241,7 +241,7 @@ setup_debug
 
 # make sure we unmask the fsck service
 trap "
-until [ -e \"${root_device}\" ]; do
+until [ -e '${root_device}' ]; do
      sleep .5
 done
 unmask_fsck_root_service" EXIT


### PR DESCRIPTION
Some hardware simply takes an unusual amount of time to detach/re-attach disks during execution of this area of the code on post-deployment reboots. This `until` loop guarantees that the `/dev/disk/by-uuid/[Root Disk Device]` Node exists before we enable the `fsck` Service regardless of what happens during repartitioning. Without this, even with the prior fix implemented, we still see situations where the Root Device isn't available in the expected location when the `fsck` SystemD Service starts.

Fixes #2185


