### PR TITLE
Limit repo alias names to be a safe POSIX name

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -1090,7 +1090,8 @@ the following optional attributes:
 alias="name"
   Specifies an alternative name for the configured repository. If the
   attribute is not specified {kiwi} will generate a random alias name
-  for the repository.
+  for the repository. The specified name must match the pattern:
+  `[a-zA-Z0-9_\-\.]+`
 
 components="name"
   Used for Debian (apt) based repositories only. Specifies the

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1002,12 +1002,13 @@ div {
         }
     k.repository.alias.attribute =
         ## Alias name to be used for this repository. This is an
-        ## optional free form text. If not set the source attribute
+        ## optional free-form text restricted to characters from the
+        ## POSIX standard. If not set the source attribute
         ## value is used and builds the alias name by running a md5 digest
         ## of the defined URI of the repository. An alias name should be
         ## set if the source argument doesn't really explain what this
         ## repository contains.
-        attribute alias { text }
+        attribute alias { safe-posix-name }
     k.repository.components.attribute =
         ## Distribution components, used for deb repositories. If
         ## not set it defaults to main

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1521,11 +1521,13 @@ definition can be composed by other existing profiles.</a:documentation>
     <define name="k.repository.alias.attribute">
       <attribute name="alias">
         <a:documentation>Alias name to be used for this repository. This is an
-optional free form text. If not set the source attribute
+optional free-form text restricted to characters from the
+POSIX standard. If not set the source attribute
 value is used and builds the alias name by running a md5 digest
 of the defined URI of the repository. An alias name should be
 set if the source argument doesn't really explain what this
 repository contains.</a:documentation>
+        <ref name="safe-posix-name"/>
       </attribute>
     </define>
     <define name="k.repository.components.attribute">

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2230,6 +2230,13 @@ class repository(k_source):
     def set_username(self, username): self.username = username
     def get_use_for_bootstrap(self): return self.use_for_bootstrap
     def set_use_for_bootstrap(self, use_for_bootstrap): self.use_for_bootstrap = use_for_bootstrap
+    def validate_safe_posix_name(self, value):
+        # Validate type safe-posix-name, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_safe_posix_name_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_safe_posix_name_patterns_, ))
+    validate_safe_posix_name_patterns_ = [['^[a-zA-Z0-9_\\-\\.]+$']]
     def hasContent_(self):
         if (
             super(repository, self).hasContent_()
@@ -2268,7 +2275,7 @@ class repository(k_source):
             outfile.write(' profiles=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.profiles), input_name='profiles')), ))
         if self.alias is not None and 'alias' not in already_processed:
             already_processed.add('alias')
-            outfile.write(' alias=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.alias), input_name='alias')), ))
+            outfile.write(' alias=%s' % (quote_attrib(self.alias), ))
         if self.sourcetype is not None and 'sourcetype' not in already_processed:
             already_processed.add('sourcetype')
             outfile.write(' sourcetype=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.sourcetype), input_name='sourcetype')), ))
@@ -2328,6 +2335,8 @@ class repository(k_source):
         if value is not None and 'alias' not in already_processed:
             already_processed.add('alias')
             self.alias = value
+            self.alias = ' '.join(self.alias.split())
+            self.validate_safe_posix_name(self.alias)    # validate type safe-posix-name
         value = find_attr_value_('sourcetype', node)
         if value is not None and 'sourcetype' not in already_processed:
             already_processed.add('sourcetype')


### PR DESCRIPTION
Characters like spaces or other symbols used in repo alias names
can cause the package manager to fail setting up the repo. Thus
this patch changes the schema to only allow for safe POSIX names
matching:

```
{pattern = "[a-zA-Z0-9_\-\.]+"}.
```

This Fixes #2170


