### PR TITLE
Support DM integrity legacy HMAC

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -612,15 +612,6 @@ integrity_legacy_hmac="true|false":
      Do not use this attribute until compatibility with
      a specific old kernel is required!
 
-integrity_legacy_padding="true|false":
-  For the `oem` type only and in combination with the `standalone_integrity`
-  attribute, allow to use inefficient legacy padding.
-
-  .. warning::
-
-     Do not use this attribute until compatibility with
-     a specific old kernel is required!
-
 integrity_keyfile="filepath":
   For the `oem` type only and in combination with the `standalone_integrity`
   attribute, protects access to the integrity map using the given keyfile.

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -609,7 +609,7 @@ integrity_legacy_hmac="true|false":
 
   .. warning::
 
-     Do not use this attribute until compatibility with
+     Do not use this attribute unless compatibility with
      a specific old kernel is required!
 
 integrity_keyfile="filepath":

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -603,6 +603,24 @@ standalone_integrity="true|false":
   For the `oem` type only, specifies to create a standalone
   `dm_integrity` layer on top of the root filesystem
 
+integrity_legacy_hmac="true|false":
+  For the `oem` type only and in combination with the `standalone_integrity`
+  attribute, Allow to use old flawed HMAC calculation (does not protect superblock).
+
+  .. warning::
+
+     Do not use this attribute until compatibility with
+     a specific old kernel is required!
+
+integrity_legacy_padding="true|false":
+  For the `oem` type only and in combination with the `standalone_integrity`
+  attribute, allow to use inefficient legacy padding.
+
+  .. warning::
+
+     Do not use this attribute until compatibility with
+     a specific old kernel is required!
+
 integrity_keyfile="filepath":
   For the `oem` type only and in combination with the `standalone_integrity`
   attribute, protects access to the integrity map using the given keyfile.

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -127,6 +127,8 @@ class DiskBuilder:
         self.force_mbr = xml_state.build_type.get_force_mbr()
         self.luks = xml_state.get_luks_credentials()
         self.integrity_root = xml_state.build_type.get_standalone_integrity()
+        self.integrity_legacy_hmac = xml_state.build_type.get_integrity_legacy_hmac()
+        self.integrity_legacy_padding = xml_state.build_type.get_integrity_legacy_padding()
         self.integrity_keyfile = xml_state.build_type.get_integrity_keyfile()
         self.integrity_key_description = \
             xml_state.build_type.get_integrity_metadata_key_description()
@@ -319,12 +321,18 @@ class DiskBuilder:
 
         # create integrity on current root device if requested
         if self.integrity_root:
+            options = []
+            if self.integrity_legacy_padding:
+                options.append('legacy_padding')
+            if self.integrity_legacy_hmac:
+                options.append('legacy_hmac')
             self.integrity_root = IntegrityDevice(
                 device_map['root'], defaults.INTEGRITY_ALGORITHM,
                 integrity_credentials_type(
                     keydescription=self.integrity_key_description,
                     keyfile=self.integrity_keyfile,
-                    keyfile_algorithm=defaults.INTEGRITY_KEY_ALGORITHM
+                    keyfile_algorithm=defaults.INTEGRITY_KEY_ALGORITHM,
+                    options=options
                 )
             )
             self.integrity_root.create_dm_integrity()

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -128,7 +128,6 @@ class DiskBuilder:
         self.luks = xml_state.get_luks_credentials()
         self.integrity_root = xml_state.build_type.get_standalone_integrity()
         self.integrity_legacy_hmac = xml_state.build_type.get_integrity_legacy_hmac()
-        self.integrity_legacy_padding = xml_state.build_type.get_integrity_legacy_padding()
         self.integrity_keyfile = xml_state.build_type.get_integrity_keyfile()
         self.integrity_key_description = \
             xml_state.build_type.get_integrity_metadata_key_description()
@@ -322,8 +321,6 @@ class DiskBuilder:
         # create integrity on current root device if requested
         if self.integrity_root:
             options = []
-            if self.integrity_legacy_padding:
-                options.append('legacy_padding')
             if self.integrity_legacy_hmac:
                 options.append('legacy_hmac')
             self.integrity_root = IntegrityDevice(

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1645,6 +1645,34 @@ div {
             is-a = "image_integrity_requirement"
             sch:param [ name = "attr" value = "standalone_integrity" ]
         ]
+    k.type.integrity_legacy_hmac.attribute =
+        ## In combination with the standalone_integrity attribute,
+        ## Allow to use old flawed HMAC calculation (does not protect superblock)
+        attribute integrity_legacy_hmac { xsd:boolean }
+        >> sch:pattern [
+            id = "integrity_legacy_hmac" is-a = "image_type"
+            sch:param [ name = "attr" value = "integrity_legacy_hmac" ]
+            sch:param [ name = "types" value = "oem" ]
+        ]
+        >> sch:pattern [
+            id = "standalone_integrity_mandatory"
+            is-a = "integrity_legacy_hmac_requirement"
+            sch:param [ name = "attr" value = "standalone_integrity" ]
+        ]
+    k.type.integrity_legacy_padding.attribute =
+        ## In combination with the standalone_integrity attribute,
+        ## use inefficient legacy padding.
+        attribute integrity_legacy_padding { xsd:boolean }
+        >> sch:pattern [
+            id = "integrity_legacy_padding" is-a = "image_type"
+            sch:param [ name = "attr" value = "integrity_legacy_padding" ]
+            sch:param [ name = "types" value = "oem" ]
+        ]
+        >> sch:pattern [
+            id = "standalone_integrity_mandatory"
+            is-a = "integrity_legacy_padding_requirement"
+            sch:param [ name = "attr" value = "standalone_integrity" ]
+        ]
     k.type.integrity_keyfile.attribute =
         ## In combination with the standalone_integrity attribute,
         ## protect access to the integrity map using the given key.
@@ -2157,6 +2185,8 @@ div {
         k.type.embed_verity_metadata.attribute? &
         k.type.standalone_integrity.attribute? &
         k.type.embed_integrity_metadata.attribute? &
+        k.type.integrity_legacy_hmac.attribute? &
+        k.type.integrity_legacy_padding.attribute? &
         k.type.integrity_metadata_key_description? &
         k.type.integrity_keyfile.attribute? &
         k.type.primary.attribute? &

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1659,20 +1659,6 @@ div {
             is-a = "integrity_legacy_hmac_requirement"
             sch:param [ name = "attr" value = "standalone_integrity" ]
         ]
-    k.type.integrity_legacy_padding.attribute =
-        ## In combination with the standalone_integrity attribute,
-        ## use inefficient legacy padding.
-        attribute integrity_legacy_padding { xsd:boolean }
-        >> sch:pattern [
-            id = "integrity_legacy_padding" is-a = "image_type"
-            sch:param [ name = "attr" value = "integrity_legacy_padding" ]
-            sch:param [ name = "types" value = "oem" ]
-        ]
-        >> sch:pattern [
-            id = "standalone_integrity_mandatory"
-            is-a = "integrity_legacy_padding_requirement"
-            sch:param [ name = "attr" value = "standalone_integrity" ]
-        ]
     k.type.integrity_keyfile.attribute =
         ## In combination with the standalone_integrity attribute,
         ## protect access to the integrity map using the given key.
@@ -2186,7 +2172,6 @@ div {
         k.type.standalone_integrity.attribute? &
         k.type.embed_integrity_metadata.attribute? &
         k.type.integrity_legacy_hmac.attribute? &
-        k.type.integrity_legacy_padding.attribute? &
         k.type.integrity_metadata_key_description? &
         k.type.integrity_keyfile.attribute? &
         k.type.primary.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2382,20 +2382,6 @@ Allow to use old flawed HMAC calculation (does not protect superblock)</a:docume
         <sch:param name="attr" value="standalone_integrity"/>
       </sch:pattern>
     </define>
-    <define name="k.type.integrity_legacy_padding.attribute">
-      <attribute name="integrity_legacy_padding">
-        <a:documentation>In combination with the standalone_integrity attribute,
-use inefficient legacy padding.</a:documentation>
-        <data type="boolean"/>
-      </attribute>
-      <sch:pattern id="integrity_legacy_padding" is-a="image_type">
-        <sch:param name="attr" value="integrity_legacy_padding"/>
-        <sch:param name="types" value="oem"/>
-      </sch:pattern>
-      <sch:pattern id="standalone_integrity_mandatory" is-a="integrity_legacy_padding_requirement">
-        <sch:param name="attr" value="standalone_integrity"/>
-      </sch:pattern>
-    </define>
     <define name="k.type.integrity_keyfile.attribute">
       <attribute name="integrity_keyfile">
         <a:documentation>In combination with the standalone_integrity attribute,
@@ -3181,9 +3167,6 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.integrity_legacy_hmac.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.type.integrity_legacy_padding.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.integrity_metadata_key_description"/>

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2368,6 +2368,34 @@ serving the root filesystem</a:documentation>
         <sch:param name="attr" value="standalone_integrity"/>
       </sch:pattern>
     </define>
+    <define name="k.type.integrity_legacy_hmac.attribute">
+      <attribute name="integrity_legacy_hmac">
+        <a:documentation>In combination with the standalone_integrity attribute,
+Allow to use old flawed HMAC calculation (does not protect superblock)</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="integrity_legacy_hmac" is-a="image_type">
+        <sch:param name="attr" value="integrity_legacy_hmac"/>
+        <sch:param name="types" value="oem"/>
+      </sch:pattern>
+      <sch:pattern id="standalone_integrity_mandatory" is-a="integrity_legacy_hmac_requirement">
+        <sch:param name="attr" value="standalone_integrity"/>
+      </sch:pattern>
+    </define>
+    <define name="k.type.integrity_legacy_padding.attribute">
+      <attribute name="integrity_legacy_padding">
+        <a:documentation>In combination with the standalone_integrity attribute,
+use inefficient legacy padding.</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="integrity_legacy_padding" is-a="image_type">
+        <sch:param name="attr" value="integrity_legacy_padding"/>
+        <sch:param name="types" value="oem"/>
+      </sch:pattern>
+      <sch:pattern id="standalone_integrity_mandatory" is-a="integrity_legacy_padding_requirement">
+        <sch:param name="attr" value="standalone_integrity"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.integrity_keyfile.attribute">
       <attribute name="integrity_keyfile">
         <a:documentation>In combination with the standalone_integrity attribute,
@@ -3150,6 +3178,12 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.embed_integrity_metadata.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.integrity_legacy_hmac.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.integrity_legacy_padding.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.integrity_metadata_key_description"/>

--- a/kiwi/storage/integrity_device.py
+++ b/kiwi/storage/integrity_device.py
@@ -37,7 +37,8 @@ integrity_credentials_type = NamedTuple(
     'integrity_credentials_type', [
         ('keydescription', str),
         ('keyfile', str),
-        ('keyfile_algorithm', str)
+        ('keyfile_algorithm', str),
+        ('options', List[str])
     ]
 )
 
@@ -80,6 +81,15 @@ class IntegrityDevice(DeviceProvider):
         self.integrity_open_options = [
             '--integrity', self.integrity_algorithm
         ]
+        if credentials and credentials.options:
+            if 'legacy_hmac' in credentials.options:
+                self.integrity_format_options.append(
+                    '--integrity-legacy-hmac'
+                )
+            if 'legacy_padding' in credentials.options:
+                self.integrity_format_options.append(
+                    '--integrity-legacy-padding'
+                )
         if credentials and credentials.keyfile:
             integrity_key_options = [
                 '--integrity-key-file', credentials.keyfile,

--- a/kiwi/storage/integrity_device.py
+++ b/kiwi/storage/integrity_device.py
@@ -86,10 +86,6 @@ class IntegrityDevice(DeviceProvider):
                 self.integrity_format_options.append(
                     '--integrity-legacy-hmac'
                 )
-            if 'legacy_padding' in credentials.options:
-                self.integrity_format_options.append(
-                    '--integrity-legacy-padding'
-                )
         if credentials and credentials.keyfile:
             integrity_key_options = [
                 '--integrity-key-file', credentials.keyfile,

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2807,7 +2807,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_legacy_padding=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2861,6 +2861,8 @@ class type_(GeneratedsSuper):
         self.embed_verity_metadata = _cast(bool, embed_verity_metadata)
         self.standalone_integrity = _cast(bool, standalone_integrity)
         self.embed_integrity_metadata = _cast(bool, embed_integrity_metadata)
+        self.integrity_legacy_hmac = _cast(bool, integrity_legacy_hmac)
+        self.integrity_legacy_padding = _cast(bool, integrity_legacy_padding)
         self.integrity_metadata_key_description = _cast(None, integrity_metadata_key_description)
         self.integrity_keyfile = _cast(None, integrity_keyfile)
         self.primary = _cast(bool, primary)
@@ -3091,6 +3093,10 @@ class type_(GeneratedsSuper):
     def set_standalone_integrity(self, standalone_integrity): self.standalone_integrity = standalone_integrity
     def get_embed_integrity_metadata(self): return self.embed_integrity_metadata
     def set_embed_integrity_metadata(self, embed_integrity_metadata): self.embed_integrity_metadata = embed_integrity_metadata
+    def get_integrity_legacy_hmac(self): return self.integrity_legacy_hmac
+    def set_integrity_legacy_hmac(self, integrity_legacy_hmac): self.integrity_legacy_hmac = integrity_legacy_hmac
+    def get_integrity_legacy_padding(self): return self.integrity_legacy_padding
+    def set_integrity_legacy_padding(self, integrity_legacy_padding): self.integrity_legacy_padding = integrity_legacy_padding
     def get_integrity_metadata_key_description(self): return self.integrity_metadata_key_description
     def set_integrity_metadata_key_description(self, integrity_metadata_key_description): self.integrity_metadata_key_description = integrity_metadata_key_description
     def get_integrity_keyfile(self): return self.integrity_keyfile
@@ -3377,6 +3383,12 @@ class type_(GeneratedsSuper):
         if self.embed_integrity_metadata is not None and 'embed_integrity_metadata' not in already_processed:
             already_processed.add('embed_integrity_metadata')
             outfile.write(' embed_integrity_metadata="%s"' % self.gds_format_boolean(self.embed_integrity_metadata, input_name='embed_integrity_metadata'))
+        if self.integrity_legacy_hmac is not None and 'integrity_legacy_hmac' not in already_processed:
+            already_processed.add('integrity_legacy_hmac')
+            outfile.write(' integrity_legacy_hmac="%s"' % self.gds_format_boolean(self.integrity_legacy_hmac, input_name='integrity_legacy_hmac'))
+        if self.integrity_legacy_padding is not None and 'integrity_legacy_padding' not in already_processed:
+            already_processed.add('integrity_legacy_padding')
+            outfile.write(' integrity_legacy_padding="%s"' % self.gds_format_boolean(self.integrity_legacy_padding, input_name='integrity_legacy_padding'))
         if self.integrity_metadata_key_description is not None and 'integrity_metadata_key_description' not in already_processed:
             already_processed.add('integrity_metadata_key_description')
             outfile.write(' integrity_metadata_key_description=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.integrity_metadata_key_description), input_name='integrity_metadata_key_description')), ))
@@ -3828,6 +3840,24 @@ class type_(GeneratedsSuper):
                 self.embed_integrity_metadata = True
             elif value in ('false', '0'):
                 self.embed_integrity_metadata = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
+        value = find_attr_value_('integrity_legacy_hmac', node)
+        if value is not None and 'integrity_legacy_hmac' not in already_processed:
+            already_processed.add('integrity_legacy_hmac')
+            if value in ('true', '1'):
+                self.integrity_legacy_hmac = True
+            elif value in ('false', '0'):
+                self.integrity_legacy_hmac = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
+        value = find_attr_value_('integrity_legacy_padding', node)
+        if value is not None and 'integrity_legacy_padding' not in already_processed:
+            already_processed.add('integrity_legacy_padding')
+            if value in ('true', '1'):
+                self.integrity_legacy_padding = True
+            elif value in ('false', '0'):
+                self.integrity_legacy_padding = False
             else:
                 raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('integrity_metadata_key_description', node)

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2807,7 +2807,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_legacy_padding=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2862,7 +2862,6 @@ class type_(GeneratedsSuper):
         self.standalone_integrity = _cast(bool, standalone_integrity)
         self.embed_integrity_metadata = _cast(bool, embed_integrity_metadata)
         self.integrity_legacy_hmac = _cast(bool, integrity_legacy_hmac)
-        self.integrity_legacy_padding = _cast(bool, integrity_legacy_padding)
         self.integrity_metadata_key_description = _cast(None, integrity_metadata_key_description)
         self.integrity_keyfile = _cast(None, integrity_keyfile)
         self.primary = _cast(bool, primary)
@@ -3095,8 +3094,6 @@ class type_(GeneratedsSuper):
     def set_embed_integrity_metadata(self, embed_integrity_metadata): self.embed_integrity_metadata = embed_integrity_metadata
     def get_integrity_legacy_hmac(self): return self.integrity_legacy_hmac
     def set_integrity_legacy_hmac(self, integrity_legacy_hmac): self.integrity_legacy_hmac = integrity_legacy_hmac
-    def get_integrity_legacy_padding(self): return self.integrity_legacy_padding
-    def set_integrity_legacy_padding(self, integrity_legacy_padding): self.integrity_legacy_padding = integrity_legacy_padding
     def get_integrity_metadata_key_description(self): return self.integrity_metadata_key_description
     def set_integrity_metadata_key_description(self, integrity_metadata_key_description): self.integrity_metadata_key_description = integrity_metadata_key_description
     def get_integrity_keyfile(self): return self.integrity_keyfile
@@ -3386,9 +3383,6 @@ class type_(GeneratedsSuper):
         if self.integrity_legacy_hmac is not None and 'integrity_legacy_hmac' not in already_processed:
             already_processed.add('integrity_legacy_hmac')
             outfile.write(' integrity_legacy_hmac="%s"' % self.gds_format_boolean(self.integrity_legacy_hmac, input_name='integrity_legacy_hmac'))
-        if self.integrity_legacy_padding is not None and 'integrity_legacy_padding' not in already_processed:
-            already_processed.add('integrity_legacy_padding')
-            outfile.write(' integrity_legacy_padding="%s"' % self.gds_format_boolean(self.integrity_legacy_padding, input_name='integrity_legacy_padding'))
         if self.integrity_metadata_key_description is not None and 'integrity_metadata_key_description' not in already_processed:
             already_processed.add('integrity_metadata_key_description')
             outfile.write(' integrity_metadata_key_description=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.integrity_metadata_key_description), input_name='integrity_metadata_key_description')), ))
@@ -3849,15 +3843,6 @@ class type_(GeneratedsSuper):
                 self.integrity_legacy_hmac = True
             elif value in ('false', '0'):
                 self.integrity_legacy_hmac = False
-            else:
-                raise_parse_error(node, 'Bad boolean attribute')
-        value = find_attr_value_('integrity_legacy_padding', node)
-        if value is not None and 'integrity_legacy_padding' not in already_processed:
-            already_processed.add('integrity_legacy_padding')
-            if value in ('true', '1'):
-                self.integrity_legacy_padding = True
-            elif value in ('false', '0'):
-                self.integrity_legacy_padding = False
             else:
                 raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('integrity_metadata_key_description', node)

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ exclude=xml_parse.py
 # we ignore warnings about quoting of escape sequences (W605)
 ignore = E501, W605
 # we allow a custom complexity level
-max-complexity = 26
+max-complexity = 28
 
 [doc8]
 max-line-length = 90

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -606,6 +606,8 @@ class TestDiskBuilder:
         filesystem = Mock()
         mock_fs.return_value = filesystem
         self.disk_builder.integrity_root = True
+        self.disk_builder.integrity_legacy_padding = True
+        self.disk_builder.integrity_legacy_hmac = True
         self.disk_builder.root_filesystem_embed_integrity_metadata = True
         self.disk_builder.root_filesystem_is_overlay = False
         self.disk_builder.volume_manager_name = None

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -606,7 +606,6 @@ class TestDiskBuilder:
         filesystem = Mock()
         mock_fs.return_value = filesystem
         self.disk_builder.integrity_root = True
-        self.disk_builder.integrity_legacy_padding = True
         self.disk_builder.integrity_legacy_hmac = True
         self.disk_builder.root_filesystem_embed_integrity_metadata = True
         self.disk_builder.root_filesystem_is_overlay = False

--- a/test/unit/storage/integrity_device_test.py
+++ b/test/unit/storage/integrity_device_test.py
@@ -37,7 +37,8 @@ class TestIntegrityDevice:
             integrity_credentials_type(
                 keydescription=None,
                 keyfile='/etc/pki/storage/dm-integrity-hmac-secret.bin',
-                keyfile_algorithm=defaults.INTEGRITY_KEY_ALGORITHM
+                keyfile_algorithm=defaults.INTEGRITY_KEY_ALGORITHM,
+                options=['legacy_hmac', 'legacy_padding']
             )
         )
 
@@ -85,6 +86,8 @@ class TestIntegrityDevice:
                 [
                     'integritysetup', '-v', '--batch-mode', 'format',
                     '--integrity', 'hmac-sha256', '--sector-size', '512',
+                    '--integrity-legacy-hmac',
+                    '--integrity-legacy-padding',
                     '--integrity-key-file',
                     '/etc/pki/storage/dm-integrity-hmac-secret.bin',
                     '--integrity-key-size', '42',

--- a/test/unit/storage/integrity_device_test.py
+++ b/test/unit/storage/integrity_device_test.py
@@ -38,7 +38,7 @@ class TestIntegrityDevice:
                 keydescription=None,
                 keyfile='/etc/pki/storage/dm-integrity-hmac-secret.bin',
                 keyfile_algorithm=defaults.INTEGRITY_KEY_ALGORITHM,
-                options=['legacy_hmac', 'legacy_padding']
+                options=['legacy_hmac']
             )
         )
 
@@ -87,7 +87,6 @@ class TestIntegrityDevice:
                     'integritysetup', '-v', '--batch-mode', 'format',
                     '--integrity', 'hmac-sha256', '--sector-size', '512',
                     '--integrity-legacy-hmac',
-                    '--integrity-legacy-padding',
                     '--integrity-key-file',
                     '/etc/pki/storage/dm-integrity-hmac-secret.bin',
                     '--integrity-key-size', '42',


### PR DESCRIPTION
Add a new attribute integrity_legacy_hmac="true|false" which
allows to use old flawed HMAC calculation (does not protect superblock)
Do not use this attribute until compatibility with a specific
old kernel is required!

