### PR TITLE
Bind-mount /dev into the OCI container instead of rsync-ing it

### DIFF
--- a/kiwi/container/setup/base.py
+++ b/kiwi/container/setup/base.py
@@ -20,7 +20,6 @@ import os
 
 # project
 from kiwi.command import Command
-from kiwi.utils.sync import DataSync
 
 from kiwi.exceptions import (
     KiwiContainerSetupError
@@ -144,28 +143,6 @@ class ContainerSetupBase:
                 'console': 'console'
             }
         )
-
-    def setup_static_device_nodes(self):
-        """
-        Container device node setup
-
-        Without subsystems like udev running in a container it is
-        required to provide a set of device nodes to let the
-        system in the container function correctly. This is
-        done by syncing the host system nodes to the container.
-        That this will also create device nodes which are not
-        necessarily present in the container later is a know
-        limitation of this method and considered harmless
-        """
-        try:
-            data = DataSync('/dev/', self.root_dir + '/dev/')
-            data.sync_data(
-                options=['-a', '-x', '--devices', '--specials']
-            )
-        except Exception as e:
-            raise KiwiContainerSetupError(
-                'Failed to create static container nodes %s' % format(e)
-            )
 
     def get_container_name(self):
         """

--- a/kiwi/container/setup/oci.py
+++ b/kiwi/container/setup/oci.py
@@ -50,7 +50,6 @@ class ContainerSetupOCI(ContainerSetupBase):
 
         self.deactivate_bootloader_setup()
         self.deactivate_root_filesystem_check()
-        self.setup_static_device_nodes()
         self.setup_root_console()
 
         for service in services_to_deactivate:

--- a/test/unit/container/setup/base_test.py
+++ b/test/unit/container/setup/base_test.py
@@ -2,7 +2,6 @@ from mock import (
     patch, call, mock_open
 )
 from pytest import raises
-import mock
 
 from kiwi.container.setup.base import ContainerSetupBase
 
@@ -102,22 +101,3 @@ class TestContainerSetupBase:
         assert m_open.return_value.write.call_args_list == [
             call('\nconsole\n')
         ]
-
-    @patch('kiwi.container.setup.base.Command.run')
-    @patch('kiwi.container.setup.base.DataSync')
-    def test_setup_static_device_nodes(self, mock_DataSync, mock_command):
-        data = mock.Mock()
-        mock_DataSync.return_value = data
-        self.container.setup_static_device_nodes()
-        mock_DataSync.assert_called_once_with(
-            '/dev/', 'root_dir/dev/'
-        )
-        data.sync_data.assert_called_once_with(
-            options=['-a', '-x', '--devices', '--specials']
-        )
-
-    @patch('kiwi.container.setup.base.Command.run')
-    def test_setup_static_device_nodes_failed(self, mock_command):
-        mock_command.side_effect = Exception
-        with raises(KiwiContainerSetupError):
-            self.container.setup_static_device_nodes()

--- a/test/unit/container/setup/oci_test.py
+++ b/test/unit/container/setup/oci_test.py
@@ -16,7 +16,6 @@ class TestContainerSetupOCI:
 
         self.container.deactivate_bootloader_setup = mock.Mock()
         self.container.deactivate_root_filesystem_check = mock.Mock()
-        self.container.setup_static_device_nodes = mock.Mock()
         self.container.setup_root_console = mock.Mock()
         self.container.deactivate_systemd_service = mock.Mock()
 
@@ -28,7 +27,6 @@ class TestContainerSetupOCI:
         self.container.setup()
         self.container.deactivate_bootloader_setup.assert_called_once_with()
         self.container.deactivate_root_filesystem_check.assert_called_once_with()
-        self.container.setup_static_device_nodes.assert_called_once_with()
         assert self.container.deactivate_systemd_service.call_args_list == [
             call('device-mapper.service'),
             call('kbd.service'),


### PR DESCRIPTION
In containers (nspawn) where part of the /dev filesystem is bind-mounted from outside system, kiwi fails to do the rsync (in creation of the nodes).

There is no reason to actually copy whole tree inside so let's just bind-mount it in.

Fixes https://github.com/OSInside/kiwi/issues/2020