### PR TITLE
Weaken type check on Result.load() return type

### DIFF
--- a/kiwi/system/result.py
+++ b/kiwi/system/result.py
@@ -162,7 +162,7 @@ class Result:
             )
 
     @staticmethod
-    def load(filename: str) -> result_type:
+    def load(filename: str) -> result_type:  # type: ignore
         """
         Load pickle dumped filename into a Result instance
 


### PR DESCRIPTION
With an update of mypy the bound TypeVar is no longer allowed. To be honest I did not get a clue on the error message and opened this pull request which basically removes the type check for the return type of the load() method. I'm happy if we find a better solution during review. Thanks

