### PR TITLE
Added support for --logsocket

### DIFF
--- a/doc/source/commands/kiwi.rst
+++ b/doc/source/commands/kiwi.rst
@@ -15,13 +15,16 @@ SYNOPSIS
            [--temp-dir=<directory>]
            [--type=<build_type>]
            [--logfile=<filename>]
+           [--logsocket=<socketfile>]
            [--debug]
            [--debug-run-scripts-in-screen]
            [--color-output]
            [--config=<configfile>]
            [--kiwi-file=<kiwifile>]
        image <command> [<args>...]
-   kiwi-ng [--debug]
+   kiwi-ng [--logfile=<filename>]
+           [--logsocket=<socketfile>]
+           [--debug]
            [--debug-run-scripts-in-screen]
            [--color-output]
            [--config=<configfile>]
@@ -32,6 +35,7 @@ SYNOPSIS
            [--target-arch=<name>]
            [--type=<build_type>]
            [--logfile=<filename>]
+           [--logsocket=<socketfile>]
            [--debug]
            [--debug-run-scripts-in-screen]
            [--color-output]
@@ -112,6 +116,11 @@ GLOBAL OPTIONS
   Specify log file. the logfile contains detailed information about
   the process. The special call: `--logfile stdout` sends all
   information to standard out instead of writing to a file
+
+--logsocket=<socketfile>
+
+  send log data to the given Unix Domain socket in the same
+  format as with --logfile
 
 --profile=<name>
 

--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -22,6 +22,7 @@ usage: kiwi-ng -h | --help
                [--target-arch=<name>]
                [--type=<build_type>]
                [--logfile=<filename>]
+               [--logsocket=<socketfile>]
                [--debug]
                [--debug-run-scripts-in-screen]
                [--color-output]
@@ -29,6 +30,7 @@ usage: kiwi-ng -h | --help
                [--kiwi-file=<kiwifile>]
            image <command> [<args>...]
        kiwi-ng [--logfile=<filename>]
+               [--logsocket=<socketfile>]
                [--debug]
                [--debug-run-scripts-in-screen]
                [--color-output]
@@ -40,6 +42,7 @@ usage: kiwi-ng -h | --help
                [--target-arch=<name>]
                [--type=<build_type>]
                [--logfile=<filename>]
+               [--logsocket=<socketfile>]
                [--debug]
                [--debug-run-scripts-in-screen]
                [--color-output]
@@ -63,6 +66,9 @@ global options:
         debug information even if this is was not requested by the
         debug switch. The special call: '--logfile stdout' sends all
         information to standard out instead of writing to a file
+    --logsocket=<socketfile>
+        send log data to the given Unix Domain socket in the same
+        format as with --logfile
     --debug
         print debug information
     --debug-run-scripts-in-screen

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -406,6 +406,12 @@ class KiwiLogFileSetupFailed(KiwiError):
     """
 
 
+class KiwiLogSocketSetupFailed(KiwiError):
+    """
+    Exception raised if the Unix Domain log socket could not be created.
+    """
+
+
 class KiwiLoopSetupError(KiwiError):
     """
     Exception raised if not enough user data to create a

--- a/kiwi/logger_socket.py
+++ b/kiwi/logger_socket.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2022 Marcus Schäfer.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import logging.handlers
+
+
+class PlainTextSocketHandler(logging.handlers.SocketHandler):
+    def makePickle(self, record):
+        """
+        Custom makePickle method which actually does not pickle
+        the messages into the pickle binary format but just
+        sends the log message as plain text. A simple server
+        listening could then look like the following example
+
+        .. code:: python
+
+            sock_file = '/tmp/log_socket'
+            buffer = 1024
+            if os.path.exists(sock_file):
+                os.unlink(sock_file)
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.bind(sock_file)
+            sock.listen(1)
+            while True:
+                connection, client_address = sock.accept()
+                try:
+                    while True:
+                        data = connection.recv(buffer)
+                        if not data:
+                            break
+                        print(data.decode())
+                finally:
+                    connection.close()
+        """
+        message = self.formatter.format(record)
+        return message.encode()

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -121,6 +121,12 @@ class CliTask:
                     self.global_args['--logfile']
                 )
 
+            # set log socket
+            if self.global_args['--logsocket']:
+                log.set_log_socket(
+                    self.global_args['--logsocket']
+                )
+
             if self.global_args['--color-output']:
                 log.set_color_format()
 

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -33,6 +33,7 @@ class TestCli:
             'system': True,
             '-h': False,
             '--logfile': None,
+            '--logsocket': None,
             '--color-output': False,
             '<legacy_args>': [],
             '--version': False,

--- a/test/unit/logger_socket_test.py
+++ b/test/unit/logger_socket_test.py
@@ -1,0 +1,15 @@
+from mock import Mock
+from kiwi.logger_socket import PlainTextSocketHandler
+
+
+class TestPlainTextSocketHandler:
+    def setup(self):
+        self.logger_socket = PlainTextSocketHandler('socket', None)
+        self.logger_socket.formatter = Mock()
+
+    def setup_method(self, cls):
+        self.setup()
+
+    def test_makePickle(self):
+        self.logger_socket.makePickle('record')
+        self.logger_socket.formatter.format.assert_called_once_with('record')

--- a/test/unit/logger_test.py
+++ b/test/unit/logger_test.py
@@ -6,7 +6,10 @@ from pytest import raises
 
 from kiwi.logger import Logger
 
-from kiwi.exceptions import KiwiLogFileSetupFailed
+from kiwi.exceptions import (
+    KiwiLogFileSetupFailed,
+    KiwiLogSocketSetupFailed
+)
 
 
 class TestLogger:
@@ -34,6 +37,13 @@ class TestLogger:
             filename='logfile', encoding='utf-8'
         )
         assert self.log.get_logfile() == 'logfile'
+
+    @patch('kiwi.logger.PlainTextSocketHandler')
+    def test_set_log_socket(self, mock_socket_handler):
+        self.log.set_log_socket('socketfile')
+        mock_socket_handler.assert_called_once_with(
+            'socketfile', None
+        )
 
     @patch('logging.StreamHandler')
     def test_set_logfile_to_stdout(self, mock_stream_handler):
@@ -66,6 +76,12 @@ class TestLogger:
         mock_file_handler.side_effect = KiwiLogFileSetupFailed
         with raises(KiwiLogFileSetupFailed):
             self.log.set_logfile('logfile')
+
+    @patch('kiwi.logger.PlainTextSocketHandler')
+    def test_set_log_socket_raise(self, mock_socket_handler):
+        mock_socket_handler.side_effect = KiwiLogSocketSetupFailed
+        with raises(KiwiLogSocketSetupFailed):
+            self.log.set_log_socket('socketfile')
 
     def test_getLogLevel(self):
         self.log.setLogLevel(42)

--- a/test/unit/tasks/base_test.py
+++ b/test/unit/tasks/base_test.py
@@ -22,6 +22,7 @@ class TestCliTask:
     @patch('kiwi.logger.Logger.setLogLevel')
     @patch('kiwi.logger.Logger.setLogFlag')
     @patch('kiwi.logger.Logger.set_logfile')
+    @patch('kiwi.logger.Logger.set_log_socket')
     @patch('kiwi.logger.Logger.set_color_format')
     @patch('kiwi.cli.Cli.show_and_exit_on_help_request')
     @patch('kiwi.cli.Cli.load_command')
@@ -31,13 +32,14 @@ class TestCliTask:
     def setup(
         self, mock_runtime_config, mock_global_args, mock_command_args,
         mock_load_command, mock_help_check, mock_color,
-        mock_setlog, mock_setLogFlag, mock_setLogLevel
+        mock_set_log_socket, mock_setlog, mock_setLogFlag, mock_setLogLevel
     ):
         Defaults.set_platform_name('x86_64')
         mock_global_args.return_value = {
             '--debug': True,
             '--debug-run-scripts-in-screen': True,
             '--logfile': 'log',
+            '--logsocket': 'log_socket',
             '--color-output': True,
             '--profile': ['vmxFlavour'],
             '--type': None
@@ -64,6 +66,7 @@ class TestCliTask:
     @patch('kiwi.logger.Logger.setLogLevel')
     @patch('kiwi.logger.Logger.setLogFlag')
     @patch('kiwi.logger.Logger.set_logfile')
+    @patch('kiwi.logger.Logger.set_log_socket')
     @patch('kiwi.logger.Logger.set_color_format')
     @patch('kiwi.cli.Cli.show_and_exit_on_help_request')
     @patch('kiwi.cli.Cli.load_command')
@@ -73,7 +76,7 @@ class TestCliTask:
     def setup_method(
         self, cls, mock_runtime_config, mock_global_args, mock_command_args,
         mock_load_command, mock_help_check, mock_color,
-        mock_setlog, mock_setLogFlag, mock_setLogLevel
+        mock_set_log_socket, mock_setlog, mock_setLogFlag, mock_setLogLevel
     ):
         self.setup()
 

--- a/tox.ini
+++ b/tox.ini
@@ -210,8 +210,8 @@ commands =
     flake8 --statistics -j auto --count {toxinidir}/kiwi
     flake8 --statistics -j auto --count {toxinidir}/test/unit
     flake8 --statistics -j auto --count {toxinidir}/test/scripts
-    bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174,SC1117 {toxinidir}/dracut/modules.d/*/* -s bash'
-    bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174,SC1117 {toxinidir}/kiwi/config/functions.sh -s bash'
+    bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174,SC1117,SC2048 {toxinidir}/dracut/modules.d/*/* -s bash'
+    bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174,SC1117,SC2048 {toxinidir}/kiwi/config/functions.sh -s bash'
 
 
 # PyPi upload


### PR DESCRIPTION
Like with --logfile this commit adds support for using an existing Unix Domain Socket for logging. It's required that there is a listener on the given socket otherwise kiwi exits with an appropriate error message from the socket layer. A simple listener could look like the following:

```python
sock_file = '/tmp/log_socket'
buffer = 1024

if os.path.exists(sock_file):
    os.unlink(sock_file)

sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
sock.bind(sock_file)
sock.listen(1)

while True:
    connection, client_address = sock.accept()
    try:
        while True:
            data = connection.recv(buffer)
            if not data:
                break
            print(data.decode())
    finally:
        connection.close()
```

With the listener in place kiwi can be called as follows:

```
kiwi-ng --logsocket /tmp/log_socket ...
```

