### PR TITLE
Logging improvements

### DIFF
--- a/doc/source/commands/kiwi.rst
+++ b/doc/source/commands/kiwi.rst
@@ -16,6 +16,7 @@ SYNOPSIS
            [--type=<build_type>]
            [--logfile=<filename>]
            [--logsocket=<socketfile>]
+           [--loglevel=<number>]
            [--debug]
            [--debug-run-scripts-in-screen]
            [--color-output]
@@ -24,6 +25,7 @@ SYNOPSIS
        image <command> [<args>...]
    kiwi-ng [--logfile=<filename>]
            [--logsocket=<socketfile>]
+           [--loglevel=<number>]
            [--debug]
            [--debug-run-scripts-in-screen]
            [--color-output]
@@ -36,6 +38,7 @@ SYNOPSIS
            [--type=<build_type>]
            [--logfile=<filename>]
            [--logsocket=<socketfile>]
+           [--loglevel=<number>]
            [--debug]
            [--debug-run-scripts-in-screen]
            [--color-output]
@@ -105,7 +108,7 @@ GLOBAL OPTIONS
 
 --debug
 
-  Print debug information on the commandline.
+  Print debug information on the commandline. Same as: '--loglevel 10'
 
 --debug-run-scripts-in-screen
 
@@ -121,6 +124,27 @@ GLOBAL OPTIONS
 
   send log data to the given Unix Domain socket in the same
   format as with --logfile
+
+--loglevel=<number>
+
+  specify logging level as number. Details about the
+  available log levels can be found at:
+  https://docs.python.org/3/library/logging.html#logging-levels
+  Setting a log level causes all message >= level to be
+  displayed.
+
+  .. code:: bash
+
+     ----------------------------
+     | Level    | Numeric value |
+     ----------------------------
+     | CRITICAL | 50            |
+     | ERROR    | 40            |
+     | WARNING  | 30            |
+     | INFO     | 20            |
+     | DEBUG    | 10            |
+     | NOTSET   | 0             |
+     ----------------------------
 
 --profile=<name>
 

--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -23,6 +23,7 @@ usage: kiwi-ng -h | --help
                [--type=<build_type>]
                [--logfile=<filename>]
                [--logsocket=<socketfile>]
+               [--loglevel=<number>]
                [--debug]
                [--debug-run-scripts-in-screen]
                [--color-output]
@@ -31,6 +32,7 @@ usage: kiwi-ng -h | --help
            image <command> [<args>...]
        kiwi-ng [--logfile=<filename>]
                [--logsocket=<socketfile>]
+               [--loglevel=<number>]
                [--debug]
                [--debug-run-scripts-in-screen]
                [--color-output]
@@ -43,6 +45,7 @@ usage: kiwi-ng -h | --help
                [--type=<build_type>]
                [--logfile=<filename>]
                [--logsocket=<socketfile>]
+               [--loglevel=<number>]
                [--debug]
                [--debug-run-scripts-in-screen]
                [--color-output]
@@ -69,8 +72,14 @@ global options:
     --logsocket=<socketfile>
         send log data to the given Unix Domain socket in the same
         format as with --logfile
+    --loglevel=<number>
+        specify logging level as number. Details about the
+        available log levels can be found at:
+        https://docs.python.org/3/library/logging.html#logging-levels
+        Setting a log level causes all message >= level to be
+        displayed.
     --debug
-        print debug information
+        print debug information, same as: '--loglevel 10'
     --debug-run-scripts-in-screen
         run scripts called by kiwi in a screen session
     -v --version

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -28,7 +28,6 @@ from kiwi.cli import Cli
 from kiwi.xml_state import XMLState
 from kiwi.xml_description import XMLDescription
 from kiwi.runtime_checker import RuntimeChecker
-from kiwi.runtime_config import RuntimeConfig
 
 from kiwi.exceptions import (
     KiwiConfigFileNotFound
@@ -68,9 +67,6 @@ class CliTask:
 
         # get global args
         self.global_args = self.cli.get_global_args()
-
-        # initialize runtime configuration
-        self.runtime_config = RuntimeConfig()
 
         # initialize generic runtime check dicts
         self.checks_before_command_args: Dict[str, List[str]] = {
@@ -118,7 +114,14 @@ class CliTask:
                 )
 
             # set log level
-            if self.global_args['--debug']:
+            if self.global_args['--loglevel']:
+                try:
+                    log.setLogLevel(int(self.global_args['--loglevel']))
+                except ValueError:
+                    # Not a numeric log level, stick with the default
+                    # which is INFO
+                    log.setLogLevel(logging.INFO)
+            elif self.global_args['--debug']:
                 log.setLogLevel(logging.DEBUG)
             else:
                 log.setLogLevel(logging.INFO)
@@ -133,6 +136,11 @@ class CliTask:
 
             if self.global_args['--color-output']:
                 log.set_color_format()
+
+        # initialize runtime configuration
+        # import RuntimeConfig late to make sure the logging setup applies
+        from kiwi.runtime_config import RuntimeConfig
+        self.runtime_config = RuntimeConfig()
 
     def load_xml_description(
         self, description_directory: str, kiwi_file: str = ''

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -105,16 +105,6 @@ class CliTask:
         }
 
         if should_perform_task_setup:
-            # set log level
-            if self.global_args['--debug']:
-                log.setLogLevel(logging.DEBUG)
-            else:
-                log.setLogLevel(logging.INFO)
-
-            # set log flags
-            if self.global_args['--debug-run-scripts-in-screen']:
-                log.setLogFlag('run-scripts-in-screen')
-
             # set log file
             if self.global_args['--logfile']:
                 log.set_logfile(
@@ -126,6 +116,20 @@ class CliTask:
                 log.set_log_socket(
                     self.global_args['--logsocket']
                 )
+
+            # set log level
+            if self.global_args['--debug']:
+                log.setLogLevel(logging.DEBUG)
+            else:
+                log.setLogLevel(logging.INFO)
+            if self.global_args['--logfile'] == 'stdout':
+                # deactivate standard console logger by setting
+                # the highest possible log entry level
+                log.setLogLevel(logging.CRITICAL, except_for=['file', 'socket'])
+
+            # set log flags
+            if self.global_args['--debug-run-scripts-in-screen']:
+                log.setLogFlag('run-scripts-in-screen')
 
             if self.global_args['--color-output']:
                 log.set_color_format()

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ verbose = 1
 
 [mypy]
 ignore_missing_imports = True
+no_implicit_optional = False
 
 [mypy-kiwi.xml_parse.*]
 # skip auto generated code

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -34,6 +34,7 @@ class TestCli:
             '-h': False,
             '--logfile': None,
             '--logsocket': None,
+            '--loglevel': None,
             '--color-output': False,
             '<legacy_args>': [],
             '--version': False,

--- a/test/unit/tasks/base_test.py
+++ b/test/unit/tasks/base_test.py
@@ -1,5 +1,7 @@
 import sys
-from mock import patch
+from mock import (
+    patch, call
+)
 from pytest import (
     raises, fixture
 )
@@ -38,7 +40,7 @@ class TestCliTask:
         mock_global_args.return_value = {
             '--debug': True,
             '--debug-run-scripts-in-screen': True,
-            '--logfile': 'log',
+            '--logfile': 'stdout',
             '--logsocket': 'log_socket',
             '--color-output': True,
             '--profile': ['vmxFlavour'],
@@ -57,9 +59,11 @@ class TestCliTask:
         mock_load_command.assert_called_once_with()
         mock_command_args.assert_called_once_with()
         mock_global_args.assert_called_once_with()
-        mock_setLogLevel.assert_called_once_with(logging.DEBUG)
+        assert mock_setLogLevel.call_args_list == [
+            call(logging.DEBUG), call(logging.CRITICAL, except_for=['file', 'socket'])
+        ]
         mock_setLogFlag.assert_called_once_with('run-scripts-in-screen')
-        mock_setlog.assert_called_once_with('log')
+        mock_setlog.assert_called_once_with('stdout')
         mock_color.assert_called_once_with()
         mock_runtime_config.assert_called_once_with()
 

--- a/test/unit/tasks/base_test.py
+++ b/test/unit/tasks/base_test.py
@@ -30,7 +30,7 @@ class TestCliTask:
     @patch('kiwi.cli.Cli.load_command')
     @patch('kiwi.cli.Cli.get_command_args')
     @patch('kiwi.cli.Cli.get_global_args')
-    @patch('kiwi.tasks.base.RuntimeConfig')
+    @patch('kiwi.runtime_config.RuntimeConfig')
     def setup(
         self, mock_runtime_config, mock_global_args, mock_command_args,
         mock_load_command, mock_help_check, mock_color,
@@ -42,6 +42,7 @@ class TestCliTask:
             '--debug-run-scripts-in-screen': True,
             '--logfile': 'stdout',
             '--logsocket': 'log_socket',
+            '--loglevel': None,
             '--color-output': True,
             '--profile': ['vmxFlavour'],
             '--type': None
@@ -76,13 +77,55 @@ class TestCliTask:
     @patch('kiwi.cli.Cli.load_command')
     @patch('kiwi.cli.Cli.get_command_args')
     @patch('kiwi.cli.Cli.get_global_args')
-    @patch('kiwi.tasks.base.RuntimeConfig')
+    @patch('kiwi.runtime_config.RuntimeConfig')
     def setup_method(
         self, cls, mock_runtime_config, mock_global_args, mock_command_args,
         mock_load_command, mock_help_check, mock_color,
         mock_set_log_socket, mock_setlog, mock_setLogFlag, mock_setLogLevel
     ):
         self.setup()
+
+    @patch('kiwi.logger.Logger.setLogLevel')
+    @patch('kiwi.cli.Cli.load_command')
+    @patch('kiwi.cli.Cli.get_command_args')
+    @patch('kiwi.cli.Cli.get_global_args')
+    @patch('kiwi.runtime_config.RuntimeConfig')
+    def test_setup_custom_log_level(
+        self, mock_runtime_config, mock_global_args, mock_command_args,
+        mock_load_command, mock_setLogLevel
+    ):
+        Defaults.set_platform_name('x86_64')
+        mock_global_args.return_value = {
+            '--debug': None,
+            '--logfile': None,
+            '--logsocket': None,
+            '--debug-run-scripts-in-screen': None,
+            '--color-output': None,
+            '--loglevel': '10',
+        }
+        self.task = CliTask()
+        mock_setLogLevel.assert_called_once_with(10)
+
+    @patch('kiwi.logger.Logger.setLogLevel')
+    @patch('kiwi.cli.Cli.load_command')
+    @patch('kiwi.cli.Cli.get_command_args')
+    @patch('kiwi.cli.Cli.get_global_args')
+    @patch('kiwi.runtime_config.RuntimeConfig')
+    def test_setup_custom_log_level_invalid(
+        self, mock_runtime_config, mock_global_args, mock_command_args,
+        mock_load_command, mock_setLogLevel
+    ):
+        Defaults.set_platform_name('x86_64')
+        mock_global_args.return_value = {
+            '--debug': None,
+            '--logfile': None,
+            '--logsocket': None,
+            '--debug-run-scripts-in-screen': None,
+            '--color-output': None,
+            '--loglevel': 'bogus',
+        }
+        self.task = CliTask()
+        mock_setLogLevel.assert_called_once_with(20)
 
     def test_quadruple_token(self):
         assert self.task.quadruple_token('a,b') == ['a', 'b', None, None]


### PR DESCRIPTION
This change is two fold

**Added --loglevel option**
    
specify logging level as number. Details about the available log levels can be found at:   https://docs.python.org/3/library/logging.html#logging-levels. Setting a log level causes all
message >= level to be displayed.

**Consolidate and cleanup logging**
    
Make sure all loggers; stream handlers, file and socket handler uses the same logging format. Also make sure that there is only one place for setLogLevel when kiwi is used as application

