### PR TITLE
Increase scope of kernel lookup

### DIFF
--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -42,7 +42,8 @@ boot_names_type = NamedTuple(
     'boot_names_type', [
         ('kernel_name', str),
         ('initrd_name', str),
-        ('kernel_version', str)
+        ('kernel_version', str),
+        ('kernel_filename', str)
     ]
 )
 
@@ -196,7 +197,8 @@ class BootImageBase:
                 boot_names_type(
                     kernel_name='INSTALLED_KERNEL',
                     initrd_name='DRACUT_OUTPUT_NAME',
-                    kernel_version='KERNEL_VERSION'
+                    kernel_version='KERNEL_VERSION',
+                    kernel_filename='KERNEL_FILE_NAME'
                 )
 
         :rtype: boot_names_type
@@ -208,7 +210,8 @@ class BootImageBase:
         if not kernel_info:
             if self.xml_state.get_initrd_system() == 'none':
                 return boot_names_type(
-                    kernel_name='none', initrd_name='none', kernel_version='none'
+                    kernel_name='none', initrd_name='none',
+                    kernel_version='none', kernel_filename='none'
                 )
             raise KiwiDiskBootImageError(
                 'No kernel in boot image tree %s found' %
@@ -222,7 +225,8 @@ class BootImageBase:
             kernel_name=kernel_info.name,
             initrd_name=dracut_output_format.format(
                 kernel_version=kernel_info.version
-            )
+            ),
+            kernel_filename=kernel_info.filename
         )
 
     def prepare(self) -> None:

--- a/kiwi/bootloader/config/systemd_boot.py
+++ b/kiwi/bootloader/config/systemd_boot.py
@@ -91,7 +91,9 @@ class BootLoaderSystemdBoot(BootLoaderSpecBase):
             [
                 'chroot', self.root_mount.mountpoint,
                 'kernel-install', 'add', kernel_info.kernel_version,
-                f'/boot/{kernel_info.kernel_name}',
+                kernel_info.kernel_filename.replace(
+                    self.root_mount.mountpoint, ''
+                ),
                 f'/boot/{kernel_info.initrd_name}'
             ]
         )

--- a/test/unit/boot/image/base_test.py
+++ b/test/unit/boot/image/base_test.py
@@ -20,12 +20,16 @@ class TestBootImageBase:
     def setup(self, mock_exists):
         Defaults.set_platform_name('x86_64')
         self.boot_names_type = namedtuple(
-            'boot_names_type', ['kernel_name', 'initrd_name', 'kernel_version']
+            'boot_names_type', [
+                'kernel_name', 'initrd_name',
+                'kernel_version', 'kernel_filename'
+            ]
         )
         self.kernel = Mock()
         kernel_info = Mock
         kernel_info.name = 'kernel_name'
         kernel_info.version = 'kernel_version'
+        kernel_info.filename = 'kernel_filename'
         self.kernel.get_kernel.return_value = kernel_info
         self.boot_xml_state = Mock()
         self.xml_state = Mock()
@@ -132,13 +136,15 @@ class TestBootImageBase:
         assert self.boot_image.get_boot_names() == self.boot_names_type(
             kernel_name='kernel_name',
             initrd_name='initrd-kernel_version',
-            kernel_version='kernel_version'
+            kernel_version='kernel_version',
+            kernel_filename='kernel_filename'
         )
         self.xml_state.get_initrd_system.return_value = 'dracut'
         assert self.boot_image.get_boot_names() == self.boot_names_type(
             kernel_name='kernel_name',
             initrd_name='initramfs-kernel_version.img',
-            kernel_version='kernel_version'
+            kernel_version='kernel_version',
+            kernel_filename='kernel_filename'
         )
 
     @patch('kiwi.boot.image.base.Kernel')
@@ -160,7 +166,8 @@ class TestBootImageBase:
         assert self.boot_image.get_boot_names() == self.boot_names_type(
             kernel_name='kernel_name',
             initrd_name='initrd.img-kernel_version',
-            kernel_version='kernel_version'
+            kernel_version='kernel_version',
+            kernel_filename='kernel_filename'
         )
 
     @patch('kiwi.boot.image.base.Kernel')
@@ -181,13 +188,15 @@ class TestBootImageBase:
             assert self.boot_image.get_boot_names() == self.boot_names_type(
                 kernel_name='kernel_name',
                 initrd_name='initrd-kernel_version',
-                kernel_version='kernel_version'
+                kernel_version='kernel_version',
+                kernel_filename='kernel_filename'
             )
             file_handle.read.return_value = 'outfile="/boot/initrd-${kernel}"'
             assert self.boot_image.get_boot_names() == self.boot_names_type(
                 kernel_name='kernel_name',
                 initrd_name='initrd-kernel_version',
-                kernel_version='kernel_version'
+                kernel_version='kernel_version',
+                kernel_filename='kernel_filename'
             )
 
     def test_noop_methods(self):

--- a/test/unit/bootloader/config/systemd_boot_test.py
+++ b/test/unit/bootloader/config/systemd_boot_test.py
@@ -56,7 +56,7 @@ class TestBootLoaderSystemdBoot:
     ):
         kernel_info = Mock()
         kernel_info.kernel_version = 'kernel-version'
-        kernel_info.kernel_name = 'kernel-name'
+        kernel_info.kernel_filename = 'kernel-filename'
         kernel_info.initrd_name = 'initrd-name'
         mock_os_path_exists.return_value = True
         mock_BootImageBase_get_boot_names.return_value = kernel_info
@@ -80,7 +80,7 @@ class TestBootLoaderSystemdBoot:
             call(
                 [
                     'chroot', 'system_root_mount', 'kernel-install', 'add',
-                    'kernel-version', '/boot/kernel-name',
+                    'kernel-version', 'kernel-filename',
                     '/boot/initrd-name'
                 ]
             )

--- a/test/unit/system/kernel_test.py
+++ b/test/unit/system/kernel_test.py
@@ -15,14 +15,6 @@ class TestKernel:
         mock_path_isdir.return_value = True
         mock_listdir.return_value = ['1.2.3-default']
         self.kernel = Kernel('root-dir')
-        assert self.kernel.kernel_names == [
-            'uImage-1.2.3-default',
-            'Image-1.2.3-default',
-            'zImage-1.2.3-default',
-            'vmlinuz-1.2.3-default',
-            'image-1.2.3-default',
-            'vmlinux-1.2.3-default'
-        ]
 
     @patch('os.listdir')
     @patch('os.path.isdir')


### PR DESCRIPTION
So far kiwi was looking up kernels only on /boot. Including other bootloaders it's no longer required that the kernel packages of the distributions provides the kernel in /boot Thus kiwi's lookup needs to be extended to other places which is done by this commit.


