### PR TITLE
Swap from DM kpartx to util-linux partx for creating loop devices

### DIFF
--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -400,7 +400,7 @@ class Disk(DeviceProvider):
         """
         if self.storage_provider.is_loop():
             Command.run(
-                ['kpartx', '-s', '-a', self.storage_provider.get_device()]
+                ['partx', '--add', self.storage_provider.get_device()]
             )
             self.is_mapped = True
         else:
@@ -482,7 +482,7 @@ class Disk(DeviceProvider):
         if self.storage_provider.is_loop():
             device_base = os.path.basename(self.storage_provider.get_device())
             device_node = ''.join(
-                ['/dev/mapper/', device_base, 'p', partition_number]
+                ['/dev/', device_base, 'p', partition_number]
             )
         else:
             device = self.storage_provider.get_device()
@@ -503,9 +503,9 @@ class Disk(DeviceProvider):
             log.info('Cleaning up %s instance', type(self).__name__)
             try:
                 for device_node in self.partition_map.values():
-                    Command.run(['dmsetup', 'remove', device_node])
+                    Command.run(['partx', '--delete', device_node])
                 Command.run(
-                    ['kpartx', '-d', self.storage_provider.get_device()]
+                    ['partx', '--delete', self.storage_provider.get_device()]
                 )
             except Exception:
                 log.warning(


### PR DESCRIPTION
The device-mapper (DM) based loop devices that kiwi has historically generated creates issues when trying to run kiwi in confined build environments. The DM tools prefer to have a tighter coupling between userspace and kernel interfaces, and we cannot necessarily guarantee that in the variety of build environments that kiwi can be run in. In particular, Koji uses either nspawn containers or chroots through Mock to run kiwi and that is where this fails.

However, we do not need to use DM for this purpose when util-linux provides a perfectly serviceable alternative. This commit changes kiwi's loop device setup to use `partx(8)` from util-linux instead.

As long as the appliance image being created doesn't use a disk scheme that requires DM, it becomes entirely possible to produce an image without needing DM at runtime at all.

Fixes #2208.
