### PR TITLE
Support repo URI's with credentials on cmdline

### DIFF
--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -19,7 +19,9 @@ SYNOPSIS
        [--ignore-repos]
        [--ignore-repos-used-for-build]
        [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>]
+       [--set-repo-credentials=<user:pass>]
        [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>...]
+       [--add-repo-credentials=<user:pass>...]
        [--add-package=<name>...]
        [--add-bootstrap-package=<name>...]
        [--delete-package=<name>...]
@@ -68,6 +70,13 @@ OPTIONS
   description. This option can be specified multiple times.
   For details about the provided option values see the **--set-repo**
   information below
+
+--add-repo-credentials=<user:pass>
+
+  For **uri://user:pass@location** type repositories, set the user and
+  password connected with an add-repo specification. The first
+  add-repo-credentials is connected with the first add-repo
+  specification and so on.
 
 --allow-existing-root
 
@@ -168,17 +177,22 @@ OPTIONS
     Set to either **true** or **false** to specify if this repository
     should validate the repository signature.
 
+--set-repo-credentials=<user:pass>
+
+  For **uri://user:pass@location** type repositories, set the user and
+  password connected to the set-repo specification
+
 --set-container-derived-from=<uri>
 
-    overwrite the source location of the base container for the selected
-    image type. The setting is only effective if the configured image type
-    is setup with an initial derived_from reference
+  Overwrite the source location of the base container for the selected
+  image type. The setting is only effective if the configured image type
+  is setup with an initial derived_from reference
 
 --set-container-tag=<name>
 
-    overwrite the container tag in the container configuration.
-    The setting is only effective if the container configuraiton
-    provides an initial tag value
+  Overwrite the container tag in the container configuration.
+  The setting is only effective if the container configuraiton
+  provides an initial tag value
 
 --signing-key=<key-file>
 

--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -19,9 +19,9 @@ SYNOPSIS
        [--ignore-repos]
        [--ignore-repos-used-for-build]
        [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>]
-       [--set-repo-credentials=<user:pass>]
+       [--set-repo-credentials=<user:pass_or_filename>]
        [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>...]
-       [--add-repo-credentials=<user:pass>...]
+       [--add-repo-credentials=<user:pass_or_filename>...]
        [--add-package=<name>...]
        [--add-bootstrap-package=<name>...]
        [--delete-package=<name>...]
@@ -71,12 +71,14 @@ OPTIONS
   For details about the provided option values see the **--set-repo**
   information below
 
---add-repo-credentials=<user:pass>
+--add-repo-credentials=<user:pass_or_filename>
 
   For **uri://user:pass@location** type repositories, set the user and
   password connected with an add-repo specification. The first
   add-repo-credentials is connected with the first add-repo
-  specification and so on.
+  specification and so on. If the provided value describes a filename
+  in the filesystem, the first line of that file is read and used
+  as credentials information.
 
 --allow-existing-root
 
@@ -177,10 +179,12 @@ OPTIONS
     Set to either **true** or **false** to specify if this repository
     should validate the repository signature.
 
---set-repo-credentials=<user:pass>
+--set-repo-credentials=<user:pass_or_filename>
 
   For **uri://user:pass@location** type repositories, set the user and
-  password connected to the set-repo specification
+  password connected to the set-repo specification. If the provided
+  value describes a filename in the filesystem, the first line of that file
+  is read and used as credentials information.
 
 --set-container-derived-from=<uri>
 

--- a/doc/source/commands/system_prepare.rst
+++ b/doc/source/commands/system_prepare.rst
@@ -17,9 +17,9 @@ SYNOPSIS
        [--ignore-repos]
        [--ignore-repos-used-for-build]
        [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>]
-       [--set-repo-credentials=<user:pass>]
+       [--set-repo-credentials=<user:pass_or_filename>]
        [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>...]
-       [--add-repo-credentials=<user:pass>...]
+       [--add-repo-credentials=<user:pass_or_filename>...]
        [--add-package=<name>...]
        [--add-bootstrap-package=<name>...]
        [--delete-package=<name>...]
@@ -71,12 +71,14 @@ OPTIONS
   For details about the provided option values see the **--set-repo**
   information below
 
---add-repo-credentials=<user:pass>
+--add-repo-credentials=<user:pass_or_filename>
 
   For **uri://user:pass@location** type repositories, set the user and
   password connected with an add-repo specification. The first
   add-repo-credentials is connected with the first add-repo
-  specification and so on.
+  specification and so on. If the provided value describes a filename
+  in the filesystem, the first line of that file is read and used
+  as credentials information.
 
 --allow-existing-root
 
@@ -178,10 +180,12 @@ OPTIONS
     Set to either **true** or **false** to specify if this repository
     should validate the repository signature.
 
---set-repo-credentials=<user:pass>
+--set-repo-credentials=<user:pass_or_filename>
 
   For **uri://user:pass@location** type repositories, set the user and
-  password connected to the set-repo specification
+  password connected to the set-repo specification. If the provided value
+  describes a filename in the filesystem, the first line of that file is
+  read and used as credentials information.
 
 --set-container-derived-from=<uri>
 

--- a/doc/source/commands/system_prepare.rst
+++ b/doc/source/commands/system_prepare.rst
@@ -17,7 +17,9 @@ SYNOPSIS
        [--ignore-repos]
        [--ignore-repos-used-for-build]
        [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>]
+       [--set-repo-credentials=<user:pass>]
        [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>...]
+       [--add-repo-credentials=<user:pass>...]
        [--add-package=<name>...]
        [--add-bootstrap-package=<name>...]
        [--delete-package=<name>...]
@@ -68,6 +70,13 @@ OPTIONS
   description. This option can be specified multiple times.
   For details about the provided option values see the **--set-repo**
   information below
+
+--add-repo-credentials=<user:pass>
+
+  For **uri://user:pass@location** type repositories, set the user and
+  password connected with an add-repo specification. The first
+  add-repo-credentials is connected with the first add-repo
+  specification and so on.
 
 --allow-existing-root
 
@@ -168,6 +177,11 @@ OPTIONS
 
     Set to either **true** or **false** to specify if this repository
     should validate the repository signature.
+
+--set-repo-credentials=<user:pass>
+
+  For **uri://user:pass@location** type repositories, set the user and
+  password connected to the set-repo specification
 
 --set-container-derived-from=<uri>
 

--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -270,7 +270,7 @@ class Cli:
                     Defaults.set_temp_location(value)
                 if arg == '--target-arch' and value:
                     Defaults.set_platform_name(value)
-                if arg == '--config' and value:
+                if arg == '--config' and value:  # pragma: no cover
                     Defaults.set_custom_runtime_config_file(value)
                 result[arg] = value
         return result

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -161,7 +161,9 @@ class SystemPrepare:
             repo_sourcetype = xml_repo.get_sourcetype()
             repo_use_for_bootstrap = \
                 True if xml_repo.get_use_for_bootstrap() else False
-            log.info('Setting up repository %s', repo_source)
+            log.info(
+                'Setting up repository %s', Uri.print_sensitive(repo_source)
+            )
             log.info('--> Type: {0}'.format(repo_type))
             if repo_sourcetype:
                 log.info('--> SourceType: {0}'.format(repo_sourcetype))
@@ -170,7 +172,11 @@ class SystemPrepare:
 
             uri = Uri(repo_source, repo_type)
             repo_source_translated = uri.translate()
-            log.info('--> Translated: {0}'.format(repo_source_translated))
+            log.info(
+                '--> Translated: {0}'.format(
+                    Uri.print_sensitive(repo_source_translated)
+                )
+            )
             if not repo_alias:
                 repo_alias = uri.alias()
             log.info('--> Alias: {0}'.format(repo_alias))

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -165,9 +165,17 @@ class SystemSetup:
             )
             if not repo_alias:
                 repo_alias = uri.alias()
-            log.info('Setting up image repository {0}'.format(repo_source))
+            log.info(
+                'Setting up image repository {0}'.format(
+                    Uri.print_sensitive(repo_source)
+                )
+            )
             log.info('--> Type: {0}'.format(repo_type))
-            log.info('--> Translated: {0}'.format(repo_source_translated))
+            log.info(
+                '--> Translated: {0}'.format(
+                    Uri.print_sensitive(repo_source_translated)
+                )
+            )
             log.info('--> Alias: {0}'.format(repo_alias))
             repo.add_repo(
                 repo_alias, repo_source_translated,

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import re
 import logging
 from lxml import etree
 from urllib.parse import (
@@ -164,6 +165,15 @@ class Uri:
             raise KiwiUriStyleUnknown(
                 'URI schema %s not supported' % self.uri
             )
+
+    @staticmethod
+    def print_sensitive(location: str) -> str:
+        uri_with_credentials_pattern = '^.*://(.*:.*)@.*'
+        sensitive_match = re.match(uri_with_credentials_pattern, location)
+        if sensitive_match:
+            return location.replace(sensitive_match.group(1), '******')
+        else:
+            return location
 
     def credentials_file_name(self) -> str:
         """

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -280,7 +280,7 @@ class CliTask:
 
         :rtype: list
         """
-        tokens = option.split(',', tuple_count - 1)
+        tokens = option.split(',', tuple_count - 1) if option else []
         return [
             self._pop_token(tokens) if len(tokens) else None for _ in range(
                 0, tuple_count

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -23,7 +23,9 @@ usage: kiwi-ng system build -h | --help
            [--ignore-repos]
            [--ignore-repos-used-for-build]
            [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>]
+           [--set-repo-credentials=<user:pass>]
            [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>...]
+           [--add-repo-credentials=<user:pass>...]
            [--add-package=<name>...]
            [--add-bootstrap-package=<name>...]
            [--delete-package=<name>...]
@@ -52,6 +54,11 @@ options:
         component list for debian based repos as string delimited by a space,
         main distribution name for debian based repos and
         repo_gpgcheck(true|false)
+    --add-repo-credentials=<user:pass>
+        for uri://user:pass@location type repositories, set the user and
+        password connected with an add-repo specification. The first
+        add-repo-credentials is connected with the first add-repo
+        specification and so on.
     --allow-existing-root
         allow to use an existing root directory from an earlier
         build attempt. Use with caution this could cause an inconsistent
@@ -90,6 +97,9 @@ options:
         component list for debian based repos as string delimited by a space,
         main distribution name for debian based repos and
         repo_gpgcheck(true|false)
+    --set-repo-credentials=<user:pass>
+        for uri://user:pass@location type repositories, set the user and
+        password connected to the set-repo specification
     --signing-key=<key-file>
         includes the key-file as a trusted key for package manager validations
     --target-dir=<directory>
@@ -97,6 +107,8 @@ options:
 """
 import os
 import logging
+from itertools import zip_longest
+from urllib.parse import urlparse
 
 # project
 from kiwi.tasks.base import CliTask
@@ -164,13 +176,19 @@ class SystemBuildTask(CliTask):
 
         if self.command_args['--set-repo']:
             self.xml_state.set_repository(
-                *self._get_repo_parameters(self.command_args['--set-repo'])
+                *self._get_repo_parameters(
+                    self.command_args['--set-repo'],
+                    self.command_args['--set-repo-credentials']
+                )
             )
 
         if self.command_args['--add-repo']:
-            for add_repo in self.command_args['--add-repo']:
+            for add_repo, add_credentials in zip_longest(
+                self.command_args['--add-repo'],
+                self.command_args['--add-repo-credentials']
+            ):
                 self.xml_state.add_repository(
-                    *self._get_repo_parameters(add_repo)
+                    *self._get_repo_parameters(add_repo, add_credentials)
                 )
 
         if self.command_args['--set-container-tag']:
@@ -311,10 +329,18 @@ class SystemBuildTask(CliTask):
             return False
         return self.manual
 
-    def _get_repo_parameters(self, tokens):
+    def _get_repo_parameters(self, tokens, credentials):
         parameters = self.tentuple_token(tokens)
         signing_keys_index = 6
+        repo_source_index = 0
         if not parameters[signing_keys_index]:
             # make sure to pass empty list for signing_keys param
             parameters[signing_keys_index] = []
+        if credentials:
+            repo_source = parameters[repo_source_index]
+            repo_scheme = urlparse(repo_source).scheme
+            if repo_scheme:
+                repo_source = repo_source.replace(f'{repo_scheme}://', '')
+                repo_source = f'{repo_scheme}://{credentials}@{repo_source}'
+                parameters[repo_source_index] = repo_source
         return parameters

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -23,7 +23,9 @@ usage: kiwi-ng system prepare -h | --help
            [--ignore-repos]
            [--ignore-repos-used-for-build]
            [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>]
+           [--set-repo-credentials=<user:pass>]
            [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>...]
+           [--add-repo-credentials=<user:pass>...]
            [--add-package=<name>...]
            [--add-bootstrap-package=<name>...]
            [--delete-package=<name>...]
@@ -51,6 +53,11 @@ options:
         component list for debian based repos as string delimited by a space,
         main distribution name for debian based repos and
         repo_gpgcheck(true|false)
+    --add-repo-credentials=<user:pass>
+        for uri://user:pass@location type repositories, set the user and
+        password connected with an add-repo specification. The first
+        add-repo-credentials is connected with the first add-repo
+        specification and so on.
     --allow-existing-root
         allow to use an existing root directory. Use with caution
         this could cause an inconsistent root tree if the existing
@@ -90,11 +97,16 @@ options:
         component list for debian based repos as string delimited by a space,
         main distribution name for debian based repos and
         repo_gpgcheck(true|false)
+     --set-repo-credentials=<user:pass>
+        for uri://user:pass@location type repositories, set the user and
+        password connected to the set-repo specification
      --signing-key=<key-file>
         includes the key-file as a trusted key for package manager validations
 """
 import os
 import logging
+from itertools import zip_longest
+from urllib.parse import urlparse
 
 # project
 from kiwi.tasks.base import CliTask
@@ -149,13 +161,19 @@ class SystemPrepareTask(CliTask):
 
         if self.command_args['--set-repo']:
             self.xml_state.set_repository(
-                *self._get_repo_parameters(self.command_args['--set-repo'])
+                *self._get_repo_parameters(
+                    self.command_args['--set-repo'],
+                    self.command_args['--set-repo-credentials']
+                )
             )
 
         if self.command_args['--add-repo']:
-            for add_repo in self.command_args['--add-repo']:
+            for add_repo, add_credentials in zip_longest(
+                self.command_args['--add-repo'],
+                self.command_args['--add-repo-credentials']
+            ):
                 self.xml_state.add_repository(
-                    *self._get_repo_parameters(add_repo)
+                    *self._get_repo_parameters(add_repo, add_credentials)
                 )
 
         if self.command_args['--set-container-tag']:
@@ -287,10 +305,18 @@ class SystemPrepareTask(CliTask):
             return False
         return self.manual
 
-    def _get_repo_parameters(self, tokens):
+    def _get_repo_parameters(self, tokens, credentials):
         parameters = self.tentuple_token(tokens)
         signing_keys_index = 6
+        repo_source_index = 0
         if not parameters[signing_keys_index]:
             # make sure to pass empty list for signing_keys param
             parameters[signing_keys_index] = []
+        if credentials:
+            repo_source = parameters[repo_source_index]
+            repo_scheme = urlparse(repo_source).scheme
+            if repo_scheme:
+                repo_source = repo_source.replace(f'{repo_scheme}://', '')
+                repo_source = f'{repo_scheme}://{credentials}@{repo_source}'
+                parameters[repo_source_index] = repo_source
         return parameters

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -23,9 +23,9 @@ usage: kiwi-ng system prepare -h | --help
            [--ignore-repos]
            [--ignore-repos-used-for-build]
            [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>]
-           [--set-repo-credentials=<user:pass>]
+           [--set-repo-credentials=<user:pass_or_filename>]
            [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>...]
-           [--add-repo-credentials=<user:pass>...]
+           [--add-repo-credentials=<user:pass_or_filename>...]
            [--add-package=<name>...]
            [--add-bootstrap-package=<name>...]
            [--delete-package=<name>...]
@@ -53,11 +53,13 @@ options:
         component list for debian based repos as string delimited by a space,
         main distribution name for debian based repos and
         repo_gpgcheck(true|false)
-    --add-repo-credentials=<user:pass>
+    --add-repo-credentials=<user:pass_or_filename>
         for uri://user:pass@location type repositories, set the user and
         password connected with an add-repo specification. The first
         add-repo-credentials is connected with the first add-repo
-        specification and so on.
+        specification and so on. If the provided value describes a
+        filename in the filesystem, the first line of that file
+        is read and used as credentials information.
     --allow-existing-root
         allow to use an existing root directory. Use with caution
         this could cause an inconsistent root tree if the existing
@@ -97,9 +99,11 @@ options:
         component list for debian based repos as string delimited by a space,
         main distribution name for debian based repos and
         repo_gpgcheck(true|false)
-     --set-repo-credentials=<user:pass>
+     --set-repo-credentials=<user:pass_or_filename>
         for uri://user:pass@location type repositories, set the user and
-        password connected to the set-repo specification
+        password connected to the set-repo specification. If the provided
+        value describes a filename in the filesystem, the first line of that
+        file is read and used as credentials information.
      --signing-key=<key-file>
         includes the key-file as a trusted key for package manager validations
 """
@@ -313,6 +317,10 @@ class SystemPrepareTask(CliTask):
             # make sure to pass empty list for signing_keys param
             parameters[signing_keys_index] = []
         if credentials:
+            if os.path.isfile(credentials):
+                credentials_data = open(credentials).readline().strip(os.linesep)
+                os.unlink(credentials)
+                credentials = credentials_data
             repo_source = parameters[repo_source_index]
             repo_scheme = urlparse(repo_source).scheme
             if repo_scheme:

--- a/test/data/credentials
+++ b/test/data/credentials
@@ -1,0 +1,1 @@
+user:pass

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -51,6 +51,7 @@ class TestCli:
         }
         self.command_args = {
             '--add-repo': [],
+            '--add-repo-credentials': [],
             '--allow-existing-root': False,
             '--description': 'description',
             '--help': False,
@@ -59,6 +60,7 @@ class TestCli:
             '--clear-cache': False,
             '--root': 'directory',
             '--set-repo': None,
+            '--set-repo-credentials': None,
             '--add-package': [],
             '--add-bootstrap-package': [],
             '--delete-package': [],

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -167,18 +167,6 @@ class TestCli:
     def test_get_command_args(self):
         assert self.cli.get_command_args() == self.command_args
 
-    def test_get_global_args(self):
-        self.cli.all_args['--config'] = 'config-file'
-        sys.argv = [
-            sys.argv[0],
-            '--config', 'config-file',
-            'system', 'build',
-            '--description', 'description',
-            '--target-dir', 'directory'
-        ]
-        cli = Cli()
-        assert cli.get_global_args() == self.expected_global_args
-
     def test_load_command(self):
         assert self.cli.load_command() == self.loaded_command
 

--- a/test/unit/system/uri_test.py
+++ b/test/unit/system/uri_test.py
@@ -264,3 +264,9 @@ class TestUri:
         mock_urlopen.side_effect = Exception
         with raises(KiwiUriOpenError):
             uri = Uri('https://metalink.com/foo', source_type='metalink')
+
+    def test_print_sensitive(self):
+        assert Uri.print_sensitive('https://user:pass@location') == \
+            'https://******@location'
+        assert Uri.print_sensitive('https://server.example.com/location') == \
+            'https://server.example.com/location'

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -92,7 +92,9 @@ class TestSystemBuildTask:
         self.task.command_args['--description'] = '../data/description'
         self.task.command_args['--target-dir'] = 'some-target'
         self.task.command_args['--set-repo'] = None
+        self.task.command_args['--set-repo-credentials'] = None
         self.task.command_args['--add-repo'] = []
+        self.task.command_args['--add-repo-credentials'] = []
         self.task.command_args['--add-package'] = []
         self.task.command_args['--add-bootstrap-package'] = []
         self.task.command_args['--delete-package'] = []
@@ -289,6 +291,13 @@ class TestSystemBuildTask:
             'http://example.com', 'yast2', 'alias',
             None, None, None, [], None, None, None
         )
+        self.task.command_args['--set-repo-credentials'] = 'user:pass'
+        mock_set_repo.reset_mock()
+        self.task.process()
+        mock_set_repo.assert_called_once_with(
+            'http://user:pass@example.com', 'yast2', 'alias',
+            None, None, None, [], None, None, None
+        )
 
     @patch('kiwi.xml_state.XMLState.add_repository')
     @patch('kiwi.logger.Logger.set_logfile')
@@ -297,13 +306,45 @@ class TestSystemBuildTask:
     ):
         self._init_command_args()
         self.task.command_args['--add-repo'] = [
-            'http://example.com,yast2,alias,99,false,true'
+            'http://example1.com,yast2,alias,99,false,true',
+            'http://example2.com,yast2,alias,99,false,true',
+            'http://example3.com,yast2,alias,99,false,true'
         ]
         self.task.process()
-        mock_add_repo.assert_called_once_with(
-            'http://example.com', 'yast2', 'alias', '99',
-            False, True, [], None, None, None
-        )
+        assert mock_add_repo.call_args_list == [
+            call(
+                'http://example1.com', 'yast2', 'alias', '99',
+                False, True, [], None, None, None
+            ),
+            call(
+                'http://example2.com', 'yast2', 'alias', '99',
+                False, True, [], None, None, None
+            ),
+            call(
+                'http://example3.com', 'yast2', 'alias', '99',
+                False, True, [], None, None, None
+            )
+        ]
+        self.task.command_args['--add-repo-credentials'] = [
+            'user1:pass1',
+            'user2:pass2'
+        ]
+        mock_add_repo.reset_mock()
+        self.task.process()
+        assert mock_add_repo.call_args_list == [
+            call(
+                'http://user1:pass1@example1.com', 'yast2', 'alias', '99',
+                False, True, [], None, None, None
+            ),
+            call(
+                'http://user2:pass2@example2.com', 'yast2', 'alias', '99',
+                False, True, [], None, None, None
+            ),
+            call(
+                'http://example3.com', 'yast2', 'alias', '99',
+                False, True, [], None, None, None
+            )
+        ]
 
     def test_process_system_build_help(self):
         self._init_command_args()

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -3,7 +3,9 @@ import sys
 import mock
 import os
 from pytest import fixture
-from mock import patch, call
+from mock import (
+    patch, call
+)
 
 import kiwi
 
@@ -281,9 +283,12 @@ class TestSystemBuildTask:
 
     @patch('kiwi.xml_state.XMLState.set_repository')
     @patch('kiwi.logger.Logger.set_logfile')
+    @patch('os.path.isfile')
+    @patch('os.unlink')
     def test_process_system_build_prepare_stage_set_repo(
-        self, mock_log, mock_set_repo
+        self, mock_os_unlink, mock_os_path_is_file, mock_log, mock_set_repo
     ):
+        mock_os_path_is_file.return_value = False
         self._init_command_args()
         self.task.command_args['--set-repo'] = 'http://example.com,yast2,alias'
         self.task.process()
@@ -298,6 +303,15 @@ class TestSystemBuildTask:
             'http://user:pass@example.com', 'yast2', 'alias',
             None, None, None, [], None, None, None
         )
+        self.task.command_args['--set-repo-credentials'] = '../data/credentials'
+        mock_os_path_is_file.return_value = True
+        mock_set_repo.reset_mock()
+        self.task.process()
+        mock_set_repo.assert_called_once_with(
+            'http://user:pass@example.com', 'yast2', 'alias',
+            None, None, None, [], None, None, None
+        )
+        mock_os_unlink.assert_called_once_with('../data/credentials')
 
     @patch('kiwi.xml_state.XMLState.add_repository')
     @patch('kiwi.logger.Logger.set_logfile')

--- a/test/unit/tasks/system_prepare_test.py
+++ b/test/unit/tasks/system_prepare_test.py
@@ -85,7 +85,9 @@ class TestSystemPrepareTask:
         self.task.command_args['--root'] = '../data/root-dir'
         self.task.command_args['--allow-existing-root'] = False
         self.task.command_args['--set-repo'] = None
+        self.task.command_args['--set-repo-credentials'] = None
         self.task.command_args['--add-repo'] = []
+        self.task.command_args['--add-repo-credentials'] = []
         self.task.command_args['--add-package'] = []
         self.task.command_args['--add-bootstrap-package'] = []
         self.task.command_args['--delete-package'] = []
@@ -270,26 +272,65 @@ class TestSystemPrepareTask:
         )
 
     @patch('kiwi.xml_state.XMLState.set_repository')
-    def test_process_system_prepare_set_repo(self, mock_state):
+    def test_process_system_prepare_set_repo(self, mock_set_repo):
         self._init_command_args()
         self.task.command_args['--set-repo'] = 'http://example.com,yast2,alias'
         self.task.process()
-        mock_state.assert_called_once_with(
+        mock_set_repo.assert_called_once_with(
             'http://example.com', 'yast2', 'alias',
+            None, None, None, [], None, None, None
+        )
+        self.task.command_args['--set-repo-credentials'] = 'user:pass'
+        mock_set_repo.reset_mock()
+        self.task.process()
+        mock_set_repo.assert_called_once_with(
+            'http://user:pass@example.com', 'yast2', 'alias',
             None, None, None, [], None, None, None
         )
 
     @patch('kiwi.xml_state.XMLState.add_repository')
-    def test_process_system_prepare_add_repo(self, mock_state):
+    def test_process_system_prepare_add_repo(self, mock_add_repo):
         self._init_command_args()
         self.task.command_args['--add-repo'] = [
-            'http://example.com,yast2,alias,99,true'
+            'http://example1.com,yast2,alias,99,true',
+            'http://example2.com,yast2,alias,99,false,true',
+            'http://example3.com,yast2,alias,99,false,true'
         ]
         self.task.process()
-        mock_state.assert_called_once_with(
-            'http://example.com', 'yast2', 'alias', '99',
-            True, None, [], None, None, None
-        )
+        assert mock_add_repo.call_args_list == [
+            call(
+                'http://example1.com', 'yast2', 'alias', '99',
+                True, None, [], None, None, None
+            ),
+            call(
+                'http://example2.com', 'yast2', 'alias', '99',
+                False, True, [], None, None, None
+            ),
+            call(
+                'http://example3.com', 'yast2', 'alias', '99',
+                False, True, [], None, None, None
+            )
+        ]
+        self.task.command_args['--add-repo-credentials'] = [
+            'user1:pass1',
+            'user2:pass2'
+        ]
+        mock_add_repo.reset_mock()
+        self.task.process()
+        assert mock_add_repo.call_args_list == [
+            call(
+                'http://user1:pass1@example1.com', 'yast2', 'alias', '99',
+                True, None, [], None, None, None
+            ),
+            call(
+                'http://user2:pass2@example2.com', 'yast2', 'alias', '99',
+                False, True, [], None, None, None
+            ),
+            call(
+                'http://example3.com', 'yast2', 'alias', '99',
+                False, True, [], None, None, None
+            )
+        ]
 
     def test_process_system_prepare_help(self):
         self._init_command_args()


### PR DESCRIPTION
Specifying a repository as part of the image description allows for credentials via the username and password attributes. Howver, repositories can also be specified on the commandline via the --set-repo / --add-repo options. The options on the commandline did not allow to specify credentials so far. This commit adds the commandline options --set-repo-credentials and --add-repo-credentials to support them

