### PR TITLE
Eliminate redundant partx calls for cleaning up loop devices

### DIFF
--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -502,8 +502,6 @@ class Disk(DeviceProvider):
         if self.storage_provider.is_loop() and self.is_mapped:
             log.info('Cleaning up %s instance', type(self).__name__)
             try:
-                for device_node in self.partition_map.values():
-                    Command.run(['partx', '--delete', device_node])
                 Command.run(
                     ['partx', '--delete', self.storage_provider.get_device()]
                 )

--- a/test/unit/storage/disk_test.py
+++ b/test/unit/storage/disk_test.py
@@ -283,14 +283,14 @@ class TestDisk:
         )
 
     @patch('kiwi.storage.disk.Command.run')
-    def test_destructor_loop_partition_cleanup_failed(self, mock_command):
+    def test_destructor_loop_cleanup_failed(self, mock_command):
         self.disk.is_mapped = True
         self.disk.partition_map = {'root': '/dev/loop0p1'}
         mock_command.side_effect = Exception
         self.disk.__del__()
         with self._caplog.at_level(logging.WARNING):
             mock_command.assert_called_once_with(
-                ['partx', '--delete', '/dev/loop0p1']
+                ['partx', '--delete', '/dev/loop0']
             )
         self.disk.is_mapped = False
 
@@ -300,7 +300,6 @@ class TestDisk:
         self.disk.partition_map = {'root': '/dev/loop0p1'}
         self.disk.__del__()
         assert mock_command.call_args_list == [
-            call(['partx', '--delete', '/dev/loop0p1']),
             call(['partx', '--delete', '/dev/loop0'])
         ]
         self.disk.is_mapped = False


### PR DESCRIPTION
partx can clean up all partition loops associated with a loop device when deleting the main loop device. Apparently, sometimes it goes and does this even when only deleting the partition loop, so to avoid this problem, we will just eliminate the redundant call.

Fixes: 8f2b8fda82a37d7a7ebbf8a6557870cc63b0ae91