### PR TITLE
Allow to select partition mapper tool

### DIFF
--- a/kiwi.yml
+++ b/kiwi.yml
@@ -79,6 +79,11 @@
 #  # is checked prior to the result bundle creation
 #  - max_size: 700m
 
+# Setup process parameters for partition mapping
+#mapper:
+#  # Specify tool to use for creating partition maps
+#  # Possible values are: kpartx and partx
+#  - part_mapper: partx
 
 # Setup process parameters to handle runtime checks
 #runtime_checks:

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1708,6 +1708,17 @@ class Defaults:
         return 'umoci'
 
     @staticmethod
+    def get_part_mapper_tool():
+        """
+        Provides the default partition mapper tool name.
+
+        :return: name
+
+        :rtype: str
+        """
+        return 'partx'
+
+    @staticmethod
     def get_default_container_tag():
         """
         Provides the default container tag.

--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -329,6 +329,25 @@ class RuntimeConfig:
         )
         return oci_archive_tool or Defaults.get_oci_archive_tool()
 
+    def get_mapper_tool(self):
+        """
+        Return partition mapper tool
+
+        mapper:
+          - part_mapper: partx
+
+        if no configuration exists the default tool from the
+        Defaults class is returned
+
+        :return: A name
+
+        :rtype: str
+        """
+        part_mapper_tool = self._get_attribute(
+            element='mapper', attribute='part_mapper'
+        )
+        return part_mapper_tool or Defaults.get_part_mapper_tool()
+
     def get_max_size_constraint(self):
         """
         Returns the maximum allowed size of the built image. The value is

--- a/test/data/kiwi_config/ok/.config/kiwi/config.yml
+++ b/test/data/kiwi_config/ok/.config/kiwi/config.yml
@@ -17,6 +17,9 @@ iso:
 oci:
   - archive_tool: umoci
 
+mapper:
+  - part_mapper: partx
+
 container:
   - compress: none
 

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -67,6 +67,7 @@ class TestRuntimeConfig:
         assert runtime_config.get_container_compression() is False
         assert runtime_config.get_iso_tool_category() == 'xorriso'
         assert runtime_config.get_oci_archive_tool() == 'umoci'
+        assert runtime_config.get_mapper_tool() == 'partx'
         assert runtime_config.get_package_changes() is True
         assert runtime_config.get_disabled_runtime_checks() == [
             'check_dracut_module_for_oem_install_in_package_list',
@@ -92,6 +93,7 @@ class TestRuntimeConfig:
         assert runtime_config.get_container_compression() is True
         assert runtime_config.get_iso_tool_category() == 'xorriso'
         assert runtime_config.get_oci_archive_tool() == 'umoci'
+        assert runtime_config.get_mapper_tool() == 'partx'
         assert runtime_config.get_package_changes() is False
         assert runtime_config.\
             get_credentials_verification_metadata_signing_key_file() == ''


### PR DESCRIPTION
The recent change from kpartx to partx caused some appliance builds to break depending on their configuration. I spotted issues when building disks with veritysetup or integritysetup root devices. There are also issues with grub-install on other architectures e.g s390. It seems partx cannot be used as a drop in replacement and so I suggest to make this a runtime configuration option with partx as the new default but also allow for the old method


