### PR TITLE
Fix container compression

### DIFF
--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -144,7 +144,10 @@ class ContainerBuilder:
             self.requested_container_type, self.root_dir, self.container_config
         )
         self.filename = container_image.create(
-            self.filename, self.base_image, self.ensure_empty_tmpdirs
+            self.filename, self.base_image, self.ensure_empty_tmpdirs,
+            self.runtime_config.get_container_compression()
+            # appx containers already contains a compressed root
+            if self.requested_container_type != 'appx' else False
         )
         Result.verify_image_size(
             self.runtime_config.get_max_size_constraint(),
@@ -152,15 +155,11 @@ class ContainerBuilder:
         )
         if self.bundle_format:
             self.result.add_bundle_format(self.bundle_format)
-        compress = False
-        # appx handles compression in container_image.create
-        if self.requested_container_type != 'appx':
-            compress = self.runtime_config.get_container_compression()
         self.result.add(
             key='container',
             filename=self.filename,
             use_for_bundle=True,
-            compress=compress,
+            compress=False,
             shasum=True
         )
         self.result.add(

--- a/kiwi/container/appx.py
+++ b/kiwi/container/appx.py
@@ -71,14 +71,15 @@ class ContainerImageAppx:
 
     def create(
         self, filename: str, base_image: str = '',
-        ensure_empty_tmpdirs: bool = None
+        ensure_empty_tmpdirs: bool = False, compress_archive: bool = False
     ):
         """
         Create WSL/Appx archive
 
         :param string filename: archive file name
         :param string base_image: not-supported
-        :param string ensure_empty_tmpdirs: not-supported
+        :param bool ensure_empty_tmpdirs: not-supported
+        :param bool compress_archive: compress container archive
         """
         exclude_list = Defaults.\
             get_exclude_list_for_root_data_sync() + Defaults.\
@@ -123,4 +124,9 @@ class ContainerImageAppx:
         Command.run(
             ['appx', '-o', filename, '-f', filemap_file.name]
         )
+        if compress_archive:
+            compress = Compress(filename)
+            compress.xz(self.runtime_config.get_xz_options())
+            filename = compress.compressed_filename
+
         return filename

--- a/kiwi/container/appx.py
+++ b/kiwi/container/appx.py
@@ -17,6 +17,7 @@
 #
 import os
 import logging
+from typing import Dict
 
 # project
 from kiwi.utils.temporary import Temporary
@@ -49,12 +50,12 @@ class ContainerImageAppx:
             'metadata_path': 'directory'
         }
     """
-    def __init__(self, root_dir, custom_args=None):
+    def __init__(self, root_dir: str, custom_args: Dict = {}):
         self.root_dir = root_dir
         self.wsl_config = custom_args or {}
         self.runtime_config = RuntimeConfig()
 
-        self.meta_data_path = self.wsl_config.get('metadata_path')
+        self.meta_data_path = format(self.wsl_config.get('metadata_path') or '')
 
         if not self.meta_data_path:
             raise KiwiContainerSetupError(
@@ -68,7 +69,10 @@ class ContainerImageAppx:
                 )
             )
 
-    def create(self, filename, base_image=None, ensure_empty_tmpdirs=None):
+    def create(
+        self, filename: str, base_image: str = '',
+        ensure_empty_tmpdirs: bool = None
+    ):
         """
         Create WSL/Appx archive
 

--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -22,6 +22,8 @@ from typing import (
 )
 
 # project
+from kiwi.utils.compress import Compress
+from kiwi.runtime_config import RuntimeConfig
 from kiwi.defaults import Defaults
 from kiwi.oci_tools import OCI
 
@@ -102,13 +104,15 @@ class ContainerImageOCI:
 
     def create(
         self, filename: str, base_image: str,
-        ensure_empty_tmpdirs: bool = True
+        ensure_empty_tmpdirs: bool = True, compress_archive: bool = False
     ):
         """
         Create compressed oci system container tar archive
 
         :param string filename: archive file name
         :param string base_image: archive used as a base image
+        :param bool ensure_empty_tmpdirs: exclude system tmp directories
+        :param bool compress_archive: compress container archive
         """
         exclude_list = Defaults.\
             get_exclude_list_for_root_data_sync(ensure_empty_tmpdirs) + Defaults.\
@@ -168,6 +172,10 @@ class ContainerImageOCI:
         oci.export_container_image(
             filename, self.archive_transport, image_ref, additional_refs
         )
+        if compress_archive:
+            compress = Compress(filename)
+            compress.xz(RuntimeConfig().get_xz_options())
+            filename = compress.compressed_filename
 
         return filename
 

--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -17,6 +17,9 @@
 #
 import os
 import logging
+from typing import (
+    Dict, List
+)
 
 # project
 from kiwi.defaults import Defaults
@@ -58,7 +61,7 @@ class ContainerImageOCI:
             }
         }
     """
-    def __init__(self, root_dir, transport, custom_args=None):
+    def __init__(self, root_dir: str, transport: str, custom_args: Dict = {}):
         self.root_dir = root_dir
         self.archive_transport = transport
         if custom_args:
@@ -97,7 +100,10 @@ class ContainerImageOCI:
             self.oci_config['history']['created_by'] = \
                 Defaults.get_default_container_created_by()
 
-    def create(self, filename, base_image, ensure_empty_tmpdirs=True):
+    def create(
+        self, filename: str, base_image: str,
+        ensure_empty_tmpdirs: bool = True
+    ):
         """
         Create compressed oci system container tar archive
 
@@ -140,7 +146,7 @@ class ContainerImageOCI:
             self.oci_config['container_name'],
             self.oci_config['container_tag']
         )
-        additional_refs = []
+        additional_refs: List[str] = []
         if self.archive_transport == 'docker-archive':
             if 'additional_names' in self.oci_config:
                 additional_refs = []

--- a/test/unit/builder/container_test.py
+++ b/test/unit/builder/container_test.py
@@ -19,7 +19,7 @@ class TestContainerBuilder:
             return_value=None
         )
         self.runtime_config.get_container_compression = mock.Mock(
-            return_value=True
+            return_value=False
         )
         kiwi.builder.container.RuntimeConfig = mock.Mock(
             return_value=self.runtime_config
@@ -142,14 +142,14 @@ class TestContainerBuilder:
             'docker', 'root_dir', self.container_config
         )
         container_image.create.assert_called_once_with(
-            'target_dir/image_name.x86_64-1.2.3.docker.tar', None, True
+            'target_dir/image_name.x86_64-1.2.3.docker.tar', None, True, False
         )
         assert self.container.result.add.call_args_list == [
             call(
                 key='container',
                 filename='target_dir/image_name.x86_64-1.2.3.docker.tar',
                 use_for_bundle=True,
-                compress=True,
+                compress=False,
                 shasum=True
             ),
             call(
@@ -229,14 +229,14 @@ class TestContainerBuilder:
         container_image.create.assert_called_once_with(
             'target_dir/image_name.x86_64-1.2.3.docker.tar',
             'root_dir/image/imported_root',
-            True
+            True, False
         )
         assert container.result.add.call_args_list == [
             call(
                 key='container',
                 filename='target_dir/image_name.x86_64-1.2.3.docker.tar',
                 use_for_bundle=True,
-                compress=True,
+                compress=False,
                 shasum=True
             ),
             call(
@@ -330,5 +330,5 @@ class TestContainerBuilder:
         container_image.create.assert_called_once_with(
             'target_dir/image_name.x86_64-1.2.3.docker.tar',
             'root_dir/image/imported_root',
-            False
+            False, False
         )

--- a/test/unit/container/appx_test.py
+++ b/test/unit/container/appx_test.py
@@ -66,7 +66,7 @@ class TestContainerImageAppx:
         with patch('builtins.open', create=True) as mock_open:
             mock_open.return_value = MagicMock(spec=io.IOBase)
             file_handle = mock_open.return_value.__enter__.return_value
-            self.appx.create('target_dir/image.appx')
+            self.appx.create('target_dir/image.appx', '', False, True)
             assert file_handle.write.call_args_list == [
                 call('[Files]\n'),
                 call('"source/baz/baz_file" "../../source/baz/baz_file"\n')
@@ -78,10 +78,14 @@ class TestContainerImageAppx:
             return_value + mock_get_exclude_list_from_custom_exclude_files.
             return_value
         )
-        mock_Compress.assert_called_once_with(
-            archive.create.return_value
-        )
+        assert mock_Compress.call_args_list == [
+            call(archive.create.return_value),
+            call('target_dir/image.appx')
+        ]
         compress.gzip.assert_called_once_with()
         mock_Command_run.assert_called_once_with(
             ['appx', '-o', 'target_dir/image.appx', '-f', 'tempfile']
+        )
+        compress.xz.assert_called_once_with(
+            self.appx.runtime_config.get_xz_options.return_value
         )


### PR DESCRIPTION
This change is two fold:

* **Add type hints for OCI and APPX classes**

* **Fixed handling of container archive compression**
    
    In kiwi we support handling of the container archive compression  via a runtime configuration setting of the following 
    form, eg  in /etc/kiwi.yml
    
    ```yaml
    container:
      # Specify compression for container images
      # Possible values are true, false, xz or none.
      - compress: true
    ```
    
    However, this setting was only taken into account in the kiwi  bundler. Meaning if the user calls 'kiwi result bundle ...' 
    after the container image has been created the result bundler will take the compression setting into account. From 
    my perspective  this behavior is misleading and also prevents users from  creating compressed container archives 
    without a subsequent result bundler call. Therefore this commit moves the place to handle the compression setting 
    into the container classes. The bundler code for containers will no longer operate on it  and just takes what it gets, 
    which can be either compressed or not. The default setting was "No compression" and this was not changed. 

This Fixes #2217
