### PR TITLE
Stick with tox v3.28.0 for unit testing

### DIFF
--- a/.github/workflows/ci-units-types.yml
+++ b/.github/workflows/ci-units-types.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Tox
         run: |
           python -m pip install --upgrade pip
-          python -m pip install tox
+          python -m pip install tox==3.28.0
       - name: Run unit and type tests
         run: |
           tox -e unit_py3_6,unit_py3_8,unit_py3_9,unit_py3_10


### PR DESCRIPTION
tox >= 3.0.15 together with virtualenv >= 20.17.1 raises strange incompatibilities and prevents the unit test run because tox calls virtualenv in a wrong way leading to strange error messages like:

```
usage: virtualenv ...
virtualenv: error: argument dest: destination '{check,devel,packagedoc,doc,doc_gh_pages,doc_suse,doc_man,scripts,}: /home/runner/work/kiwi/kiwi/.tox/3\n/home/runner/work/kiwi/kiwi/.tox/3.8' must not contain the path separator (:) as this would break the activation scripts
```

All this doesn't make sense to me at all and worked without any issues before.


