### PR TITLE
Allow fat16/fat32 as filesystem in partitions

### DIFF
--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2428,7 +2428,7 @@ div {
     k.partition.filesystem.attribute =
         ## Filesystem which should be created on the partition
         attribute filesystem {
-            "btrfs" | "ext2" | "ext3" | "ext4" | "squashfs" | "xfs"
+            "btrfs" | "ext2" | "ext3" | "ext4" | "squashfs" | "xfs" | "fat32" | "fat16"
         }
     k.partition.clone.attribute =
         ## Clone this partition N times

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -3637,6 +3637,8 @@ Allowed values are: t.linux</a:documentation>
           <value>ext4</value>
           <value>squashfs</value>
           <value>xfs</value>
+          <value>fat32</value>
+          <value>fat16</value>
         </choice>
       </attribute>
     </define>


### PR DESCRIPTION
The partitions element allows to specify the filesystem for the individual partition. In the schema fat16 and fat32 were missing


