### PR TITLE
Pass along tmpdir to skopeo

### DIFF
--- a/kiwi/oci_tools/base.py
+++ b/kiwi/oci_tools/base.py
@@ -15,9 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import os
 from datetime import datetime
 
 # project
+from kiwi.path import Path
+from kiwi.utils.command_capabilities import CommandCapabilities
 from kiwi.utils.sync import DataSync
 
 
@@ -154,3 +157,18 @@ class OCIBase:
         sync.sync_data(
             options=options, exclude=exclude_list
         )
+
+    @staticmethod
+    def _skopeo_provides_tmpdir_option() -> bool:
+        """
+        Check if skopeo provides the --tmpdir option
+        Beginning with version >= 0.2 skopeo provides it.
+        """
+        tool = 'skopeo'
+        expected_version = (0, 2, 0)
+        if Path.which(filename=tool, access_mode=os.X_OK):
+            if CommandCapabilities.check_version(
+                tool, expected_version, raise_on_error=False
+            ):
+                return True
+        return False

--- a/kiwi/oci_tools/buildah.py
+++ b/kiwi/oci_tools/buildah.py
@@ -68,7 +68,9 @@ class OCIBuildah(OCIBase):
             [
                 'skopeo', 'copy', container_image_ref,
                 'containers-storage:{0}'.format(self.imported_image)
-            ]
+            ] + [
+                '--tmpdir', Defaults.get_temp_location()
+            ] if self._skopeo_provides_tmpdir_option() else []
         )
 
         if not self.working_container:
@@ -117,10 +119,14 @@ class OCIBuildah(OCIBase):
 
         # we are using 'skopeo copy' to export images instead of 'buildah push'
         # because buildah does not support multiple tags
-        Command.run([
-            'skopeo', 'copy', 'containers-storage:{0}'.format(export_image),
-            '{0}:{1}:{2}'.format(transport, filename, image_ref)
-        ] + extra_tags_opt)
+        Command.run(
+            [
+                'skopeo', 'copy', 'containers-storage:{0}'.format(export_image),
+                '{0}:{1}:{2}'.format(transport, filename, image_ref)
+            ] + extra_tags_opt + [
+                '--tmpdir', Defaults.get_temp_location()
+            ] if self._skopeo_provides_tmpdir_option() else []
+        )
 
     def init_container(self):
         """

--- a/kiwi/oci_tools/umoci.py
+++ b/kiwi/oci_tools/umoci.py
@@ -56,11 +56,15 @@ class OCIUmoci(OCIBase):
 
         :param str container_image_ref: container image reference
         """
-        Command.run([
-            'skopeo', 'copy', container_image_ref, 'oci:{0}:{1}'.format(
-                self.container_dir, Defaults.get_container_base_image_tag()
-            )
-        ])
+        Command.run(
+            [
+                'skopeo', 'copy', container_image_ref, 'oci:{0}:{1}'.format(
+                    self.container_dir, Defaults.get_container_base_image_tag()
+                )
+            ] + [
+                '--tmpdir', Defaults.get_temp_location()
+            ] if self._skopeo_provides_tmpdir_option() else []
+        )
 
     def export_container_image(
         self, filename, transport, image_ref, additional_names=None
@@ -82,10 +86,14 @@ class OCIUmoci(OCIBase):
         # make sure the target tar file does not exist
         # skopeo doesn't support force overwrite
         Path.wipe(filename)
-        Command.run([
-            'skopeo', 'copy', 'oci:{0}'.format(self.working_image),
-            '{0}:{1}:{2}'.format(transport, filename, image_ref)
-        ] + extra_tags_opt)
+        Command.run(
+            [
+                'skopeo', 'copy', 'oci:{0}'.format(self.working_image),
+                '{0}:{1}:{2}'.format(transport, filename, image_ref)
+            ] + extra_tags_opt + [
+                '--tmpdir', Defaults.get_temp_location()
+            ] if self._skopeo_provides_tmpdir_option() else []
+        )
 
     def init_container(self):
         """

--- a/test/unit/oci_tools/base_test.py
+++ b/test/unit/oci_tools/base_test.py
@@ -1,4 +1,5 @@
 from pytest import raises
+from mock import patch
 
 from kiwi.oci_tools.base import OCIBase
 
@@ -47,3 +48,14 @@ class TestOCIBase:
     def test_post_process(self):
         with raises(NotImplementedError):
             self.oci.post_process()
+
+    @patch('kiwi.oci_tools.base.Path.which')
+    @patch('kiwi.oci_tools.base.CommandCapabilities.check_version')
+    def test_skopeo_provides_tmpdir_option(
+        self, mock_Path_which, mock_CommandCapabilities_check_version
+    ):
+        mock_Path_which.return_value = 'skopeo'
+        mock_CommandCapabilities_check_version.return_value = (0, 2, 0)
+        assert self.oci._skopeo_provides_tmpdir_option() is True
+        mock_Path_which.return_value = None
+        assert self.oci._skopeo_provides_tmpdir_option() is False

--- a/test/unit/oci_tools/buildah_test.py
+++ b/test/unit/oci_tools/buildah_test.py
@@ -9,6 +9,7 @@ from collections import namedtuple
 
 from kiwi.oci_tools.buildah import OCIBuildah
 from kiwi.exceptions import KiwiBuildahError
+from kiwi.oci_tools.base import OCIBase
 
 
 class TestOCIBuildah:
@@ -160,13 +161,18 @@ class TestOCIBuildah:
 
     @patch('kiwi.oci_tools.buildah.random.choice')
     @patch('kiwi.oci_tools.buildah.Command.run')
-    def test_import_container_image(self, mock_Command_run, mock_choice):
+    @patch.object(OCIBase, '_skopeo_provides_tmpdir_option')
+    def test_import_container_image(
+        self, mock_skopeo_provides_tmpdir_option, mock_Command_run, mock_choice
+    ):
+        mock_skopeo_provides_tmpdir_option.return_value = True
         mock_choice.return_value = 'x'
         self.oci.import_container_image('oci-archive:image.tar')
         assert mock_Command_run.call_args_list == [
             call([
                 'skopeo', 'copy', 'oci-archive:image.tar',
-                'containers-storage:kiwi-image-xxxxxx:base_layer'
+                'containers-storage:kiwi-image-xxxxxx:base_layer',
+                '--tmpdir', '/var/tmp'
             ]),
             call([
                 'buildah', 'from', '--name', 'kiwi-container-xxxxxx',
@@ -197,7 +203,11 @@ class TestOCIBuildah:
 
     @patch('kiwi.oci_tools.buildah.Path.wipe')
     @patch('kiwi.oci_tools.buildah.Command.run')
-    def test_export_container_image(self, mock_Command_run, mock_wipe):
+    @patch.object(OCIBase, '_skopeo_provides_tmpdir_option')
+    def test_export_container_image(
+        self, mock_skopeo_provides_tmpdir_option, mock_Command_run, mock_wipe
+    ):
+        mock_skopeo_provides_tmpdir_option.return_value = True
         self.oci.working_image = 'kiwi-image:tag'
         self.oci.export_container_image(
             'image.tar', 'docker-archive', 'myimage:tag',
@@ -205,14 +215,20 @@ class TestOCIBuildah:
         )
         mock_Command_run.assert_called_once_with([
             'skopeo', 'copy', 'containers-storage:kiwi-image:tag',
-            'docker-archive:image.tar:myimage:tag', '--additional-tag',
-            'myimage:tag2', '--additional-tag', 'myimage:tag3'
+            'docker-archive:image.tar:myimage:tag',
+            '--additional-tag', 'myimage:tag2',
+            '--additional-tag', 'myimage:tag3',
+            '--tmpdir', '/var/tmp'
         ])
         mock_wipe.assert_called_once_with('image.tar')
 
     @patch('kiwi.oci_tools.buildah.Path.wipe')
     @patch('kiwi.oci_tools.buildah.Command.run')
-    def test_export_container_image_imported(self, mock_Command_run, mock_wipe):
+    @patch.object(OCIBase, '_skopeo_provides_tmpdir_option')
+    def test_export_container_image_imported(
+        self, mock_skopeo_provides_tmpdir_option, mock_Command_run, mock_wipe
+    ):
+        mock_skopeo_provides_tmpdir_option.return_value = True
         self.oci.working_image = None
         self.oci.imported_image = 'kiwi-image:base_layer'
         self.oci.export_container_image(
@@ -221,8 +237,10 @@ class TestOCIBuildah:
         )
         mock_Command_run.assert_called_once_with([
             'skopeo', 'copy', 'containers-storage:kiwi-image:base_layer',
-            'docker-archive:image.tar:myimage:tag', '--additional-tag',
-            'myimage:tag2', '--additional-tag', 'myimage:tag3'
+            'docker-archive:image.tar:myimage:tag',
+            '--additional-tag', 'myimage:tag2',
+            '--additional-tag', 'myimage:tag3',
+            '--tmpdir', '/var/tmp'
         ])
         mock_wipe.assert_called_once_with('image.tar')
 


### PR DESCRIPTION
When using the --temp-dir parameter, it was not passed to the skopeo calls when building a container image with kiwi.

