### PR TITLE
Allow to specify fixed size for the root partition

### DIFF
--- a/doc/source/working_with_images/custom_partitions.rst
+++ b/doc/source/working_with_images/custom_partitions.rst
@@ -84,7 +84,7 @@ clone="number"
 Despite the customization options of the partition table shown above
 there are the following limitations:
 
-1. The root partition is always the last one
+1. By default the root partition is always the last one
 
    Disk imags build with {kiwi} are designed to be expandable.
    For this feature to work the partition containing the system
@@ -93,20 +93,27 @@ there are the following limitations:
    partition with the option to be also placed at the end of the
    table. For details lookup `spare_part` in :ref:`image-description-elements`
 
-2. There can be no gaps in the partition table
+2. By default there are no gaps in the partition table
 
-   The way partitions are configured does not allow for gaps in the
-   table. As of today there was no use case were it made sense to
-   leave a gap between table entries. However, leaving some space
+   The way partitions are configured is done such that there are no
+   gaps in the table of the image. However, leaving some space
    free at the **end** of the partition geometry is possible in the
    following ways:
 
    * **Deploy with unpartitioned free space.**
 
      To leave space unpartitioned on first boot of a disk image
-     it is possible to configured an `<oem-systemsize>` which is
+     it is possible to configure an `<oem-systemsize>` which is
      smaller than the disk the image gets deployed to. Details
      about this setting can be found in :ref:`image-description-elements`
+
+   * **Build with unpartitioned free space.**
+
+     To leave space unpartitioned at build time of the image it
+     is possible to disable `<oem-resize>` and configure an
+     `<oem-systemsize>` which is smaller than the kiwi calculated
+     disk size or the fixed setting for the disk size via the
+     `size>` element.
 
    * **Build with unpartitioned free space.**
 

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1054,6 +1054,20 @@ class XMLState:
         else:
             return True
 
+    def get_oemconfig_oem_systemsize(self) -> int:
+        """
+        State value to retrieve root partition size
+
+        :return: Content of <oem-systemsize> section value
+
+        :rtype: int
+        """
+        oemconfig = self.get_build_type_oemconfig_section()
+        if oemconfig and oemconfig.get_oem_systemsize():
+            return int(oemconfig.get_oem_systemsize()[0])
+        else:
+            return 0
+
     def get_oemconfig_oem_multipath_scan(self) -> bool:
         """
         State value to activate multipath maps. Returns a boolean

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -787,6 +787,37 @@ class TestDiskBuilder:
             '/dev/root-device'
         )
 
+    @patch('kiwi.builder.disk.FileSystem.new')
+    @patch('random.randrange')
+    @patch('kiwi.builder.disk.Command.run')
+    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
+    @patch('os.path.exists')
+    @patch('os.path.getsize')
+    @patch('kiwi.builder.disk.SystemSetup')
+    @patch('kiwi.builder.disk.ImageSystem')
+    @patch('kiwi.builder.disk.Temporary.new_file')
+    def test_create_disk_standard_root_with_fixed_rootfs_size(
+        self, mock_Temporary_new_file,
+        mock_ImageSystem, mock_SystemSetup, mock_os_path_getsize,
+        mock_path, mock_grub_dir, mock_command, mock_rand, mock_fs
+    ):
+        self.disk_builder.root_filesystem_embed_verity_metadata = False
+        self.disk_builder.root_filesystem_is_overlay = False
+        self.disk_builder.volume_manager_name = None
+        self.setup.script_exists.return_value = False
+        self.disk_builder.initrd_system = 'dracut'
+        self.disk_builder.root_clone_count = 1
+        self.disk_builder.oem_systemsize = 1024
+        self.disk_builder.oem_resize = False
+
+        m_open = mock_open()
+        with patch('builtins.open', m_open, create=True):
+            self.disk_builder.create_disk()
+
+        self.disk.create_root_partition.assert_called_once_with(
+            'clone:1024:1024', 1
+        )
+
     @patch('kiwi.builder.disk.DeviceProvider')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.FileSystemSquashFs')

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -576,6 +576,11 @@ class TestXMLState:
         state = XMLState(xml_data)
         assert state.get_oemconfig_oem_resize() is False
 
+    def test_get_oemconfig_oem_systemsize(self):
+        xml_data = self.description.load()
+        state = XMLState(xml_data, ['vmxFlavour'], 'oem')
+        assert state.get_oemconfig_oem_systemsize() == 2048
+
     def test_get_oemconfig_oem_multipath_scan(self):
         xml_data = self.description.load()
         state = XMLState(xml_data, ['vmxFlavour'], 'oem')


### PR DESCRIPTION
So far the last partition (typically root) in the partition table takes all the rest space of the partition table in the image file. At deployment/boot time users had several options to let that partition grow to a custom size. However, during build time of the image it was not possible to specify a specific fixed size for the root partition as we don't wanted to produce gaps of unpartitioned space in the image file. It has turned out that there is hardware available which requires a partition to be an exact multiple of some blocksize. As kiwi supports size constraints for all other partitions but not for root this commit now allows for it. The oem-systemsize element is now also taken into account at build time of the image if the oem-resize which would do that at deployment/boot time is switched off like the following example shows:

```xml
<oemconfig>
    <!-- set root partition to 2048MB -->
    <oem-systemsize>2048</oem-systemsize>
    <oem-resize>false</oem-resize>
</oemconfig>
```

This Fixes #2203