### PR TITLE
Added 90-brd.conf for test-image-disk-ramdisk

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-disk-ramdisk/root/etc/dracut.conf.d/90-brd.conf
+++ b/build-tests/x86/tumbleweed/test-image-disk-ramdisk/root/etc/dracut.conf.d/90-brd.conf
@@ -1,0 +1,1 @@
+add_drivers+=" brd "

--- a/test/unit/storage/disk_test.py
+++ b/test/unit/storage/disk_test.py
@@ -55,7 +55,7 @@ class TestDisk:
 
     def test_is_loop(self):
         self.disk.is_loop()
-        self.storage_provider.is_loop.called_once_with()
+        self.storage_provider.is_loop.assert_called_once_with()
 
     def test_create_root_partition(self):
         self.disk.create_root_partition('100', 1)

--- a/test/unit/system/root_import/oci_test.py
+++ b/test/unit/system/root_import/oci_test.py
@@ -47,7 +47,6 @@ class TestRootImportOCI:
     def test_sync_data(self, mock_OCI, mock_path, mock_md5, mock_compress):
         oci = Mock()
         mock_OCI.new.return_value = oci
-        md5 = Mock()
         mock_md5.return_value = Mock()
 
         uncompress = Mock()
@@ -63,7 +62,6 @@ class TestRootImportOCI:
             'root_dir'
         )
         mock_md5.assert_called_once_with('root_dir/image/imported_root')
-        md5.md5.called_once_with('root_dir/image/imported_root.md5')
         uncompress.get_format.assert_called_once_with()
 
     @patch('kiwi.system.root_import.oci.Compress')
@@ -75,7 +73,6 @@ class TestRootImportOCI:
     ):
         oci = Mock()
         mock_OCI.new.return_value = oci
-        md5 = Mock()
         mock_md5.return_value = Mock()
 
         uncompress = Mock()
@@ -91,7 +88,6 @@ class TestRootImportOCI:
             'root_dir'
         )
         mock_md5.assert_called_once_with('root_dir/image/imported_root')
-        md5.md5.called_once_with('root_dir/image/imported_root.md5')
         uncompress.get_format.assert_called_once_with()
         uncompress.uncompress.assert_called_once_with(True)
 
@@ -105,7 +101,6 @@ class TestRootImportOCI:
         mock_exists.return_value = True
         oci = Mock()
         mock_OCI.new.return_value = oci
-        md5 = Mock()
         mock_md5.return_value = Mock()
         with patch.dict('os.environ', {'HOME': '../data'}):
             oci_import = RootImportOCI(
@@ -124,4 +119,3 @@ class TestRootImportOCI:
                 'root_dir'
             )
             mock_md5.assert_called_once_with('root_dir/image/imported_root')
-            md5.md5.called_once_with('root_dir/image/imported_root.md5')

--- a/test/unit/tasks/system_create_test.py
+++ b/test/unit/tasks/system_create_test.py
@@ -77,10 +77,10 @@ class TestSystemCreateTask:
         self.task.process()
         self.runtime_checker.\
             check_target_directory_not_in_shared_cache.\
-            called_once_with(self.abs_target_dir)
+            assert_called_once_with(self.abs_root_dir)
         self.runtime_checker.\
             check_dracut_module_versions_compatible_to_kiwi.\
-            called_once_with(self.abs_target_dir)
+            assert_called_once_with(self.abs_root_dir)
         self.setup.call_image_script.assert_called_once_with()
         self.builder.create.assert_called_once_with()
         self.result.print_results.assert_called_once_with()


### PR DESCRIPTION
By default the brd ramdisk module is no longer added to the initrd. For ramdisk deployments this is required though. This Fixes #2230

