### PR TITLE
Allow squashfscompression for plain squashfs

### DIFF
--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1596,7 +1596,7 @@ div {
         }
         >> sch:pattern [ id = "squashfscompression" is-a = "image_type"
             sch:param [ name = "attr" value = "squashfscompression" ]
-            sch:param [ name = "types" value = "oem pxe kis iso" ]
+            sch:param [ name = "types" value = "oem pxe kis iso squashfs" ]
         ]
     k.type.verity_blocks.attribute =
         ## Specifies to create a dm verity hash from the number of

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2311,7 +2311,7 @@ structure</a:documentation>
       </attribute>
       <sch:pattern id="squashfscompression" is-a="image_type">
         <sch:param name="attr" value="squashfscompression"/>
-        <sch:param name="types" value="oem pxe kis iso"/>
+        <sch:param name="types" value="oem pxe kis iso squashfs"/>
       </sch:pattern>
     </define>
     <define name="k.type.verity_blocks.attribute">


### PR DESCRIPTION
The schematron rule to limit the squashfscompression attribute to certain image types did not allow it for a plain squashfs filesystem build. This commit fixes that limitation. This Fixes #2241


