### PR TITLE
Support new bootloadersettings section

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -1083,6 +1083,27 @@ For details see: :ref:`custom_volumes`
    or mount points. As a result, whatever is written in `<partitions>`
    cannot be expressed in the same way in `<volumes>`.
 
+<preferences><type><bootloader><bootloadersettings>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Used to specify custom arguments for the tools called to setup
+secure boot e.g `shiminstall`, installation of the bootloader
+e.g `grub-install` or configuration of the bootloader e.g `grub-mkconfig`.
+
+.. code:: xml
+
+   <bootloadersettings>
+       <shimoption name="--suse-enable-tpm"/>
+       <shimoption name="--bootloader-id" value="some-id"/>
+       <installoption name="--suse-enable-tpm"/>
+       <configoption name="--debug"/>
+   </bootloadersettings>
+
+.. note::
+
+   {kiwi-ng} does not judge on the given parameters and if the provided
+   data is effectively used depends on the individual bootloader
+   implementation.
+
 <preferences><type><partitions>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Used to describe the geometry of the disk on the level of the

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -62,6 +62,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 {'grub_directory_name': 'grub|grub2'}
         """
         self.custom_args = custom_args
+        self.config_options = []
         arch = Defaults.get_platform_name()
         if arch == 'x86_64':
             # grub2 support for bios and efi systems
@@ -90,6 +91,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             self.boot_directory_name = self.custom_args['grub_directory_name']
         else:
             self.boot_directory_name = 'grub'
+
+        if self.custom_args and 'config_options' in self.custom_args:
+            self.config_options = self.custom_args['config_options']
 
         self.terminal = self.xml_state.get_build_type_bootloader_console() \
             or 'gfxterm'
@@ -549,6 +553,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         * DEFAULT_APPEND
         * FAILSAFE_APPEND
         * SECURE_BOOT
+        * TRUSTED_BOOT
         """
         sysconfig_bootloader_entries = {
             'LOADER_TYPE':
@@ -556,6 +561,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             'LOADER_LOCATION':
                 'none' if self.firmware.efi_mode() else 'mbr'
         }
+        if '--set-trusted-boot' in self.config_options:
+            sysconfig_bootloader_entries['TRUSTED_BOOT'] = 'yes'
         if self.firmware.efi_mode() == 'uefi':
             sysconfig_bootloader_entries['SECURE_BOOT'] = 'yes'
         if self.cmdline:

--- a/kiwi/bootloader/install/grub2.py
+++ b/kiwi/bootloader/install/grub2.py
@@ -61,6 +61,7 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
         self.arch = Defaults.get_platform_name()
         self.custom_args = custom_args
         self.install_arguments = []
+        self.shim_install_arguments = []
         self.firmware = None
         self.efi_mount = None
         self.root_mount = None
@@ -77,6 +78,10 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
             self.volumes = custom_args['system_volumes']
         if custom_args and 'firmware' in custom_args:
             self.firmware = custom_args['firmware']
+        if custom_args and 'install_options' in custom_args:
+            self.install_arguments = custom_args['install_options']
+        if custom_args and 'shim_options' in custom_args:
+            self.shim_install_arguments = custom_args['shim_options']
 
         if self.firmware and self.firmware.efi_mode():
             if not custom_args or 'efi_device' not in custom_args:
@@ -265,7 +270,8 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
                 Command.run(
                     [
                         'chroot', self.root_mount.mountpoint,
-                        'shim-install', '--removable',
+                        'shim-install', '--removable'
+                    ] + self.shim_install_arguments + [
                         self.device
                     ]
                 )

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -296,7 +296,9 @@ class DiskBuilder:
                     'crypto_disk':
                         True if self.luks is not None else False,
                     'boot_is_crypto':
-                        self.boot_is_crypto
+                        self.boot_is_crypto,
+                    'config_options':
+                        self.xml_state.get_bootloader_config_options()
                 }
             )
 
@@ -1490,7 +1492,9 @@ class DiskBuilder:
             'boot_device': boot_device.get_device(),
             'root_device': root_device.get_device(),
             'firmware': self.firmware,
-            'target_removable': self.target_removable
+            'target_removable': self.target_removable,
+            'install_options': self.xml_state.get_bootloader_install_options(),
+            'shim_options': self.xml_state.get_bootloader_shim_options()
         }
 
         if 'efi' in device_map:

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -881,6 +881,63 @@ div {
 }
 
 #==========================================
+# common element <shimoption>
+#
+div {
+    k.shimoption.name.attribute =
+        attribute name { text }
+    k.shimoption.value.attribute =
+        attribute value { text }
+    k.shimoption.attlist =
+        k.shimoption.name.attribute &
+        k.shimoption.value.attribute?
+    k.shimoption =
+        ## A shim setup option specification
+        element shimoption {
+            k.shimoption.attlist,
+            empty
+        }
+}
+
+#==========================================
+# common element <installoption>
+#
+div {
+    k.installoption.name.attribute =
+        attribute name { text }
+    k.installoption.value.attribute =
+        attribute value { text }
+    k.installoption.attlist =
+        k.installoption.name.attribute &
+        k.installoption.value.attribute?
+    k.installoption =
+        ## A install command option specification
+        element installoption {
+            k.installoption.attlist,
+            empty
+        }
+}
+
+#==========================================
+# common element <configoption>
+#
+div {
+    k.configoption.name.attribute =
+        attribute name { text }
+    k.configoption.value.attribute =
+        attribute value { text }
+    k.configoption.attlist =
+        k.configoption.name.attribute &
+        k.configoption.value.attribute?
+    k.configoption =
+        ## A config command option specification
+        element configoption {
+            k.configoption.attlist,
+            empty
+        }
+}
+
+#==========================================
 # common element <package>
 #
 div {
@@ -2703,7 +2760,7 @@ div {
         ## and to provide configuration parameters for it
         element bootloader {
             k.bootloader.attlist &
-            empty
+            k.bootloadersettings?
         }
 }
 
@@ -2947,6 +3004,21 @@ div {
         element luksformat {
             k.luksformat.attlist &
             k.option+
+        }
+}
+
+#==========================================
+# main block: <bootloadersettings>
+#
+div {
+    k.bootloadersettings.attlist = empty
+    k.bootloadersettings =
+        ## Additional bootloader settings
+        element bootloadersettings {
+            k.bootloadersettings.attlist &
+            k.shimoption* &
+            k.installoption* &
+            k.configoption*
         }
 }
 

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1334,6 +1334,90 @@ the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
   </div>
   <!--
     ==========================================
+    common element <shimoption>
+    
+  -->
+  <div>
+    <define name="k.shimoption.name.attribute">
+      <attribute name="name"/>
+    </define>
+    <define name="k.shimoption.value.attribute">
+      <attribute name="value"/>
+    </define>
+    <define name="k.shimoption.attlist">
+      <interleave>
+        <ref name="k.shimoption.name.attribute"/>
+        <optional>
+          <ref name="k.shimoption.value.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="k.shimoption">
+      <element name="shimoption">
+        <a:documentation>A shim setup option specification</a:documentation>
+        <ref name="k.shimoption.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <installoption>
+    
+  -->
+  <div>
+    <define name="k.installoption.name.attribute">
+      <attribute name="name"/>
+    </define>
+    <define name="k.installoption.value.attribute">
+      <attribute name="value"/>
+    </define>
+    <define name="k.installoption.attlist">
+      <interleave>
+        <ref name="k.installoption.name.attribute"/>
+        <optional>
+          <ref name="k.installoption.value.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="k.installoption">
+      <element name="installoption">
+        <a:documentation>A install command option specification</a:documentation>
+        <ref name="k.installoption.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <configoption>
+    
+  -->
+  <div>
+    <define name="k.configoption.name.attribute">
+      <attribute name="name"/>
+    </define>
+    <define name="k.configoption.value.attribute">
+      <attribute name="value"/>
+    </define>
+    <define name="k.configoption.attlist">
+      <interleave>
+        <ref name="k.configoption.name.attribute"/>
+        <optional>
+          <ref name="k.configoption.value.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="k.configoption">
+      <element name="configoption">
+        <a:documentation>A config command option specification</a:documentation>
+        <ref name="k.configoption.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
     common element <package>
     
   -->
@@ -4047,7 +4131,9 @@ for 4k DASD devices use CDL</a:documentation>
 and to provide configuration parameters for it</a:documentation>
         <interleave>
           <ref name="k.bootloader.attlist"/>
-          <empty/>
+          <optional>
+            <ref name="k.bootloadersettings"/>
+          </optional>
         </interleave>
       </element>
     </define>
@@ -4384,6 +4470,33 @@ of the storage device</a:documentation>
           <oneOrMore>
             <ref name="k.option"/>
           </oneOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <bootloadersettings>
+    
+  -->
+  <div>
+    <define name="k.bootloadersettings.attlist">
+      <empty/>
+    </define>
+    <define name="k.bootloadersettings">
+      <element name="bootloadersettings">
+        <a:documentation>Additional bootloader settings</a:documentation>
+        <interleave>
+          <ref name="k.bootloadersettings.attlist"/>
+          <zeroOrMore>
+            <ref name="k.shimoption"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="k.installoption"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="k.configoption"/>
+          </zeroOrMore>
         </interleave>
       </element>
     </define>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/ms/Project/kiwi/.tox/3.6/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/ms/Project/kiwi/.tox/3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -1840,6 +1840,246 @@ class option(GeneratedsSuper):
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class option
+
+
+class shimoption(GeneratedsSuper):
+    """A shim setup option specification"""
+    subclass = None
+    superclass = None
+    def __init__(self, name=None, value=None):
+        self.original_tagname_ = None
+        self.name = _cast(None, name)
+        self.value = _cast(None, value)
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, shimoption)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if shimoption.subclass:
+            return shimoption.subclass(*args_, **kwargs_)
+        else:
+            return shimoption(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_name(self): return self.name
+    def set_name(self, name): self.name = name
+    def get_value(self): return self.value
+    def set_value(self, value): self.value = value
+    def hasContent_(self):
+        if (
+
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', name_='shimoption', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('shimoption')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='shimoption')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='shimoption', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='shimoption'):
+        if self.name is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
+        if self.value is not None and 'value' not in already_processed:
+            already_processed.add('value')
+            outfile.write(' value=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.value), input_name='value')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='shimoption', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('name', node)
+        if value is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            self.name = value
+        value = find_attr_value_('value', node)
+        if value is not None and 'value' not in already_processed:
+            already_processed.add('value')
+            self.value = value
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        pass
+# end class shimoption
+
+
+class installoption(GeneratedsSuper):
+    """A install command option specification"""
+    subclass = None
+    superclass = None
+    def __init__(self, name=None, value=None):
+        self.original_tagname_ = None
+        self.name = _cast(None, name)
+        self.value = _cast(None, value)
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, installoption)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if installoption.subclass:
+            return installoption.subclass(*args_, **kwargs_)
+        else:
+            return installoption(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_name(self): return self.name
+    def set_name(self, name): self.name = name
+    def get_value(self): return self.value
+    def set_value(self, value): self.value = value
+    def hasContent_(self):
+        if (
+
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', name_='installoption', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('installoption')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='installoption')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='installoption', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='installoption'):
+        if self.name is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
+        if self.value is not None and 'value' not in already_processed:
+            already_processed.add('value')
+            outfile.write(' value=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.value), input_name='value')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='installoption', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('name', node)
+        if value is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            self.name = value
+        value = find_attr_value_('value', node)
+        if value is not None and 'value' not in already_processed:
+            already_processed.add('value')
+            self.value = value
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        pass
+# end class installoption
+
+
+class configoption(GeneratedsSuper):
+    """A config command option specification"""
+    subclass = None
+    superclass = None
+    def __init__(self, name=None, value=None):
+        self.original_tagname_ = None
+        self.name = _cast(None, name)
+        self.value = _cast(None, value)
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, configoption)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if configoption.subclass:
+            return configoption.subclass(*args_, **kwargs_)
+        else:
+            return configoption(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_name(self): return self.name
+    def set_name(self, name): self.name = name
+    def get_value(self): return self.value
+    def set_value(self, value): self.value = value
+    def hasContent_(self):
+        if (
+
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', name_='configoption', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('configoption')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='configoption')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='configoption', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='configoption'):
+        if self.name is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
+        if self.value is not None and 'value' not in already_processed:
+            already_processed.add('value')
+            outfile.write(' value=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.value), input_name='value')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='configoption', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('name', node)
+        if value is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            self.name = value
+        value = find_attr_value_('value', node)
+        if value is not None and 'value' not in already_processed:
+            already_processed.add('value')
+            self.value = value
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        pass
+# end class configoption
 
 
 class package(GeneratedsSuper):
@@ -5238,7 +5478,7 @@ class bootloader(GeneratedsSuper):
     provide configuration parameters for it"""
     subclass = None
     superclass = None
-    def __init__(self, name=None, console=None, serial_line=None, timeout=None, timeout_style=None, targettype=None, grub_template=None):
+    def __init__(self, name=None, console=None, serial_line=None, timeout=None, timeout_style=None, targettype=None, grub_template=None, bootloadersettings=None):
         self.original_tagname_ = None
         self.name = _cast(None, name)
         self.console = _cast(None, console)
@@ -5247,6 +5487,7 @@ class bootloader(GeneratedsSuper):
         self.timeout_style = _cast(None, timeout_style)
         self.targettype = _cast(None, targettype)
         self.grub_template = _cast(None, grub_template)
+        self.bootloadersettings = bootloadersettings
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -5258,6 +5499,8 @@ class bootloader(GeneratedsSuper):
         else:
             return bootloader(*args_, **kwargs_)
     factory = staticmethod(factory)
+    def get_bootloadersettings(self): return self.bootloadersettings
+    def set_bootloadersettings(self, bootloadersettings): self.bootloadersettings = bootloadersettings
     def get_name(self): return self.name
     def set_name(self, name): self.name = name
     def get_console(self): return self.console
@@ -5281,7 +5524,7 @@ class bootloader(GeneratedsSuper):
     validate_grub_console_patterns_ = [['^(console|gfxterm|serial)( (console|gfxterm|serial))*$']]
     def hasContent_(self):
         if (
-
+            self.bootloadersettings is not None
         ):
             return True
         else:
@@ -5303,6 +5546,7 @@ class bootloader(GeneratedsSuper):
         if self.hasContent_():
             outfile.write('>%s' % (eol_, ))
             self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='bootloader', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
             outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
         else:
             outfile.write('/>%s' % (eol_, ))
@@ -5329,7 +5573,12 @@ class bootloader(GeneratedsSuper):
             already_processed.add('grub_template')
             outfile.write(' grub_template=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.grub_template), input_name='grub_template')), ))
     def exportChildren(self, outfile, level, namespaceprefix_='', name_='bootloader', fromsubclass_=False, pretty_print=True):
-        pass
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.bootloadersettings is not None:
+            self.bootloadersettings.export(outfile, level, namespaceprefix_, name_='bootloadersettings', pretty_print=pretty_print)
     def build(self, node):
         already_processed = set()
         self.buildAttributes(node, node.attrib, already_processed)
@@ -5377,7 +5626,11 @@ class bootloader(GeneratedsSuper):
             already_processed.add('grub_template')
             self.grub_template = value
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
-        pass
+        if nodeName_ == 'bootloadersettings':
+            obj_ = bootloadersettings.factory()
+            obj_.build(child_)
+            self.bootloadersettings = obj_
+            obj_.original_tagname_ = 'bootloadersettings'
 # end class bootloader
 
 
@@ -6314,6 +6567,121 @@ class luksformat(GeneratedsSuper):
             self.option.append(obj_)
             obj_.original_tagname_ = 'option'
 # end class luksformat
+
+
+class bootloadersettings(GeneratedsSuper):
+    """Additional bootloader settings"""
+    subclass = None
+    superclass = None
+    def __init__(self, shimoption=None, installoption=None, configoption=None):
+        self.original_tagname_ = None
+        if shimoption is None:
+            self.shimoption = []
+        else:
+            self.shimoption = shimoption
+        if installoption is None:
+            self.installoption = []
+        else:
+            self.installoption = installoption
+        if configoption is None:
+            self.configoption = []
+        else:
+            self.configoption = configoption
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, bootloadersettings)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if bootloadersettings.subclass:
+            return bootloadersettings.subclass(*args_, **kwargs_)
+        else:
+            return bootloadersettings(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_shimoption(self): return self.shimoption
+    def set_shimoption(self, shimoption): self.shimoption = shimoption
+    def add_shimoption(self, value): self.shimoption.append(value)
+    def insert_shimoption_at(self, index, value): self.shimoption.insert(index, value)
+    def replace_shimoption_at(self, index, value): self.shimoption[index] = value
+    def get_installoption(self): return self.installoption
+    def set_installoption(self, installoption): self.installoption = installoption
+    def add_installoption(self, value): self.installoption.append(value)
+    def insert_installoption_at(self, index, value): self.installoption.insert(index, value)
+    def replace_installoption_at(self, index, value): self.installoption[index] = value
+    def get_configoption(self): return self.configoption
+    def set_configoption(self, configoption): self.configoption = configoption
+    def add_configoption(self, value): self.configoption.append(value)
+    def insert_configoption_at(self, index, value): self.configoption.insert(index, value)
+    def replace_configoption_at(self, index, value): self.configoption[index] = value
+    def hasContent_(self):
+        if (
+            self.shimoption or
+            self.installoption or
+            self.configoption
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', name_='bootloadersettings', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('bootloadersettings')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='bootloadersettings')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='bootloadersettings', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='bootloadersettings'):
+        pass
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='bootloadersettings', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for shimoption_ in self.shimoption:
+            shimoption_.export(outfile, level, namespaceprefix_, name_='shimoption', pretty_print=pretty_print)
+        for installoption_ in self.installoption:
+            installoption_.export(outfile, level, namespaceprefix_, name_='installoption', pretty_print=pretty_print)
+        for configoption_ in self.configoption:
+            configoption_.export(outfile, level, namespaceprefix_, name_='configoption', pretty_print=pretty_print)
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        pass
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        if nodeName_ == 'shimoption':
+            obj_ = shimoption.factory()
+            obj_.build(child_)
+            self.shimoption.append(obj_)
+            obj_.original_tagname_ = 'shimoption'
+        elif nodeName_ == 'installoption':
+            obj_ = installoption.factory()
+            obj_.build(child_)
+            self.installoption.append(obj_)
+            obj_.original_tagname_ = 'installoption'
+        elif nodeName_ == 'configoption':
+            obj_ = configoption.factory()
+            obj_.build(child_)
+            self.configoption.append(obj_)
+            obj_.original_tagname_ = 'configoption'
+# end class bootloadersettings
 
 
 class environment(GeneratedsSuper):
@@ -8943,7 +9311,9 @@ __all__ = [
     "archive",
     "argument",
     "bootloader",
+    "bootloadersettings",
     "collectionModule",
+    "configoption",
     "containerconfig",
     "description",
     "dracut",
@@ -8960,6 +9330,7 @@ __all__ = [
     "include",
     "initrd",
     "installmedia",
+    "installoption",
     "k_source",
     "label",
     "labels",
@@ -8979,6 +9350,7 @@ __all__ = [
     "profiles",
     "repository",
     "requires",
+    "shimoption",
     "signing",
     "size",
     "source",

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1026,6 +1026,61 @@ class XMLState:
             return bootloader.get_targettype()
         return None
 
+    def get_build_type_bootloader_settings_section(self) -> Any:
+        """
+        First bootloadersettings section from the build
+        type bootloader section
+
+        :return: <bootloadersettings> section reference
+
+        :rtype: xml_parse::bootloadersettings
+        """
+        bootloader_section = self.get_build_type_bootloader_section()
+        bootloader_settings_section = None
+        if bootloader_section:
+            bootloader_settings_section = \
+                bootloader_section.get_bootloadersettings()
+        return bootloader_settings_section
+
+    def get_bootloader_options(self, option_type: str) -> List[str]:
+        """
+        List of custom options used in the process to
+        run bootloader setup workloads
+        """
+        result: List[str] = []
+        bootloader_settings = self.get_build_type_bootloader_settings_section()
+        if bootloader_settings:
+            options = []
+            if option_type == 'shim':
+                options = bootloader_settings.get_shimoption()
+            elif option_type == 'install':
+                options = bootloader_settings.get_installoption()
+            elif option_type == 'config':
+                options = bootloader_settings.get_configoption()
+            for option in options:
+                result.append(option.get_name())
+                if option.get_value():
+                    result.append(option.get_value())
+        return result
+
+    def get_bootloader_shim_options(self) -> List[str]:
+        """
+        List of custom options used in the process to setup secure boot
+        """
+        return self.get_bootloader_options('shim')
+
+    def get_bootloader_install_options(self) -> List[str]:
+        """
+        List of custom options used in the bootloader installation
+        """
+        return self.get_bootloader_options('install')
+
+    def get_bootloader_config_options(self) -> List[str]:
+        """
+        List of custom options used in the bootloader configuration
+        """
+        return self.get_bootloader_options('config')
+
     def get_build_type_oemconfig_section(self) -> Any:
         """
         First oemconfig section from the build type section

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -115,6 +115,16 @@
     </preferences>
     <preferences profiles="vmxSimpleFlavour">
         <type image="oem" filesystem="ext3" format="vmdk" kernelcmdline="splash" bootpartition="false">
+            <bootloader name="grub2">
+                <bootloadersettings>
+                    <shimoption name="--foo" value="bar"/>
+                    <shimoption name="--suse-we-adapt-you-succeed"/>
+                    <installoption name="--A" value="123"/>
+                    <installoption name="B"/>
+                    <configoption name="--joe"/>
+                    <configoption name="-x"/>
+                </bootloadersettings>
+            </bootloader>
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -114,7 +114,8 @@ class TestBootLoaderConfigGrub2:
                 'grub_directory_name': 'grub2',
                 'boot_is_crypto': True,
                 'crypto_disk': True,
-                'targetbase': 'rootdev'
+                'targetbase': 'rootdev',
+                'config_options': ['--set-trusted-boot']
             }
         )
         self.bootloader.cmdline = 'some-cmdline root=UUID=foo'
@@ -740,7 +741,8 @@ class TestBootLoaderConfigGrub2:
                 '"some-cmdline root=UUID=foo failsafe-options"'
             ),
             call('LOADER_LOCATION', 'mbr'),
-            call('LOADER_TYPE', 'grub2')
+            call('LOADER_TYPE', 'grub2'),
+            call('TRUSTED_BOOT', 'yes')
         ]
         self.firmware.efi_mode = Mock(
             return_value='uefi'
@@ -755,7 +757,8 @@ class TestBootLoaderConfigGrub2:
             ),
             call('LOADER_LOCATION', 'none'),
             call('LOADER_TYPE', 'grub2-efi'),
-            call('SECURE_BOOT', 'yes')
+            call('SECURE_BOOT', 'yes'),
+            call('TRUSTED_BOOT', 'yes')
         ]
 
     @patch('os.path.exists')

--- a/test/unit/bootloader/install/grub2_test.py
+++ b/test/unit/bootloader/install/grub2_test.py
@@ -33,7 +33,9 @@ class TestBootLoaderInstallGrub2:
                 'volume_device': 'device'
             }},
             'firmware': self.firmware,
-            'target_removable': None
+            'target_removable': None,
+            'install_options': [],
+            'shim_options': []
         }
 
         self.root_mount = mock.Mock()

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -353,7 +353,9 @@ class TestDiskBuilder:
                 'firmware': self.firmware,
                 'target_removable': None,
                 'efi_device': '/dev/efi-device',
-                'prep_device': '/dev/prep-device'
+                'prep_device': '/dev/prep-device',
+                'install_options': [],
+                'shim_options': []
             }
         )
         self.setup.call_edit_boot_config_script.assert_called_once_with(
@@ -709,7 +711,9 @@ class TestDiskBuilder:
                 'firmware': self.firmware,
                 'target_removable': None,
                 'efi_device': '/dev/efi-device',
-                'prep_device': '/dev/prep-device'
+                'prep_device': '/dev/prep-device',
+                'install_options': [],
+                'shim_options': []
             }
         )
         assert self.setup.script_exists.call_args_list == [

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1104,3 +1104,16 @@ class TestXMLState:
 
     def test_get_bootstrap_package_name(self):
         assert self.apt_state.get_bootstrap_package_name() == 'bootstrap-me'
+
+    def test_get_bootloader_options(self):
+        xml_data = self.description.load()
+        state = XMLState(xml_data, ['vmxSimpleFlavour'], 'oem')
+        assert state.get_bootloader_shim_options() == [
+            '--foo', 'bar', '--suse-we-adapt-you-succeed'
+        ]
+        assert state.get_bootloader_install_options() == [
+            '--A', '123', 'B'
+        ]
+        assert state.get_bootloader_config_options() == [
+            '--joe', '-x'
+        ]


### PR DESCRIPTION
Allow to specify an optional <bootloadersettings> element inside of the <bootloader> section. The information is used to specify custom arguments for the tools called in a bootloader setup procedure, e.g shim-install, grub-install or grub-mkconfig. kiwi does not judge on the given parameters and if the provided data is effectively used depends on the individual bootloader implementation. In this commit the data will be effectively handled if bootloader="grub2" is configured. More precisely the custom additions to support SUSE's TPM model with grub2 can be configured as follows:

```xml
<bootloadersettings>
    <shimoption name="--suse-enable-tpm"/>
    <installoption name="--suse-enable-tpm"/>
    <configoption name="--set-trusted-boot"/>
</bootloadersettings>
```

This Fixes #2224

