### PR TITLE
Fix evaluation of write partition and parameters for overlayroot setup

### DIFF
--- a/build-tests/arm/tumbleweed/test-image-rpi-overlay/appliance.kiwi
+++ b/build-tests/arm/tumbleweed/test-image-rpi-overlay/appliance.kiwi
@@ -13,7 +13,7 @@
         <keytable>us</keytable>
         <timezone>UTC</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
-        <type image="oem" filesystem="xfs" firmware="efi" kernelcmdline="loglevel=3 splash=silent plymouth.enable=0 console=tty0 rd.root.overlay.readonly" efipartsize="64" efiparttable="msdos" editbootinstall="uboot-image-raspberrypi4-install" overlayroot="true">
+        <type image="oem" filesystem="xfs" firmware="efi" kernelcmdline="loglevel=3 splash=silent plymouth.enable=0 console=tty0 rd.root.overlay.temporary" efipartsize="64" efiparttable="msdos" editbootinstall="uboot-image-raspberrypi4-install" overlayroot="true">
             <bootloader name="grub2" console="serial" timeout="10"/>
             <oemconfig>
                 <oem-swap>false</oem-swap>

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -714,22 +714,21 @@ embed_verity_metadata="true|false":
 overlayroot="true|false":
   For the `oem` type only, specifies to use an `overlayfs` based root
   filesystem consisting out of a squashfs compressed read-only root
-  filesystem combined with a write-partition or tmpfs.
-  The optional kernel boot parameter `rd.root.overlay.readonly` can
+  filesystem combined with an optional write-partition or tmpfs.
+  The optional kernel boot parameter `rd.root.overlay.temporary` can
   be used to point the write area into a `tmpfs` instead of
-  the existing persistent write-partition. In this mode all
-  written data is temporary until reboot of the system. The kernel
-  boot parameter `rd.root.overlay.size` can be used to configure
-  the size for the `tmpfs` that is used for the `overlayfs` mount
-  process if `rd.root.overlay.readonly` is requested. That size
-  basically configures the amount of space available for writing
-  new data during the runtime of the system. The default value
-  is set to `50%` which means one half of the available RAM space can
-  be used for writing new data. By default the persistent
-  write-partition is used. The size of that partition can be
-  influenced via the optional `<size>` element in the `<type>`
-  section or via the optional `<oem-resize>` element in the
-  `<oemconfig>` section of the XML description. Setting a fixed
+  a persistent write-partition. In this mode all written data is
+  temporary until reboot of the system. The kernel boot parameter
+  `rd.root.overlay.size` can be used to configure the size for the
+  `tmpfs` that is used for the `overlayfs` mount process if
+  `rd.root.overlay.temporary` is requested. That size configures the
+  amount of space available for writing new data during the runtime
+  of the system. The default value is set to `50%` which means one
+  half of the available RAM space can be used for writing new data.
+  By default the persistent write-partition is used. The size of that
+  partition can be influenced via the optional `<size>` element in
+  the `<type>` section or via the optional `<oem-resize>` element in
+  the `<oemconfig>` section of the XML description. Setting a fixed
   `<size>` value will set the size of the image disk to that
   value and results in an image file of that size. The available
   space for the write partition is that size reduced by the
@@ -737,6 +736,12 @@ overlayroot="true|false":
   element is set to `true` an eventually given `<size>` element
   will not have any effect because the write partition will be
   resized on first boot to the available disk space.
+  To disable the use of any overlay the kernel boot parameter
+  `rd.root.overlay.readonly` can be used. It takes precedence
+  over all other overlay kernel parameters because it leads to the
+  deactivation of any overlayfs based action and just boots up with
+  the squashfs root filesystem. In fact this mode is the same
+  as not installing the `kiwi-overlay` dracut module.
 
 overlayroot_write_partition="true|false":
   For the `oem` type only, allows to specify if the extra read-write

--- a/dracut/modules.d/90kiwi-overlay/kiwi-generator.sh
+++ b/dracut/modules.d/90kiwi-overlay/kiwi-generator.sh
@@ -16,19 +16,44 @@ GENERATOR_DIR="$2"
 [ -z "$GENERATOR_DIR" ] && exit 1
 [ -d "$GENERATOR_DIR" ] || mkdir "$GENERATOR_DIR"
 
-OVERLAY_BASE="$(getOverlayBaseDirectory)"
-ROOTFLAGS="$(getarg rootflags)"
-{
-    echo "[Unit]"
-    echo "Before=initrd-root-fs.target"
-    echo "DefaultDependencies=no"
-    echo "[Mount]"
-    echo "Where=/sysroot"
-    echo "What=OverlayOS_rootfs"
-    echo "Options=${ROOTFLAGS},lowerdir=${OVERLAY_BASE}/rootfsbase,upperdir=${OVERLAY_BASE}/overlayfs/rw,workdir=${OVERLAY_BASE}/overlayfs/work"
-    echo "Type=overlay"
-    _dev=OverlayOS_rootfs
-} > "$GENERATOR_DIR"/sysroot.mount
+if getargbool 0 rd.root.overlay.readonly; then
+    case "${overlayroot}" in
+        overlay:PARTUUID=*|PARTUUID=*) \
+            root="${root#overlay:}"
+            root="${root//\//\\x2f}"
+            root="block:/dev/disk/by-partuuid/${root#PARTUUID=}"
+        ;;
+        overlay:PARTLABEL=*|PARTLABEL=*) \
+            root="${root#overlay:}"
+            root="${root//\//\\x2f}"
+            root="block:/dev/disk/by-partlabel/${root#PARTLABEL=}"
+        ;;
+    esac
+    {
+        echo "[Unit]"
+        echo "Before=initrd-root-fs.target"
+        echo "DefaultDependencies=no"
+        echo "[Mount]"
+        echo "Where=/sysroot"
+        echo "What=${root#block:}"
+        echo "Type=squashfs"
+        _dev=ReadOnlyOS_rootfs
+    } > "$GENERATOR_DIR"/sysroot.mount
+else
+    OVERLAY_BASE="$(getOverlayBaseDirectory)"
+    ROOTFLAGS="$(getarg rootflags)"
+    {
+        echo "[Unit]"
+        echo "Before=initrd-root-fs.target"
+        echo "DefaultDependencies=no"
+        echo "[Mount]"
+        echo "Where=/sysroot"
+        echo "What=OverlayOS_rootfs"
+        echo "Options=${ROOTFLAGS},lowerdir=${OVERLAY_BASE}/rootfsbase,upperdir=${OVERLAY_BASE}/overlayfs/rw,workdir=${OVERLAY_BASE}/overlayfs/work"
+        echo "Type=overlay"
+        _dev=OverlayOS_rootfs
+    } > "$GENERATOR_DIR"/sysroot.mount
+fi
 
 if [ ! -e "$GENERATOR_DIR/initrd-root-fs.target.requires/sysroot.mount" ]; then
     mkdir -p "$GENERATOR_DIR"/initrd-root-fs.target.requires

--- a/dracut/modules.d/90kiwi-overlay/kiwi-overlay-root.sh
+++ b/dracut/modules.d/90kiwi-overlay/kiwi-overlay-root.sh
@@ -38,15 +38,7 @@ function initGlobalDevices {
     elif [[ "${root_cmdline}" =~ "overlay:aoe=" ]];then
         read_only_partition="/dev/etherd/$(echo "${root_cmdline}"|cut -f2 -d=)"
     else
-        write_partition="$1"
-        root_disk=$(
-            lsblk -p -n -r -s -o NAME,TYPE "${write_partition}" \
-                | grep disk | cut -f1 -d ' '
-        )
-        read_only_partition=$(
-            lsblk -p -r --fs -o NAME,FSTYPE "${root_disk}" \
-                | grep squashfs | head -n 1 | cut -f1 -d ' '
-        )
+        read_only_partition="$1"
     fi
 }
 

--- a/dracut/modules.d/90kiwi-overlay/kiwi-overlay-root.sh
+++ b/dracut/modules.d/90kiwi-overlay/kiwi-overlay-root.sh
@@ -100,7 +100,10 @@ loadKernelModules
 mountReadOnlyRootImage
 
 # prepare overlay for generated systemd OverlayOS_rootfs service
-if [ -z "${write_partition}" ] || getargbool 0 rd.root.overlay.readonly; then
+if getargbool 0 rd.root.overlay.readonly; then
+    # no overlay requested, readonly system
+    :
+elif [ -z "${write_partition}" ] || getargbool 0 rd.root.overlay.temporary; then
     prepareTemporaryOverlay
 else
     preparePersistentOverlay

--- a/dracut/modules.d/90kiwi-overlay/parse-kiwi-overlay.sh
+++ b/dracut/modules.d/90kiwi-overlay/parse-kiwi-overlay.sh
@@ -31,6 +31,12 @@ case "${overlayroot}" in
         root="block:/dev/disk/by-partuuid/${root#PARTUUID=}"
         rootok=1
     ;;
+    overlay:PARTLABEL=*|PARTLABEL=*) \
+        root="${root#overlay:}"
+        root="${root//\//\\x2f}"
+        root="block:/dev/disk/by-partlabel/${root#PARTLABEL=}"
+        rootok=1
+    ;;
     overlay:LABEL=*|LABEL=*) \
         root="${root#overlay:}"
         root="${root//\//\\x2f}"

--- a/kiwi/bootloader/config/bootloader_spec_base.py
+++ b/kiwi/bootloader/config/bootloader_spec_base.py
@@ -100,7 +100,12 @@ class BootLoaderSpecBase(BootLoaderConfigBase):
         self.custom_args['initrd'] = initrd
         self.custom_args['boot_options'] = boot_options
         self.cmdline = ' '.join(
-            [self.get_boot_cmdline(boot_options.get('root_device'))]
+            [
+                self.get_boot_cmdline(
+                    boot_options.get('root_device'),
+                    boot_options.get('write_device')
+                )
+            ]
         )
         self.setup_loader(self.target.disk)
         self.set_loader_entry(self.target.disk)

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -176,7 +176,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             with open(config_file, 'w') as config:
                 config.write(self.config)
 
-    def write_meta_data(self, root_device=None, boot_options=''):
+    def write_meta_data(
+        self, root_device=None, write_device=None, boot_options=''
+    ):
         """
         Write bootloader setup meta data files
 
@@ -186,16 +188,19 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         * etc/sysconfig/bootloader
 
         :param string root_device: root device node
+        :param string write_device: overlay root write device node
         :param string boot_options: kernel options as string
         :param bool iso_boot: indicate target is an ISO
         """
         self.cmdline = ' '.join(
-            [self.get_boot_cmdline(root_device), boot_options]
+            [self.get_boot_cmdline(root_device, write_device), boot_options]
         )
         self.cmdline_failsafe = ' '.join(
             [self.cmdline, Defaults.get_failsafe_kernel_options(), boot_options]
         )
-        self.root_reference = self._get_root_cmdline_parameter(root_device)
+        self.root_reference = self._get_root_cmdline_parameter(
+            root_device
+        )
 
         self._setup_default_grub()
         self._setup_sysconfig_bootloader()

--- a/kiwi/bootloader/config/isolinux.py
+++ b/kiwi/bootloader/config/isolinux.py
@@ -74,7 +74,7 @@ class BootLoaderConfigIsoLinux(BootLoaderConfigBase):
         # isolinux counts the timeout in units of 1/10 sec
         self.timeout = self.get_boot_timeout_seconds() * 10
         self.continue_on_timeout = self.get_continue_on_timeout()
-        self.cmdline = self.get_boot_cmdline()
+        self.cmdline = self.get_boot_cmdline(boot_device=None)
         self.cmdline_failsafe = ' '.join(
             [self.cmdline, Defaults.get_failsafe_kernel_options()]
         )

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -344,12 +344,15 @@ class TestDiskBuilder:
             '0815'
         )
         self.bootloader_config.write_meta_data.assert_called_once_with(
-            root_device='/dev/root-device', boot_options=''
+            root_device='/dev/readonly-root-device',
+            write_device='/dev/root-device',
+            boot_options=''
         )
         self.bootloader_config.setup_disk_image_config.assert_called_once_with(
             boot_options={
                 'boot_device': '/dev/boot-device',
                 'root_device': '/dev/readonly-root-device',
+                'write_device': '/dev/root-device',
                 'firmware': self.firmware,
                 'target_removable': None,
                 'efi_device': '/dev/efi-device',
@@ -702,12 +705,15 @@ class TestDiskBuilder:
             '0815'
         )
         self.bootloader_config.write_meta_data.assert_called_once_with(
-            root_device='/dev/root-device', boot_options=''
+            root_device='/dev/readonly-root-device',
+            write_device='/dev/root-device',
+            boot_options=''
         )
         self.bootloader_config.setup_disk_image_config.assert_called_once_with(
             boot_options={
                 'boot_device': '/dev/boot-device',
                 'root_device': '/dev/readonly-root-device',
+                'write_device': '/dev/root-device',
                 'firmware': self.firmware,
                 'target_removable': None,
                 'efi_device': '/dev/efi-device',


### PR DESCRIPTION
The device selection for the read-only and read-write devices in an overlayroot setup was implicitly done in the ```kiwi-overlay``` dracut module by only reading the ```root=``` information. This is a concept which barely works and should be refactored in a way that the ```root=``` information always points to the root device and that an eventually existing write location is *explicitly* provided via the existing ```rd.root.overlay.write``` parameter which is allowed to be overwritten for providing an alternative write location. Making this information consistent and explicit on the kernel commandline simplifies the dracut code to consume this information correctly. This Fixes #2251

In addition there is also an inconsistency fixed with the ```rd.root.overlay.readonly``` parameter. In contrast to the name it does not set the system read-only but produced a tmpfs based overlay. Thus the behavior of the option has been fixed to do what the name says and a new parameter ```rd.root.overlay.temporary``` has been added to specify on a temporary overlay based on a tmpfs. The documentation regarding the parameters has been adapted accordingly