### PR TITLE
Fix permissions of live ISO system files

### DIFF
--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -278,6 +278,7 @@ class LiveImageBuilder:
             container_image.name
         )
         Path.create(self.media_dir.name + '/LiveOS')
+        os.chmod(container_image.name, 0o644)
         shutil.copy(
             container_image.name, self.media_dir.name + '/LiveOS/squashfs.img'
         )
@@ -367,6 +368,7 @@ class LiveImageBuilder:
 
         # Move initrd to iso filesystem structure
         if os.path.exists(self.boot_image.initrd_filename):
+            os.chmod(self.boot_image.initrd_filename, 0o644)
             shutil.move(
                 self.boot_image.initrd_filename, boot_path + '/initrd'
             )

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -144,9 +144,10 @@ class TestLiveImageBuilder:
     @patch('kiwi.builder.live.SystemSize')
     @patch('kiwi.builder.live.Defaults.get_grub_boot_directory_name')
     @patch('os.path.exists')
+    @patch('os.chmod')
     def test_create_overlay_structure(
-        self, mock_exists, mock_grub_dir, mock_size, mock_filesystem,
-        mock_isofs, mock_Iso, mock_tag, mock_shutil,
+        self, mock_chmod, mock_exists, mock_grub_dir, mock_size,
+        mock_filesystem, mock_isofs, mock_Iso, mock_tag, mock_shutil,
         mock_Temporary, mock_setup_media_loader_directory, mock_DeviceProvider
     ):
         mock_exists.return_value = True
@@ -217,6 +218,9 @@ class TestLiveImageBuilder:
         assert mock_shutil.copy.call_args_list == [
             call('kiwi-tmpfile', 'temp-squashfs/LiveOS/rootfs.img'),
             call('kiwi-tmpfile', 'temp_media_dir/LiveOS/squashfs.img')
+        ]
+        assert mock_chmod.call_args_list == [
+            call('initrd', 0o644), call('kiwi-tmpfile', 0o644)
         ]
 
         self.setup.call_edit_boot_config_script.assert_called_once_with(


### PR DESCRIPTION
Make sure initrd and squashfs.img takes permissions o644 This Fixes #2246

