### PR TITLE
Use module anymarkup-core directly instead of anymarkup

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -18,7 +18,8 @@ xattr==0.9.3
 requests
 
 # markup support
-anymarkup
+anymarkup-core
+xmltodict
 
 # json support that also knows about tuples
 simplejson

--- a/kiwi/markup/any.py
+++ b/kiwi/markup/any.py
@@ -17,6 +17,7 @@
 #
 from typing import Any
 import importlib
+import importlib.util
 
 # project
 from kiwi.utils.temporary import Temporary
@@ -40,7 +41,10 @@ class MarkupAny(MarkupBase):
         input format and can convert YAML, JSON and INI to XML
         """
         try:
-            self.anymarkup: Any = importlib.import_module('anymarkup_core')
+            anymarkup_mod = 'anymarkup'
+            if importlib.util.find_spec('anymarkup_core'):
+                anymarkup_mod = 'anymarkup_core'
+            self.anymarkup: Any = importlib.import_module(anymarkup_mod)
         except Exception as issue:
             raise KiwiAnyMarkupPluginError(issue)
         try:

--- a/kiwi/markup/any.py
+++ b/kiwi/markup/any.py
@@ -40,7 +40,7 @@ class MarkupAny(MarkupBase):
         input format and can convert YAML, JSON and INI to XML
         """
         try:
-            self.anymarkup: Any = importlib.import_module('anymarkup')
+            self.anymarkup: Any = importlib.import_module('anymarkup_core')
         except Exception as issue:
             raise KiwiAnyMarkupPluginError(issue)
         try:

--- a/kiwi/markup/xml.py
+++ b/kiwi/markup/xml.py
@@ -42,5 +42,5 @@ class MarkupXML(MarkupBase):
         Conversion into YAML format not supported by base XML markup
         """
         raise KiwiMarkupConversionError(
-            'Conversion to YAML not supported, install anymarkup module'
+            'Conversion to YAML not supported, install anymarkup-core module'
         )

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -300,7 +300,7 @@ Recommends:     jing
 Requires:       python%{python3_pkgversion}-solv
 %endif
 %if ! (0%{?rhel} && 0%{?rhel} < 8)
-Recommends:     python%{python3_pkgversion}-anymarkup
+Recommends:     python%{python3_pkgversion}-anymarkup-core
 %endif
 
 %description -n kiwi-systemdeps-image-validation

--- a/test/unit/markup/any_test.py
+++ b/test/unit/markup/any_test.py
@@ -16,7 +16,7 @@ class TestMarkupXML:
     def setup_method(self, cls):
         self.setup()
 
-    @patch('anymarkup.parse_file')
+    @patch('anymarkup_core.parse_file')
     def test_raises_markup_conversion_error(self, mock_anymarkup_parse_file):
         mock_anymarkup_parse_file.side_effect = Exception
         with raises(KiwiDescriptionInvalid):


### PR DESCRIPTION
Module `anymarkup` is just a wrapper for `anymarkup-core` and was recently dropped from openSUSE.
