### PR TITLE
Fix Arch Linux EFI install ISO integration test

### DIFF
--- a/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
+++ b/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
@@ -46,12 +46,11 @@
     <preferences profiles="Disk">
         <!--
              KIWI does not natively provide EFI support for Arch Linux,
-             because of that the editbootinstall script is used to hot pacth
-             grub.cfg file. This hotpatch only applies for disk images
-             therefore the installation ISO does not support EFI
+             because of that the editbootinstall script and iso_boot.template
+             is used to hot patch grub.cfg file.
         -->
         <type image="oem" filesystem="ext4" installiso="true" installboot="install" kernelcmdline="console=ttyS0" editbootinstall="editbootinstall_arch.sh" firmware="efi">
-            <bootloader name="grub2" console="serial" timeout="10"/>
+            <bootloader name="grub2" console="serial" timeout="10" grub_template="iso_boot.template"/>
             <oemconfig>
                 <oem-unattended>true</oem-unattended>
             </oemconfig>

--- a/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
+++ b/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
@@ -31,8 +31,8 @@
         <rpm-check-signatures>false</rpm-check-signatures>
     </preferences>
     <preferences profiles="Live">
-        <type image="iso" flags="overlay" hybridpersistent_filesystem="ext4" hybridpersistent="true" kernelcmdline="console=ttyS0">
-            <bootloader name="grub2" console="serial"/>
+        <type image="iso" firmware="efi" flags="overlay" hybridpersistent_filesystem="ext4" hybridpersistent="true" kernelcmdline="console=ttyS0">
+            <bootloader name="grub2" console="serial" grub_template="iso_boot.template"/>
         </type>
     </preferences>
     <preferences profiles="Virtual">

--- a/build-tests/x86/archlinux/test-image-live-disk-kis/iso_boot.template
+++ b/build-tests/x86/archlinux/test-image-live-disk-kis/iso_boot.template
@@ -1,0 +1,56 @@
+set btrfs_relative_path="y"
+export btrfs_relative_path
+search ${search_params}
+set default=${default_boot}
+set timeout=${boot_timeout}
+set timeout_style=${boot_timeout_style}
+set linux=linux
+set initrd=initrd
+export linux initrd
+if [ "$${grub_platform}" = "efi" ]; then
+    echo "Please press 't' to show the boot menu on this console"
+fi
+set gfxmode=${gfxmode}
+set font=($$root)${bootpath}/${boot_directory_name}/fonts/unicode.pf2
+set ascii_font=${boot_directory_name}/themes/${theme}/ascii.pf2
+set sans_bold_14_font=${boot_directory_name}/themes/${theme}/DejaVuSans-Bold14.pf2
+set sans_10_font=${boot_directory_name}/themes/${theme}/DejaVuSans10.pf2
+set sans_12_font=${boot_directory_name}/themes/${theme}/DejaVuSans12.pf2
+if [ -f $${font} ];then
+  loadfont $${font}
+fi
+if [ -f ($$root)/boot/$${ascii_font} ];then
+  loadfont ($$root)/boot/$${ascii_font}
+fi
+if [ -f ($$root)/boot/$${sans_bold_14_font} ];then
+  loadfont ($$root)/boot/$${sans_bold_14_font}
+fi
+if [ -f ($$root)/boot/$${sans_10_font} ];then
+  loadfont ($$root)/boot/$${sans_10_font}
+fi
+if [ -f ($$root)/boot/$${sans_12_font} ];then
+  loadfont ($$root)/boot/$${sans_12_font}
+fi
+if [ -f ($$root)/boot/${boot_directory_name}/themes/${theme}/theme.txt ];then
+  set theme=($$root)/boot/${boot_directory_name}/themes/${theme}/theme.txt
+fi
+terminal_input ${terminal_setup}
+terminal_output ${terminal_setup}
+
+menuentry "${title}" --class os --unrestricted {
+    set gfxpayload=keep
+    echo Loading kernel...
+    $$linux ($$root)${bootpath}/${kernel_file} $${extra_cmdline} $${isoboot} ${boot_options}
+    echo Loading initrd...
+    $$initrd ($$root)${bootpath}/${initrd_file}
+}
+menuentry "Failsafe -- ${title}" --class os --unrestricted {
+    set gfxpayload=keep
+    echo Loading kernel...
+    $$linux ($$root)${bootpath}/${kernel_file} $${extra_cmdline} $${isoboot} ${failsafe_boot_options}
+    echo Loading initrd...
+    $$initrd ($$root)${bootpath}/${initrd_file}
+}
+menuentry "Boot from Hard Disk" --class os --unrestricted {
+    exit
+}

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -316,7 +316,12 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             'efi_image_name': Defaults.get_efi_image_name(self.arch),
             'terminal_setup': self.terminal
         }
-        if self.multiboot:
+        custom_template_path = self._get_custom_template()
+        if custom_template_path:
+            log.info('--> Using custom boot template')
+            with open(custom_template_path) as custom_template_file:
+                template = Template(custom_template_file.read())
+        elif self.multiboot:
             log.info('--> Using multiboot install template')
             parameters['hypervisor'] = hypervisor
             template = self.grub2.get_multiboot_install_template(

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -793,6 +793,38 @@ class TestBootLoaderConfigGrub2:
         self.bootloader.setup_live_image_config(self.mbrid)
         self.grub2.get_iso_template.assert_called_once()
 
+    @patch('os.path.exists')
+    def test_setup_install_image_config_custom_template(self, mock_exists):
+        bootloader = Mock()
+        bootloader.get_grub_template.return_value = "example.template"
+        self.bootloader.xml_state.build_type.bootloader.append(bootloader)
+        mock_exists.return_value = True
+        self.bootloader.multiboot = False
+        with patch('builtins.open') as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            file_handle.read.return_value = "example template contents"
+            self.bootloader.setup_install_image_config(self.mbrid)
+        assert self.bootloader.config == "example template contents"
+
+    @patch('os.path.exists')
+    def test_setup_install_image_config_custom_template_file_does_not_exist(self, mock_exists):
+        bootloader = Mock()
+        bootloader.get_grub_template.return_value = "example.template"
+        self.bootloader.xml_state.build_type.bootloader.append(bootloader)
+        mock_exists.return_value = False
+        self.bootloader.multiboot = False
+        with raises(KiwiFileNotFound):
+            self.bootloader.setup_install_image_config(self.mbrid)
+
+    def test_setup_install_image_config_custom_template_not_set(self):
+        bootloader = Mock()
+        bootloader.get_grub_template.return_value = ""
+        self.bootloader.xml_state.build_type.bootloader.append(bootloader)
+        self.bootloader.multiboot = False
+        self.bootloader.setup_install_image_config(self.mbrid)
+        self.grub2.get_install_template.assert_called_once()
+
     def test_setup_live_image_config_multiboot(self):
         self.bootloader.multiboot = True
         self.bootloader.setup_live_image_config(self.mbrid)


### PR DESCRIPTION
kiwi has code in bootloader/template/grub2.py which uses linuxefi/initrdefi commands according to the configured grub_platform. These commands does not exist on Arch and therefore the integration test provides its own ISO template. This Fixes #2232


