### PR TITLE
Add selinux integration test for Leap

### DIFF
--- a/build-tests/x86/leap/test-image-disk-selinux/appliance.kiwi
+++ b/build-tests/x86/leap/test-image-disk-selinux/appliance.kiwi
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="7.5" name="kiwi-test-image-disk-selinux" displayname="Selinux">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>marcus.schaefer@gmail.com</contact>
+        <specification>Simple selinux disk, devel policy</specification>
+    </description>
+    <preferences>
+        <version>1.15.4</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>false</rpm-check-signatures>
+        <bootsplash-theme>bgrt</bootsplash-theme>
+        <bootloader-theme>openSUSE</bootloader-theme>
+        <type image="oem" filesystem="xfs" kernelcmdline="console=ttyS0 security=selinux selinux=1 enforcing=1" firmware="uefi" format="qcow2">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+            <bootloader name="grub2" console="serial" timeout="10"/>
+        </type>
+    </preferences>
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
+    </users>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-base-minimal_base"/>
+        <package name="restorecond"/>
+        <package name="policycoreutils"/>
+        <package name="setools-console"/>
+        <package name="selinux-policy-targeted"/>
+        <package name="selinux-policy-devel"/>
+        <package name="selinux-autorelabel"/>
+        <package name="bind-utils"/>
+        <package name="systemd"/>
+        <package name="plymouth-theme-bgrt"/>
+        <package name="grub2-branding-openSUSE"/>
+        <package name="iputils"/>
+        <package name="vim"/>
+        <package name="grub2"/>
+        <package name="grub2-x86_64-efi" arch="x86_64"/>
+        <package name="grub2-i386-pc"/>
+        <package name="syslinux"/>
+        <package name="lvm2"/>
+        <package name="plymouth"/>
+        <package name="fontconfig"/>
+        <package name="fonts-config"/>
+        <package name="tar"/>
+        <package name="parted"/>
+        <package name="openssh"/>
+        <package name="iproute2"/>
+        <package name="less"/>
+        <package name="bash-completion"/>
+        <package name="dhcp-client"/>
+        <package name="which"/>
+        <package name="kernel-default"/>
+        <package name="shim"/>
+        <package name="timezone"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+        <package name="cracklib-dict-full"/>
+        <package name="ca-certificates"/>
+        <package name="ca-certificates-mozilla"/>
+        <package name="openSUSE-release"/>
+    </packages>
+</image>

--- a/build-tests/x86/leap/test-image-disk-selinux/config.sh
+++ b/build-tests/x86/leap/test-image-disk-selinux/config.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# shellcheck disable=SC1091
+test -f /.kconfig && . /.kconfig
+
+set -ex
+
+#======================================
+# Setup baseproduct link
+#--------------------------------------
+suseSetupProduct
+
+#======================================
+# Delete auto relabel trigger
+#--------------------------------------
+rm -f /.autorelabel
+
+#======================================
+# Activate services
+#--------------------------------------
+suseInsertService sshd
+
+#======================================
+# Setup default target, multi-user
+#--------------------------------------
+baseSetRunlevel 3


### PR DESCRIPTION
SUSE systems supports both, apparmor and selinux, whereas apparmor is the default. As selinux requires to create security labels during build time of an image, this integration test checks if the labeling works for SUSE based OS'es. This Fixes #2244


