### PR TITLE
Fixed build of dracut-kiwi-verity

### DIFF
--- a/dracut/modules.d/80kiwi-verity/Makefile
+++ b/dracut/modules.d/80kiwi-verity/Makefile
@@ -2,7 +2,7 @@ buildroot ?= /
 
 CROSS_COMPILE ?=
 CC ?= $(CROSS_COMPILE)gcc
-CFLAGS += -Werror -Wall -Wextra -std=c17
+CFLAGS += -Werror -Wall -Wextra
 
 BINARY := kiwi-parse-verity
 

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -712,6 +712,10 @@ fi
 %files -n dracut-kiwi-overlay
 %{_usr}/lib/dracut/modules.d/90kiwi-overlay
 
+%files -n dracut-kiwi-verity
+%{_usr}/lib/dracut/modules.d/80kiwi-verity
+%{_bindir}/kiwi-parse-verity
+
 %if "%{_vendor}" != "debbuild"
 %ifarch %{ix86} x86_64
 %files -n kiwi-pxeboot


### PR DESCRIPTION
The spec file was missing the package definition to actually create the dracut-kiwi-verity package. In addition the fixed setting to the C standard 17 caused build errors for me on distributions that uses C standard 11/12.


