### PR TITLE
Make a proper use of `btrfs_relative_path` grub2 variable

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -1018,9 +1018,10 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
 
     def _create_early_boot_script_for_uuid_search(self, filename, uuid):
         with open(filename, 'w') as early_boot:
-            early_boot.write(
-                'set btrfs_relative_path="yes"{0}'.format(os.linesep)
-            )
+            if self.xml_state.build_type.get_btrfs_root_is_snapshot():
+                early_boot.write(
+                    'set btrfs_relative_path="yes"{0}'.format(os.linesep)
+                )
             if self.custom_args.get('boot_is_crypto'):
                 early_boot.write(
                     'insmod cryptodisk{0}'.format(os.linesep)
@@ -1054,9 +1055,10 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
 
     def _create_early_boot_script_for_mbrid_search(self, filename, mbrid):
         with open(filename, 'w') as early_boot:
-            early_boot.write(
-                'set btrfs_relative_path="yes"{0}'.format(os.linesep)
-            )
+            if self.xml_state.build_type.get_btrfs_root_is_snapshot():
+                early_boot.write(
+                    'set btrfs_relative_path="yes"{0}'.format(os.linesep)
+                )
             early_boot.write(
                 'search --file --set=root /boot/{0}{1}'.format(
                     mbrid.get_id(), os.linesep


### PR DESCRIPTION
This commit gates the inclusion of `btrfs_relative_path` variable in early boot grub2 configuration based on the `btrfs_root_is_snapshot` attribute. This SUSE specific grub variable is added by grub2-mkconfig according to the variable `SUSE_BTRFS_SNAPSHOT_BOOTING` in `/etc/default/grub`.

This commit alignes early boot grub2 setup use of `btrfs_relative_path` with the flag `SUSE_BTRFS_SNAPSHOT_BOOTING` included in `/etc/default/grub`.

Fixes bsc#1209165