### PR TITLE
Fix /.snapshots mounting in the btrfs volume manager

### DIFF
--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -122,17 +122,19 @@ class VolumeManagerBtrfs(VolumeManagerBase):
                 ['btrfs', 'subvolume', 'create', snapshot_volume]
             )
             os.chmod(snapshot_volume, 0o700)
-            volume_mount = MountManager(
-                device=self.device,
-                mountpoint=self.mountpoint + '/.snapshots'
-            )
-            self.subvol_mount_list.append(volume_mount)
             Path.create(snapshot_volume + '/1')
             snapshot = self.mountpoint + '/@/.snapshots/1/snapshot'
             Command.run(
-                ['btrfs', 'subvolume', 'snapshot', root_volume, snapshot]
+                ['btrfs', 'subvolume', 'create', snapshot]
             )
             self._set_default_volume('@/.snapshots/1/snapshot')
+            snapshot = self.mountpoint + '/@/.snapshots/1/snapshot'
+            # Mount /@/.snapshots as /.snapshots inside the root
+            snapshots_mount = MountManager(
+                device=self.device,
+                mountpoint=snapshot + '/.snapshots'
+            )
+            self.subvol_mount_list.append(snapshots_mount)
         else:
             self._set_default_volume('@')
 

--- a/test/unit/volume_manager/btrfs_test.py
+++ b/test/unit/volume_manager/btrfs_test.py
@@ -127,7 +127,7 @@ class TestVolumeManagerBtrfs:
 
         assert mock_mount.call_args_list == [
             call(device='/dev/storage', mountpoint='tmpdir'),
-            call(device='/dev/storage', mountpoint='tmpdir/.snapshots')
+            call(device='/dev/storage', mountpoint='tmpdir/@/.snapshots/1/snapshot/.snapshots')
         ]
         toplevel_mount.mount.assert_called_once_with([])
         assert mock_command.call_args_list == [
@@ -135,10 +135,7 @@ class TestVolumeManagerBtrfs:
             call(['btrfs', 'subvolume', 'create', 'tmpdir/@']),
             call(['btrfs', 'subvolume', 'create', 'tmpdir/@/.snapshots']),
             call(['mkdir', '-p', 'tmpdir/@/.snapshots/1']),
-            call([
-                'btrfs', 'subvolume', 'snapshot', 'tmpdir/@',
-                'tmpdir/@/.snapshots/1/snapshot'
-            ]),
+            call(['btrfs', 'subvolume', 'create', 'tmpdir/@/.snapshots/1/snapshot']),
             call(['btrfs', 'subvolume', 'list', 'tmpdir']),
             call(['btrfs', 'subvolume', 'set-default', '258', 'tmpdir'])
         ]


### PR DESCRIPTION
The /@/.snapshots subvolume was not mounted as /.snapshots in the root filesystem snapshot. This is now necessary for snapper to work.

While at it, create 1/snapshot as plain subvolume, it does not make sense to snapshot @ itself.

Testsuite needs updating before merging, but before I do that I'd like to understand what the old code was trying to do:

1. Why `btrfs subvol snapshot /@ /@/.snapshots/1/snapshot`?
2. Why did it mount `self.mountpoint + '/.snapshots'`? That's then next to `@`