### PR TITLE
Support EFI boot from squashfs

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -276,10 +276,11 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         # More details can be found in the individual methods.
         # One fine day the following fix methods can hopefully
         # be deleted...
-        self._fix_grub_to_support_dynamic_efi_and_bios_boot(config_file)
-        self._fix_grub_root_device_reference(config_file, boot_options)
-        self._fix_grub_loader_entries_boot_cmdline()
-        self._fix_grub_loader_entries_linux_and_initrd_paths()
+        if self.xml_state.build_type.get_overlayroot_write_partition() is not False:
+            self._fix_grub_to_support_dynamic_efi_and_bios_boot(config_file)
+            self._fix_grub_root_device_reference(config_file, boot_options)
+            self._fix_grub_loader_entries_boot_cmdline()
+            self._fix_grub_loader_entries_linux_and_initrd_paths()
 
         if self.firmware.efi_mode() and self.early_boot_script_efi:
             self._copy_grub_config_to_efi_path(
@@ -828,7 +829,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         if not lookup_path:
             lookup_path = self.boot_dir
         grub_image = Defaults.get_unsigned_grub_loader(lookup_path)
-        if grub_image:
+        if grub_image and self.xml_state.build_type.get_overlayroot_write_partition() is not False:
             log.info('--> Using prebuilt unsigned efi image')
             Command.run(
                 ['cp', grub_image, self._get_efi_image_name()]
@@ -1063,8 +1064,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 'set btrfs_relative_path="yes"{0}'.format(os.linesep)
             )
             early_boot.write(
-                'search --file --set=root /boot/{0}{1}'.format(
-                    mbrid.get_id(), os.linesep
+                'search --file --set=root /boot/mbrid{0}'.format(
+                    os.linesep
                 )
             )
             early_boot.write(

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1533,17 +1533,22 @@ class DiskBuilder:
                 # cleanup bootloader config resources taken prior to next steps
                 del self.bootloader_config
 
-            log.debug(
-                "custom arguments for bootloader installation %s",
-                custom_install_arguments
-            )
-            bootloader = BootLoaderInstall.new(
-                self.bootloader, self.root_dir, disk.storage_provider,
-                custom_install_arguments
-            )
-            if bootloader.install_required():
-                bootloader.install()
-            bootloader.secure_boot_install()
+            if self.root_filesystem_has_write_partition is not False:
+                log.debug(
+                    "custom arguments for bootloader installation %s",
+                    custom_install_arguments
+                )
+                bootloader = BootLoaderInstall.new(
+                    self.bootloader, self.root_dir, disk.storage_provider,
+                    custom_install_arguments
+                )
+                if bootloader.install_required():
+                    bootloader.install()
+                bootloader.secure_boot_install()
+            else:
+                log.warning(
+                    'No install of bootcode on read-only root possible'
+                )
 
         self.system_setup.call_edit_boot_install_script(
             self.diskname, boot_device.get_device()

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -626,6 +626,7 @@ class Defaults:
             'all_video',
             'xfs',
             'btrfs',
+            'squash4',
             'lvm',
             'luks',
             'gcry_rijndael',

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -1143,7 +1143,7 @@ class TestBootLoaderConfigGrub2:
                     'search_label', 'search_fs_file', 'search',
                     'search_fs_uuid', 'ls', 'normal', 'gzio', 'png', 'fat',
                     'gettext', 'font', 'minicmd', 'gfxterm', 'gfxmenu',
-                    'all_video', 'xfs', 'btrfs', 'lvm', 'luks',
+                    'all_video', 'xfs', 'btrfs', 'squash4', 'lvm', 'luks',
                     'gcry_rijndael', 'gcry_sha256', 'gcry_sha512', 'crypto',
                     'cryptodisk', 'test', 'true', 'loadenv', 'multiboot',
                     'part_gpt', 'part_msdos', 'efi_gop', 'efi_uga', 'linuxefi'
@@ -1217,7 +1217,7 @@ class TestBootLoaderConfigGrub2:
                     'search_label', 'search_fs_file', 'search',
                     'search_fs_uuid', 'ls', 'normal', 'gzio', 'png', 'fat',
                     'gettext', 'font', 'minicmd', 'gfxterm', 'gfxmenu',
-                    'all_video', 'xfs', 'btrfs', 'lvm', 'luks',
+                    'all_video', 'xfs', 'btrfs', 'squash4', 'lvm', 'luks',
                     'gcry_rijndael', 'gcry_sha256', 'gcry_sha512', 'crypto',
                     'cryptodisk', 'test', 'true', 'loadenv', 'part_gpt',
                     'part_msdos', 'efi_gop', 'efi_uga', 'linuxefi'
@@ -1656,11 +1656,11 @@ class TestBootLoaderConfigGrub2:
             ]
             assert file_handle.write.call_args_list == [
                 call('set btrfs_relative_path="yes"\n'),
-                call('search --file --set=root /boot/0xffffffff\n'),
+                call('search --file --set=root /boot/mbrid\n'),
                 call('set prefix=($root)/boot/grub2\n'),
                 call('configfile ($root)/boot/grub2/grub.cfg\n'),
                 call('set btrfs_relative_path="yes"\n'),
-                call('search --file --set=root /boot/0xffffffff\n'),
+                call('search --file --set=root /boot/mbrid\n'),
                 call('set prefix=($root)/boot/grub2\n'),
                 call('configfile ($root)/boot/grub2/grub.cfg\n'),
                 call('source /boot/grub2/grub.cfg\n')
@@ -1693,7 +1693,7 @@ class TestBootLoaderConfigGrub2:
                     'search_label', 'search_fs_file', 'search',
                     'search_fs_uuid', 'ls', 'normal', 'gzio', 'png', 'fat',
                     'gettext', 'font', 'minicmd', 'gfxterm', 'gfxmenu',
-                    'all_video', 'xfs', 'btrfs', 'lvm', 'luks',
+                    'all_video', 'xfs', 'btrfs', 'squash4', 'lvm', 'luks',
                     'gcry_rijndael', 'gcry_sha256', 'gcry_sha512',
                     'crypto', 'cryptodisk', 'test', 'true', 'loadenv',
                     'part_gpt', 'part_msdos', 'biosdisk', 'vga', 'vbe',
@@ -1719,7 +1719,7 @@ class TestBootLoaderConfigGrub2:
                     'search_label', 'search_fs_file', 'search',
                     'search_fs_uuid', 'ls', 'normal', 'gzio', 'png', 'fat',
                     'gettext', 'font', 'minicmd', 'gfxterm', 'gfxmenu',
-                    'all_video', 'xfs', 'btrfs', 'lvm', 'luks',
+                    'all_video', 'xfs', 'btrfs', 'squash4', 'lvm', 'luks',
                     'gcry_rijndael', 'gcry_sha256', 'gcry_sha512',
                     'crypto', 'cryptodisk', 'test', 'true', 'loadenv',
                     'part_gpt', 'part_msdos', 'efi_gop', 'efi_uga', 'linuxefi'
@@ -1769,7 +1769,7 @@ class TestBootLoaderConfigGrub2:
 
             assert file_handle.write.call_args_list == [
                 call('set btrfs_relative_path="yes"\n'),
-                call('search --file --set=root /boot/0xffffffff\n'),
+                call('search --file --set=root /boot/mbrid\n'),
                 call('set prefix=($root)/boot/grub2\n'),
                 call('configfile ($root)/boot/grub2/grub.cfg\n'),
                 call('source /boot/grub2/grub.cfg\n')
@@ -1837,7 +1837,7 @@ class TestBootLoaderConfigGrub2:
                 )
                 assert file_handle.write.call_args_list == [
                     call('set btrfs_relative_path="yes"\n'),
-                    call('search --file --set=root /boot/0xffffffff\n'),
+                    call('search --file --set=root /boot/mbrid\n'),
                     call('set prefix=($root)/boot/grub2\n'),
                     call('configfile ($root)/boot/grub2/grub.cfg\n'),
                     call('source /boot/grub2/grub.cfg\n')


### PR DESCRIPTION
grub supports reading from ```squashfs```. If no extra bootloader installation is required this allows to boot from a squashfs rootfs without extra boot partition. 

The prebuilt grub images usually does not contain the ```squash4``` module which is the reason why kiwi creates the EFI module itself if the system is fully immutable.

Please note: The grub configuration must be provided manually as part of the image description in this case because ```grub-mkconfig``` at the time of its invocation has no write permissions anymore.


