### PR TITLE
Bring back create_parted_partitions method

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -17,7 +17,7 @@ function create_partitions {
             create_gpt_partitions "${disk_device}" "${partition_setup}"
         ;;
         "dasd")
-            create_dasd_partitions "${disk_device}" "${partition_setup}"
+            create_parted_partitions "${disk_device}" "${partition_setup}"
         ;;
     esac
     partprobe "${disk_device}"
@@ -172,6 +172,131 @@ function create_dasd_partitions {
     fdasd "${disk_device}" < ${partition_setup_file} 1>&2
 }
 
+function create_parted_partitions {
+    # """
+    # create partitions using parted
+    # """
+    local disk_device=$1
+    local partition_setup=$2
+    local index=0
+    local commands
+    local partid
+    local part_name
+    local part_start_cyl
+    local part_stop_cyl
+    local part_type
+    local cmd_list
+    local cmd
+
+    _parted_init "${disk_device}"
+    _parted_sector_init "${disk_device}"
+
+    # put partition setup in a command list(cmd_list)
+    for cmd in ${partition_setup};do
+        cmd_list[$index]=${cmd}
+        index=$((index + 1))
+    done
+
+    # operate on index based cmd_list
+    index=0
+    for cmd in ${cmd_list[*]};do
+        case ${cmd} in
+        "d")
+            # delete a partition...
+            partid=${cmd_list[$index + 1]}
+            partid=$((partid / 1))
+            commands="${commands} rm $partid"
+            _parted_write "${disk_device}" "${commands}"
+            unset commands
+        ;;
+        "n")
+            # create a partition...
+            part_name=${cmd_list[$index + 1]}
+            partid=${cmd_list[$index + 2]}
+            partid=$((partid / 1))
+            part_start_cyl=${cmd_list[$index + 3]}
+            if [ ! "${partedTableType}" = "gpt" ];then
+                part_name=primary
+            else
+                part_name=$(echo ${part_name} | cut -f2 -d:)
+            fi
+            if [ "${part_start_cyl}" = "1" ];then
+                part_start_cyl=$(echo "${partedStartSectors}" |\
+                    cut -f ${partid} -d:
+                )
+            fi
+            if [ "${part_start_cyl}" = "." ];then
+                # start is next cylinder according to previous partition
+                part_start_cyl=$((partid - 1))
+                if [ ${part_start_cyl} -gt 0 ];then
+                    part_start_cyl=$(echo "${partedEndSectors}" |\
+                        cut -f ${part_start_cyl} -d:
+                    )
+                else
+                    part_start_cyl=$(echo "${partedStartSectors}" |\
+                        cut -f ${partid} -d:
+                    )
+                fi
+            fi
+            part_stop_cyl=${cmd_list[$index + 4]}
+            if [ "${part_stop_cyl}" = "." ];then
+                # use rest of the disk for partition end
+                part_stop_cyl=${partedCylCount}
+            elif echo "${part_stop_cyl}" | grep -qi M;then
+                # calculate stopp cylinder from size
+                part_stop_cyl=$((partid - 1))
+                if [ ${part_stop_cyl} -gt 0 ];then
+                    part_stop_cyl=$(_parted_end_cylinder ${part_stop_cyl})
+                fi
+                local part_size_mbytes
+                part_size_mbytes=$(
+                    echo "${cmd_list[$index + 4]}" | cut -f1 -dM | tr -d +
+                )
+                local part_size_cyl
+                part_size_cyl=$(
+                    _parted_mb_to_cylinder "${part_size_mbytes}"
+                )
+                part_stop_cyl=$((1 + part_stop_cyl + part_size_cyl))
+                if [ "${part_stop_cyl}" -gt "${partedCylCount}" ];then
+                    # given size is out of bounds, reduce to end of disk
+                    part_stop_cyl=${partedCylCount}
+                fi
+            fi
+            commands="${commands} mkpart ${part_name}"
+            commands="${commands} ${part_start_cyl} ${part_stop_cyl}"
+            _parted_write "${disk_device}" "${commands}"
+            _parted_sector_init "${disk_device}"
+            unset commands
+        ;;
+        "t")
+            # change a partition type...
+            part_type=${cmd_list[$index + 2]}
+            partid=${cmd_list[$index + 1]}
+            local flagok=1
+            if [ "${part_type}" = "82" ];then
+                # parted can not consistently set swap flag.
+                # There is no general solution to this issue.
+                # Thus swap flag setup is skipped
+                flagok=0
+            elif [ "${part_type}" = "fd" ];then
+                commands="${commands} set ${partid} raid on"
+            elif [ "${part_type}" = "8e" ];then
+                commands="${commands} set ${partid} lvm on"
+            elif [ "${part_type}" = "83" ];then
+                # default partition type set by parted is linux(83)
+                flagok=0
+            fi
+            if [ ! "${partedTableType}" = "gpt" ] && [ ${flagok} = 1 ];then
+                _parted_write "${disk_device}" "${commands}"
+            fi
+            unset commands
+        ;;
+        esac
+        index=$((index + 1))
+    done
+    partprobe "${disk_device}"
+}
+
 function get_partition_node_name {
     local disk=$1
     local partid=$2
@@ -278,7 +403,16 @@ function get_free_disk_bytes {
 }
 
 function get_partition_table_type {
-    blkid -s PTTYPE -o value "$1"
+    case $(basename "$1") in
+        # Assume DASD if the device starts with "dasd" blkid does not
+        # properly recognize dasd as PTTYPE bsc#1209247
+        dasd*)
+            echo "dasd"
+            ;;
+        *)
+            blkid -s PTTYPE -o value "$1"
+            ;;
+    esac
 }
 
 function get_partition_uuid {
@@ -406,6 +540,17 @@ function resize_wanted {
 }
 
 #======================================
+# Global pareted exports
+#--------------------------------------
+export partedTableType
+export partedOutput
+export partedCylCount
+export partedCylKSize
+export partedStartSectors
+export partedEndSectors
+
+
+#======================================
 # Methods considered private
 #--------------------------------------
 function _get_msdos_partition_start_sector {
@@ -439,4 +584,132 @@ function _to_guid {
         # Assume Linux filesystem
         echo 8300
     fi
+}
+
+function _parted_init {
+    # """
+    # initialize current partition table output
+    # as well as the number of cylinders and the
+    # cyliner size in kB for this disk
+    # """
+    local disk_device=$1
+    local IFS=""
+    local parted
+    local header
+    local ccount
+    local cksize
+    local diskhd
+    local plabel
+    parted=$(
+        parted -m -s "${disk_device}" unit cyl print | grep -v Warning:
+    )
+    header=$(echo "${parted}" | head -n 3 | tail -n 1)
+    ccount=$(
+        echo "${parted}" | grep ^"${disk_device}" | cut -f 2 -d: | tr -d cyl
+    )
+    cksize=$(echo "${header}" | cut -f4 -d: | cut -f1 -dk)
+    diskhd=$(echo "${parted}" | head -n 3 | tail -n 2 | head -n 1)
+    plabel=$(echo "${diskhd}" | cut -f6 -d:)
+    if [[ "${plabel}" =~ gpt ]];then
+        plabel=gpt
+    fi
+    export partedTableType=${plabel}
+    export partedOutput=${parted}
+    export partedCylCount=${ccount}
+    export partedCylKSize=${cksize}
+}
+
+function _parted_sector_init {
+    # """
+    # calculate aligned start/end sectors of
+    # the current table.
+    #
+    # Uses following kiwi profile values if present:
+    #
+    # kiwi_align
+    # kiwi_sectorsize
+    # kiwi_startsector
+    #
+    # """
+    declare kiwi_align=${kiwi_align}
+    declare kiwi_sectorsize=${kiwi_sectorsize}
+    declare kiwi_startsector=${kiwi_startsector}
+    local disk_device=$1
+    local s_start
+    local s_stopp
+    local align=1048576
+    local sector_size=512
+    local sector_start=2048
+    local part
+    [ -n "${kiwi_align}" ] && align=${kiwi_align}
+    [ -n "${kiwi_sectorsize}" ] && sector_size=${kiwi_sectorsize}
+    [ -n "${kiwi_startsector}" ] && sector_start=${kiwi_startsector}
+    local align=$((align / sector_size))
+
+    unset partedStartSectors
+    unset partedEndSectors
+
+    for part in $(
+        parted -m -s "${disk_device}" unit s print |\
+        grep -E "^[1-9]+:" | cut -f2-3 -d: | tr -d s
+    );do
+        s_start=$(echo "${part}" | cut -f1 -d:)
+        s_stopp=$(echo "${part}" | cut -f2 -d:)
+        if [ -z "${partedStartSectors}" ];then
+            partedStartSectors=${s_start}s
+        else
+            partedStartSectors=${partedStartSectors}:${s_start}s
+        fi
+        if [ -z "${partedEndSectors}" ];then
+            partedEndSectors=$((s_stopp/align*align+align))s
+        else
+            partedEndSectors=${partedEndSectors}:$((s_stopp/align*align+align))s
+        fi
+    done
+    # The default start sector applies for an empty disk
+    if [ -z "${partedStartSectors}" ];then
+        partedStartSectors=${sector_start}s
+    fi
+}
+
+function _parted_end_cylinder {
+    # """
+    # return end cylinder of given partition, next
+    # partition must start at return value plus 1
+    # """
+    local partition_id=$(($1 + 3))
+    local IFS=""
+    local header
+    local ccount
+    header=$(echo "${partedOutput}" | head -n "${partition_id}" | tail -n 1)
+    ccount=$(echo "${header}" | cut -f3 -d: | tr -d cyl)
+    echo "${ccount}"
+}
+
+function _parted_mb_to_cylinder {
+    # """
+    # convert partition size in MB to cylinder count
+    # """
+    local sizeBytes=$(($1 * 1048576))
+    # bc truncates to zero decimal places, which results in
+    # a partition that is slightly smaller than the requested
+    # size. Add one cylinder to compensate.
+    local required_cylinders
+    required_cylinders=$(
+        echo "scale=0; ${sizeBytes} / (${partedCylKSize} * 1000) + 1" | bc
+    )
+    echo "${required_cylinders}"
+}
+
+function _parted_write {
+    # """
+    # call parted with current command queue.
+    # and reinitialize the new table data
+    # """
+    local disk_device=$1
+    local commands=$2
+    if ! parted -a cyl -m -s "${disk_device}" unit cyl "${commands}";then
+        die "Failed to create partition table"
+    fi
+    _parted_init "${disk_device}"
 }

--- a/dracut/modules.d/99kiwi-lib/module-setup.sh
+++ b/dracut/modules.d/99kiwi-lib/module-setup.sh
@@ -26,7 +26,7 @@ install() {
         dmsetup
     inst_multiple -o dolly
     if [[ "$(uname -m)" =~ s390 ]];then
-        inst_multiple fdasd
+        inst_multiple fdasd parted
     fi
     inst_simple \
         "${moddir}/kiwi-lib.sh" "/lib/kiwi-lib.sh"

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -457,6 +457,7 @@ Requires:       device-mapper
 %endif
 %ifarch s390 s390x
 Requires:       s390-tools
+Requires:       parted
 %endif
 License:        GPL-3.0-or-later
 Group:          %{sysgroup}


### PR DESCRIPTION
This commit brings back the create_parted_partitions method as it was before commit 1c48f33. Within the mentioned commit the partitioner logic of the dracut modules dropped the use of `parted` in favor of `sgdisk` and `sfdisk` depending on the partition table type.

For s390 platforms it was used `fdasd`, however its seams that nowadays support for DASD is better for `parted` compared with `fdasd`. More specific, `fdasd` does not support resizing the partition table and expanding partitions, but parted does.

For s390 parted should delete and recreate the partition to be expanded, `resizepart` is not functional in that context.

According to SUSE s390 experts `parted` has superseded `fdasd` and it should be the preferred tool for s390 whenever possible.

Within the same issue it has also been noted that `blkid` does not properly detect dasd type, hence an heuristic approach has been implemented based on the device name.

Fixes bsc#1209247
