### PR TITLE
Fixed evaluation of custom start sector

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1006,7 +1006,7 @@ class DiskBuilder:
             log.info('--> setting active flag to primary PReP partition')
             disk.activate_boot_partition()
 
-        if not self.firmware.efi_mode() and self.disk_start_sector:
+        if self.firmware.get_partition_table_type() == 'msdos' and self.disk_start_sector:
             log.info(f'--> setting start sector to: {self.disk_start_sector}')
             disk.set_start_sector(self.disk_start_sector)
 

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -1248,8 +1248,8 @@ class TestDiskBuilder:
         self.disk_builder.volume_manager_name = None
         self.disk_builder.install_media = False
         self.disk_builder.disk_start_sector = 4096
-        self.firmware.efi_mode = Mock(
-            return_value=None
+        self.firmware.get_partition_table_type = Mock(
+            return_value='msdos'
         )
 
         with patch('builtins.open'):


### PR DESCRIPTION
In case an alternative partition table start sector is configured, the check to effectively apply it should be based on the partition table type not on the firmware name

