### PR TITLE
Expand partition table with parted on s390

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -137,6 +137,13 @@ function create_dasd_partitions {
     local ignore_cmd=0
     local ignore_cmd_once=0
     local cmd
+
+    # We resize first partition to enfore rewrite of the current
+    # partition table updated to the actual disk geometry. This is
+    # to circumvent the fdasd limitation of not being capable to
+    # expand the partition table up to the disk size bsc#1209247
+    parted --script --machine "${disk_device}" resizepart 1
+
     for cmd in ${partition_setup};do
         if [ "${ignore_cmd}" = 1 ] && echo "${cmd}" | grep -qE '[dntwq]';then
             ignore_cmd=0
@@ -278,7 +285,9 @@ function get_free_disk_bytes {
 }
 
 function get_partition_table_type {
-    blkid -s PTTYPE -o value "$1"
+    local disk_device="$1"
+    
+    parted --script --machine "${disk_device}" print | grep "^${disk_device}" | cut -d":" -f6
 }
 
 function get_partition_uuid {

--- a/dracut/modules.d/99kiwi-lib/module-setup.sh
+++ b/dracut/modules.d/99kiwi-lib/module-setup.sh
@@ -17,7 +17,7 @@ install() {
     inst_multiple \
         blkid blockdev dd mkdir rmdir \
         grep cut tail head tr bc true false mountpoint \
-        basename partprobe sfdisk sgdisk mkswap readlink lsblk \
+        basename partprobe parted sfdisk sgdisk mkswap readlink lsblk \
         btrfs xfs_growfs resize2fs \
         e2fsck btrfsck xfs_repair \
         vgs vgchange lvextend lvcreate lvresize pvresize \


### PR DESCRIPTION
Make use of parted to detect partition table type and to expand dasd partition table types.

Fixes bsc#1209247
