### PR TITLE
Add potential shim binary for Ubuntu

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -805,6 +805,7 @@ class Defaults:
         )
 
         shim_file_patterns = [
+            shim_pattern_type('/usr/lib/shim/shim*.efi.signed.latest', 'shimx64.efi'),
             shim_pattern_type('/usr/lib/shim/shim*.efi.signed', 'shimx64.efi'),
             shim_pattern_type('/usr/share/efi/*/shim.efi', None),
             shim_pattern_type('/usr/lib64/efi/shim.efi', None),


### PR DESCRIPTION
Looks like `shim*.efi` is gone in latest `shim-signed` package. The package now contains `shimx64.efi.signed.latest` and `shimx64.efi.signed.previous` binaries, let's take latest.

```
shim-signed_1.40.9+15.7-0ubuntu1_amd64/usr/lib/shim/: total 4688
drwxr-xr-x. 3 root root    209 Jan 31 12:57 .
drwxr-xr-x. 3 root root     18 Jan 31 12:57 ..
-rw-r--r--. 1 root root    108 Jan 31 12:57 BOOTX64.CSV
-rwxr-xr-x. 1 root root   1622 Jan 31 12:57 is-not-revoked
drwxr-xr-x. 2 root root     25 Jan 31 12:57 mok
-rw-r--r--. 1 root root 950891 Jan 31 12:57 shimx64.efi
-rw-r--r--. 1 root root 962400 Jan 31 12:57 shimx64.efi.dualsigned
-rw-r--r--. 1 root root 960472 Jan 31 12:57 shimx64.efi.signed.latest
-rw-r--r--. 1 root root 955656 Jan 31 12:57 shimx64.efi.signed.previous
-rw-r--r--. 1 root root  88296 Jan 27 20:09 fbx64.efi
-rw-r--r--. 1 root root 860824 Jan 27 20:09 mmx64.efi
shim-signed_1.40.7+15.4-0ubuntu9_amd64/usr/lib/shim/: total 3728
drwxr-xr-x. 3 root root    145 Aug 13  2021 .
drwxr-xr-x. 3 root root     18 Aug 13  2021 ..
-rw-r--r--. 1 root root    108 Aug 13  2021 BOOTX64.CSV
-rw-r--r--. 1 root root  85672 Aug 13  2021 fbx64.efi
-rw-r--r--. 1 root root 856232 Aug 13  2021 mmx64.efi
drwxr-xr-x. 2 root root     25 Aug 13  2021 mok
-rw-r--r--. 1 root root 947143 Aug 13  2021 shimx64.efi
-rw-r--r--. 1 root root 957576 Aug 13  2021 shimx64.efi.dualsigned
-rw-r--r--. 1 root root 955656 Aug 13  2021 shimx64.efi.signed
```