### PR TITLE
Add zstd and xzio to grub image

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -627,6 +627,8 @@ class Defaults:
             'xfs',
             'btrfs',
             'squash4',
+            'zstd',
+            'xzio',
             'lvm',
             'luks',
             'gcry_rijndael',

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -1175,10 +1175,11 @@ class TestBootLoaderConfigGrub2:
                     'search_label', 'search_fs_file', 'search',
                     'search_fs_uuid', 'ls', 'normal', 'gzio', 'png', 'fat',
                     'gettext', 'font', 'minicmd', 'gfxterm', 'gfxmenu',
-                    'all_video', 'xfs', 'btrfs', 'squash4', 'lvm', 'luks',
-                    'gcry_rijndael', 'gcry_sha256', 'gcry_sha512', 'crypto',
-                    'cryptodisk', 'test', 'true', 'loadenv', 'multiboot',
-                    'part_gpt', 'part_msdos', 'efi_gop', 'efi_uga', 'linuxefi'
+                    'all_video', 'xfs', 'btrfs', 'squash4', 'zstd', 'xzio',
+                    'lvm', 'luks', 'gcry_rijndael', 'gcry_sha256',
+                    'gcry_sha512', 'crypto', 'cryptodisk', 'test',
+                    'true', 'loadenv', 'multiboot', 'part_gpt',
+                    'part_msdos', 'efi_gop', 'efi_uga', 'linuxefi'
                 ]
             )
         ]
@@ -1249,10 +1250,11 @@ class TestBootLoaderConfigGrub2:
                     'search_label', 'search_fs_file', 'search',
                     'search_fs_uuid', 'ls', 'normal', 'gzio', 'png', 'fat',
                     'gettext', 'font', 'minicmd', 'gfxterm', 'gfxmenu',
-                    'all_video', 'xfs', 'btrfs', 'squash4', 'lvm', 'luks',
-                    'gcry_rijndael', 'gcry_sha256', 'gcry_sha512', 'crypto',
-                    'cryptodisk', 'test', 'true', 'loadenv', 'part_gpt',
-                    'part_msdos', 'efi_gop', 'efi_uga', 'linuxefi'
+                    'all_video', 'xfs', 'btrfs', 'squash4', 'zstd', 'xzio',
+                    'lvm', 'luks', 'gcry_rijndael', 'gcry_sha256',
+                    'gcry_sha512', 'crypto', 'cryptodisk', 'test',
+                    'true', 'loadenv', 'part_gpt', 'part_msdos',
+                    'efi_gop', 'efi_uga', 'linuxefi'
                 ]
             )
         ]
@@ -1725,11 +1727,11 @@ class TestBootLoaderConfigGrub2:
                     'search_label', 'search_fs_file', 'search',
                     'search_fs_uuid', 'ls', 'normal', 'gzio', 'png', 'fat',
                     'gettext', 'font', 'minicmd', 'gfxterm', 'gfxmenu',
-                    'all_video', 'xfs', 'btrfs', 'squash4', 'lvm', 'luks',
-                    'gcry_rijndael', 'gcry_sha256', 'gcry_sha512',
-                    'crypto', 'cryptodisk', 'test', 'true', 'loadenv',
-                    'part_gpt', 'part_msdos', 'biosdisk', 'vga', 'vbe',
-                    'chain', 'boot'
+                    'all_video', 'xfs', 'btrfs', 'squash4', 'zstd', 'xzio',
+                    'lvm', 'luks', 'gcry_rijndael', 'gcry_sha256',
+                    'gcry_sha512', 'crypto', 'cryptodisk', 'test',
+                    'true', 'loadenv', 'part_gpt', 'part_msdos',
+                    'biosdisk', 'vga', 'vbe', 'chain', 'boot'
                 ]
             ),
             call(
@@ -1751,10 +1753,11 @@ class TestBootLoaderConfigGrub2:
                     'search_label', 'search_fs_file', 'search',
                     'search_fs_uuid', 'ls', 'normal', 'gzio', 'png', 'fat',
                     'gettext', 'font', 'minicmd', 'gfxterm', 'gfxmenu',
-                    'all_video', 'xfs', 'btrfs', 'squash4', 'lvm', 'luks',
-                    'gcry_rijndael', 'gcry_sha256', 'gcry_sha512',
-                    'crypto', 'cryptodisk', 'test', 'true', 'loadenv',
-                    'part_gpt', 'part_msdos', 'efi_gop', 'efi_uga', 'linuxefi'
+                    'all_video', 'xfs', 'btrfs', 'squash4', 'zstd', 'xzio',
+                    'lvm', 'luks', 'gcry_rijndael', 'gcry_sha256',
+                    'gcry_sha512', 'crypto', 'cryptodisk', 'test',
+                    'true', 'loadenv', 'part_gpt', 'part_msdos',
+                    'efi_gop', 'efi_uga', 'linuxefi'
                 ]
             )
         ]


### PR DESCRIPTION
If kiwi builds its own grub image, make sure the compression algorithms zstd and xz are supported

