### PR TITLE
Fixed Fedora prebuild EFI binary lookup

### DIFF
--- a/.github/workflows/ci-code-style.yml
+++ b/.github/workflows/ci-code-style.yml
@@ -22,7 +22,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Tox
         run: |
-          sudo apt update && sudo apt install tox
+          python -m pip install --upgrade pip
+          python -m pip install tox==3.28.0
       - name: Run code checks
         run: |
           tox -e check

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -789,7 +789,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         code should act as the fallback solution
         """
         log.warning(
-            '--> Running fallback setup for shim secure boot efi image'
+            'Running fallback setup for shim secure boot efi image'
         )
         if not lookup_path:
             lookup_path = self.boot_dir
@@ -805,6 +805,12 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             # a grub image that got signed by the shim. The shim image
             # is the one that gets loaded by the firmware which itself
             # loads the second stage grub image
+            log.info(
+                f'--> Using shim image: {shim_image.filename}'
+            )
+            log.info(
+                f'--> Using grub image: {grub_image.filename}'
+            )
             Command.run(
                 ['cp', shim_image.filename, self._get_efi_image_name()]
             )
@@ -822,6 +828,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         else:
             # Without shim a self signed grub image is used that
             # gets loaded by the firmware
+            log.info(
+                f'--> No shim image, using grub image: {grub_image.filename}'
+            )
             Command.run(
                 ['cp', grub_image.filename, self._get_efi_image_name()]
             )
@@ -841,7 +850,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             lookup_path = self.boot_dir
         grub_image = Defaults.get_unsigned_grub_loader(lookup_path, target_type)
         if grub_image and self.xml_state.build_type.get_overlayroot_write_partition() is not False:
-            log.info('--> Using prebuilt unsigned efi image')
+            log.info(f'--> Using prebuilt unsigned efi image: {grub_image}')
             Command.run(
                 ['cp', grub_image, self._get_efi_image_name()]
             )
@@ -860,7 +869,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             lookup_path = self.boot_dir
         grub_image = Defaults.get_grub_bios_core_loader(lookup_path)
         if grub_image:
-            log.info('--> Using prebuilt bios image')
+            log.info(f'--> Using prebuilt bios image: {grub_image}')
         else:
             log.info('--> Creating bios image')
             self._create_bios_image(

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -349,7 +349,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
         if self.firmware.efi_mode() and self.early_boot_script_efi:
             self._copy_grub_config_to_efi_path(
-                self.boot_dir, self.early_boot_script_efi
+                self.boot_dir, self.early_boot_script_efi, 'iso'
             )
 
     def setup_live_image_config(
@@ -413,7 +413,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
         if self.firmware.efi_mode() and self.early_boot_script_efi:
             self._copy_grub_config_to_efi_path(
-                self.boot_dir, self.early_boot_script_efi
+                self.boot_dir, self.early_boot_script_efi, 'iso'
             )
 
     def setup_install_boot_images(self, mbrid, lookup_path=None):
@@ -452,11 +452,11 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             self._setup_EFI_path(lookup_path)
 
         if self.firmware.efi_mode() == 'efi':
-            self._setup_efi_image(mbrid=mbrid, lookup_path=lookup_path)
+            self._setup_efi_image(mbrid=mbrid, lookup_path=lookup_path, target_type='iso')
             self._copy_efi_modules_to_boot_directory(lookup_path)
         elif self.firmware.efi_mode() == 'uefi':
             self._setup_secure_boot_efi_image(
-                lookup_path=lookup_path, mbrid=mbrid
+                lookup_path=lookup_path, mbrid=mbrid, target_type='iso'
             )
 
         log.info('--> Creating loopback config')
@@ -509,7 +509,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         if self.xen_guest:
             self._copy_xen_modules_to_boot_directory(lookup_path)
 
-    def _copy_grub_config_to_efi_path(self, root_path, config_file):
+    def _copy_grub_config_to_efi_path(
+        self, root_path, config_file, target_type='disk'
+    ):
         efi_boot_path = Defaults.get_shim_vendor_directory(
             root_path
         )
@@ -518,7 +520,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             # have them in their encoded early boot script. Thus
             # the following code tries to look up the vendor string
             # from the signed grub binary
-            grub_image = Defaults.get_signed_grub_loader(self.root_dir)
+            grub_image = Defaults.get_signed_grub_loader(self.root_dir, target_type)
             if grub_image and grub_image.filename:
                 bash_command = [
                     'strings', grub_image.filename, '|', 'grep', 'EFI\/'
@@ -772,7 +774,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                         grub_default[key] = value
                 grub_default.write()
 
-    def _setup_secure_boot_efi_image(self, lookup_path, uuid=None, mbrid=None):
+    def _setup_secure_boot_efi_image(
+        self, lookup_path, uuid=None, mbrid=None, target_type='disk'
+    ):
         """
         Provide the shim loader and the shim signed grub2 loader
         in the required boot path. Normally this task is done by
@@ -789,7 +793,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         )
         if not lookup_path:
             lookup_path = self.boot_dir
-        grub_image = Defaults.get_signed_grub_loader(lookup_path)
+        grub_image = Defaults.get_signed_grub_loader(lookup_path, target_type)
         if not grub_image:
             raise KiwiBootLoaderGrubSecureBootError(
                 'Signed grub2 efi loader not found'
@@ -823,7 +827,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
         self._create_efi_config_search(uuid, mbrid)
 
-    def _setup_efi_image(self, uuid=None, mbrid=None, lookup_path=None):
+    def _setup_efi_image(
+        self, uuid=None, mbrid=None, lookup_path=None, target_type='disk'
+    ):
         """
         Provide the unsigned grub2 efi image in the required boot path
         If a prebuilt efi image as provided by the distribution could
@@ -833,7 +839,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         """
         if not lookup_path:
             lookup_path = self.boot_dir
-        grub_image = Defaults.get_unsigned_grub_loader(lookup_path)
+        grub_image = Defaults.get_unsigned_grub_loader(lookup_path, target_type)
         if grub_image and self.xml_state.build_type.get_overlayroot_write_partition() is not False:
             log.info('--> Using prebuilt unsigned efi image')
             Command.run(

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -870,12 +870,14 @@ class Defaults:
                 return font_dir
 
     @staticmethod
-    def get_unsigned_grub_loader(root_path):
+    def get_unsigned_grub_loader(
+        root_path: str, target_type: str = 'disk'
+    ) -> Optional[str]:
         """
         Provides unsigned grub efi loader file path
 
-        Searches distribution specific locations to find grub.efi
-        below the given root path
+        Searches distribution specific locations to find a distro
+        grub EFI binary within the given root path
 
         :param string root_path: image root path
 
@@ -883,16 +885,28 @@ class Defaults:
 
         :rtype: str
         """
-        unsigned_grub_file_patterns = [
-            '/usr/share/grub*/*-efi/grub.efi',
-            '/usr/lib/grub*/*-efi/grub.efi',
-            '/boot/efi/EFI/*/grubx64.efi'
-        ]
-        for unsigned_grub_file_pattern in unsigned_grub_file_patterns:
+        unsigned_grub_file = None
+        unsigned_grub_file_patterns = {
+            'disk': [
+                '/usr/share/grub*/*-efi/grub.efi',
+                '/usr/lib/grub*/*-efi/grub.efi',
+                '/boot/efi/EFI/*/grubx64.efi',
+                '/boot/efi/EFI/*/grubaa64.efi'
+            ],
+            'iso': [
+                '/boot/efi/EFI/*/gcdx64.efi',
+                '/usr/share/grub*/*-efi/grub.efi',
+                '/usr/lib/grub*/*-efi/grub.efi',
+                '/boot/efi/EFI/*/grubx64.efi',
+                '/boot/efi/EFI/*/grubaa64.efi'
+            ]
+        }
+        for unsigned_grub_file_pattern in unsigned_grub_file_patterns[target_type]:
             for unsigned_grub_file in glob.iglob(
                 root_path + unsigned_grub_file_pattern
             ):
                 return unsigned_grub_file
+        return None
 
     @staticmethod
     def get_grub_bios_core_loader(root_path):
@@ -975,12 +989,14 @@ class Defaults:
         return 'eltorito.img'
 
     @staticmethod
-    def get_signed_grub_loader(root_path: str) -> Optional[grub_loader_type]:
+    def get_signed_grub_loader(
+        root_path: str, target_type: str = 'disk'
+    ) -> Optional[grub_loader_type]:
         """
         Provides shim signed grub loader file path
 
-        Searches distribution specific locations to find grub.efi
-        below the given root path
+        Searches distribution specific locations to find a grub
+        EFI binary within the given root path
 
         :param str root_path: image root path
 
@@ -991,25 +1007,54 @@ class Defaults:
         grub_pattern_type = namedtuple(
             'grub_pattern_type', ['pattern', 'binaryname']
         )
-        signed_grub_file_patterns = [
-            grub_pattern_type(
-                '/usr/share/efi/*/grub.efi', None
-            ),
-            grub_pattern_type(
-                '/usr/lib64/efi/grub.efi', None
-            ),
-            grub_pattern_type(
-                '/boot/efi/EFI/*/grub*.efi', None
-            ),
-            grub_pattern_type(
-                '/usr/share/grub*/*-efi/grub.efi', None
-            ),
-            grub_pattern_type(
-                '/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed',
-                'grubx64.efi'
-            )
-        ]
-        for signed_grub in signed_grub_file_patterns:
+        signed_grub_file_patterns = {
+            'disk': [
+                grub_pattern_type(
+                    '/usr/share/efi/*/grub.efi', None
+                ),
+                grub_pattern_type(
+                    '/usr/lib64/efi/grub.efi', None
+                ),
+                grub_pattern_type(
+                    '/boot/efi/EFI/*/grub*.efi', None
+                ),
+                grub_pattern_type(
+                    '/usr/share/grub*/*-efi/grub.efi', None
+                ),
+                grub_pattern_type(
+                    '/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed',
+                    'grubx64.efi'
+                )
+            ],
+            'iso': [
+                grub_pattern_type(
+                    '/boot/efi/EFI/*/gcdx64.efi',
+                    'grubx64.efi'
+                ),
+                grub_pattern_type(
+                    '/boot/efi/EFI/*/gcdaa64.efi',
+                    'grubaa64.efi'
+                ),
+                grub_pattern_type(
+                    '/usr/share/efi/*/grub.efi', None
+                ),
+                grub_pattern_type(
+                    '/usr/lib64/efi/grub.efi', None
+                ),
+                grub_pattern_type(
+                    '/boot/efi/EFI/*/grub*.efi', None
+                ),
+                grub_pattern_type(
+                    '/usr/share/grub*/*-efi/grub.efi', None
+                ),
+                grub_pattern_type(
+                    '/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed',
+                    'grubx64.efi'
+                )
+
+            ]
+        }
+        for signed_grub in signed_grub_file_patterns[target_type]:
             for signed_grub_file in glob.iglob(root_path + signed_grub.pattern):
                 if not signed_grub.binaryname:
                     binaryname = os.path.basename(signed_grub_file)

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -846,7 +846,7 @@ class TestBootLoaderConfigGrub2:
             True, True, 'gfxterm', None
         )
         mock_copy_grub_config_to_efi_path.assert_called_once_with(
-            'root_dir', 'earlyboot.cfg'
+            'root_dir', 'earlyboot.cfg', 'iso'
         )
 
     def test_setup_install_image_config_multiboot(self):
@@ -1041,7 +1041,7 @@ class TestBootLoaderConfigGrub2:
             True, True, 'gfxterm', True
         )
         mock_copy_grub_config_to_efi_path.assert_called_once_with(
-            'root_dir', 'earlyboot.cfg'
+            'root_dir', 'earlyboot.cfg', 'iso'
         )
 
     def test_setup_iso_image_config_substitute_error(self):
@@ -1902,7 +1902,7 @@ class TestBootLoaderConfigGrub2:
                     call(
                         [
                             'cp', 'root_dir/usr/lib64/efi/grub.efi',
-                            'root_dir/EFI/BOOT/grub.efi'
+                            'root_dir/EFI/BOOT/grubx64.efi'
                         ]
                     ),
                     call(

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -89,6 +89,9 @@ class TestDefaults:
         assert Defaults.get_unsigned_grub_loader('root') == \
             mock_glob.return_value.pop()
         mock_glob.assert_called_once_with('root/usr/share/grub*/*-efi/grub.efi')
+        mock_glob.reset_mock()
+        mock_glob.return_value = []
+        assert Defaults.get_unsigned_grub_loader('root') is None
 
     def test_is_x86_arch(self):
         assert Defaults.is_x86_arch('x86_64') is True


### PR DESCRIPTION
When creating CentOS/Fedora live media, kiwi does not install the right signed grub2 EFI binary. This was caused by kiwi not being aware of the gcdx64.efi(x86_64), gcdaa64.efi(aarch64) binaries for CD/ISO boot. This Fixes #2270


