### PR TITLE
Encode remote URLs

### DIFF
--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -219,7 +219,7 @@ class RepositoryDnf(RepositoryBase):
         if os.path.exists(uri):
             # dnf requires local paths to take the file: type
             uri = 'file://' + uri
-        repo_config = ConfigParser()
+        repo_config = ConfigParser(interpolation=None)
         repo_config.add_section(name)
         repo_config.set(
             name, 'name', name
@@ -317,7 +317,7 @@ class RepositoryDnf(RepositoryBase):
         )
 
     def _create_runtime_config_parser(self) -> None:
-        self.runtime_dnf_config = ConfigParser()
+        self.runtime_dnf_config = ConfigParser(interpolation=None)
         self.runtime_dnf_config["main"] = {
             "cachedir": self.shared_dnf_dir['cache-dir'],
             "reposdir": self.shared_dnf_dir['reposd-dir'],
@@ -340,7 +340,7 @@ class RepositoryDnf(RepositoryBase):
 
     def _create_runtime_plugin_config_parsers(self) -> None:
         self.runtime_dnf_plugin_configs = {
-            plugin: ConfigParser() for plugin in ("priorities", "versionlock")
+            plugin: ConfigParser(interpolation=None) for plugin in ("priorities", "versionlock")
         }
         self.runtime_dnf_plugin_configs["priorities"]["main"] = {"enabled": "1"}
         self.runtime_dnf_plugin_configs["versionlock"]["main"] = {"enabled": "0"}

--- a/test/unit/repository/zypper_test.py
+++ b/test/unit/repository/zypper_test.py
@@ -191,6 +191,36 @@ class TestRepositoryZypper:
     @patch('kiwi.repository.zypper.Path.wipe')
     @patch('os.path.exists')
     @patch('kiwi.repository.zypper.Uri')
+    def test_add_repo_with_credentials_in_uri(
+        self, mock_uri, mock_exists, mock_wipe, mock_command, mock_config
+    ):
+        repo_config = mock.Mock()
+        mock_config.return_value = repo_config
+        mock_exists.return_value = True
+        with patch('builtins.open', create=True) as mock_open:
+            self.repo.add_repo(
+                'foo',
+                'https://some_user%40domain.com:my_token123@example.com/foo',
+                'rpm-md'
+            )
+            assert repo_config.set.call_args_list == [
+                call(
+                    'foo',
+                    'baseurl',
+                    'https://some_user%40domain.com:my_token123@example.com/foo'
+                ),
+                call('foo', 'repo_gpgcheck', '0'),
+                call('foo', 'pkg_gpgcheck', '0')
+            ]
+            mock_open.assert_called_once_with(
+                '../data/shared-dir/zypper/repos/foo.repo', 'w'
+            )
+
+    @patch('kiwi.repository.zypper.ConfigParser')
+    @patch('kiwi.command.Command.run')
+    @patch('kiwi.repository.zypper.Path.wipe')
+    @patch('os.path.exists')
+    @patch('kiwi.repository.zypper.Uri')
     def test_add_repo_with_gpgchecks(
         self, mock_uri, mock_exists, mock_wipe,
         mock_command, mock_config

--- a/test/unit/system/uri_test.py
+++ b/test/unit/system/uri_test.py
@@ -110,6 +110,17 @@ class TestUri:
         uri = Uri('/path/to/repo')
         assert uri.is_remote() is False
 
+    def test_uri_needs_encoding(self):
+        uri = Uri(
+            'https://user@mycompany.com:token_password@'
+            'artifactory-edge.mycompany.com/artifactory/'
+            'some_rpm_path/Base-Prod/sample.rpm'
+        )
+        assert uri.translate(False) == \
+            'https://user%40mycompany.com:token_password@' \
+            'artifactory-edge.mycompany.com/artifactory/' \
+            'some_rpm_path/Base-Prod/sample.rpm'
+
     @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
     def test_is_remote_in_buildservice(
         self, mock_buildservice


### PR DESCRIPTION
Special characters in a URL e.g the @ sign needs to be encoded as part of a remote URL.

