### PR TITLE
Look for specific `shimx64.efi` binary first

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -811,12 +811,12 @@ class Defaults:
             shim_pattern_type('/usr/lib/shim/shim*.efi.signed', 'shimx64.efi'),
             shim_pattern_type('/usr/share/efi/*/shim.efi', None),
             shim_pattern_type('/usr/lib64/efi/shim.efi', None),
-            shim_pattern_type('/boot/efi/EFI/*/shimx64.efi', None),
-            shim_pattern_type('/boot/efi/EFI/*/shim*.efi', None),
+            shim_pattern_type('/boot/efi/EFI/*/shim[a-z]*.efi', None),
+            shim_pattern_type('/boot/efi/EFI/*/shim.efi', None),
             shim_pattern_type('/usr/lib/shim/shim*.efi', None)
         ]
         for shim_file_pattern in shim_file_patterns:
-            for shim_file in glob.iglob(root_path + shim_file_pattern.pattern):
+            for shim_file in sorted(glob.iglob(root_path + shim_file_pattern.pattern), key=len):
                 if not shim_file_pattern.binaryname:
                     binaryname = os.path.basename(shim_file)
                 else:

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -811,6 +811,7 @@ class Defaults:
             shim_pattern_type('/usr/lib/shim/shim*.efi.signed', 'shimx64.efi'),
             shim_pattern_type('/usr/share/efi/*/shim.efi', None),
             shim_pattern_type('/usr/lib64/efi/shim.efi', None),
+            shim_pattern_type('/boot/efi/EFI/*/shimx64.efi', None),
             shim_pattern_type('/boot/efi/EFI/*/shim*.efi', None),
             shim_pattern_type('/usr/lib/shim/shim*.efi', None)
         ]


### PR DESCRIPTION
In CentOS, `/boot/efi/EFI/*/shim*.efi` extends to
`/boot/efi/EFI/centos/shimx64-centos.efi` which is not signed by M$ but CentOS itself. This in turn does not boot on SecureBoot enabled systems.

---

CentOS 8 Stream ISO does not boot on SecureBoot enabled systems.

Problem is the selected `shimx64-centos.efi` binary which is signed by CentOS, not M$:
```
[ DEBUG   ]: 14:39:06 | EXEC: [cp /tmp/centos/build/image-root/boot/efi/EFI/centos/shimx64-centos.efi /tmp/centos/live-media.s0dscud5/EFI/BOOT/bootx64.efi]
```
```
# pesign -S -i ./mnt/EFI/BOOT/bootx64.efi | grep common
The signer's common name is CentOS Secure Boot Signing 201
``` 

This might fix https://github.com/OSInside/kiwi/issues/2172