### PR TITLE
Fix restoration of grub2-install (bsc#1210948)

### DIFF
--- a/kiwi/bootloader/install/grub2.py
+++ b/kiwi/bootloader/install/grub2.py
@@ -373,7 +373,7 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
             grub2_install_backup = ''.join(
                 [grub2_install, '.orig']
             )
-            if os.path.exists(grub2_install_backup):
+            if os.path.exists(''.join([root_path, grub2_install_backup])):
                 Command.run(
                     [
                         'chroot', root_path,


### PR DESCRIPTION
It checked for grub2-install.orig in the host, not the buildroot. This meant that it left /usr/sbin/grub2-install as a noop.

~Draft because not verified yet.~