### PR TITLE
Added appx-util as WSL requires for Fedora/RHEL

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -156,6 +156,9 @@ Provides:       kiwi-image:appx
 %if 0%{?suse_version}
 Requires:       fb-util-for-appx
 %endif
+%if 0%{?fedora} || 0%{?rhel}
+Requires:       appx-util
+%endif
 
 %description -n kiwi-systemdeps-containers-wsl
 Host setup helper to pull in all packages required/useful on


### PR DESCRIPTION
Make sure the kiwi-systemdeps-containers-wsl meta package pulls in the required tools for Fedora/RHEL when building WSL containers. This is a followup to #2286


