### PR TITLE
Do not depend on dnf for SUSE ALP

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -96,11 +96,11 @@ Recommends:     debootstrap
 Recommends:     dpkg
 %endif
 # package managers required by distro
-%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?suse_version} >= 1550
+%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?suse_version} >= 1650
 Provides:       kiwi-packagemanager:microdnf
 Requires:       microdnf
 %endif
-%if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version} >= 1550
+%if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version} >= 1650
 Requires:       dnf
 Provides:       kiwi-packagemanager:dnf
 Provides:       kiwi-packagemanager:yum


### PR DESCRIPTION
Changes proposed in this pull request:
SUSE ALP does not include dnf package manager, behave the same as for SLE15. For Tumbleweed nothing changes as suse_version got bumped to 1699.