### PR TITLE
dracut: modules.d: 99kiwi-lib: add bash shebangs and dependency

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
 function run_dialog {

--- a/dracut/modules.d/99kiwi-lib/kiwi-filesystem-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-filesystem-lib.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
 function getOverlayBaseDirectory {

--- a/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
 function setup_debug {

--- a/dracut/modules.d/99kiwi-lib/kiwi-luks-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-luks-lib.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 type set_root_map >/dev/null 2>&1 || . /lib/kiwi-lib.sh
 type wait_for_storage_device >/dev/null 2>&1 || . /lib/kiwi-partitions-lib.sh

--- a/dracut/modules.d/99kiwi-lib/kiwi-lvm-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lvm-lib.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 type udev_pending >/dev/null 2>&1 || . /lib/kiwi-lib.sh
 

--- a/dracut/modules.d/99kiwi-lib/kiwi-mdraid-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-mdraid-lib.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 type set_root_map >/dev/null 2>&1 || . /lib/kiwi-lib.sh
 type wait_for_storage_device >/dev/null 2>&1 || . /lib/kiwi-partitions-lib.sh

--- a/dracut/modules.d/99kiwi-lib/kiwi-net-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-net-lib.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
 # URI pattern Based on https://tools.ietf.org/html/rfc3986#appendix-B

--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 type udev_pending >/dev/null 2>&1 || . /lib/kiwi-lib.sh
 

--- a/dracut/modules.d/99kiwi-lib/module-setup.sh
+++ b/dracut/modules.d/99kiwi-lib/module-setup.sh
@@ -7,7 +7,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo udev-rules crypt
+    echo udev-rules crypt bash
     return 0
 }
 


### PR DESCRIPTION
The scripts in the kiwi-lib module use bash-specific syntax like `function`, which causes the script to fail if another shell (like dash or busybox) is used to interpret the scripts. Specifically set the shebang to use bash as the shell interpreter and add bash as a dependency to the dracut module to fix this.

This resolves the following errors which are printed at boot when busybox tries to interpret the scripts:

    /bin/dracut-pre-mount: 3: /lib/kiwi-filesystem-lib.sh: function: not found
    /bin/dracut-pre-mount: 15: /lib/kiwi-filesystem-lib.sh: Syntax error: "}" unexpected

