### PR TITLE
dracut: modules.d: 90kiwi-overlay: add support for device mapper targets

### DIFF
--- a/dracut/modules.d/90kiwi-overlay/parse-kiwi-overlay.sh
+++ b/dracut/modules.d/90kiwi-overlay/parse-kiwi-overlay.sh
@@ -49,6 +49,12 @@ case "${overlayroot}" in
         root="block:/dev/${root#UNIXNODE=}"
         rootok=1
     ;;
+    overlay:MAPPER=*|MAPPER=*) \
+        root="${root#overlay:}"
+        root="${root//\//\\x2f}"
+        root="block:/dev/mapper/${root#MAPPER=}"
+        rootok=1
+    ;;
     overlay:nbd=*) \
         root="${root#overlay:nbd=}"
         root="block:/dev/${root}"


### PR DESCRIPTION
Allow specifying a device mapper target for the root of the overlayfs. This adds support for features like adding a dm-verity or dm-crypt backend to the overlayfs.

A device mapper target can be specified using the following syntax on the kernel command line:

    root=overlay:MAPPER=verityRoot

This translates to using the path `/dev/mapper/verityRoot` as the base of the overlayfs.
