### PR TITLE
Apply patches needed to support creating images for full disk encrpytion

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -1423,8 +1423,9 @@ any of its required packages and any recommended packages.
 
    On RedHat based distributions collections are called `groups` and are
    extra metadata. To get the names of these groups type the following
-   command: `$ dnf group list`. Please note that group names are allowed
-   to contain whitespace characters.
+   command: `$ dnf group list -v`. Please note that since {kiwi} v9.23.39,
+   group IDs are allowed only, e.g.: 
+   <namedCollection name="minimal-environment"/>
 
 <packages><collectionModule>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/dracut/modules.d/90kiwi-dump/module-setup.sh
+++ b/dracut/modules.d/90kiwi-dump/module-setup.sh
@@ -13,7 +13,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods squashfs loop iso9660
+    instmods squashfs loop iso9660 aesni_intel sha256_ssse3
 }
 
 # called by dracut

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -124,6 +124,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             Defaults.get_volume_id()
         self.install_volid = self.xml_state.build_type.get_volid() or \
             Defaults.get_install_volume_id()
+        self.use_disk_password = self.xml_state.get_build_type_bootloader_use_disk_password()
 
         self.live_boot_options = [
             'root=live:CDLABEL={0}'.format(self.volume_id),

--- a/kiwi/bootloader/install/grub2.py
+++ b/kiwi/bootloader/install/grub2.py
@@ -278,6 +278,31 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
                 # restore the grub installer noop
                 self._enable_grub2_install(self.root_mount.mountpoint)
 
+    def set_disk_password(self, password):
+        log.debug(f'set_disk_password({password})')
+        if password is None:
+            return
+
+        config_file = f'{self.root_mount.mountpoint}/boot/efi/EFI/BOOT/grub.cfg'
+        if not os.path.exists(config_file):
+            log.debug(f'{config_file} does not exist')
+            return
+
+        with open(config_file) as config:
+            import re
+
+            grub_config = config.read()
+            grub_config = re.sub(
+                    r'cryptomount',
+                    f'cryptomount -p "{password}"',
+                    grub_config
+                )
+
+        with open(config_file, 'w') as grub_config_file:
+            grub_config_file.write(grub_config)
+
+        log.debug(f'<<< {grub_config} >>>')
+
     def _mount_device_and_volumes(self):
         if self.root_mount is None:
             self.root_mount = MountManager(

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -134,6 +134,7 @@ class DiskBuilder:
         self.root_filesystem_embed_integrity_metadata = \
             xml_state.build_type.get_embed_integrity_metadata()
         self.luks_format_options = xml_state.get_luks_format_options()
+        self.luks_randomize = xml_state.build_type.get_luks_randomize()
         self.luks_os = xml_state.build_type.get_luksOS()
         self.xen_server = xml_state.is_xen_server()
         self.requested_filesystem = xml_state.build_type.get_filesystem()
@@ -351,6 +352,7 @@ class DiskBuilder:
             self.luks_boot_keyfile = ''.join(
                 [self.root_dir, self.luks_boot_keyname]
             )
+            luks_root.luks_randomize = self.luks_randomize
             # use LUKS key file for the following conditions:
             # 1. /boot is encrypted
             #    In this case grub needs to read from LUKS via the

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -135,6 +135,7 @@ class DiskBuilder:
             xml_state.build_type.get_embed_integrity_metadata()
         self.luks_format_options = xml_state.get_luks_format_options()
         self.luks_randomize = xml_state.build_type.get_luks_randomize()
+        self.luks_pbkdf = xml_state.build_type.get_luks_pbkdf()
         self.luks_os = xml_state.build_type.get_luksOS()
         self.xen_server = xml_state.is_xen_server()
         self.requested_filesystem = xml_state.build_type.get_filesystem()
@@ -353,6 +354,7 @@ class DiskBuilder:
                 [self.root_dir, self.luks_boot_keyname]
             )
             luks_root.luks_randomize = self.luks_randomize
+            luks_root.luks_pbkdf = self.luks_pbkdf
             # use LUKS key file for the following conditions:
             # 1. /boot is encrypted
             #    In this case grub needs to read from LUKS via the

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1523,6 +1523,11 @@ class DiskBuilder:
 
         if self.bootloader != 'custom':
             # create bootloader config prior bootloader installation
+            disk_password = None
+            if self.bootloader_config.use_disk_password and self.luks:
+                disk_password = self.luks
+            log.debug(f'Passing disk encryption password "{disk_password}" to boot loader')
+
             try:
                 self.bootloader_config.setup_disk_image_config(
                     boot_options=custom_install_arguments
@@ -1549,6 +1554,9 @@ class DiskBuilder:
                 log.warning(
                     'No install of bootcode on read-only root possible'
                 )
+
+            if disk_password:
+                bootloader.set_disk_password(disk_password)
 
         self.system_setup.call_edit_boot_install_script(
             self.diskname, boot_device.get_device()

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -347,7 +347,7 @@ class DiskBuilder:
         luks_root = None
         if self.luks is not None:
             luks_root = LuksDevice(device_map['root'])
-            self.luks_boot_keyname = '/.root.keyfile'
+            self.luks_boot_keyname = '/root/.root.keyfile'
             self.luks_boot_keyfile = ''.join(
                 [self.root_dir, self.luks_boot_keyname]
             )

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -809,6 +809,7 @@ class Defaults:
             shim_pattern_type('/usr/lib/shim/shim*.efi.signed', 'shimx64.efi'),
             shim_pattern_type('/usr/share/efi/*/shim.efi', None),
             shim_pattern_type('/usr/lib64/efi/shim.efi', None),
+            shim_pattern_type('/boot/efi/EFI/*/shimx64.efi', None),
             shim_pattern_type('/boot/efi/EFI/*/shim*.efi', None),
             shim_pattern_type('/usr/lib/shim/shim*.efi', None)
         ]

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -809,12 +809,12 @@ class Defaults:
             shim_pattern_type('/usr/lib/shim/shim*.efi.signed', 'shimx64.efi'),
             shim_pattern_type('/usr/share/efi/*/shim.efi', None),
             shim_pattern_type('/usr/lib64/efi/shim.efi', None),
-            shim_pattern_type('/boot/efi/EFI/*/shimx64.efi', None),
-            shim_pattern_type('/boot/efi/EFI/*/shim*.efi', None),
+            shim_pattern_type('/boot/efi/EFI/*/shim[a-z]*.efi', None),
+            shim_pattern_type('/boot/efi/EFI/*/shim.efi', None),
             shim_pattern_type('/usr/lib/shim/shim*.efi', None)
         ]
         for shim_file_pattern in shim_file_patterns:
-            for shim_file in glob.iglob(root_path + shim_file_pattern.pattern):
+            for shim_file in sorted(glob.iglob(root_path + shim_file_pattern.pattern), key=len):
                 if not shim_file_pattern.binaryname:
                     binaryname = os.path.basename(shim_file)
                 else:

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2754,6 +2754,11 @@ div {
             sch:param [ name = "attr" value = "targettype" ]
             sch:param [ name = "types" value = "grub2_s390x_emu" ]
         ]
+    k.bootloader.use_disk_password.attribute =
+	## When /boot is encrypted, make the boot loader store the
+	## password in its configuration file (in cleartext). This
+	## is useful for full disk encryption images
+	attribute use_disk_password { xsd:boolean }
     k.bootloader.attlist =
         k.bootloader.name.attribute &
         k.bootloader.console.attribute? &
@@ -2761,6 +2766,7 @@ div {
         k.bootloader.timeout.attribute? &
         k.bootloader.timeout_style.attribute? &
         k.bootloader.targettype.attribute? &
+        k.bootloader.use_disk_password.attribute? &
         k.bootloader.grub_template.attribute?
 
     k.bootloader =

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2035,6 +2035,17 @@ div {
             sch:param [ name = "attr" value = "luksOS" ]
             sch:param [ name = "types" value = "oem iso pxe kis" ]
         ]
+    k.type.luks_randomize.attribute =
+        ## By default, all blocks of a LUKS volume will be filled
+	## with pseudo-random data. If you're shipping an image with
+	## a well-known key, which is going to be re-encrypted at
+	## deployment time, you can decrease the size of the image
+	## by setting this attribute to false.
+        attribute luks_randomize { xsd:boolean }
+        >> sch:pattern [ id = "luks_randomize" is-a = "image_type"
+            sch:param [ name = "attr" value = "luksversion" ]
+            sch:param [ name = "types" value = "oem iso pxe kis" ]
+        ]
     k.type.mdraid.attribute =
         ## Setup software raid in degraded mode with one disk
         ## Thus only mirroring and striping is possible
@@ -2227,6 +2238,7 @@ div {
         k.type.luks.attribute? &
         k.type.luks_version.attribute? &
         k.type.luksOS.attribute? &
+        k.type.luks_randomize.attribute? &
         k.type.mdraid.attribute? &
         k.type.overlayroot.attribute? &
         k.type.overlayroot_write_partition.attribute? &

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2046,6 +2046,17 @@ div {
             sch:param [ name = "attr" value = "luksversion" ]
             sch:param [ name = "types" value = "oem iso pxe kis" ]
         ]
+    k.type.luks_pbkdf.attribute =
+        ## When LUKS unlocks a key slot using a user provided
+        ## password, it uses a so-called key derivation function
+        ## to derive a symmetric encryption key from the password.
+        ## Not all boot loaders support all KDF algorithms, hence
+        ## this attribute can be used to select a specific algorithm.
+        attribute luks_pbkdf { "pbkdf2" | "argon2i" | "argon2id" }
+        >> sch:pattern [ id = "luks_pbkdf" is-a = "image_type"
+            sch:param [ name = "attr" value = "luks_pbkdf" ]
+            sch:param [ name = "types" value = "oem iso pxe kis" ]
+        ]
     k.type.mdraid.attribute =
         ## Setup software raid in degraded mode with one disk
         ## Thus only mirroring and striping is possible
@@ -2239,6 +2250,7 @@ div {
         k.type.luks_version.attribute? &
         k.type.luksOS.attribute? &
         k.type.luks_randomize.attribute? &
+        k.type.luks_pbkdf.attribute? &
         k.type.mdraid.attribute? &
         k.type.overlayroot.attribute? &
         k.type.overlayroot_write_partition.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2907,6 +2907,20 @@ distribution</a:documentation>
         <sch:param name="types" value="oem iso pxe kis"/>
       </sch:pattern>
     </define>
+    <define name="k.type.luks_randomize.attribute">
+      <attribute name="luks_randomize">
+        <a:documentation>By default, all blocks of a LUKS volume will be filled
+with pseudo-random data. If you're shipping an image with
+a well-known key, which is going to be re-encrypted at
+deployment time, you can decrease the size of the image
+by setting this attribute to false.</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="luks_randomize" is-a="image_type">
+        <sch:param name="attr" value="luksversion"/>
+        <sch:param name="types" value="oem iso pxe kis"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.mdraid.attribute">
       <attribute name="mdraid">
         <a:documentation>Setup software raid in degraded mode with one disk
@@ -3234,6 +3248,9 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.luksOS.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.luks_randomize.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.mdraid.attribute"/>

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -4115,6 +4115,14 @@ for 4k DASD devices use CDL</a:documentation>
         <sch:param name="types" value="grub2_s390x_emu"/>
       </sch:pattern>
     </define>
+    <define name="k.bootloader.use_disk_password.attribute">
+      <attribute name="use_disk_password">
+        <a:documentation>When /boot is encrypted, make the boot loader store the
+password in its configuration file (in cleartext). This
+is useful for full disk encryption images</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+    </define>
     <define name="k.bootloader.attlist">
       <interleave>
         <ref name="k.bootloader.name.attribute"/>
@@ -4132,6 +4140,9 @@ for 4k DASD devices use CDL</a:documentation>
         </optional>
         <optional>
           <ref name="k.bootloader.targettype.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.bootloader.use_disk_password.attribute"/>
         </optional>
         <optional>
           <ref name="k.bootloader.grub_template.attribute"/>

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2921,6 +2921,24 @@ by setting this attribute to false.</a:documentation>
         <sch:param name="types" value="oem iso pxe kis"/>
       </sch:pattern>
     </define>
+    <define name="k.type.luks_pbkdf.attribute">
+      <attribute name="luks_pbkdf">
+        <a:documentation>When LUKS unlocks a key slot using a user provided
+password, it uses a so-called key derivation function
+to derive a symmetric encryption key from the password.
+Not all boot loaders support all KDF algorithms, hence
+this attribute can be used to select a specific algorithm.</a:documentation>
+        <choice>
+          <value>pbkdf2</value>
+          <value>argon2i</value>
+          <value>argon2id</value>
+        </choice>
+      </attribute>
+      <sch:pattern id="luks_pbkdf" is-a="image_type">
+        <sch:param name="attr" value="luks_pbkdf"/>
+        <sch:param name="types" value="oem iso pxe kis"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.mdraid.attribute">
       <attribute name="mdraid">
         <a:documentation>Setup software raid in degraded mode with one disk
@@ -3251,6 +3269,9 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.luks_randomize.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.luks_pbkdf.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.mdraid.attribute"/>

--- a/kiwi/storage/luks_device.py
+++ b/kiwi/storage/luks_device.py
@@ -91,6 +91,8 @@ class LuksDevice(DeviceProvider):
             file path name which contains an alternative key
             to unlock the luks device
         """
+        pbkdf_options: List[str] = []
+
         if not options:
             options = []
         if os:
@@ -106,7 +108,6 @@ class LuksDevice(DeviceProvider):
 
         # Allow the user to override the pbkdf algorithm that cryptsetup uses by
         # default. Cryptsetup may use argon2i by default, which grub2 doesn't support (yet).
-        pbkdf_options: List[str] = []
         if self.luks_pbkdf is not None:
             pbkdf_options = ['--pbkdf', self.luks_pbkdf]
 

--- a/kiwi/storage/luks_device.py
+++ b/kiwi/storage/luks_device.py
@@ -49,6 +49,7 @@ class LuksDevice(DeviceProvider):
         self.luks_keyfile: Optional[str] = None
         self.luks_name = 'luksRoot'
         self.luks_randomize = True
+        self.luks_pbkdf = None
 
         self.option_map = {
             'sle12': [
@@ -103,9 +104,10 @@ class LuksDevice(DeviceProvider):
         storage_device = self.storage_provider.get_device()
         log.info('Creating crypto LUKS on %s', storage_device)
 
-        # HACK: since grub2 doesn't support argon2 at all for the time being,
-        # force PBKDF2
-        pbkdf_options = ['--pbkdf', 'pbkdf2']
+        # Allow the user to override the pbkdf algorithm that cryptsetup uses by
+        # default. Cryptsetup may use argon2i by default, which grub2 doesn't support (yet).
+        if self.luks_pbkdf is not None:
+            pbkdf_options = ['--pbkdf', self.luks_pbkdf]
 
         if not passphrase:
             log.warning('Using an empty passphrase for the key setup')

--- a/kiwi/storage/luks_device.py
+++ b/kiwi/storage/luks_device.py
@@ -48,6 +48,7 @@ class LuksDevice(DeviceProvider):
         self.luks_device: Optional[str] = None
         self.luks_keyfile: Optional[str] = None
         self.luks_name = 'luksRoot'
+        self.luks_randomize = True
 
         self.option_map = {
             'sle12': [
@@ -109,17 +110,19 @@ class LuksDevice(DeviceProvider):
         if not passphrase:
             log.warning('Using an empty passphrase for the key setup')
 
-        log.info('--> Randomizing...')
-        storage_size_mbytes = self.storage_provider.get_byte_size(
-            storage_device
-        ) / 1048576
-        Command.run(
-            [
-                'dd', 'if=/dev/urandom', 'bs=1M',
-                'count=%d' % storage_size_mbytes,
-                'of=%s' % storage_device
-            ]
-        )
+        if self.luks_randomize:
+            log.info('--> Randomizing...')
+            storage_size_mbytes = self.storage_provider.get_byte_size(
+                storage_device
+            ) / 1048576
+            Command.run(
+                [
+                    'dd', 'if=/dev/urandom', 'bs=1M',
+                    'count=%d' % storage_size_mbytes,
+                    'of=%s' % storage_device
+                ]
+            )
+
         log.info('--> Creating LUKS map')
 
         if passphrase:

--- a/kiwi/storage/luks_device.py
+++ b/kiwi/storage/luks_device.py
@@ -106,6 +106,7 @@ class LuksDevice(DeviceProvider):
 
         # Allow the user to override the pbkdf algorithm that cryptsetup uses by
         # default. Cryptsetup may use argon2i by default, which grub2 doesn't support (yet).
+        pbkdf_options = []
         if self.luks_pbkdf is not None:
             pbkdf_options = ['--pbkdf', self.luks_pbkdf]
 

--- a/kiwi/storage/luks_device.py
+++ b/kiwi/storage/luks_device.py
@@ -17,7 +17,9 @@
 #
 import os
 import logging
-from typing import Optional
+from typing import (
+    List, Optional
+)
 
 # project
 from kiwi.utils.temporary import Temporary

--- a/kiwi/storage/luks_device.py
+++ b/kiwi/storage/luks_device.py
@@ -106,7 +106,7 @@ class LuksDevice(DeviceProvider):
 
         # Allow the user to override the pbkdf algorithm that cryptsetup uses by
         # default. Cryptsetup may use argon2i by default, which grub2 doesn't support (yet).
-        pbkdf_options = []
+        pbkdf_options: List[str] = []
         if self.luks_pbkdf is not None:
             pbkdf_options = ['--pbkdf', self.luks_pbkdf]
 

--- a/kiwi/storage/luks_device.py
+++ b/kiwi/storage/luks_device.py
@@ -102,6 +102,10 @@ class LuksDevice(DeviceProvider):
         storage_device = self.storage_provider.get_device()
         log.info('Creating crypto LUKS on %s', storage_device)
 
+        # HACK: since grub2 doesn't support argon2 at all for the time being,
+        # force PBKDF2
+        pbkdf_options = ['--pbkdf', 'pbkdf2']
+
         if not passphrase:
             log.warning('Using an empty passphrase for the key setup')
 
@@ -133,7 +137,7 @@ class LuksDevice(DeviceProvider):
         Command.run(
             [
                 'cryptsetup', '-q', '--key-file', passphrase_file
-            ] + options + extra_options + [
+            ] + options + extra_options + pbkdf_options + [
                 'luksFormat', storage_device
             ]
         )
@@ -143,7 +147,7 @@ class LuksDevice(DeviceProvider):
             Command.run(
                 [
                     'cryptsetup', '--key-file', passphrase_file
-                ] + extra_options + [
+                ] + extra_options + pbkdf_options + [
                     'luksAddKey', storage_device, keyfile
                 ]
             )

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3047,7 +3047,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -3093,6 +3093,7 @@ class type_(GeneratedsSuper):
         self.luks = _cast(None, luks)
         self.luks_version = _cast(None, luks_version)
         self.luksOS = _cast(None, luksOS)
+        self.luks_randomize = _cast(bool, luks_randomize)
         self.mdraid = _cast(None, mdraid)
         self.overlayroot = _cast(bool, overlayroot)
         self.overlayroot_write_partition = _cast(bool, overlayroot_write_partition)
@@ -3317,6 +3318,8 @@ class type_(GeneratedsSuper):
     def set_luks_version(self, luks_version): self.luks_version = luks_version
     def get_luksOS(self): return self.luksOS
     def set_luksOS(self, luksOS): self.luksOS = luksOS
+    def get_luks_randomize(self): return self.luks_randomize
+    def set_luks_randomize(self, luks_randomize): self.luks_randomize = luks_randomize
     def get_mdraid(self): return self.mdraid
     def set_mdraid(self, mdraid): self.mdraid = mdraid
     def get_overlayroot(self): return self.overlayroot
@@ -3599,6 +3602,9 @@ class type_(GeneratedsSuper):
         if self.luksOS is not None and 'luksOS' not in already_processed:
             already_processed.add('luksOS')
             outfile.write(' luksOS=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.luksOS), input_name='luksOS')), ))
+        if self.luks_randomize is not None and 'luks_randomize' not in already_processed:
+            already_processed.add('luks_randomize')
+            outfile.write(' luks_randomize="%s"' % self.gds_format_boolean(self.luks_randomize, input_name='luks_randomize'))
         if self.mdraid is not None and 'mdraid' not in already_processed:
             already_processed.add('mdraid')
             outfile.write(' mdraid=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.mdraid), input_name='mdraid')), ))
@@ -4017,6 +4023,15 @@ class type_(GeneratedsSuper):
             already_processed.add('luksOS')
             self.luksOS = value
             self.luksOS = ' '.join(self.luksOS.split())
+        value = find_attr_value_('luks_randomize', node)
+        if value is not None and 'luks_randomize' not in already_processed:
+            already_processed.add('luks_randomize')
+            if value in ('true', '1'):
+                self.luks_randomize = True
+            elif value in ('false', '0'):
+                self.luks_randomize = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('mdraid', node)
         if value is not None and 'mdraid' not in already_processed:
             already_processed.add('mdraid')

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -5493,7 +5493,7 @@ class bootloader(GeneratedsSuper):
     provide configuration parameters for it"""
     subclass = None
     superclass = None
-    def __init__(self, name=None, console=None, serial_line=None, timeout=None, timeout_style=None, targettype=None, grub_template=None, bootloadersettings=None):
+    def __init__(self, name=None, console=None, serial_line=None, timeout=None, timeout_style=None, targettype=None, use_disk_password=None, grub_template=None, bootloadersettings=None):
         self.original_tagname_ = None
         self.name = _cast(None, name)
         self.console = _cast(None, console)
@@ -5501,6 +5501,7 @@ class bootloader(GeneratedsSuper):
         self.timeout = _cast(int, timeout)
         self.timeout_style = _cast(None, timeout_style)
         self.targettype = _cast(None, targettype)
+        self.use_disk_password = _cast(bool, use_disk_password)
         self.grub_template = _cast(None, grub_template)
         self.bootloadersettings = bootloadersettings
     def factory(*args_, **kwargs_):
@@ -5528,6 +5529,8 @@ class bootloader(GeneratedsSuper):
     def set_timeout_style(self, timeout_style): self.timeout_style = timeout_style
     def get_targettype(self): return self.targettype
     def set_targettype(self, targettype): self.targettype = targettype
+    def get_use_disk_password(self): return self.use_disk_password
+    def set_use_disk_password(self, use_disk_password): self.use_disk_password = use_disk_password
     def get_grub_template(self): return self.grub_template
     def set_grub_template(self, grub_template): self.grub_template = grub_template
     def validate_grub_console(self, value):
@@ -5584,6 +5587,9 @@ class bootloader(GeneratedsSuper):
         if self.targettype is not None and 'targettype' not in already_processed:
             already_processed.add('targettype')
             outfile.write(' targettype=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.targettype), input_name='targettype')), ))
+        if self.use_disk_password is not None and 'use_disk_password' not in already_processed:
+            already_processed.add('use_disk_password')
+            outfile.write(' use_disk_password="%s"' % self.gds_format_boolean(self.use_disk_password, input_name='use_disk_password'))
         if self.grub_template is not None and 'grub_template' not in already_processed:
             already_processed.add('grub_template')
             outfile.write(' grub_template=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.grub_template), input_name='grub_template')), ))
@@ -5636,6 +5642,15 @@ class bootloader(GeneratedsSuper):
             already_processed.add('targettype')
             self.targettype = value
             self.targettype = ' '.join(self.targettype.split())
+        value = find_attr_value_('use_disk_password', node)
+        if value is not None and 'use_disk_password' not in already_processed:
+            already_processed.add('use_disk_password')
+            if value in ('true', '1'):
+                self.use_disk_password = True
+            elif value in ('false', '0'):
+                self.use_disk_password = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('grub_template', node)
         if value is not None and 'grub_template' not in already_processed:
             already_processed.add('grub_template')

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/ms/Project/kiwi/.tox/3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/okir/.local/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -3047,7 +3047,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -3094,6 +3094,7 @@ class type_(GeneratedsSuper):
         self.luks_version = _cast(None, luks_version)
         self.luksOS = _cast(None, luksOS)
         self.luks_randomize = _cast(bool, luks_randomize)
+        self.luks_pbkdf = _cast(None, luks_pbkdf)
         self.mdraid = _cast(None, mdraid)
         self.overlayroot = _cast(bool, overlayroot)
         self.overlayroot_write_partition = _cast(bool, overlayroot_write_partition)
@@ -3320,6 +3321,8 @@ class type_(GeneratedsSuper):
     def set_luksOS(self, luksOS): self.luksOS = luksOS
     def get_luks_randomize(self): return self.luks_randomize
     def set_luks_randomize(self, luks_randomize): self.luks_randomize = luks_randomize
+    def get_luks_pbkdf(self): return self.luks_pbkdf
+    def set_luks_pbkdf(self, luks_pbkdf): self.luks_pbkdf = luks_pbkdf
     def get_mdraid(self): return self.mdraid
     def set_mdraid(self, mdraid): self.mdraid = mdraid
     def get_overlayroot(self): return self.overlayroot
@@ -3605,6 +3608,9 @@ class type_(GeneratedsSuper):
         if self.luks_randomize is not None and 'luks_randomize' not in already_processed:
             already_processed.add('luks_randomize')
             outfile.write(' luks_randomize="%s"' % self.gds_format_boolean(self.luks_randomize, input_name='luks_randomize'))
+        if self.luks_pbkdf is not None and 'luks_pbkdf' not in already_processed:
+            already_processed.add('luks_pbkdf')
+            outfile.write(' luks_pbkdf=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.luks_pbkdf), input_name='luks_pbkdf')), ))
         if self.mdraid is not None and 'mdraid' not in already_processed:
             already_processed.add('mdraid')
             outfile.write(' mdraid=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.mdraid), input_name='mdraid')), ))
@@ -4032,6 +4038,11 @@ class type_(GeneratedsSuper):
                 self.luks_randomize = False
             else:
                 raise_parse_error(node, 'Bad boolean attribute')
+        value = find_attr_value_('luks_pbkdf', node)
+        if value is not None and 'luks_pbkdf' not in already_processed:
+            already_processed.add('luks_pbkdf')
+            self.luks_pbkdf = value
+            self.luks_pbkdf = ' '.join(self.luks_pbkdf.split())
         value = find_attr_value_('mdraid', node)
         if value is not None and 'mdraid' not in already_processed:
             already_processed.add('mdraid')

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1081,6 +1081,20 @@ class XMLState:
         """
         return self.get_bootloader_options('config')
 
+    def get_build_type_bootloader_use_disk_password(self) -> bool:
+        """
+        Indicate whether the bootloader configuration should use the
+	password protecting the encrypted root volume.
+
+        :return: True|False
+
+        :rtype: bool
+        """
+        bootloader = self.get_build_type_bootloader_section()
+        if bootloader:
+            return bootloader.get_use_disk_password()
+        return False
+
     def get_build_type_oemconfig_section(self) -> Any:
         """
         First oemconfig section from the build type section


### PR DESCRIPTION
This PR contains a set of patches which are needed to build with kiwi encrypted images for SUSE ALP. The patches have been tested on the previous ALP prototypes, see e.g.

https://build.opensuse.org/package/show/SUSE:ALP:Source:Standard:Core:0.1/python-kiwi