### PR TITLE
Documentation: clearify dnf based collection selectors

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -1423,8 +1423,9 @@ any of its required packages and any recommended packages.
 
    On RedHat based distributions collections are called `groups` and are
    extra metadata. To get the names of these groups type the following
-   command: `$ dnf group list`. Please note that group names are allowed
-   to contain whitespace characters.
+   command: `$ dnf group list -v`. Please note that since {kiwi} v9.23.39,
+   group IDs are allowed only, e.g.: 
+   <namedCollection name="minimal-environment"/>
 
 <packages><collectionModule>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
With 89b5a6f5269, the selection of collections was changed to allow group IDs only for `dnf` based package installers.

Complements #1860.
