### PR TITLE
The actual padding is 0. And switch to sha256.

### DIFF
--- a/kiwi/iso_tools/iso.py
+++ b/kiwi/iso_tools/iso.py
@@ -48,9 +48,9 @@ class Iso:
         Command.run(
             [
                 'tagmedia',
-                '--md5',
+                '--digest', 'sha256',
                 '--check',
-                '--pad', '150',
+                '--pad', '0',
                 isofile
             ]
         )

--- a/test/unit/iso_tools/iso_test.py
+++ b/test/unit/iso_tools/iso_test.py
@@ -60,5 +60,5 @@ class TestIso:
     def test_set_media_tag(self, mock_command):
         Iso.set_media_tag('foo')
         mock_command.assert_called_once_with(
-            ['tagmedia', '--md5', '--check', '--pad', '150', 'foo']
+            ['tagmedia', '--digest', 'sha256', '--check', '--pad', '0', 'foo']
         )


### PR DESCRIPTION
## Issues

1. The actual padding used is 0. See https://github.com/OSInside/kiwi/blob/master/kiwi/iso_tools/xorriso.py#L95. Adjust the padding in `tagmedia`. Otherwise media checks will not verify the last 150 kiB.
2. While we change the `tagmedia` call anyway, move to sha256 as checksum.

Note: I haven't looked at what the 'mediacheck' boot option on Live media actually does. Does it rely on md5?