### PR TITLE
make alias unique in any cases

### DIFF
--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -138,10 +138,10 @@ OPTIONS
 
   - **alias**
 
-    An alias name for the repository. If not specified kiwi calculates
-    an alias name as result from a sha sum. The sha sum is used to uniquely
-    identify the repository, but not very expressive. We recommend to
-    set an expressive and uniq alias name.
+    An alias name for the repository. If not specified kiwi generate
+    an alias name as result of hex representation from uuid4. The hex 
+    is used to uniquely identify the repository, but not very expressive. 
+    We recommend to set an expressive and uniq alias name.
 
   - **priority**
 

--- a/doc/source/commands/system_prepare.rst
+++ b/doc/source/commands/system_prepare.rst
@@ -139,10 +139,10 @@ OPTIONS
 
   - **alias**
 
-    An alias name for the repository. If not specified kiwi calculates
-    an alias name as result from a sha sum. The sha sum is used to uniquely
-    identify the repository, but not very expressive. We recommend to
-    set an expressive and uniq alias name.
+    An alias name for the repository. If not specified kiwi generate
+    an alias name as result of hex representation from uuid4. The hex 
+    is used to uniquely identify the repository, but not very expressive. 
+    We recommend to set an expressive and uniq alias name.
 
   - **priority**
 

--- a/doc/source/concept_and_workflow/repository_setup.rst
+++ b/doc/source/concept_and_workflow/repository_setup.rst
@@ -55,9 +55,8 @@ following optional attributes:
 
 - `alias`: Name to be used for this repository, it will appear as the
   repository's name in the image, which is visible via ``zypper repos`` or
-  ``dnf repolist``. {kiwi} will construct an alias from the path in the
-  `source` child element (replacing each `/` with a `_`), if no value is
-  given.
+  ``dnf repolist``. {kiwi} will construct an alias name as result of hex 
+  representation from uuid4, if no value is given.
 
 - `repository_gpgcheck`: Specify whether or not this specific repository is
   configured to to run repository signature validation. If not set, the

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -25,7 +25,7 @@ from urllib.parse import (
 from urllib.request import urlopen
 from urllib.request import Request
 import requests
-import hashlib
+from uuid import uuid4
 from typing import Optional
 
 # project
@@ -205,18 +205,18 @@ class Uri:
 
     def alias(self) -> str:
         """
-        Create hexdigest from URI as alias
+        Create hex representation of uuid4
 
         If the repository definition from the XML description does
         not provide an alias, kiwi creates one for you. However it's
         better to assign a human readable alias in the XML
         configuration
 
-        :return: alias name as hexdigest
+        :return: alias name as hex representation of uuid4
 
         :rtype: str
         """
-        return hashlib.md5(self.uri.encode()).hexdigest()
+        return uuid4().hex
 
     def is_remote(self) -> bool:
         """

--- a/test/unit/system/uri_test.py
+++ b/test/unit/system/uri_test.py
@@ -6,7 +6,6 @@ from mock import (
 from pytest import (
     raises, fixture
 )
-import hashlib
 import mock
 
 from kiwi.system.uri import Uri
@@ -151,11 +150,14 @@ class TestUri:
         uri = Uri('httpx://example.com', 'rpm-md')
         assert uri.is_public() is False
 
-    def test_alias(self):
+    def test_alias_is_str(self):
         uri = Uri('https://example.com', 'rpm-md')
-        assert uri.alias() == hashlib.md5(
-            'https://example.com'.encode()).hexdigest(
-        )
+        assert isinstance(uri.alias(), str) is True
+
+    def test_alias_is_uniq(self):
+        uri1 = Uri('https://example.com', 'rpm-md')
+        uri2 = Uri('https://example.com', 'rpm-md')
+        assert uri1.alias() != uri2.alias()
 
     def test_credentials_file_name(self):
         uri = Uri(


### PR DESCRIPTION
Fixes #2297 .

Changes proposed in this pull request:
* Replace mechanism of alias generation from URI md5 hash with UUID4 hex. This will help avoid non-unique alias (and in fact repository names) when the apt-deb type is being used and the link to repository might be the same in multiple repositories.