### PR TITLE
Change package manager dnf to dnf4

### DIFF
--- a/doc/source/api/kiwi.package_manager.rst
+++ b/doc/source/api/kiwi.package_manager.rst
@@ -14,10 +14,10 @@ Submodules
     :undoc-members:
     :show-inheritance:
 
-`kiwi.package_manager.dnf` Module
----------------------------------
+`kiwi.package_manager.dnf4` Module
+----------------------------------
 
-.. automodule:: kiwi.package_manager.dnf
+.. automodule:: kiwi.package_manager.dnf4
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/source/api/kiwi.repository.rst
+++ b/doc/source/api/kiwi.repository.rst
@@ -14,10 +14,10 @@ Submodules
     :undoc-members:
     :show-inheritance:
 
-`kiwi.repository.dnf` Module
-----------------------------
+`kiwi.repository.dnf4` Module
+-----------------------------
 
-.. automodule:: kiwi.repository.dnf
+.. automodule:: kiwi.repository.dnf4
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -170,7 +170,7 @@ table shows which package manager is connected to which distributor:
 +==============+=================+
 | SUSE         | zypper          |
 +--------------+-----------------+
-| RedHat       | dnf / dnf5      |
+| RedHat       | dnf4 / dnf5     |
 +--------------+-----------------+
 | Debian Based | apt             |
 +--------------+-----------------+ 
@@ -1164,7 +1164,7 @@ Setup software sources for the image.
 
 The mandatory repository element specifies the location and type of a
 repository to be used by the package manager as a package installation
-source. {kiwi} supports apt, dnf, dnf5, pacman and zypper as package managers,
+source. {kiwi} supports apt, dnf4, dnf5, pacman and zypper as package managers,
 specified with the packagemanager element. The repository element has
 the following optional attributes:
 

--- a/kiwi/config/strip.xml
+++ b/kiwi/config/strip.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.2" name="initrd-strip-metadata">
+<image schemaversion="7.6" name="initrd-strip-metadata">
     <description type="boot">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1825,7 +1825,7 @@ class Defaults:
 
         :rtype: str
         """
-        return 'dnf'
+        return 'dnf4'
 
     @staticmethod
     def get_default_packager_tool(package_manager):
@@ -1838,7 +1838,7 @@ class Defaults:
 
         :rtype: str
         """
-        rpm_based = ['zypper', 'dnf', 'dnf5', 'microdnf']
+        rpm_based = ['zypper', 'dnf4', 'dnf5', 'microdnf']
         deb_based = ['apt']
         if package_manager in rpm_based:
             return 'rpm'

--- a/kiwi/package_manager/__init__.py
+++ b/kiwi/package_manager/__init__.py
@@ -56,6 +56,7 @@ class PackageManager(metaclass=ABCMeta):
             'zypper': ['zypper', 'Zypper'],
             'dnf': ['dnf', 'Dnf'],
             'dnf5': ['dnf5', 'Dnf5'],
+            'dnf4': ['dnf4', 'Dnf4'],
             'microdnf': ['microdnf', 'MicroDnf'],
             'pacman': ['pacman', 'Pacman'],
             'apt': ['apt', 'Apt']

--- a/kiwi/package_manager/dnf.py
+++ b/kiwi/package_manager/dnf.py
@@ -15,335 +15,97 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-import re
 from typing import (
-    List, Dict
+    List, Dict, no_type_check
 )
 
 # project
 from kiwi.command import command_call_type
-from kiwi.command import Command
-from kiwi.utils.rpm_database import RpmDataBase
-from kiwi.utils.rpm import Rpm
 from kiwi.package_manager.base import PackageManagerBase
 from kiwi.system.root_bind import RootBind
-from kiwi.path import Path
-from kiwi.defaults import Defaults
-
-from kiwi.exceptions import KiwiRequestError
+from kiwi.api_helper import decommissioned
 
 
 class PackageManagerDnf(PackageManagerBase):
     """
-    ***Implements base class for installation/deletion of
-    packages and collections using dnf***
-
-    :param doct dnf_args: dnf arguments from repository runtime configuration
-    :param dict command_env: dnf command environment from repository runtime
-        configuration
+    decommissioned, moved to PackageManagerDnf4
     """
+    @decommissioned
     def post_init(self, custom_args: List = []) -> None:
-        """
-        Post initialization method
+        pass  # pragma: no cover
 
-        :param list custom_args: custom dnf arguments
-        """
-        self.custom_args = custom_args
-
-        runtime_config = self.repository.runtime_config()
-        self.dnf_args = runtime_config['dnf_args']
-        self.command_env = runtime_config['command_env']
-
+    @decommissioned
     def request_package(self, name: str) -> None:
-        """
-        Queue a package request
+        pass  # pragma: no cover
 
-        :param str name: package name
-        """
-        self.package_requests.append(name)
-
+    @decommissioned
     def request_collection(self, name: str) -> None:
-        """
-        Queue a collection request
+        pass  # pragma: no cover
 
-        :param str name: dnf group ID name
-        """
-        self.collection_requests.append(f'@{name}')
-
+    @decommissioned
     def request_product(self, name: str) -> None:
-        """
-        Queue a product request
+        pass  # pragma: no cover
 
-        There is no product definition in the fedora repo data
-
-        :param str name: unused
-        """
-        pass
-
+    @decommissioned
     def request_package_exclusion(self, name: str) -> None:
-        """
-        Queue a package exclusion(skip) request
+        pass  # pragma: no cover
 
-        :param str name: package name
-        """
-        self.exclude_requests.append(name)
-
+    @decommissioned
     def setup_repository_modules(
         self, collection_modules: Dict[str, List[str]]
     ) -> None:
-        """
-        Setup repository modules and streams
+        pass  # pragma: no cover
 
-        :param dict collection_modules:
-            Expect dict of the form:
-
-            .. code:: python
-
-                {
-                    'enable': [
-                        "module:stream", "module"
-                    ],
-                    'disable': [
-                        "module"
-                    ]
-                }
-        """
-        dnf_module_command = [
-            'dnf'
-        ] + self.dnf_args + [
-            '--installroot', self.root_dir,
-            f'--releasever={self.release_version}'
-        ] + self.custom_args + [
-            'module'
-        ]
-        for disable_module in collection_modules['disable']:
-            Command.run(
-                dnf_module_command + [
-                    'disable', disable_module
-                ], self.command_env
-            )
-        for enable_module in collection_modules['enable']:
-            Command.run(
-                dnf_module_command + [
-                    'reset', enable_module.split(':')[0]
-                ], self.command_env
-            )
-            Command.run(
-                dnf_module_command + [
-                    'enable', enable_module
-                ], self.command_env
-            )
-
+    @no_type_check
+    @decommissioned
     def process_install_requests_bootstrap(
         self, root_bind: RootBind = None, bootstrap_package: str = None
     ) -> command_call_type:
-        """
-        Process package install requests for bootstrap phase (no chroot)
+        pass  # pragma: no cover
 
-        :param object root_bind: unused
-        :param str bootstrap_package: unused
-
-        :return: process results in command type
-
-        :rtype: namedtuple
-        """
-        Command.run(
-            ['dnf'] + self.dnf_args + [
-                f'--releasever={self.release_version}'
-            ] + ['makecache']
-        )
-        dnf_command = [
-            'dnf'
-        ] + self.dnf_args + [
-            '--installroot', self.root_dir,
-            f'--releasever={self.release_version}'
-        ] + self.custom_args + [
-            'install'
-        ] + self.package_requests + self.collection_requests
-        self.cleanup_requests()
-        return Command.call(
-            dnf_command, self.command_env
-        )
-
+    @no_type_check
+    @decommissioned
     def process_install_requests(self) -> command_call_type:
-        """
-        Process package install requests for image phase (chroot)
+        pass  # pragma: no cover
 
-        :return: process results in command type
-
-        :rtype: namedtuple
-        """
-        exclude_args = []
-        if self.exclude_requests:
-            # For DNF, excluding a package means removing it from
-            # the solver operation. This is done by adding --exclude
-            # to the command line. This means that if the package is
-            # hard required by another package, it will break the transaction.
-            for package in self.exclude_requests:
-                exclude_args.append('--exclude=' + package)
-        chroot_dnf_args = Path.move_to_root(
-            self.root_dir, self.dnf_args
-        )
-        dnf_command = [
-            'chroot', self.root_dir, 'dnf'
-        ] + chroot_dnf_args + [
-            f'--releasever={self.release_version}'
-        ] + self.custom_args + exclude_args + [
-            'install'
-        ] + self.package_requests + self.collection_requests
-        self.cleanup_requests()
-        return Command.call(
-            dnf_command, self.command_env
-        )
-
+    @no_type_check
+    @decommissioned
     def process_delete_requests(self, force: bool = False) -> command_call_type:
-        """
-        Process package delete requests (chroot)
+        pass  # pragma: no cover
 
-        :param bool force: force deletion: true|false
-
-        :raises KiwiRequestError: if none of the packages to delete is
-            installed.
-        :return: process results in command type
-
-        :rtype: namedtuple
-        """
-        if force:
-            delete_items = []
-            for delete_item in self.package_requests:
-                try:
-                    Command.run(
-                        ['chroot', self.root_dir, 'rpm', '-q', delete_item]
-                    )
-                    delete_items.append(delete_item)
-                except Exception:
-                    # ignore packages which are not installed
-                    pass
-            if not delete_items:
-                raise KiwiRequestError(
-                    'None of the requested packages to delete are installed'
-                )
-            self.cleanup_requests()
-            delete_options = ['--nodeps', '--allmatches', '--noscripts']
-            return Command.call(
-                [
-                    'chroot', self.root_dir, 'rpm', '-e'
-                ] + delete_options + delete_items,
-                self.command_env
-            )
-        else:
-            chroot_dnf_args = Path.move_to_root(self.root_dir, self.dnf_args)
-            dnf_command = [
-                'chroot', self.root_dir, 'dnf'
-            ] + chroot_dnf_args + [
-                f'--releasever={self.release_version}'
-            ] + self.custom_args + [
-                'autoremove'
-            ] + self.package_requests
-            self.cleanup_requests()
-            return Command.call(
-                dnf_command, self.command_env
-            )
-
+    @no_type_check
+    @decommissioned
     def update(self) -> command_call_type:
-        """
-        Process package update requests (chroot)
+        pass  # pragma: no cover
 
-        :return: process results in command type
-
-        :rtype: namedtuple
-        """
-        chroot_dnf_args = Path.move_to_root(self.root_dir, self.dnf_args)
-        return Command.call(
-            [
-                'chroot', self.root_dir, 'dnf'
-            ] + chroot_dnf_args + [
-                f'--releasever={self.release_version}'
-            ] + self.custom_args + [
-                'upgrade'
-            ],
-            self.command_env
-        )
-
+    @decommissioned
     def process_only_required(self) -> None:
-        """
-        Setup package processing only for required packages
-        """
-        if '--setopt=install_weak_deps=False' not in self.custom_args:
-            self.custom_args.append('--setopt=install_weak_deps=False')
+        pass  # pragma: no cover
 
+    @decommissioned
     def process_plus_recommended(self) -> None:
-        """
-        Setup package processing to also include recommended dependencies.
-        """
-        if '--setopt=install_weak_deps=False' in self.custom_args:
-            self.custom_args.remove('--setopt=install_weak_deps=False')
+        pass  # pragma: no cover
 
+    @no_type_check
+    @decommissioned
     def match_package_installed(
         self, package_name: str, package_manager_output: str
     ) -> bool:
-        """
-        Match expression to indicate a package has been installed
+        pass  # pragma: no cover
 
-        This match for the package to be installed in the output
-        of the dnf command is not 100% accurate. There might
-        be false positives due to sub package names starting with
-        the same base package name
-
-        :param str package_name: package_name
-        :param str package_manager_output: dnf status line
-
-        :returns: True|False
-
-        :rtype: bool
-        """
-        return bool(
-            re.match(
-                '.*Installing  : {0}.*'.format(re.escape(package_name)),
-                package_manager_output
-            )
-        )
-
+    @no_type_check
+    @decommissioned
     def match_package_deleted(
         self, package_name: str, package_manager_output: str
     ) -> bool:
-        """
-        Match expression to indicate a package has been deleted
+        pass  # pragma: no cover
 
-        :param str package_name: package_name
-        :param str package_manager_output: dnf status line
-
-        :returns: True|False
-
-        :rtype: bool
-        """
-        return bool(
-            re.match(
-                '.*Removing: {0}.*'.format(re.escape(package_name)),
-                package_manager_output
-            )
-        )
-
+    @decommissioned
     def post_process_install_requests_bootstrap(
         self, root_bind: RootBind = None, delta_root: bool = False
     ) -> None:
-        """
-        Move the rpm database to the place as it is expected by the
-        rpm package installed during bootstrap phase
+        pass  # pragma: no cover
 
-        :param object root_bind: unused
-        :param bool delta_root: unused
-        """
-        rpmdb = RpmDataBase(self.root_dir)
-        if rpmdb.has_rpm():
-            rpmdb.rebuild_database()
-            rpmdb.set_database_to_image_path()
-
+    @decommissioned
     def clean_leftovers(self) -> None:
-        """
-        Cleans package manager related data not needed in the
-        resulting image such as custom macros
-        """
-        Rpm(
-            self.root_dir, Defaults.get_custom_rpm_image_macro_name()
-        ).wipe_config()
+        pass  # pragma: no cover

--- a/kiwi/repository/__init__.py
+++ b/kiwi/repository/__init__.py
@@ -50,6 +50,7 @@ class Repository(metaclass=ABCMeta):
             'zypper': ['zypper', 'Zypper'],
             'dnf': ['dnf', 'Dnf'],
             'dnf5': ['dnf5', 'Dnf5'],
+            'dnf4': ['dnf4', 'Dnf4'],
             'microdnf': ['dnf', 'Dnf'],
             'apt': ['apt', 'Apt'],
             'pacman': ['pacman', 'Pacman']

--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -15,177 +15,37 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-import os
-import glob
-from configparser import ConfigParser
-from typing import List, Dict
+from typing import (
+    List, Dict, no_type_check
+)
 
 # project
-from kiwi.utils.temporary import Temporary
-from kiwi.defaults import Defaults
-from kiwi.command import Command
 from kiwi.repository.base import RepositoryBase
-from kiwi.path import Path
-from kiwi.utils.rpm_database import RpmDataBase
+from kiwi.api_helper import decommissioned
 
 
 class RepositoryDnf(RepositoryBase):
     """
-    **Implements repository handling for dnf package manager**
-
-    :param str shared_dnf_dir: shared directory between image root
-        and build system root
-    :param str runtime_dnf_config_file: dnf runtime config file name
-    :param dict command_env: customized os.environ for dnf
-    :param str runtime_dnf_config: instance of :class:`ConfigParser`
+    decommissioned
     """
-
+    @decommissioned
     def post_init(self, custom_args: List = []) -> None:
-        """
-        Post initialization method
+        pass  # pragma: no cover
 
-        Store custom dnf arguments and create runtime configuration
-        and environment
-
-        :param list custom_args: dnf arguments
-        """
-        self.custom_args = custom_args
-        self.exclude_docs = False
-        self.locale = None
-        self.target_arch = None
-
-        # extract custom arguments not used in dnf call
-        if 'exclude_docs' in self.custom_args:
-            self.custom_args.remove('exclude_docs')
-            self.exclude_docs = True
-
-        if 'check_signatures' in self.custom_args:
-            self.custom_args.remove('check_signatures')
-            self.gpg_check = '1'
-        else:
-            self.gpg_check = '0'
-
-        for argument in self.custom_args:
-            if '_install_langs' in argument:
-                self.locale = argument
-            elif '_target_arch' in argument:
-                self.target_arch = argument
-        if self.locale:
-            self.custom_args.remove(self.locale)
-        if self.target_arch:
-            self.custom_args.remove(self.target_arch)
-            self.target_arch = self.target_arch.split('%')[1]
-
-        self.repo_names: List = []
-
-        # dnf support is based on creating repo files which contains
-        # path names to the repo and its cache. In order to allow a
-        # persistent use of the files in and outside of a chroot call
-        # an active bind mount from RootBind::mount_shared_directory
-        # is expected and required
-        manager_base = self.shared_location + '/dnf'
-
-        self.shared_dnf_dir = {
-            'reposd-dir': manager_base + '/repos',
-            'cache-dir': manager_base + '/cache',
-            'pluginconf-dir': manager_base + '/pluginconf',
-            'vars-dir': manager_base + '/vars'
-        }
-
-        self.runtime_dnf_config_file = Temporary(
-            path=self.root_dir
-        ).new_file()
-
-        self.dnf_args = [
-            '--config', self.runtime_dnf_config_file.name, '-y'
-        ] + self.custom_args
-
-        self.command_env = self._create_dnf_runtime_environment()
-
-        # config file parameters for dnf tool
-        self._create_runtime_config_parser()
-        self._create_runtime_plugin_config_parsers()
-        self._write_runtime_config()
-
+    @decommissioned
     def setup_package_database_configuration(self) -> None:
-        """
-        Setup rpm macros for bootstrapping and image building
+        pass  # pragma: no cover
 
-        1. Create the rpm image macro which persists during the build
-        2. Create the rpm bootstrap macro to make sure for bootstrapping
-           the rpm database location matches the host rpm database setup.
-           This macro only persists during the bootstrap phase. If the
-           image was already bootstrapped a compat link is created instead.
-        """
-        rpmdb = RpmDataBase(
-            self.root_dir, Defaults.get_custom_rpm_image_macro_name()
-        )
-        if self.locale:
-            rpmdb.set_macro_from_string(self.locale)
-        rpmdb.write_config()
-
-        rpmdb = RpmDataBase(self.root_dir)
-        if rpmdb.has_rpm():
-            rpmdb.link_database_to_host_path()
-        else:
-            rpmdb.set_database_to_host_path()
-        # SUSE compat code:
-        #
-        # Manually adding the compat link /var/lib/rpm that points to the
-        # rpmdb location as it is configured in the host rpm setup. DNF makes
-        # use of the host setup to bootstrap or to read the signing keys
-        # from the rpm database setup provisioned by rpm itself (macro level).
-        # It assumes the host setup is the default for the system being built.
-        #
-        # For SUSE this is causing a mismatch as the host setup is not the RPM
-        # default (/var/lib/rpm) and SUSE distros proactively relocate the rpm
-        # database from the default location to a custom one when the
-        # rpm package and related macros are installed for the first time.
-        rpmdb.init_database()
-        image_rpm_compat_link = '/var/lib/rpm'
-        host_rpm_dbpath = rpmdb.rpmdb_host.expand_query('%_dbpath')
-        if host_rpm_dbpath != image_rpm_compat_link:
-            Path.create(
-                self.root_dir + os.path.dirname(image_rpm_compat_link)
-            )
-            Command.run(
-                [
-                    'ln', '-s', '--no-target-directory',
-                    ''.join(['../..', host_rpm_dbpath]),
-                    self.root_dir + image_rpm_compat_link
-                ], raise_on_error=False
-            )
-
+    @decommissioned
     def use_default_location(self) -> None:
-        """
-        Setup dnf repository operations to store all data
-        in the default places
-        """
-        self.shared_dnf_dir['reposd-dir'] = \
-            self.root_dir + '/etc/yum.repos.d'
-        self.shared_dnf_dir['cache-dir'] = \
-            self.root_dir + '/var/cache/dnf'
-        self.shared_dnf_dir['pluginconf-dir'] = \
-            self.root_dir + '/etc/dnf/plugins'
-        self.shared_dnf_dir['vars-dir'] = \
-            self.root_dir + '/etc/dnf/vars'
-        self._create_runtime_config_parser()
-        self._create_runtime_plugin_config_parsers()
-        self._write_runtime_config()
+        pass  # pragma: no cover
 
+    @no_type_check
+    @decommissioned
     def runtime_config(self) -> Dict:
-        """
-        dnf runtime configuration and environment
+        pass  # pragma: no cover
 
-        :return: dnf_args:list, command_env:dict
-
-        :rtype: dict
-        """
-        return {
-            'dnf_args': self.dnf_args,
-            'command_env': self.command_env
-        }
-
+    @decommissioned
     def add_repo(
         self, name: str, uri: str, repo_type: str = 'rpm-md',
         prio: int = None, dist: str = None, components: str = None,
@@ -194,162 +54,41 @@ class RepositoryDnf(RepositoryBase):
         sourcetype: str = None, use_for_bootstrap: bool = False,
         customization_script: str = None
     ) -> None:
-        """
-        Add dnf repository
+        pass  # pragma: no cover
 
-        :param str name: repository base file name
-        :param str uri: repository URI
-        :param str repo_type: repostory type name
-        :param int prio: dnf repostory priority
-        :param str dist: unused
-        :param str components: unused
-        :param str user: unused
-        :param str secret: unused
-        :param str credentials_file: unused
-        :param bool repo_gpgcheck: enable repository signature validation
-        :param bool pkg_gpgcheck: enable package signature validation
-        :param str sourcetype:
-            source type, one of 'baseurl', 'metalink' or 'mirrorlist'
-        :param bool use_for_bootstrap: unused
-        :param str customization_script:
-            custom script called after the repo file was created
-        """
-        repo_file = self.shared_dnf_dir['reposd-dir'] + '/' + name + '.repo'
-        self.repo_names.append(name + '.repo')
-        if os.path.exists(uri):
-            # dnf requires local paths to take the file: type
-            uri = 'file://' + uri
-        repo_config = ConfigParser(interpolation=None)
-        repo_config.add_section(name)
-        repo_config.set(
-            name, 'name', name
-        )
-        repo_config.set(
-            name, sourcetype if sourcetype else 'baseurl', uri
-        )
-        if prio:
-            repo_config.set(
-                name, 'priority', format(prio)
-            )
-        repo_config.set(
-            name, 'repo_gpgcheck', '1' if repo_gpgcheck else '0'
-        )
-        repo_config.set(
-            name, 'gpgcheck', '1' if pkg_gpgcheck else '0'
-        )
-        if Defaults.is_buildservice_worker():
-            # when building in the build service, modular metadata is
-            # inaccessible. In order to use modular content in the build
-            # service, we need to disable modular filtering, which is
-            # done with module_hotfixes option
-            repo_config.set(
-                name, 'module_hotfixes', '1'
-            )
-        with open(repo_file, 'w') as repo:
-            repo_config.write(repo)
-        if customization_script:
-            self.run_repo_customize(customization_script, repo_file)
-
+    @decommissioned
     def import_trusted_keys(self, signing_keys: List) -> None:
-        """
-        Imports trusted keys into the image
+        pass  # pragma: no cover
 
-        :param list signing_keys: list of the key files to import
-        """
-        rpmdb = RpmDataBase(self.root_dir)
-        for key in signing_keys:
-            rpmdb.import_signing_key_to_image(key)
-
+    @decommissioned
     def delete_repo(self, name: str) -> None:
-        """
-        Delete dnf repository
+        pass  # pragma: no cover
 
-        :param str name: repository base file name
-        """
-        Path.wipe(
-            self.shared_dnf_dir['reposd-dir'] + '/' + name + '.repo'
-        )
-
+    @decommissioned
     def delete_all_repos(self) -> None:
-        """
-        Delete all dnf repositories
-        """
-        Path.wipe(self.shared_dnf_dir['reposd-dir'])
-        Path.create(self.shared_dnf_dir['reposd-dir'])
+        pass  # pragma: no cover
 
+    @decommissioned
     def delete_repo_cache(self, name: str) -> None:
-        """
-        Delete dnf repository cache
+        pass  # pragma: no cover
 
-        The cache data for each repository is stored in a directory
-        and additional files all starting with the repository name.
-        The method glob deletes all files and directories matching
-        the repository name followed by any characters to cleanup
-        the cache information
-
-        :param str name: repository name
-        """
-        dnf_cache_glob_pattern = ''.join(
-            [self.shared_dnf_dir['cache-dir'], os.sep, name, '*']
-        )
-        for dnf_cache_file in glob.iglob(dnf_cache_glob_pattern):
-            Path.wipe(dnf_cache_file)
-
+    @decommissioned
     def cleanup_unused_repos(self) -> None:
-        """
-        Delete unused dnf repositories
+        pass  # pragma: no cover
 
-        Repository configurations which are not used for this build
-        must be removed otherwise they are taken into account for
-        the package installations
-        """
-        repos_dir = self.shared_dnf_dir['reposd-dir']
-        repo_files = list(os.walk(repos_dir))[0][2]
-        for repo_file in repo_files:
-            if repo_file not in self.repo_names:
-                Path.wipe(repos_dir + '/' + repo_file)
-
+    @no_type_check
+    @decommissioned
     def _create_dnf_runtime_environment(self) -> Dict:
-        for dnf_dir in list(self.shared_dnf_dir.values()):
-            Path.create(dnf_dir)
-        return dict(
-            os.environ, LANG='C'
-        )
+        pass  # pragma: no cover
 
+    @decommissioned
     def _create_runtime_config_parser(self) -> None:
-        self.runtime_dnf_config = ConfigParser(interpolation=None)
-        self.runtime_dnf_config["main"] = {
-            "cachedir": self.shared_dnf_dir['cache-dir'],
-            "reposdir": self.shared_dnf_dir['reposd-dir'],
-            "varsdir": self.shared_dnf_dir['vars-dir'],
-            "pluginconfpath": self.shared_dnf_dir['pluginconf-dir'],
-            "keepcache": "1",
-            "debuglevel": "2",
-            "best": "1",
-            "obsoletes": "1",
-            "plugins": "1",
-            "gpgcheck": self.gpg_check,
-        }
-        if self.exclude_docs:
-            self.runtime_dnf_config["main"]["tsflags"] = "nodocs"
-        if self.target_arch:
-            self.runtime_dnf_config["main"].update({
-                "arch": self.target_arch,
-                "ignorearch": "1",
-            })
+        pass  # pragma: no cover
 
+    @decommissioned
     def _create_runtime_plugin_config_parsers(self) -> None:
-        self.runtime_dnf_plugin_configs = {
-            plugin: ConfigParser(interpolation=None) for plugin in ("priorities", "versionlock")
-        }
-        self.runtime_dnf_plugin_configs["priorities"]["main"] = {"enabled": "1"}
-        self.runtime_dnf_plugin_configs["versionlock"]["main"] = {"enabled": "0"}
+        pass  # pragma: no cover
 
+    @decommissioned
     def _write_runtime_config(self) -> None:
-        with open(self.runtime_dnf_config_file.name, 'w') as config:
-            self.runtime_dnf_config.write(config)
-        if os.path.exists(self.shared_dnf_dir['pluginconf-dir']):
-            for plugin_name, plugin_config in self.runtime_dnf_plugin_configs.items():
-                path = f"{self.shared_dnf_dir['pluginconf-dir']}/{plugin_name}.conf"
-                with open(path, "w") as plugin_config_fobj:
-                    plugin_config.write(plugin_config_fobj)
+        pass  # pragma: no cover

--- a/kiwi/repository/dnf4.py
+++ b/kiwi/repository/dnf4.py
@@ -1,0 +1,355 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+import glob
+from configparser import ConfigParser
+from typing import List, Dict
+
+# project
+from kiwi.utils.temporary import Temporary
+from kiwi.defaults import Defaults
+from kiwi.command import Command
+from kiwi.repository.base import RepositoryBase
+from kiwi.path import Path
+from kiwi.utils.rpm_database import RpmDataBase
+
+
+class RepositoryDnf4(RepositoryBase):
+    """
+    **Implements repository handling for dnf package manager**
+
+    :param str shared_dnf_dir: shared directory between image root
+        and build system root
+    :param str runtime_dnf_config_file: dnf runtime config file name
+    :param dict command_env: customized os.environ for dnf
+    :param str runtime_dnf_config: instance of :class:`ConfigParser`
+    """
+
+    def post_init(self, custom_args: List = []) -> None:
+        """
+        Post initialization method
+
+        Store custom dnf arguments and create runtime configuration
+        and environment
+
+        :param list custom_args: dnf arguments
+        """
+        self.custom_args = custom_args
+        self.exclude_docs = False
+        self.locale = None
+        self.target_arch = None
+
+        # extract custom arguments not used in dnf call
+        if 'exclude_docs' in self.custom_args:
+            self.custom_args.remove('exclude_docs')
+            self.exclude_docs = True
+
+        if 'check_signatures' in self.custom_args:
+            self.custom_args.remove('check_signatures')
+            self.gpg_check = '1'
+        else:
+            self.gpg_check = '0'
+
+        for argument in self.custom_args:
+            if '_install_langs' in argument:
+                self.locale = argument
+            elif '_target_arch' in argument:
+                self.target_arch = argument
+        if self.locale:
+            self.custom_args.remove(self.locale)
+        if self.target_arch:
+            self.custom_args.remove(self.target_arch)
+            self.target_arch = self.target_arch.split('%')[1]
+
+        self.repo_names: List = []
+
+        # dnf support is based on creating repo files which contains
+        # path names to the repo and its cache. In order to allow a
+        # persistent use of the files in and outside of a chroot call
+        # an active bind mount from RootBind::mount_shared_directory
+        # is expected and required
+        manager_base = self.shared_location + '/dnf'
+
+        self.shared_dnf_dir = {
+            'reposd-dir': manager_base + '/repos',
+            'cache-dir': manager_base + '/cache',
+            'pluginconf-dir': manager_base + '/pluginconf',
+            'vars-dir': manager_base + '/vars'
+        }
+
+        self.runtime_dnf_config_file = Temporary(
+            path=self.root_dir
+        ).new_file()
+
+        self.dnf_args = [
+            '--config', self.runtime_dnf_config_file.name, '-y'
+        ] + self.custom_args
+
+        self.command_env = self._create_dnf_runtime_environment()
+
+        # config file parameters for dnf tool
+        self._create_runtime_config_parser()
+        self._create_runtime_plugin_config_parsers()
+        self._write_runtime_config()
+
+    def setup_package_database_configuration(self) -> None:
+        """
+        Setup rpm macros for bootstrapping and image building
+
+        1. Create the rpm image macro which persists during the build
+        2. Create the rpm bootstrap macro to make sure for bootstrapping
+           the rpm database location matches the host rpm database setup.
+           This macro only persists during the bootstrap phase. If the
+           image was already bootstrapped a compat link is created instead.
+        """
+        rpmdb = RpmDataBase(
+            self.root_dir, Defaults.get_custom_rpm_image_macro_name()
+        )
+        if self.locale:
+            rpmdb.set_macro_from_string(self.locale)
+        rpmdb.write_config()
+
+        rpmdb = RpmDataBase(self.root_dir)
+        if rpmdb.has_rpm():
+            rpmdb.link_database_to_host_path()
+        else:
+            rpmdb.set_database_to_host_path()
+        # SUSE compat code:
+        #
+        # Manually adding the compat link /var/lib/rpm that points to the
+        # rpmdb location as it is configured in the host rpm setup. DNF makes
+        # use of the host setup to bootstrap or to read the signing keys
+        # from the rpm database setup provisioned by rpm itself (macro level).
+        # It assumes the host setup is the default for the system being built.
+        #
+        # For SUSE this is causing a mismatch as the host setup is not the RPM
+        # default (/var/lib/rpm) and SUSE distros proactively relocate the rpm
+        # database from the default location to a custom one when the
+        # rpm package and related macros are installed for the first time.
+        rpmdb.init_database()
+        image_rpm_compat_link = '/var/lib/rpm'
+        host_rpm_dbpath = rpmdb.rpmdb_host.expand_query('%_dbpath')
+        if host_rpm_dbpath != image_rpm_compat_link:
+            Path.create(
+                self.root_dir + os.path.dirname(image_rpm_compat_link)
+            )
+            Command.run(
+                [
+                    'ln', '-s', '--no-target-directory',
+                    ''.join(['../..', host_rpm_dbpath]),
+                    self.root_dir + image_rpm_compat_link
+                ], raise_on_error=False
+            )
+
+    def use_default_location(self) -> None:
+        """
+        Setup dnf repository operations to store all data
+        in the default places
+        """
+        self.shared_dnf_dir['reposd-dir'] = \
+            self.root_dir + '/etc/yum.repos.d'
+        self.shared_dnf_dir['cache-dir'] = \
+            self.root_dir + '/var/cache/dnf'
+        self.shared_dnf_dir['pluginconf-dir'] = \
+            self.root_dir + '/etc/dnf/plugins'
+        self.shared_dnf_dir['vars-dir'] = \
+            self.root_dir + '/etc/dnf/vars'
+        self._create_runtime_config_parser()
+        self._create_runtime_plugin_config_parsers()
+        self._write_runtime_config()
+
+    def runtime_config(self) -> Dict:
+        """
+        dnf runtime configuration and environment
+
+        :return: dnf_args:list, command_env:dict
+
+        :rtype: dict
+        """
+        return {
+            'dnf_args': self.dnf_args,
+            'command_env': self.command_env
+        }
+
+    def add_repo(
+        self, name: str, uri: str, repo_type: str = 'rpm-md',
+        prio: int = None, dist: str = None, components: str = None,
+        user: str = None, secret: str = None, credentials_file: str = None,
+        repo_gpgcheck: bool = False, pkg_gpgcheck: bool = False,
+        sourcetype: str = None, use_for_bootstrap: bool = False,
+        customization_script: str = None
+    ) -> None:
+        """
+        Add dnf repository
+
+        :param str name: repository base file name
+        :param str uri: repository URI
+        :param str repo_type: repostory type name
+        :param int prio: dnf repostory priority
+        :param str dist: unused
+        :param str components: unused
+        :param str user: unused
+        :param str secret: unused
+        :param str credentials_file: unused
+        :param bool repo_gpgcheck: enable repository signature validation
+        :param bool pkg_gpgcheck: enable package signature validation
+        :param str sourcetype:
+            source type, one of 'baseurl', 'metalink' or 'mirrorlist'
+        :param bool use_for_bootstrap: unused
+        :param str customization_script:
+            custom script called after the repo file was created
+        """
+        repo_file = self.shared_dnf_dir['reposd-dir'] + '/' + name + '.repo'
+        self.repo_names.append(name + '.repo')
+        if os.path.exists(uri):
+            # dnf requires local paths to take the file: type
+            uri = 'file://' + uri
+        repo_config = ConfigParser(interpolation=None)
+        repo_config.add_section(name)
+        repo_config.set(
+            name, 'name', name
+        )
+        repo_config.set(
+            name, sourcetype if sourcetype else 'baseurl', uri
+        )
+        if prio:
+            repo_config.set(
+                name, 'priority', format(prio)
+            )
+        repo_config.set(
+            name, 'repo_gpgcheck', '1' if repo_gpgcheck else '0'
+        )
+        repo_config.set(
+            name, 'gpgcheck', '1' if pkg_gpgcheck else '0'
+        )
+        if Defaults.is_buildservice_worker():
+            # when building in the build service, modular metadata is
+            # inaccessible. In order to use modular content in the build
+            # service, we need to disable modular filtering, which is
+            # done with module_hotfixes option
+            repo_config.set(
+                name, 'module_hotfixes', '1'
+            )
+        with open(repo_file, 'w') as repo:
+            repo_config.write(repo)
+        if customization_script:
+            self.run_repo_customize(customization_script, repo_file)
+
+    def import_trusted_keys(self, signing_keys: List) -> None:
+        """
+        Imports trusted keys into the image
+
+        :param list signing_keys: list of the key files to import
+        """
+        rpmdb = RpmDataBase(self.root_dir)
+        for key in signing_keys:
+            rpmdb.import_signing_key_to_image(key)
+
+    def delete_repo(self, name: str) -> None:
+        """
+        Delete dnf repository
+
+        :param str name: repository base file name
+        """
+        Path.wipe(
+            self.shared_dnf_dir['reposd-dir'] + '/' + name + '.repo'
+        )
+
+    def delete_all_repos(self) -> None:
+        """
+        Delete all dnf repositories
+        """
+        Path.wipe(self.shared_dnf_dir['reposd-dir'])
+        Path.create(self.shared_dnf_dir['reposd-dir'])
+
+    def delete_repo_cache(self, name: str) -> None:
+        """
+        Delete dnf repository cache
+
+        The cache data for each repository is stored in a directory
+        and additional files all starting with the repository name.
+        The method glob deletes all files and directories matching
+        the repository name followed by any characters to cleanup
+        the cache information
+
+        :param str name: repository name
+        """
+        dnf_cache_glob_pattern = ''.join(
+            [self.shared_dnf_dir['cache-dir'], os.sep, name, '*']
+        )
+        for dnf_cache_file in glob.iglob(dnf_cache_glob_pattern):
+            Path.wipe(dnf_cache_file)
+
+    def cleanup_unused_repos(self) -> None:
+        """
+        Delete unused dnf repositories
+
+        Repository configurations which are not used for this build
+        must be removed otherwise they are taken into account for
+        the package installations
+        """
+        repos_dir = self.shared_dnf_dir['reposd-dir']
+        repo_files = list(os.walk(repos_dir))[0][2]
+        for repo_file in repo_files:
+            if repo_file not in self.repo_names:
+                Path.wipe(repos_dir + '/' + repo_file)
+
+    def _create_dnf_runtime_environment(self) -> Dict:
+        for dnf_dir in list(self.shared_dnf_dir.values()):
+            Path.create(dnf_dir)
+        return dict(
+            os.environ, LANG='C'
+        )
+
+    def _create_runtime_config_parser(self) -> None:
+        self.runtime_dnf_config = ConfigParser(interpolation=None)
+        self.runtime_dnf_config["main"] = {
+            "cachedir": self.shared_dnf_dir['cache-dir'],
+            "reposdir": self.shared_dnf_dir['reposd-dir'],
+            "varsdir": self.shared_dnf_dir['vars-dir'],
+            "pluginconfpath": self.shared_dnf_dir['pluginconf-dir'],
+            "keepcache": "1",
+            "debuglevel": "2",
+            "best": "1",
+            "obsoletes": "1",
+            "plugins": "1",
+            "gpgcheck": self.gpg_check,
+        }
+        if self.exclude_docs:
+            self.runtime_dnf_config["main"]["tsflags"] = "nodocs"
+        if self.target_arch:
+            self.runtime_dnf_config["main"].update({
+                "arch": self.target_arch,
+                "ignorearch": "1",
+            })
+
+    def _create_runtime_plugin_config_parsers(self) -> None:
+        self.runtime_dnf_plugin_configs = {
+            plugin: ConfigParser(interpolation=None) for plugin in ("priorities", "versionlock")
+        }
+        self.runtime_dnf_plugin_configs["priorities"]["main"] = {"enabled": "1"}
+        self.runtime_dnf_plugin_configs["versionlock"]["main"] = {"enabled": "0"}
+
+    def _write_runtime_config(self) -> None:
+        with open(self.runtime_dnf_config_file.name, 'w') as config:
+            self.runtime_dnf_config.write(config)
+        if os.path.exists(self.shared_dnf_dir['pluginconf-dir']):
+            for plugin_name, plugin_config in self.runtime_dnf_plugin_configs.items():
+                path = f"{self.shared_dnf_dir['pluginconf-dir']}/{plugin_name}.conf"
+                with open(path, "w") as plugin_config_fobj:
+                    plugin_config.write(plugin_config_fobj)

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -65,7 +65,7 @@ div {
         attribute xsi:schemaLocation { xsd:anyURI }
     k.image.schemaversion.attribute =
         ## The allowed Schema version (fixed value)
-        attribute schemaversion { "7.5" }
+        attribute schemaversion { "7.6" }
     k.image.id =
         ## An identification number which is represented in a file
         ## named /etc/ImageID
@@ -963,7 +963,7 @@ div {
 #
 div {
     k.packagemanager.content = 
-        "apt" | "zypper" | "dnf" | "dnf5" | "microdnf" | "pacman"
+        "apt" | "zypper" | "dnf4" | "dnf5" | "microdnf" | "pacman"
     k.packagemanager.attlist = empty
     k.packagemanager =
         ## Name of the Package Manager

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -145,7 +145,7 @@ second the location of the XSD Schema
     <define name="k.image.schemaversion.attribute">
       <attribute name="schemaversion">
         <a:documentation>The allowed Schema version (fixed value)</a:documentation>
-        <value>7.5</value>
+        <value>7.6</value>
       </attribute>
     </define>
     <define name="k.image.id">
@@ -1466,7 +1466,7 @@ the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
       <choice>
         <value>apt</value>
         <value>zypper</value>
-        <value>dnf</value>
+        <value>dnf4</value>
         <value>dnf5</value>
         <value>microdnf</value>
         <value>pacman</value>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -728,7 +728,7 @@ def _cast(typ, value):
 class k_packagemanager_content(object):
     APT='apt'
     ZYPPER='zypper'
-    DNF='dnf'
+    DNF_4='dnf4'
     DNF_5='dnf5'
     MICRODNF='microdnf'
     PACMAN='pacman'

--- a/kiwi/xsl/convert75to76.xsl
+++ b/kiwi/xsl/convert75to76.xsl
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv75to76">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv75to76"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>7.5</literal> to <literal>7.6</literal>.
+</para>
+<xsl:template match="image" mode="conv75to76">
+    <xsl:choose>
+        <!-- nothing to do if already at 7.6 -->
+        <xsl:when test="@schemaversion > 7.5">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="7.6">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv75to76"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- change packagemanager to dnf4 if set to dnf -->
+<xsl:template match="packagemanager" mode="conv75to76">
+    <xsl:choose>
+        <xsl:when test="text()='dnf'">
+            <packagemanager>dnf4</packagemanager>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:copy-of select="."/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/kiwi/xsl/master.xsl
+++ b/kiwi/xsl/master.xsl
@@ -47,6 +47,7 @@
 <xsl:import href="convert72to73.xsl"/>
 <xsl:import href="convert73to74.xsl"/>
 <xsl:import href="convert74to75.xsl"/>
+<xsl:import href="convert75to76.xsl"/>
 <xsl:import href="pretty.xsl"/>
 
 <xsl:output encoding="utf-8"/>
@@ -220,8 +221,12 @@
         <xsl:apply-templates select="exslt:node-set($v74)" mode="conv74to75"/>
     </xsl:variable>
 
+    <xsl:variable name="v76">
+        <xsl:apply-templates select="exslt:node-set($v75)" mode="conv75to76"/>
+    </xsl:variable>
+
     <xsl:apply-templates
-        select="exslt:node-set($v75)" mode="pretty"
+        select="exslt:node-set($v76)" mode="pretty"
     />
 </xsl:template>
 

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -110,6 +110,7 @@ Provides:       kiwi-packagemanager:dnf5
 %if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version} >= 1650
 Requires:       dnf
 Provides:       kiwi-packagemanager:dnf
+Provides:       kiwi-packagemanager:dnf4
 Provides:       kiwi-packagemanager:yum
 %endif
 %endif

--- a/test/data/example_apt_config.xml
+++ b/test/data/example_apt_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="apt-testing">
+<image schemaversion="7.6" name="apt-testing">
     <description type="system">
         <author>Bob</author>
         <contact>user@example.com</contact>

--- a/test/data/example_arm_disk_size_config.xml
+++ b/test/data/example_arm_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_btrfs_config.xml
+++ b/test/data/example_btrfs_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS" displayname="Bob">
+<image schemaversion="7.6" name="LimeJeOS" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>

--- a/test/data/example_config_target_dir.xml
+++ b/test/data/example_config_target_dir.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS" displayname="Bob">
+<image schemaversion="7.6" name="LimeJeOS" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>

--- a/test/data/example_disk_config.xml
+++ b/test/data/example_disk_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_config.xml
+++ b/test/data/example_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_empty_vol_config.xml
+++ b/test/data/example_disk_size_empty_vol_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_oem_volume_config.xml
+++ b/test/data/example_disk_size_oem_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_partition_too_small_config.xml
+++ b/test/data/example_disk_size_partition_too_small_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="TestPartitions">
+<image schemaversion="7.6" name="TestPartitions">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_partitions_config.xml
+++ b/test/data/example_disk_size_partitions_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="TestPartitions">
+<image schemaversion="7.6" name="TestPartitions">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_vol_root_config.xml
+++ b/test/data/example_disk_size_vol_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_volume_config.xml
+++ b/test/data/example_disk_size_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_volume_too_small_config.xml
+++ b/test/data/example_disk_size_volume_too_small_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="JeOS">
+<image schemaversion="7.6" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_dot_profile_config.xml
+++ b/test/data/example_dot_profile_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_include_config.xml
+++ b/test/data/example_include_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS">
+<image schemaversion="7.6" name="LimeJeOS">
     <description type="system">
         <author>Marcus</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_include_config_from_description_dir.xml
+++ b/test/data/example_include_config_from_description_dir.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS">
+<image schemaversion="7.6" name="LimeJeOS">
     <description type="system">
         <author>Marcus</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_include_config_missing_reference.xml
+++ b/test/data/example_include_config_missing_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="JeOS">
+<image schemaversion="7.6" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_custom_rootvol_config.xml
+++ b/test/data/example_lvm_custom_rootvol_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="custom-root-volume-setup">
+<image schemaversion="7.6" name="custom-root-volume-setup">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_default_config.xml
+++ b/test/data/example_lvm_default_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_config.xml
+++ b/test/data/example_lvm_no_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_full_usr_config.xml
+++ b/test/data/example_lvm_no_root_full_usr_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_preferred_config.xml
+++ b/test/data/example_lvm_preferred_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_multiple_users_config.xml
+++ b/test/data/example_multiple_users_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_default_type.xml
+++ b/test/data/example_no_default_type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_image_packages_config.xml
+++ b/test/data/example_no_image_packages_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_imageinclude_config.xml
+++ b/test/data/example_no_imageinclude_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_partitions_config.xml
+++ b/test/data/example_partitions_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="TestPartitions">
+<image schemaversion="7.6" name="TestPartitions">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_ppc_disk_size_config.xml
+++ b/test/data/example_ppc_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_pxe_config.xml
+++ b/test/data/example_pxe_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_boot_desc_not_found.xml
+++ b/test/data/example_runtime_checker_boot_desc_not_found.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="JeOS">
+<image schemaversion="7.6" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>

--- a/test/data/example_runtime_checker_conflicting_types.xml
+++ b/test/data/example_runtime_checker_conflicting_types.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="TypeConflict">
+<image schemaversion="7.6" name="TypeConflict">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/test/data/example_runtime_checker_include_nested_reference.xml
+++ b/test/data/example_runtime_checker_include_nested_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="JeOS">
+<image schemaversion="7.6" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_no_boot_reference.xml
+++ b/test/data/example_runtime_checker_no_boot_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="JeOS">
+<image schemaversion="7.6" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_no_initrd_system_reference.xml
+++ b/test/data/example_runtime_checker_no_initrd_system_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="JeOS">
+<image schemaversion="7.6" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_this_path_config.xml
+++ b/test/data/example_this_path_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="JeOS">
+<image schemaversion="7.6" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/image_info/config.xml
+++ b/test/data/image_info/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="LimeJeOS" displayname="Bob">
+<image schemaversion="7.6" name="LimeJeOS" displayname="Bob">
     <description type="system">
         <author>Marcus</author>
         <contact>ms@suse.com</contact>

--- a/test/data/isoboot/example-distribution-no-delete-section/config.xml
+++ b/test/data/isoboot/example-distribution-no-delete-section/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="initrd-isoboot-suse-13.2">
+<image schemaversion="7.6" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/isoboot/example-distribution/config.xml
+++ b/test/data/isoboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="initrd-isoboot-suse-13.2">
+<image schemaversion="7.6" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/oemboot/example-distribution/config.xml
+++ b/test/data/oemboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="initrd-oemboot-suse-13.2">
+<image schemaversion="7.6" name="initrd-oemboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/unit/package_manager/dnf4_test.py
+++ b/test/unit/package_manager/dnf4_test.py
@@ -4,12 +4,12 @@ from mock import (
 from pytest import raises
 import mock
 
-from kiwi.package_manager.dnf import PackageManagerDnf
+from kiwi.package_manager.dnf4 import PackageManagerDnf4
 
 from kiwi.exceptions import KiwiRequestError
 
 
-class TestPackageManagerDnf:
+class TestPackageManagerDnf4:
     def setup(self):
         repository = mock.Mock()
         repository.root_dir = '/root-dir'
@@ -20,7 +20,7 @@ class TestPackageManagerDnf:
                 'command_env': ['env']
             }
         )
-        self.manager = PackageManagerDnf(repository)
+        self.manager = PackageManagerDnf4(repository)
 
     def setup_method(self, cls):
         self.setup()
@@ -185,7 +185,7 @@ class TestPackageManagerDnf:
     def test_match_package_deleted(self):
         assert self.manager.match_package_deleted('foo', 'Removing: foo')
 
-    @patch('kiwi.package_manager.dnf.RpmDataBase')
+    @patch('kiwi.package_manager.dnf4.RpmDataBase')
     def test_post_process_install_requests_bootstrap(self, mock_RpmDataBase):
         rpmdb = mock.Mock()
         rpmdb.has_rpm.return_value = True
@@ -194,7 +194,7 @@ class TestPackageManagerDnf:
         rpmdb.rebuild_database.assert_called_once_with()
         rpmdb.set_database_to_image_path.assert_called_once_with()
 
-    @patch('kiwi.package_manager.dnf.Rpm')
+    @patch('kiwi.package_manager.dnf4.Rpm')
     def test_clean_leftovers(self, mock_rpm):
         mock_rpm.return_value = mock.Mock()
         self.manager.clean_leftovers()

--- a/test/unit/repository/dnf4_test.py
+++ b/test/unit/repository/dnf4_test.py
@@ -4,17 +4,17 @@ from mock import (
 )
 import mock
 
-from kiwi.repository.dnf import RepositoryDnf
+from kiwi.repository.dnf4 import RepositoryDnf4
 
 
-class TestRepositoryDnf:
+class TestRepositoryDnf4:
     @fixture(autouse=True)
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
-    @patch('kiwi.repository.dnf.Temporary.new_file')
-    @patch('kiwi.repository.dnf.ConfigParser')
-    @patch('kiwi.repository.dnf.Path.create')
+    @patch('kiwi.repository.dnf4.Temporary.new_file')
+    @patch('kiwi.repository.dnf4.ConfigParser')
+    @patch('kiwi.repository.dnf4.Path.create')
     def setup(self, mock_path, mock_config, mock_temp):
         runtime_dnf_config = mock.MagicMock()
         mock_config.return_value = runtime_dnf_config
@@ -26,7 +26,7 @@ class TestRepositoryDnf:
         root_bind.shared_location = '/shared-dir'
 
         with patch('builtins.open', create=True):
-            self.repo = RepositoryDnf(
+            self.repo = RepositoryDnf4(
                 root_bind, [
                     'exclude_docs', '_install_langs%en_US:de_DE',
                     '_target_arch%x86_64'
@@ -50,21 +50,21 @@ class TestRepositoryDnf:
             call('main', {'enabled': '0'})
         ]
 
-    @patch('kiwi.repository.dnf.Temporary.new_file')
-    @patch('kiwi.repository.dnf.ConfigParser')
-    @patch('kiwi.repository.dnf.Path.create')
+    @patch('kiwi.repository.dnf4.Temporary.new_file')
+    @patch('kiwi.repository.dnf4.ConfigParser')
+    @patch('kiwi.repository.dnf4.Path.create')
     def setup_method(self, cls, mock_path, mock_config, mock_temp):
         self.setup()
 
-    @patch('kiwi.repository.dnf.Temporary.new_file')
-    @patch('kiwi.repository.dnf.Path.create')
+    @patch('kiwi.repository.dnf4.Temporary.new_file')
+    @patch('kiwi.repository.dnf4.Path.create')
     def test_post_init_no_custom_args(self, mock_path, mock_temp):
         with patch('builtins.open', create=True):
             self.repo.post_init()
         assert self.repo.custom_args == []
 
-    @patch('kiwi.repository.dnf.Temporary.new_file')
-    @patch('kiwi.repository.dnf.Path.create')
+    @patch('kiwi.repository.dnf4.Temporary.new_file')
+    @patch('kiwi.repository.dnf4.Path.create')
     @patch('os.path.exists')
     def test_post_init_with_custom_args(
         self, mock_exists, mock_path, mock_temp
@@ -81,7 +81,7 @@ class TestRepositoryDnf:
         assert self.repo.custom_args == []
         assert self.repo.gpg_check == '1'
 
-    @patch('kiwi.repository.dnf.ConfigParser')
+    @patch('kiwi.repository.dnf4.ConfigParser')
     def test_use_default_location(self, mock_config):
         runtime_dnf_config = mock.MagicMock()
         mock_config.return_value = runtime_dnf_config
@@ -112,8 +112,8 @@ class TestRepositoryDnf:
         assert self.repo.runtime_config()['command_env'] == \
             self.repo.command_env
 
-    @patch('kiwi.repository.dnf.ConfigParser')
-    @patch('kiwi.repository.dnf.Defaults.is_buildservice_worker')
+    @patch('kiwi.repository.dnf4.ConfigParser')
+    @patch('kiwi.repository.dnf4.Defaults.is_buildservice_worker')
     @patch('os.path.exists')
     @patch('kiwi.command.Command.run')
     def test_add_repo(
@@ -167,8 +167,8 @@ class TestRepositoryDnf:
                 '/shared-dir/dnf/repos/bar.repo', 'w'
             )
 
-    @patch('kiwi.repository.dnf.ConfigParser')
-    @patch('kiwi.repository.dnf.Defaults.is_buildservice_worker')
+    @patch('kiwi.repository.dnf4.ConfigParser')
+    @patch('kiwi.repository.dnf4.Defaults.is_buildservice_worker')
     @patch('os.path.exists')
     def test_add_repo_inside_buildservice(
         self, mock_exists, mock_buildservice, mock_config
@@ -194,9 +194,9 @@ class TestRepositoryDnf:
                 '/shared-dir/dnf/repos/foo.repo', 'w'
             )
 
-    @patch('kiwi.repository.dnf.RpmDataBase')
+    @patch('kiwi.repository.dnf4.RpmDataBase')
     @patch('kiwi.command.Command.run')
-    @patch('kiwi.repository.dnf.Path.create')
+    @patch('kiwi.repository.dnf4.Path.create')
     def test_setup_package_database_configuration(
         self, mock_Path_create, mock_Command_run, mock_RpmDataBase
     ):
@@ -222,9 +222,9 @@ class TestRepositoryDnf:
             ], raise_on_error=False
         )
 
-    @patch('kiwi.repository.dnf.RpmDataBase')
+    @patch('kiwi.repository.dnf4.RpmDataBase')
     @patch('kiwi.command.Command.run')
-    @patch('kiwi.repository.dnf.Path.create')
+    @patch('kiwi.repository.dnf4.Path.create')
     def test_setup_package_database_configuration_bootstrapped_system(
         self, mock_Path_create, mock_Command_run, mock_RpmDataBase
     ):
@@ -250,8 +250,8 @@ class TestRepositoryDnf:
             ], raise_on_error=False
         )
 
-    @patch('kiwi.repository.dnf.ConfigParser')
-    @patch('kiwi.repository.dnf.Defaults.is_buildservice_worker')
+    @patch('kiwi.repository.dnf4.ConfigParser')
+    @patch('kiwi.repository.dnf4.Defaults.is_buildservice_worker')
     @patch('os.path.exists')
     def test_add_repo_with_gpgchecks(
         self, mock_exists, mock_buildservice, mock_config
@@ -279,7 +279,7 @@ class TestRepositoryDnf:
                 '/shared-dir/dnf/repos/foo.repo', 'w'
             )
 
-    @patch('kiwi.repository.dnf.RpmDataBase')
+    @patch('kiwi.repository.dnf4.RpmDataBase')
     def test_import_trusted_keys(self, mock_RpmDataBase):
         rpmdb = mock.Mock()
         mock_RpmDataBase.return_value = rpmdb
@@ -321,7 +321,7 @@ class TestRepositoryDnf:
         )
 
     @patch('kiwi.path.Path.wipe')
-    @patch('kiwi.repository.dnf.glob.iglob')
+    @patch('kiwi.repository.dnf4.glob.iglob')
     def test_delete_repo_cache(self, mock_glob, mock_wipe):
         mock_glob.return_value = ['foo_cache']
         self.repo.delete_repo_cache('foo')

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -116,7 +116,7 @@ class TestXMLState:
     @patch('kiwi.xml_state.XMLState.get_preferences_sections')
     def test_get_default_package_manager(self, mock_preferences):
         mock_preferences.return_value = []
-        assert self.state.get_package_manager() == 'dnf'
+        assert self.state.get_package_manager() == 'dnf4'
 
     def test_get_image_version(self):
         assert self.state.get_image_version() == '1.13.2'


### PR DESCRIPTION
With dnf5 there is a successor for dnf but there will also be a transition period where there will be both, the former dnf and the new dnf5 available. For a clear distinction between the two we got the recommendation from the RedHat team to support both in different namespaces. This commit now implements a backward compatible change for kiwi which includes the following modifications:

* XSL stylesheet for automatic schema transformation from

  <packagemanager>dnf</packagemanager> to <packagemanager>dnf4</packagemanager>

* Code copy of dnf API interface from

  PackageManagerDnf -> PackageManagerDnf4 RepositoryDnf -> RepositoryDnf4

* Deprecation of former Dnf API interface

The code change here will force developers to adapt their code if they used RepositoryDnf / PackageManagerDnf classes in their python code. After this change developers will be dropped into a raise condition which exits kiwi at the time of the call. Related to Issue #2300
and Issue #2262

