### PR TITLE
Fixed image install of dnf package manager

### DIFF
--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -498,7 +498,12 @@ class XMLState:
             for package in package_list:
                 result.append(package.package_section.get_name().strip())
             if self.get_system_packages():
-                result.append(self.get_package_manager())
+                package_manager_name = self.get_package_manager()
+                if package_manager_name == 'dnf4':
+                    # The package name for dnf4 is just dnf. Thus
+                    # the name must be adapted in this case
+                    package_manager_name = 'dnf'
+                result.append(package_manager_name)
         if plus_packages:
             result += plus_packages
         return sorted(list(set(result)))

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -131,6 +131,12 @@ class TestXMLState:
         assert self.no_image_packages_boot_state.get_bootstrap_packages() == [
             'patterns-openSUSE-base'
         ]
+        self.state.get_package_manager = Mock(
+            return_value="dnf4"
+        )
+        assert self.state.get_bootstrap_packages() == [
+            'dnf', 'filesystem',
+        ]
 
     def test_get_system_packages(self):
         assert self.state.get_system_packages() == [


### PR DESCRIPTION
If the package manager is set to 'dnf4', this name is taken also as package name to install this package manager into the image. Problem is 'dnf4' is not a valid package name. The correct name for 'dnf4' is 'dnf'. This commit fixes the name bug introduced with the changes for Issue #2262


