### PR TITLE
Alp disk encryption

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -124,6 +124,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             Defaults.get_volume_id()
         self.install_volid = self.xml_state.build_type.get_volid() or \
             Defaults.get_install_volume_id()
+        self.use_disk_password = self.xml_state.get_build_type_bootloader_use_disk_password()
 
         self.live_boot_options = [
             'root=live:CDLABEL={0}'.format(self.volume_id),

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -124,7 +124,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             Defaults.get_volume_id()
         self.install_volid = self.xml_state.build_type.get_volid() or \
             Defaults.get_install_volume_id()
-        self.use_disk_password = self.xml_state.get_build_type_bootloader_use_disk_password()
+        self.use_disk_password = \
+            self.xml_state.get_build_type_bootloader_use_disk_password()
 
         self.live_boot_options = [
             'root=live:CDLABEL={0}'.format(self.volume_id),

--- a/kiwi/bootloader/install/grub2.py
+++ b/kiwi/bootloader/install/grub2.py
@@ -278,6 +278,31 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
                 # restore the grub installer noop
                 self._enable_grub2_install(self.root_mount.mountpoint)
 
+    def set_disk_password(self, password):
+        log.debug(f'set_disk_password({password})')
+        if password is None:
+            return
+
+        config_file = f'{self.root_mount.mountpoint}/boot/efi/EFI/BOOT/grub.cfg'
+        if not os.path.exists(config_file):
+            log.debug(f'{config_file} does not exist')
+            return
+
+        with open(config_file) as config:
+            import re
+
+            grub_config = config.read()
+            grub_config = re.sub(
+                r'cryptomount',
+                f'cryptomount -p "{password}"',
+                grub_config
+            )
+
+        with open(config_file, 'w') as grub_config_file:
+            grub_config_file.write(grub_config)
+
+        log.debug(f'<<< {grub_config} >>>')
+
     def _mount_device_and_volumes(self):
         if self.root_mount is None:
             self.root_mount = MountManager(

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -349,7 +349,7 @@ class DiskBuilder:
         luks_root = None
         if self.luks is not None:
             luks_root = LuksDevice(device_map['root'])
-            self.luks_boot_keyname = '/.root.keyfile'
+            self.luks_boot_keyname = '/root/.root.keyfile'
             self.luks_boot_keyfile = ''.join(
                 [self.root_dir, self.luks_boot_keyname]
             )
@@ -383,7 +383,7 @@ class DiskBuilder:
                     config_file=self.luks_boot_keyfile_setup
                 )
                 self.boot_image.include_file(
-                    os.sep + os.path.basename(self.luks_boot_keyfile)
+                    '/root/' + os.path.basename(self.luks_boot_keyfile)
                 )
             device_map['luks_root'] = device_map['root']
             device_map['root'] = luks_root.get_device()

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2035,6 +2035,28 @@ div {
             sch:param [ name = "attr" value = "luksOS" ]
             sch:param [ name = "types" value = "oem iso pxe kis" ]
         ]
+    k.type.luks_randomize.attribute =
+        ## By default, all blocks of a LUKS volume will be filled
+	## with pseudo-random data. If you're shipping an image with
+	## a well-known key, which is going to be re-encrypted at
+	## deployment time, you can decrease the size of the image
+	## by setting this attribute to false.
+        attribute luks_randomize { xsd:boolean }
+        >> sch:pattern [ id = "luks_randomize" is-a = "image_type"
+            sch:param [ name = "attr" value = "luksversion" ]
+            sch:param [ name = "types" value = "oem iso pxe kis" ]
+        ]
+    k.type.luks_pbkdf.attribute =
+        ## When LUKS unlocks a key slot using a user provided
+        ## password, it uses a so-called key derivation function
+        ## to derive a symmetric encryption key from the password.
+        ## Not all boot loaders support all KDF algorithms, hence
+        ## this attribute can be used to select a specific algorithm.
+        attribute luks_pbkdf { "pbkdf2" | "argon2i" | "argon2id" }
+        >> sch:pattern [ id = "luks_pbkdf" is-a = "image_type"
+            sch:param [ name = "attr" value = "luks_pbkdf" ]
+            sch:param [ name = "types" value = "oem iso pxe kis" ]
+        ]
     k.type.mdraid.attribute =
         ## Setup software raid in degraded mode with one disk
         ## Thus only mirroring and striping is possible
@@ -2227,6 +2249,8 @@ div {
         k.type.luks.attribute? &
         k.type.luks_version.attribute? &
         k.type.luksOS.attribute? &
+        k.type.luks_randomize.attribute? &
+        k.type.luks_pbkdf.attribute? &
         k.type.mdraid.attribute? &
         k.type.overlayroot.attribute? &
         k.type.overlayroot_write_partition.attribute? &
@@ -2754,6 +2778,11 @@ div {
             sch:param [ name = "attr" value = "targettype" ]
             sch:param [ name = "types" value = "grub2_s390x_emu" ]
         ]
+    k.bootloader.use_disk_password.attribute =
+	## When /boot is encrypted, make the boot loader store the
+	## password in its configuration file (in cleartext). This
+	## is useful for full disk encryption images
+	attribute use_disk_password { xsd:boolean }
     k.bootloader.attlist =
         k.bootloader.name.attribute &
         k.bootloader.console.attribute? &
@@ -2761,6 +2790,7 @@ div {
         k.bootloader.timeout.attribute? &
         k.bootloader.timeout_style.attribute? &
         k.bootloader.targettype.attribute? &
+        k.bootloader.use_disk_password.attribute? &
         k.bootloader.grub_template.attribute?
 
     k.bootloader =

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2908,6 +2908,38 @@ distribution</a:documentation>
         <sch:param name="types" value="oem iso pxe kis"/>
       </sch:pattern>
     </define>
+    <define name="k.type.luks_randomize.attribute">
+      <attribute name="luks_randomize">
+        <a:documentation>By default, all blocks of a LUKS volume will be filled
+with pseudo-random data. If you're shipping an image with
+a well-known key, which is going to be re-encrypted at
+deployment time, you can decrease the size of the image
+by setting this attribute to false.</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="luks_randomize" is-a="image_type">
+        <sch:param name="attr" value="luksversion"/>
+        <sch:param name="types" value="oem iso pxe kis"/>
+      </sch:pattern>
+    </define>
+    <define name="k.type.luks_pbkdf.attribute">
+      <attribute name="luks_pbkdf">
+        <a:documentation>When LUKS unlocks a key slot using a user provided
+password, it uses a so-called key derivation function
+to derive a symmetric encryption key from the password.
+Not all boot loaders support all KDF algorithms, hence
+this attribute can be used to select a specific algorithm.</a:documentation>
+        <choice>
+          <value>pbkdf2</value>
+          <value>argon2i</value>
+          <value>argon2id</value>
+        </choice>
+      </attribute>
+      <sch:pattern id="luks_pbkdf" is-a="image_type">
+        <sch:param name="attr" value="luks_pbkdf"/>
+        <sch:param name="types" value="oem iso pxe kis"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.mdraid.attribute">
       <attribute name="mdraid">
         <a:documentation>Setup software raid in degraded mode with one disk
@@ -3235,6 +3267,12 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.luksOS.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.luks_randomize.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.luks_pbkdf.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.mdraid.attribute"/>
@@ -4116,6 +4154,14 @@ for 4k DASD devices use CDL</a:documentation>
         <sch:param name="types" value="grub2_s390x_emu"/>
       </sch:pattern>
     </define>
+    <define name="k.bootloader.use_disk_password.attribute">
+      <attribute name="use_disk_password">
+        <a:documentation>When /boot is encrypted, make the boot loader store the
+password in its configuration file (in cleartext). This
+is useful for full disk encryption images</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+    </define>
     <define name="k.bootloader.attlist">
       <interleave>
         <ref name="k.bootloader.name.attribute"/>
@@ -4133,6 +4179,9 @@ for 4k DASD devices use CDL</a:documentation>
         </optional>
         <optional>
           <ref name="k.bootloader.targettype.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.bootloader.use_disk_password.attribute"/>
         </optional>
         <optional>
           <ref name="k.bootloader.grub_template.attribute"/>

--- a/kiwi/storage/luks_device.py
+++ b/kiwi/storage/luks_device.py
@@ -17,9 +17,7 @@
 #
 import os
 import logging
-from typing import (
-    List, Optional
-)
+from typing import Optional
 
 # project
 from kiwi.utils.temporary import Temporary
@@ -50,8 +48,6 @@ class LuksDevice(DeviceProvider):
         self.luks_device: Optional[str] = None
         self.luks_keyfile: Optional[str] = None
         self.luks_name = 'luksRoot'
-        self.luks_randomize = True
-        self.luks_pbkdf = None
 
         self.option_map = {
             'sle12': [
@@ -77,7 +73,7 @@ class LuksDevice(DeviceProvider):
 
     def create_crypto_luks(
         self, passphrase: str, os: str = None,
-        options: list = None, keyfile: str = ''
+        options: list = None, keyfile: str = '', randomize: bool = True
     ) -> None:
         """
         Create luks device. Please note the passphrase is readable
@@ -93,8 +89,6 @@ class LuksDevice(DeviceProvider):
             file path name which contains an alternative key
             to unlock the luks device
         """
-        pbkdf_options: List[str] = []
-
         if not options:
             options = []
         if os:
@@ -108,15 +102,10 @@ class LuksDevice(DeviceProvider):
         storage_device = self.storage_provider.get_device()
         log.info('Creating crypto LUKS on %s', storage_device)
 
-        # Allow the user to override the pbkdf algorithm that cryptsetup uses by
-        # default. Cryptsetup may use argon2i by default, which grub2 doesn't support (yet).
-        if self.luks_pbkdf is not None:
-            pbkdf_options = ['--pbkdf', self.luks_pbkdf]
-
         if not passphrase:
             log.warning('Using an empty passphrase for the key setup')
 
-        if self.luks_randomize:
+        if randomize:
             log.info('--> Randomizing...')
             storage_size_mbytes = self.storage_provider.get_byte_size(
                 storage_device
@@ -146,7 +135,7 @@ class LuksDevice(DeviceProvider):
         Command.run(
             [
                 'cryptsetup', '-q', '--key-file', passphrase_file
-            ] + options + extra_options + pbkdf_options + [
+            ] + options + extra_options + [
                 'luksFormat', storage_device
             ]
         )
@@ -156,7 +145,7 @@ class LuksDevice(DeviceProvider):
             Command.run(
                 [
                     'cryptsetup', '--key-file', passphrase_file
-                ] + extra_options + pbkdf_options + [
+                ] + extra_options + [
                     'luksAddKey', storage_device, keyfile
                 ]
             )

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3048,7 +3048,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -3094,6 +3094,8 @@ class type_(GeneratedsSuper):
         self.luks = _cast(None, luks)
         self.luks_version = _cast(None, luks_version)
         self.luksOS = _cast(None, luksOS)
+        self.luks_randomize = _cast(bool, luks_randomize)
+        self.luks_pbkdf = _cast(None, luks_pbkdf)
         self.mdraid = _cast(None, mdraid)
         self.overlayroot = _cast(bool, overlayroot)
         self.overlayroot_write_partition = _cast(bool, overlayroot_write_partition)
@@ -3318,6 +3320,10 @@ class type_(GeneratedsSuper):
     def set_luks_version(self, luks_version): self.luks_version = luks_version
     def get_luksOS(self): return self.luksOS
     def set_luksOS(self, luksOS): self.luksOS = luksOS
+    def get_luks_randomize(self): return self.luks_randomize
+    def set_luks_randomize(self, luks_randomize): self.luks_randomize = luks_randomize
+    def get_luks_pbkdf(self): return self.luks_pbkdf
+    def set_luks_pbkdf(self, luks_pbkdf): self.luks_pbkdf = luks_pbkdf
     def get_mdraid(self): return self.mdraid
     def set_mdraid(self, mdraid): self.mdraid = mdraid
     def get_overlayroot(self): return self.overlayroot
@@ -3600,6 +3606,12 @@ class type_(GeneratedsSuper):
         if self.luksOS is not None and 'luksOS' not in already_processed:
             already_processed.add('luksOS')
             outfile.write(' luksOS=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.luksOS), input_name='luksOS')), ))
+        if self.luks_randomize is not None and 'luks_randomize' not in already_processed:
+            already_processed.add('luks_randomize')
+            outfile.write(' luks_randomize="%s"' % self.gds_format_boolean(self.luks_randomize, input_name='luks_randomize'))
+        if self.luks_pbkdf is not None and 'luks_pbkdf' not in already_processed:
+            already_processed.add('luks_pbkdf')
+            outfile.write(' luks_pbkdf=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.luks_pbkdf), input_name='luks_pbkdf')), ))
         if self.mdraid is not None and 'mdraid' not in already_processed:
             already_processed.add('mdraid')
             outfile.write(' mdraid=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.mdraid), input_name='mdraid')), ))
@@ -4018,6 +4030,20 @@ class type_(GeneratedsSuper):
             already_processed.add('luksOS')
             self.luksOS = value
             self.luksOS = ' '.join(self.luksOS.split())
+        value = find_attr_value_('luks_randomize', node)
+        if value is not None and 'luks_randomize' not in already_processed:
+            already_processed.add('luks_randomize')
+            if value in ('true', '1'):
+                self.luks_randomize = True
+            elif value in ('false', '0'):
+                self.luks_randomize = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
+        value = find_attr_value_('luks_pbkdf', node)
+        if value is not None and 'luks_pbkdf' not in already_processed:
+            already_processed.add('luks_pbkdf')
+            self.luks_pbkdf = value
+            self.luks_pbkdf = ' '.join(self.luks_pbkdf.split())
         value = find_attr_value_('mdraid', node)
         if value is not None and 'mdraid' not in already_processed:
             already_processed.add('mdraid')
@@ -5494,7 +5520,7 @@ class bootloader(GeneratedsSuper):
     provide configuration parameters for it"""
     subclass = None
     superclass = None
-    def __init__(self, name=None, console=None, serial_line=None, timeout=None, timeout_style=None, targettype=None, grub_template=None, bootloadersettings=None):
+    def __init__(self, name=None, console=None, serial_line=None, timeout=None, timeout_style=None, targettype=None, use_disk_password=None, grub_template=None, bootloadersettings=None):
         self.original_tagname_ = None
         self.name = _cast(None, name)
         self.console = _cast(None, console)
@@ -5502,6 +5528,7 @@ class bootloader(GeneratedsSuper):
         self.timeout = _cast(int, timeout)
         self.timeout_style = _cast(None, timeout_style)
         self.targettype = _cast(None, targettype)
+        self.use_disk_password = _cast(bool, use_disk_password)
         self.grub_template = _cast(None, grub_template)
         self.bootloadersettings = bootloadersettings
     def factory(*args_, **kwargs_):
@@ -5529,6 +5556,8 @@ class bootloader(GeneratedsSuper):
     def set_timeout_style(self, timeout_style): self.timeout_style = timeout_style
     def get_targettype(self): return self.targettype
     def set_targettype(self, targettype): self.targettype = targettype
+    def get_use_disk_password(self): return self.use_disk_password
+    def set_use_disk_password(self, use_disk_password): self.use_disk_password = use_disk_password
     def get_grub_template(self): return self.grub_template
     def set_grub_template(self, grub_template): self.grub_template = grub_template
     def validate_grub_console(self, value):
@@ -5585,6 +5614,9 @@ class bootloader(GeneratedsSuper):
         if self.targettype is not None and 'targettype' not in already_processed:
             already_processed.add('targettype')
             outfile.write(' targettype=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.targettype), input_name='targettype')), ))
+        if self.use_disk_password is not None and 'use_disk_password' not in already_processed:
+            already_processed.add('use_disk_password')
+            outfile.write(' use_disk_password="%s"' % self.gds_format_boolean(self.use_disk_password, input_name='use_disk_password'))
         if self.grub_template is not None and 'grub_template' not in already_processed:
             already_processed.add('grub_template')
             outfile.write(' grub_template=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.grub_template), input_name='grub_template')), ))
@@ -5637,6 +5669,15 @@ class bootloader(GeneratedsSuper):
             already_processed.add('targettype')
             self.targettype = value
             self.targettype = ' '.join(self.targettype.split())
+        value = find_attr_value_('use_disk_password', node)
+        if value is not None and 'use_disk_password' not in already_processed:
+            already_processed.add('use_disk_password')
+            if value in ('true', '1'):
+                self.use_disk_password = True
+            elif value in ('false', '0'):
+                self.use_disk_password = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('grub_template', node)
         if value is not None and 'grub_template' not in already_processed:
             already_processed.add('grub_template')

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1086,6 +1086,20 @@ class XMLState:
         """
         return self.get_bootloader_options('config')
 
+    def get_build_type_bootloader_use_disk_password(self) -> bool:
+        """
+        Indicate whether the bootloader configuration should use the
+        password protecting the encrypted root volume.
+
+        :return: True|False
+
+        :rtype: bool
+        """
+        bootloader = self.get_build_type_bootloader_section()
+        if bootloader:
+            return bootloader.get_use_disk_password()
+        return False
+
     def get_build_type_oemconfig_section(self) -> Any:
         """
         First oemconfig section from the build type section

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -2386,6 +2386,7 @@ class XMLState:
         result = []
         luksversion = self.build_type.get_luks_version()
         luksformat = self.build_type.get_luksformat()
+        luks_pbkdf = self.build_type.get_luks_pbkdf()
         if luksversion:
             result.append('--type')
             result.append(luksversion)
@@ -2394,6 +2395,12 @@ class XMLState:
                 result.append(option.get_name())
                 if option.get_value():
                     result.append(option.get_value())
+        if luks_pbkdf:
+            # Allow to override the pbkdf algorithm that cryptsetup
+            # uses by default. Cryptsetup may use argon2i by default,
+            # which is not supported by all bootloaders.
+            result.append('--pbkdf')
+            result.append(luks_pbkdf)
         return result
 
     def get_derived_from_image_uri(self) -> Optional[Uri]:

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -58,7 +58,7 @@
         <type image="iso" firmware="efi"/>
     </preferences>
     <preferences profiles="vmxFlavour">
-        <type image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" fscreateoptions="-O ^has_journal" btrfs_root_is_snapshot="true" spare_part="200M" spare_part_fs_attributes="no-copy-on-write" xen_server="true" formatoptions="force_size,super=man" filesystem="ext4" installiso="true" luks="linux" luks_version="luks2">
+        <type image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" fscreateoptions="-O ^has_journal" btrfs_root_is_snapshot="true" spare_part="200M" spare_part_fs_attributes="no-copy-on-write" xen_server="true" formatoptions="force_size,super=man" filesystem="ext4" installiso="true" luks="linux" luks_version="luks2" luks_pbkdf="pbkdf2">
             <luksformat>
                 <option name="--cipher" value="aes-gcm-random"/>
                 <option name="--integrity" value="aead"/>

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -1045,18 +1045,18 @@ class TestDiskBuilder:
 
         self.luks_root.create_crypto_luks.assert_called_once_with(
             passphrase='passphrase', os=None,
-            options=[], keyfile='root_dir/.root.keyfile'
+            options=[], keyfile='root_dir/root/.root.keyfile'
         )
         self.luks_root.create_crypttab.assert_called_once_with(
             'root_dir/etc/crypttab'
         )
         assert self.boot_image_task.include_file.call_args_list == [
-            call('/.root.keyfile'),
+            call('/root/.root.keyfile'),
             call('/config.partids'),
             call('/etc/crypttab')
         ]
         self.boot_image_task.write_system_config_file.assert_called_once_with(
-            config={'install_items': ['/.root.keyfile']},
+            config={'install_items': ['/root/.root.keyfile']},
             config_file='root_dir/etc/dracut.conf.d/99-luks-boot.conf'
         )
 

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1113,7 +1113,8 @@ class TestXMLState:
         assert self.state.get_luks_format_options() == [
             '--type', 'luks2',
             '--cipher', 'aes-gcm-random',
-            '--integrity', 'aead'
+            '--integrity', 'aead',
+            '--pbkdf', 'pbkdf2'
         ]
 
     def test_get_bootstrap_package_name(self):

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -60,6 +60,7 @@ class TestXMLState:
         self.bootloader.get_targettype.return_value = 'some-target'
         self.bootloader.get_console.return_value = 'some-console'
         self.bootloader.get_serial_line.return_value = 'some-serial'
+        self.bootloader.get_use_disk_password.return_value = True
 
     def setup_method(self, cls):
         self.setup()
@@ -1019,6 +1020,13 @@ class TestXMLState:
         assert self.state.get_build_type_bootloader_name() == 'grub2'
         mock_bootloader.return_value = [self.bootloader]
         assert self.state.get_build_type_bootloader_name() == 'some-loader'
+
+    @patch('kiwi.xml_parse.type_.get_bootloader')
+    def test_get_build_type_bootloader_use_disk_password(self, mock_bootloader):
+        mock_bootloader.return_value = [None]
+        assert self.state.get_build_type_bootloader_use_disk_password() is False
+        mock_bootloader.return_value = [self.bootloader]
+        assert self.state.get_build_type_bootloader_use_disk_password() is True
 
     @patch('kiwi.xml_parse.type_.get_bootloader')
     def test_get_build_type_bootloader_console(self, mock_bootloader):


### PR DESCRIPTION
Add improvements for fully encrypted disk images
    
This commit adds more flexibility when using LUKS encrypted images. In addition support for key derivation on user provided passwords has been added. The following new attributes were added to the schema:
  
* type.luks_randomize
   allow to enable/disable the data randomizing if luks  encryption is used
    
* type.luks_pbkdf
    When LUKS unlocks a key slot using a user provided  password, it uses a so-called key derivation function to derive a symmetric encryption key from the password. Not all boot loaders support all KDF algorithms, hence  this attribute can be used to select a specific algorithm
    
* bootloader.use_disk_password
   When /boot is encrypted, make the boot loader store the  password in its configuration file (in cleartext). This is useful for full disk encryption images
