### PR TITLE
Add alternative re-reading of the partition table

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -22,7 +22,11 @@ function create_partitions {
             create_dasd_partitions "${disk_device}" "${partition_setup}"
         ;;
     esac
-    partprobe "${disk_device}"
+    if type partprobe &> /dev/null;then
+        partprobe "${disk_device}"
+    else
+        blockdev --rereadpt "${disk_device}"
+    fi
 }
 
 function create_msdos_partitions {


### PR DESCRIPTION
To inform the kernel about disk geometry changes, kiwi uses partprobe as a primary tool. However it is provided by parted and not necessarily available due to the package requirements on the dracut module. A second attempt via blockdev which is expected to exist is therefore made by this commit


