### PR TITLE
Improve loopback.cfg example

### DIFF
--- a/doc/source/working_with_images/iso_to_usb_stick_grub2_boot_from_iso.rst
+++ b/doc/source/working_with_images/iso_to_usb_stick_grub2_boot_from_iso.rst
@@ -50,12 +50,12 @@ The following procedure shows how to setup Grub2 on your hard drive:
 
    .. code:: bash
 
-      menuentry "Boot from openSUSE ISO" {
+      submenu "Boot from openSUSE ISO" {
 	   iso_path="(hd0,gpt2)/path/to/openSUSE.iso"
 	   export iso_path
 	   loopback loop "$iso_path"
 	   root=(loop)
-	   configfile /boot/grub2/loopback.cfg
+	   source /boot/grub2/loopback.cfg
 	   loopback --delete loop
       }
 


### PR DESCRIPTION
submenu+source should be preferred over menuentry+configfile:

- submenu creates a new context, menuentry does not. As a result, changes made to vars inside menuentry's braces pollute the current scope. In this particular case what is notably wrong is root=loop happens in the current scope. If we activate the "Boot from openSUSE ISO" menu entry and then press Esc to return back to explore other menu entries, $root would still be set to 'loop'. Instead of manually saving and restoring $root value it is better to wrap the whole thing in a new context with submenu

- configfile is not just 'source in a new context', it has as least one side effect. For details look for grub_err_printed_errors usage in [1] and [2] in grub sources

[1] grub-core/normal/menu.c
[2] grub-core/normal/menu_entry.c

Changes proposed in this pull request:
* Improve loopback.cfg example

