### PR TITLE
Evaluate the @root volume name also for btrfs

### DIFF
--- a/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
@@ -30,7 +30,7 @@
         </type>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="oem" filesystem="btrfs" kernelcmdline="console=ttyS0 rootflags=subvol=root" firmware="uefi" format="qcow2" btrfs_root_is_subvolume="true" btrfs_set_default_volume="false" rootfs_label="fedora" bootpartition="true" bootfilesystem="ext4">
+        <type image="oem" filesystem="btrfs" kernelcmdline="console=ttyS0" firmware="uefi" format="qcow2" btrfs_root_is_subvolume="true" btrfs_set_default_volume="false" rootfs_label="fedora" bootpartition="true" bootfilesystem="ext4">
             <systemdisk name="fedora">
                 <volume name="@root=root"/>
                 <volume name="home" parent="/"/>

--- a/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
@@ -30,7 +30,7 @@
         </type>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="oem" filesystem="btrfs" kernelcmdline="console=ttyS0" firmware="uefi" format="qcow2" btrfs_create_toplevel_subvolume="true" rootfs_label="fedora" bootpartition="true" bootfilesystem="ext4">
+        <type image="oem" filesystem="btrfs" kernelcmdline="console=ttyS0 rootflags=subvol=root" firmware="uefi" format="qcow2" btrfs_root_is_subvolume="true" btrfs_set_default_volume="false" rootfs_label="fedora" bootpartition="true" bootfilesystem="ext4">
             <systemdisk name="fedora">
                 <volume name="@root=root"/>
                 <volume name="home" parent="/"/>

--- a/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
@@ -30,7 +30,11 @@
         </type>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="uefi" format="qcow2">
+        <type image="oem" filesystem="btrfs" kernelcmdline="console=ttyS0" firmware="uefi" format="qcow2" btrfs_create_toplevel_subvolume="true" rootfs_label="fedora">
+            <systemdisk name="fedora">
+                <volume name="@root=root"/>
+                <volume name="home" parent="/"/>
+            </systemdisk>
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
@@ -67,6 +71,7 @@
         <package name="vim"/>
         <package name="tzdata"/>
         <package name="NetworkManager"/>
+        <package name="btrfs-progs"/>
     </packages>
     <packages type="image" profiles="Live,Disk">
         <package name="syslinux"/>

--- a/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
@@ -30,7 +30,7 @@
         </type>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="oem" filesystem="btrfs" kernelcmdline="console=ttyS0" firmware="uefi" format="qcow2" btrfs_create_toplevel_subvolume="true" rootfs_label="fedora">
+        <type image="oem" filesystem="btrfs" kernelcmdline="console=ttyS0" firmware="uefi" format="qcow2" btrfs_create_toplevel_subvolume="true" rootfs_label="fedora" bootpartition="true" bootfilesystem="ext4">
             <systemdisk name="fedora">
                 <volume name="@root=root"/>
                 <volume name="home" parent="/"/>

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -412,6 +412,20 @@ btrfs_quota_groups="true|false":
   Boolean parameter to activate filesystem quotas if
   the filesystem is `btrfs`. By default quotas are inactive.
 
+btrfs_create_toplevel_subvolume="true|false":
+  Tell kiwi to nest all subvolumes below a toplevel volume.
+  The name of this toplevel volume is by default set to: `@`
+  The name of the toplevel volume can be changed via
+  a volume entry of the form
+
+  .. code:: xml
+
+     <systemdisk>
+       <volume name="@root=TOPLEVEL_NAME"/>
+     </systemdisk>
+
+  By default the creation of a toplevel volume is set to: `true`
+
 btrfs_root_is_snapshot="true|false":
   Boolean parameter that tells {kiwi} to install
   the system into a btrfs snapshot. The snapshot layout is compatible with

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -412,11 +412,19 @@ btrfs_quota_groups="true|false":
   Boolean parameter to activate filesystem quotas if
   the filesystem is `btrfs`. By default quotas are inactive.
 
-btrfs_create_toplevel_subvolume="true|false":
-  Tell kiwi to nest all subvolumes below a toplevel volume.
-  The name of this toplevel volume is by default set to: `@`
-  The name of the toplevel volume can be changed via
-  a volume entry of the form
+btrfs_set_default_volume="true|false":
+  Tell kiwi to explicitly make a volume the default volume
+  This can be either `/` or the root subvolume or the root
+  snapshot depending on the specified btrfs configuration
+  attributes. By default btrfs_set_default_volume is set to: true
+  If no default volume should be set, this attribute can be
+  used to turn it off
+
+btrfs_root_is_subvolume="true|false":
+  Tell kiwi to create a root volume to host (/) inside.
+  The name of this subvolume is by default set to: `@`.
+  The name of the subvolume can be changed via a volume entry
+  of the form:
 
   .. code:: xml
 

--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -501,7 +501,8 @@ class BootLoaderConfigBase:
             return gfxmode
 
     def _mount_system(
-        self, root_device, boot_device, efi_device=None, volumes=None
+        self, root_device, boot_device, efi_device=None,
+        volumes=None, root_volume_name=None
     ):
         self.root_mount = MountManager(
             device=root_device
@@ -522,7 +523,10 @@ class BootLoaderConfigBase:
                 mountpoint=self.root_mount.mountpoint + '/boot/efi'
             )
 
-        self.root_mount.mount()
+        custom_root_mount_args = []
+        if root_volume_name and root_volume_name != '/':
+            custom_root_mount_args += [f'subvol={root_volume_name}']
+        self.root_mount.mount(options=custom_root_mount_args)
 
         if not self.root_mount.device == self.boot_mount.device:
             self.boot_mount.mount()

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -809,35 +809,47 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             # a grub image that got signed by the shim. The shim image
             # is the one that gets loaded by the firmware which itself
             # loads the second stage grub image
-            log.info(
-                f'--> Using shim image: {shim_image.filename}'
+            target_efi_image_name = self._get_efi_image_name()
+            target_grub_image_name = os.sep.join(
+                [self.efi_boot_path, grub_image.binaryname]
             )
-            log.info(
-                f'--> Using grub image: {grub_image.filename}'
-            )
-            Command.run(
-                ['cp', shim_image.filename, self._get_efi_image_name()]
-            )
-            Command.run(
-                [
-                    'cp', grub_image.filename,
-                    os.sep.join([self.efi_boot_path, grub_image.binaryname])
-                ]
-            )
+            if not os.path.isfile(target_efi_image_name):
+                log.info(
+                    f'--> Using shim image: {shim_image.filename}'
+                )
+                Command.run(
+                    ['cp', shim_image.filename, target_efi_image_name]
+                )
+            if not os.path.isfile(target_grub_image_name):
+                log.info(
+                    f'--> Using grub image: {grub_image.filename}'
+                )
+                Command.run(
+                    ['cp', grub_image.filename, target_grub_image_name]
+                )
             mok_manager = Defaults.get_mok_manager(lookup_path)
             if mok_manager:
-                Command.run(
-                    ['cp', mok_manager, self.efi_boot_path]
+                target_mok_manager = os.sep.join(
+                    [self.efi_boot_path, os.path.basename(mok_manager)]
                 )
+                if not os.path.isfile(target_mok_manager):
+                    log.info(
+                        f'--> Using mok image: {mok_manager}'
+                    )
+                    Command.run(
+                        ['cp', mok_manager, self.efi_boot_path]
+                    )
         else:
             # Without shim a self signed grub image is used that
             # gets loaded by the firmware
-            log.info(
-                f'--> No shim image, using grub image: {grub_image.filename}'
-            )
-            Command.run(
-                ['cp', grub_image.filename, self._get_efi_image_name()]
-            )
+            target_efi_image_name = self._get_efi_image_name()
+            if not os.path.isfile(target_efi_image_name):
+                log.info(
+                    f'--> No shim image, using grub image: {grub_image.filename}'
+                )
+                Command.run(
+                    ['cp', grub_image.filename, target_efi_image_name]
+                )
         self._create_efi_config_search(uuid, mbrid)
 
     def _setup_efi_image(

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -233,14 +233,18 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 'root_device': string,
                 'boot_device': string,
                 'efi_device': string,
-                'system_volumes': volume_manager_instance.get_volumes()
+                'system_volumes':
+                    volume_manager_instance.get_volumes(),
+                'system_root_volume':
+                    volume_manager_instance.get_root_volume_name()
             }
         """
         self._mount_system(
             boot_options.get('root_device'),
             boot_options.get('boot_device'),
             boot_options.get('efi_device'),
-            boot_options.get('system_volumes')
+            boot_options.get('system_volumes'),
+            boot_options.get('system_root_volume')
         )
         config_file = os.sep.join(
             [

--- a/kiwi/bootloader/install/grub2.py
+++ b/kiwi/bootloader/install/grub2.py
@@ -52,6 +52,7 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
                 {
                     'target_removable': bool,
                     'system_volumes': list_of_volumes,
+                    'system_root_volume': root volume name if required
                     'firmware': FirmWare_instance,
                     'efi_device': string,
                     'boot_device': string,
@@ -71,12 +72,15 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
         self.proc_mount = None
         self.sysfs_mount = None
         self.volumes = None
+        self.root_volume_name = None
         self.volumes_mount = []
         self.target_removable = None
         if custom_args and 'target_removable' in custom_args:
             self.target_removable = custom_args['target_removable']
         if custom_args and 'system_volumes' in custom_args:
             self.volumes = custom_args['system_volumes']
+        if custom_args and 'system_root_volume' in custom_args:
+            self.root_volume_name = custom_args['system_root_volume']
         if custom_args and 'firmware' in custom_args:
             self.firmware = custom_args['firmware']
         if custom_args and 'install_options' in custom_args:
@@ -302,7 +306,10 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
             self.root_mount = MountManager(
                 device=self.custom_args['root_device']
             )
-            self.root_mount.mount()
+            custom_root_mount_args = []
+            if self.root_volume_name and self.root_volume_name != '/':
+                custom_root_mount_args += [f'subvol={self.root_volume_name}']
+            self.root_mount.mount(options=custom_root_mount_args)
 
         if self.boot_mount is None:
             if 's390' in self.arch:

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1119,6 +1119,13 @@ class DiskBuilder:
             custom_root_mount_args += ['ro']
             fs_check_interval = '0 0'
 
+        if self.volume_manager_name and self.volume_manager_name == 'btrfs':
+            root_volume_name = system.get_root_volume_name()
+            if root_volume_name != '/':
+                custom_root_mount_args += [
+                    f'defaults,subvol={root_volume_name}'
+                ]
+
         self._add_fstab_entry(
             device_map['root'].get_device(), '/',
             custom_root_mount_args, fs_check_interval

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1537,7 +1537,12 @@ class DiskBuilder:
         if self.volume_manager_name:
             system.umount_volumes()
             custom_install_arguments.update(
-                {'system_volumes': system.get_volumes()}
+                {
+                    'system_volumes': system.get_volumes(),
+                    'system_root_volume':
+                        system.get_root_volume_name()
+                        if self.volume_manager_name == 'btrfs' else None
+                }
             )
 
         if self.bootloader != 'custom':

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -417,9 +417,12 @@ class DiskBuilder:
                 'root_is_readonly_snapshot':
                     self.xml_state.build_type.
                     get_btrfs_root_is_readonly_snapshot(),
-                'create_toplevel_subvolume':
+                'root_is_subvolume':
                     self.xml_state.build_type.
-                    get_btrfs_create_toplevel_subvolume(),
+                    get_btrfs_root_is_subvolume(),
+                'set_default_volume':
+                    self.xml_state.build_type.
+                    get_btrfs_set_default_volume(),
                 'quota_groups':
                     self.xml_state.build_type.get_btrfs_quota_groups(),
                 'resize_on_boot':

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -417,6 +417,9 @@ class DiskBuilder:
                 'root_is_readonly_snapshot':
                     self.xml_state.build_type.
                     get_btrfs_root_is_readonly_snapshot(),
+                'create_toplevel_subvolume':
+                    self.xml_state.build_type.
+                    get_btrfs_create_toplevel_subvolume(),
                 'quota_groups':
                     self.xml_state.build_type.get_btrfs_quota_groups(),
                 'resize_on_boot':

--- a/kiwi/mount_manager.py
+++ b/kiwi/mount_manager.py
@@ -19,7 +19,9 @@ import os
 import time
 import logging
 from textwrap import dedent
-from typing import List
+from typing import (
+    List, Dict
+)
 
 # project
 from kiwi.path import Path
@@ -41,9 +43,14 @@ class MountManager:
 
     * :param string device: device node name
     * :param string mountpoint: mountpoint directory name
+    * :param dict attributes: optional attributes to store
     """
-    def __init__(self, device: str, mountpoint: str = ''):
+    def __init__(
+        self, device: str, mountpoint: str = '',
+        attributes: Dict[str, str] = {}
+    ):
         self.device = device
+        self.attributes = attributes
         if not mountpoint:
             self.mountpoint_tempdir = Temporary(
                 prefix='kiwi_mount_manager.'
@@ -52,6 +59,12 @@ class MountManager:
         else:
             Path.create(mountpoint)
             self.mountpoint = mountpoint
+
+    def get_attributes(self) -> Dict[str, str]:
+        """
+        Return attributes dict for this mount manager
+        """
+        return self.attributes
 
     def bind_mount(self) -> None:
         """

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1433,15 +1433,27 @@ div {
             sch:param [ name = "attr" value = "btrfs_quota_groups" ]
             sch:param [ name = "types" value = "oem" ]
         ]
-    k.type.btrfs_create_toplevel_subvolume =
-        ## Tell kiwi to nest all subvolumes below a toplevel volume.
-        ## The name of this toplevel volume is by default set to: '@'
-        ## The name of the toplevel volume can be changed via
-        ## a volume entry of the form '<volume name="@root=TOPLEVEL_NAME"/>'
-        ## By default the creation of a toplevel volume is set to: true
-        attribute btrfs_create_toplevel_subvolume { xsd:boolean }
-        >> sch:pattern [ id = "btrfs_create_toplevel_subvolume" is-a = "image_type"
-            sch:param [ name = "attr" value = "btrfs_create_toplevel_subvolume" ]
+    k.type.btrfs_set_default_volume.attribute =
+        ## Tell kiwi to explicitly make a volume the default volume
+        ## This can be either (/) or the root subvolume or the root
+        ## snapshot depending on the specified btrfs configuration
+        ## attributes. By default btrfs_set_default_volume is set to: true
+        ## If no default volume should be set, this attribute can be
+        ## used to turn it off
+        attribute btrfs_set_default_volume { xsd:boolean }
+        >> sch:pattern [ id = "btrfs_set_default_volume" is-a = "image_type"
+            sch:param [ name = "attr" value = "btrfs_set_default_volume" ]
+            sch:param [ name = "types" value = "oem" ]
+        ]
+    k.type.btrfs_root_is_subvolume.attribute =
+        ## Tell kiwi to create a root volume to host (/) inside.
+        ## The name of this subvolume is by default set to: '@'
+        ## The name of the subvolume can be changed via
+        ## a volume entry of the form '<volume name="@root=NAME"/>'
+        ## By default the creation of a root subvolume is set to: true
+        attribute btrfs_root_is_subvolume { xsd:boolean }
+        >> sch:pattern [ id = "btrfs_root_is_subvolume" is-a = "image_type"
+            sch:param [ name = "attr" value = "btrfs_root_is_subvolume" ]
             sch:param [ name = "types" value = "oem" ]
         ]
     k.type.btrfs_root_is_snapshot.attribute =
@@ -2229,7 +2241,8 @@ div {
         k.type.bootprofile.attribute? &
         k.type.btrfs_quota_groups.attribute? &
         k.type.btrfs_root_is_snapshot.attribute? &
-        k.type.btrfs_create_toplevel_subvolume? &
+        k.type.btrfs_root_is_subvolume.attribute? &
+        k.type.btrfs_set_default_volume.attribute? &
         k.type.btrfs_root_is_readonly_snapshot.attribute? &
         k.type.compressed.attribute? &
         k.type.devicepersistency.attribute? &

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2564,6 +2564,13 @@ div {
         ## not specified the name specifies a path which has to
         ## exist inside the root directory.
         attribute name { text }
+    k.volume.parent.attribute =
+        ## The name/path of the parent volume.
+        ## Evaluated only for the btrfs volume manager to allow
+        ## specifying the parent subvolume to nest this volume in.
+        ## If not specified the parent is always the volume set
+        ## as the default volume
+        attribute parent { text }
     k.volume.mountpoint.attribute =
         ## volume path. The mountpoint specifies a path which has to
         ## exist inside the root directory.
@@ -2596,6 +2603,7 @@ div {
         k.volume.mountpoint.attribute? &
         k.volume.label.attribute? &
         k.volume.name.attribute &
+        k.volume.parent.attribute? &
         k.volume.size.attribute?
     k.volume =
         ## Specify which parts of the filesystem should be

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1433,6 +1433,17 @@ div {
             sch:param [ name = "attr" value = "btrfs_quota_groups" ]
             sch:param [ name = "types" value = "oem" ]
         ]
+    k.type.btrfs_create_toplevel_subvolume =
+        ## Tell kiwi to nest all subvolumes below a toplevel volume.
+        ## The name of this toplevel volume is by default set to: '@'
+        ## The name of the toplevel volume can be changed via
+        ## a volume entry of the form '<volume name="@root=TOPLEVEL_NAME"/>'
+        ## By default the creation of a toplevel volume is set to: true
+        attribute btrfs_create_toplevel_subvolume { xsd:boolean }
+        >> sch:pattern [ id = "btrfs_create_toplevel_subvolume" is-a = "image_type"
+            sch:param [ name = "attr" value = "btrfs_create_toplevel_subvolume" ]
+            sch:param [ name = "types" value = "oem" ]
+        ]
     k.type.btrfs_root_is_snapshot.attribute =
         ## Tell kiwi to install the system into a btrfs snapshot
         ## The snapshot layout is compatible with the snapper management
@@ -2218,6 +2229,7 @@ div {
         k.type.bootprofile.attribute? &
         k.type.btrfs_quota_groups.attribute? &
         k.type.btrfs_root_is_snapshot.attribute? &
+        k.type.btrfs_create_toplevel_subvolume? &
         k.type.btrfs_root_is_readonly_snapshot.attribute? &
         k.type.compressed.attribute? &
         k.type.devicepersistency.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2093,6 +2093,20 @@ By default the quota system is inactive</a:documentation>
         <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
+    <define name="k.type.btrfs_create_toplevel_subvolume">
+      <attribute name="btrfs_create_toplevel_subvolume">
+        <a:documentation>Tell kiwi to nest all subvolumes below a toplevel volume.
+The name of this toplevel volume is by default set to: '@'
+The name of the toplevel volume can be changed via
+a volume entry of the form '&lt;volume name="@root=TOPLEVEL_NAME"/&gt;'
+By default the creation of a toplevel volume is set to: true</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="btrfs_create_toplevel_subvolume" is-a="image_type">
+        <sch:param name="attr" value="btrfs_create_toplevel_subvolume"/>
+        <sch:param name="types" value="oem"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.btrfs_root_is_snapshot.attribute">
       <attribute name="btrfs_root_is_snapshot">
         <a:documentation>Tell kiwi to install the system into a btrfs snapshot
@@ -3176,6 +3190,9 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.btrfs_root_is_snapshot.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.btrfs_create_toplevel_subvolume"/>
         </optional>
         <optional>
           <ref name="k.type.btrfs_root_is_readonly_snapshot.attribute"/>

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2093,17 +2093,32 @@ By default the quota system is inactive</a:documentation>
         <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
-    <define name="k.type.btrfs_create_toplevel_subvolume">
-      <attribute name="btrfs_create_toplevel_subvolume">
-        <a:documentation>Tell kiwi to nest all subvolumes below a toplevel volume.
-The name of this toplevel volume is by default set to: '@'
-The name of the toplevel volume can be changed via
-a volume entry of the form '&lt;volume name="@root=TOPLEVEL_NAME"/&gt;'
-By default the creation of a toplevel volume is set to: true</a:documentation>
+    <define name="k.type.btrfs_set_default_volume.attribute">
+      <attribute name="btrfs_set_default_volume">
+        <a:documentation>Tell kiwi to explicitly make a volume the default volume
+This can be either (/) or the root subvolume or the root
+snapshot depending on the specified btrfs configuration
+attributes. By default btrfs_set_default_volume is set to: true
+If no default volume should be set, this attribute can be
+used to turn it off</a:documentation>
         <data type="boolean"/>
       </attribute>
-      <sch:pattern id="btrfs_create_toplevel_subvolume" is-a="image_type">
-        <sch:param name="attr" value="btrfs_create_toplevel_subvolume"/>
+      <sch:pattern id="btrfs_set_default_volume" is-a="image_type">
+        <sch:param name="attr" value="btrfs_set_default_volume"/>
+        <sch:param name="types" value="oem"/>
+      </sch:pattern>
+    </define>
+    <define name="k.type.btrfs_root_is_subvolume.attribute">
+      <attribute name="btrfs_root_is_subvolume">
+        <a:documentation>Tell kiwi to create a root volume to host (/) inside.
+The name of this subvolume is by default set to: '@'
+The name of the subvolume can be changed via
+a volume entry of the form '&lt;volume name="@root=NAME"/&gt;'
+By default the creation of a root subvolume is set to: true</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="btrfs_root_is_subvolume" is-a="image_type">
+        <sch:param name="attr" value="btrfs_root_is_subvolume"/>
         <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
@@ -3192,7 +3207,10 @@ kiwi-ng result bundle ...</a:documentation>
           <ref name="k.type.btrfs_root_is_snapshot.attribute"/>
         </optional>
         <optional>
-          <ref name="k.type.btrfs_create_toplevel_subvolume"/>
+          <ref name="k.type.btrfs_root_is_subvolume.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.btrfs_set_default_volume.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.btrfs_root_is_readonly_snapshot.attribute"/>

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -3851,6 +3851,15 @@ not specified the name specifies a path which has to
 exist inside the root directory.</a:documentation>
       </attribute>
     </define>
+    <define name="k.volume.parent.attribute">
+      <attribute name="parent">
+        <a:documentation>The name/path of the parent volume.
+Evaluated only for the btrfs volume manager to allow
+specifying the parent subvolume to nest this volume in.
+If not specified the parent is always the volume set
+as the default volume</a:documentation>
+      </attribute>
+    </define>
     <define name="k.volume.mountpoint.attribute">
       <attribute name="mountpoint">
         <a:documentation>volume path. The mountpoint specifies a path which has to
@@ -3907,6 +3916,9 @@ The latter is the default.</a:documentation>
           <ref name="k.volume.label.attribute"/>
         </optional>
         <ref name="k.volume.name.attribute"/>
+        <optional>
+          <ref name="k.volume.parent.attribute"/>
+        </optional>
         <optional>
           <ref name="k.volume.size.attribute"/>
         </optional>

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -331,6 +331,19 @@ class VolumeManagerBase(DeviceProvider):
         """
         return self.mountpoint
 
+    def get_root_volume_name(self) -> str:
+        """
+        Provides name of the root volume
+
+        This is by default set to '/'. Volume Managers that supports
+        the concept of sub-volumes overrides this method
+
+        :return: directory path name
+
+        :rtype: string
+        """
+        return '/'
+
     def sync_data(self, exclude=None):
         """
         Implements sync of root directory to mounted volumes

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -150,7 +150,7 @@ class VolumeManagerBase(DeviceProvider):
                 Command.run(
                     [
                         'chattr', '+C',
-                        os.path.normpath(toplevel + volume.realpath)
+                        os.path.normpath(toplevel + os.sep + volume.realpath)
                     ]
                 )
 

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -4984,7 +4984,7 @@ class volume(GeneratedsSuper):
     """Specify which parts of the filesystem should be on an extra volume."""
     subclass = None
     superclass = None
-    def __init__(self, copy_on_write=None, filesystem_check=None, freespace=None, mountpoint=None, label=None, name=None, size=None):
+    def __init__(self, copy_on_write=None, filesystem_check=None, freespace=None, mountpoint=None, label=None, name=None, parent=None, size=None):
         self.original_tagname_ = None
         self.copy_on_write = _cast(bool, copy_on_write)
         self.filesystem_check = _cast(bool, filesystem_check)
@@ -4992,6 +4992,7 @@ class volume(GeneratedsSuper):
         self.mountpoint = _cast(None, mountpoint)
         self.label = _cast(None, label)
         self.name = _cast(None, name)
+        self.parent = _cast(None, parent)
         self.size = _cast(None, size)
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
@@ -5016,6 +5017,8 @@ class volume(GeneratedsSuper):
     def set_label(self, label): self.label = label
     def get_name(self): return self.name
     def set_name(self, name): self.name = name
+    def get_parent(self): return self.parent
+    def set_parent(self, parent): self.parent = parent
     def get_size(self): return self.size
     def set_size(self, size): self.size = size
     def validate_volume_size_type(self, value):
@@ -5071,6 +5074,9 @@ class volume(GeneratedsSuper):
         if self.name is not None and 'name' not in already_processed:
             already_processed.add('name')
             outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
+        if self.parent is not None and 'parent' not in already_processed:
+            already_processed.add('parent')
+            outfile.write(' parent=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.parent), input_name='parent')), ))
         if self.size is not None and 'size' not in already_processed:
             already_processed.add('size')
             outfile.write(' size=%s' % (quote_attrib(self.size), ))
@@ -5120,6 +5126,10 @@ class volume(GeneratedsSuper):
         if value is not None and 'name' not in already_processed:
             already_processed.add('name')
             self.name = value
+        value = find_attr_value_('parent', node)
+        if value is not None and 'parent' not in already_processed:
+            already_processed.add('parent')
+            self.parent = value
         value = find_attr_value_('size', node)
         if value is not None and 'size' not in already_processed:
             already_processed.add('size')

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.29.24.
-# Python 3.6.15 (default, Sep 23 2021, 15:41:43) [GCC]
+# Python 3.11.3 (main, Jun 03 2023, 22:12:18) [GCC]
 #
 # Command line options:
 #   ('-f', '')
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/ms/Project/kiwi/.tox/3.6/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/ms/Project/kiwi/.tox/unit_py3_11/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -3048,7 +3048,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_create_toplevel_subvolume=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_subvolume=None, btrfs_set_default_volume=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -3063,7 +3063,8 @@ class type_(GeneratedsSuper):
         self.bootprofile = _cast(None, bootprofile)
         self.btrfs_quota_groups = _cast(bool, btrfs_quota_groups)
         self.btrfs_root_is_snapshot = _cast(bool, btrfs_root_is_snapshot)
-        self.btrfs_create_toplevel_subvolume = _cast(bool, btrfs_create_toplevel_subvolume)
+        self.btrfs_root_is_subvolume = _cast(bool, btrfs_root_is_subvolume)
+        self.btrfs_set_default_volume = _cast(bool, btrfs_set_default_volume)
         self.btrfs_root_is_readonly_snapshot = _cast(bool, btrfs_root_is_readonly_snapshot)
         self.compressed = _cast(bool, compressed)
         self.devicepersistency = _cast(None, devicepersistency)
@@ -3259,8 +3260,10 @@ class type_(GeneratedsSuper):
     def set_btrfs_quota_groups(self, btrfs_quota_groups): self.btrfs_quota_groups = btrfs_quota_groups
     def get_btrfs_root_is_snapshot(self): return self.btrfs_root_is_snapshot
     def set_btrfs_root_is_snapshot(self, btrfs_root_is_snapshot): self.btrfs_root_is_snapshot = btrfs_root_is_snapshot
-    def get_btrfs_create_toplevel_subvolume(self): return self.btrfs_create_toplevel_subvolume
-    def set_btrfs_create_toplevel_subvolume(self, btrfs_create_toplevel_subvolume): self.btrfs_create_toplevel_subvolume = btrfs_create_toplevel_subvolume
+    def get_btrfs_root_is_subvolume(self): return self.btrfs_root_is_subvolume
+    def set_btrfs_root_is_subvolume(self, btrfs_root_is_subvolume): self.btrfs_root_is_subvolume = btrfs_root_is_subvolume
+    def get_btrfs_set_default_volume(self): return self.btrfs_set_default_volume
+    def set_btrfs_set_default_volume(self, btrfs_set_default_volume): self.btrfs_set_default_volume = btrfs_set_default_volume
     def get_btrfs_root_is_readonly_snapshot(self): return self.btrfs_root_is_readonly_snapshot
     def set_btrfs_root_is_readonly_snapshot(self, btrfs_root_is_readonly_snapshot): self.btrfs_root_is_readonly_snapshot = btrfs_root_is_readonly_snapshot
     def get_compressed(self): return self.compressed
@@ -3516,9 +3519,12 @@ class type_(GeneratedsSuper):
         if self.btrfs_root_is_snapshot is not None and 'btrfs_root_is_snapshot' not in already_processed:
             already_processed.add('btrfs_root_is_snapshot')
             outfile.write(' btrfs_root_is_snapshot="%s"' % self.gds_format_boolean(self.btrfs_root_is_snapshot, input_name='btrfs_root_is_snapshot'))
-        if self.btrfs_create_toplevel_subvolume is not None and 'btrfs_create_toplevel_subvolume' not in already_processed:
-            already_processed.add('btrfs_create_toplevel_subvolume')
-            outfile.write(' btrfs_create_toplevel_subvolume="%s"' % self.gds_format_boolean(self.btrfs_create_toplevel_subvolume, input_name='btrfs_create_toplevel_subvolume'))
+        if self.btrfs_root_is_subvolume is not None and 'btrfs_root_is_subvolume' not in already_processed:
+            already_processed.add('btrfs_root_is_subvolume')
+            outfile.write(' btrfs_root_is_subvolume="%s"' % self.gds_format_boolean(self.btrfs_root_is_subvolume, input_name='btrfs_root_is_subvolume'))
+        if self.btrfs_set_default_volume is not None and 'btrfs_set_default_volume' not in already_processed:
+            already_processed.add('btrfs_set_default_volume')
+            outfile.write(' btrfs_set_default_volume="%s"' % self.gds_format_boolean(self.btrfs_set_default_volume, input_name='btrfs_set_default_volume'))
         if self.btrfs_root_is_readonly_snapshot is not None and 'btrfs_root_is_readonly_snapshot' not in already_processed:
             already_processed.add('btrfs_root_is_readonly_snapshot')
             outfile.write(' btrfs_root_is_readonly_snapshot="%s"' % self.gds_format_boolean(self.btrfs_root_is_readonly_snapshot, input_name='btrfs_root_is_readonly_snapshot'))
@@ -3846,13 +3852,22 @@ class type_(GeneratedsSuper):
                 self.btrfs_root_is_snapshot = False
             else:
                 raise_parse_error(node, 'Bad boolean attribute')
-        value = find_attr_value_('btrfs_create_toplevel_subvolume', node)
-        if value is not None and 'btrfs_create_toplevel_subvolume' not in already_processed:
-            already_processed.add('btrfs_create_toplevel_subvolume')
+        value = find_attr_value_('btrfs_root_is_subvolume', node)
+        if value is not None and 'btrfs_root_is_subvolume' not in already_processed:
+            already_processed.add('btrfs_root_is_subvolume')
             if value in ('true', '1'):
-                self.btrfs_create_toplevel_subvolume = True
+                self.btrfs_root_is_subvolume = True
             elif value in ('false', '0'):
-                self.btrfs_create_toplevel_subvolume = False
+                self.btrfs_root_is_subvolume = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
+        value = find_attr_value_('btrfs_set_default_volume', node)
+        if value is not None and 'btrfs_set_default_volume' not in already_processed:
+            already_processed.add('btrfs_set_default_volume')
+            if value in ('true', '1'):
+                self.btrfs_set_default_volume = True
+            elif value in ('false', '0'):
+                self.btrfs_set_default_volume = False
             else:
                 raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('btrfs_root_is_readonly_snapshot', node)

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3048,7 +3048,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_create_toplevel_subvolume=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -3063,6 +3063,7 @@ class type_(GeneratedsSuper):
         self.bootprofile = _cast(None, bootprofile)
         self.btrfs_quota_groups = _cast(bool, btrfs_quota_groups)
         self.btrfs_root_is_snapshot = _cast(bool, btrfs_root_is_snapshot)
+        self.btrfs_create_toplevel_subvolume = _cast(bool, btrfs_create_toplevel_subvolume)
         self.btrfs_root_is_readonly_snapshot = _cast(bool, btrfs_root_is_readonly_snapshot)
         self.compressed = _cast(bool, compressed)
         self.devicepersistency = _cast(None, devicepersistency)
@@ -3258,6 +3259,8 @@ class type_(GeneratedsSuper):
     def set_btrfs_quota_groups(self, btrfs_quota_groups): self.btrfs_quota_groups = btrfs_quota_groups
     def get_btrfs_root_is_snapshot(self): return self.btrfs_root_is_snapshot
     def set_btrfs_root_is_snapshot(self, btrfs_root_is_snapshot): self.btrfs_root_is_snapshot = btrfs_root_is_snapshot
+    def get_btrfs_create_toplevel_subvolume(self): return self.btrfs_create_toplevel_subvolume
+    def set_btrfs_create_toplevel_subvolume(self, btrfs_create_toplevel_subvolume): self.btrfs_create_toplevel_subvolume = btrfs_create_toplevel_subvolume
     def get_btrfs_root_is_readonly_snapshot(self): return self.btrfs_root_is_readonly_snapshot
     def set_btrfs_root_is_readonly_snapshot(self, btrfs_root_is_readonly_snapshot): self.btrfs_root_is_readonly_snapshot = btrfs_root_is_readonly_snapshot
     def get_compressed(self): return self.compressed
@@ -3513,6 +3516,9 @@ class type_(GeneratedsSuper):
         if self.btrfs_root_is_snapshot is not None and 'btrfs_root_is_snapshot' not in already_processed:
             already_processed.add('btrfs_root_is_snapshot')
             outfile.write(' btrfs_root_is_snapshot="%s"' % self.gds_format_boolean(self.btrfs_root_is_snapshot, input_name='btrfs_root_is_snapshot'))
+        if self.btrfs_create_toplevel_subvolume is not None and 'btrfs_create_toplevel_subvolume' not in already_processed:
+            already_processed.add('btrfs_create_toplevel_subvolume')
+            outfile.write(' btrfs_create_toplevel_subvolume="%s"' % self.gds_format_boolean(self.btrfs_create_toplevel_subvolume, input_name='btrfs_create_toplevel_subvolume'))
         if self.btrfs_root_is_readonly_snapshot is not None and 'btrfs_root_is_readonly_snapshot' not in already_processed:
             already_processed.add('btrfs_root_is_readonly_snapshot')
             outfile.write(' btrfs_root_is_readonly_snapshot="%s"' % self.gds_format_boolean(self.btrfs_root_is_readonly_snapshot, input_name='btrfs_root_is_readonly_snapshot'))
@@ -3838,6 +3844,15 @@ class type_(GeneratedsSuper):
                 self.btrfs_root_is_snapshot = True
             elif value in ('false', '0'):
                 self.btrfs_root_is_snapshot = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
+        value = find_attr_value_('btrfs_create_toplevel_subvolume', node)
+        if value is not None and 'btrfs_create_toplevel_subvolume' not in already_processed:
+            already_processed.add('btrfs_create_toplevel_subvolume')
+            if value in ('true', '1'):
+                self.btrfs_create_toplevel_subvolume = True
+            elif value in ('false', '0'):
+                self.btrfs_create_toplevel_subvolume = False
             else:
                 raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('btrfs_root_is_readonly_snapshot', node)

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1680,6 +1680,9 @@ class XMLState:
         if not have_root_volume_setup:
             # There must always be a root volume setup. It will be the
             # full size volume if no other volume has this setup
+            volume_management = self.get_volume_management()
+            root_volume_name = \
+                defaults.ROOT_VOLUME_NAME if volume_management == 'lvm' else ''
             if have_full_size_volume:
                 size = 'freespace:' + format(
                     Defaults.get_min_volume_mbytes()
@@ -1690,7 +1693,7 @@ class XMLState:
                 fullsize = True
             volume_type_list.append(
                 volume_type(
-                    name=defaults.ROOT_VOLUME_NAME,
+                    name=root_volume_name,
                     size=size,
                     fullsize=fullsize,
                     mountpoint=None,

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -67,6 +67,7 @@ size_type = NamedTuple(
 volume_type = NamedTuple(
     'volume_type', [
         ('name', str),
+        ('parent', str),
         ('size', str),
         ('realpath', str),
         ('mountpoint', Optional[str]),
@@ -1574,6 +1575,7 @@ class XMLState:
                 [
                     volume_type(
                         name=volume_name,
+                        parent=volume_parent,
                         size=volume_size,
                         realpath=path,
                         mountpoint=path,
@@ -1600,6 +1602,7 @@ class XMLState:
                 # volume setup for a full qualified volume with name and
                 # mountpoint information. See below for exceptions
                 name = volume.get_name()
+                parent = volume.get_parent() or ''
                 mountpoint = volume.get_mountpoint()
                 realpath = mountpoint
                 size = volume.get_size()
@@ -1667,6 +1670,7 @@ class XMLState:
                 volume_type_list.append(
                     volume_type(
                         name=name,
+                        parent=parent,
                         size=size,
                         fullsize=fullsize,
                         mountpoint=mountpoint,
@@ -1694,6 +1698,7 @@ class XMLState:
             volume_type_list.append(
                 volume_type(
                     name=root_volume_name,
+                    parent='',
                     size=size,
                     fullsize=fullsize,
                     mountpoint=None,
@@ -1708,6 +1713,7 @@ class XMLState:
             volume_type_list.append(
                 volume_type(
                     name=swap_name,
+                    parent='',
                     size='size:{0}'.format(swap_mbytes),
                     fullsize=False,
                     mountpoint=None,

--- a/test/unit/bootloader/config/base_test.py
+++ b/test/unit/bootloader/config/base_test.py
@@ -397,7 +397,7 @@ class TestBootLoaderConfigBase:
                     'volume_options': 'subvol=@/boot/grub2',
                     'volume_device': 'device'
                 }
-            }
+            }, root_volume_name='root'
         )
         assert mock_MountManager.call_args_list == [
             call(device='rootdev'),
@@ -409,7 +409,9 @@ class TestBootLoaderConfigBase:
             call(device='/proc', mountpoint='root_mount_point/proc'),
             call(device='/sys', mountpoint='root_mount_point/sys')
         ]
-        root_mount.mount.assert_called_once_with()
+        root_mount.mount.assert_called_once_with(
+            options=['subvol=root']
+        )
         boot_mount.mount.assert_called_once_with()
         efi_mount.mount.assert_called_once_with()
         volume_mount.mount.assert_called_once_with(

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -1494,8 +1494,9 @@ class TestBootLoaderConfigGrub2:
     @patch('glob.iglob')
     @patch('os.chmod')
     @patch('os.stat')
+    @patch('os.path.isfile')
     def test_setup_disk_boot_images_bios_plus_efi_secure_boot_no_shim_install(
-        self, mock_stat, mock_chmod, mock_glob,
+        self, mock_isfile, mock_stat, mock_chmod, mock_glob,
         mock_exists, mock_command, mock_which, mock_get_boot_path
     ):
         # we expect the copy of shim.efi and grub.efi from the fallback
@@ -1503,6 +1504,7 @@ class TestBootLoaderConfigGrub2:
         Defaults.set_platform_name('x86_64')
         mock_get_boot_path.return_value = '/boot'
         mock_which.return_value = None
+        mock_isfile.return_value = False
         self.firmware.efi_mode = Mock(
             return_value='uefi'
         )
@@ -1587,8 +1589,9 @@ class TestBootLoaderConfigGrub2:
     @patch('glob.iglob')
     @patch('os.chmod')
     @patch('os.stat')
+    @patch('os.path.isfile')
     def test_setup_disk_boot_images_bios_plus_efi_secure_boot_no_shim_at_all(
-        self, mock_stat, mock_chmod, mock_glob,
+        self, mock_isfile, mock_stat, mock_chmod, mock_glob,
         mock_exists, mock_command, mock_which, mock_get_boot_path,
         mock_get_shim_loader
     ):
@@ -1599,6 +1602,7 @@ class TestBootLoaderConfigGrub2:
         Defaults.set_platform_name('x86_64')
         mock_get_boot_path.return_value = '/boot'
         mock_which.return_value = None
+        mock_isfile.return_value = False
         self.firmware.efi_mode = Mock(
             return_value='uefi'
         )
@@ -1878,12 +1882,14 @@ class TestBootLoaderConfigGrub2:
     @patch('glob.iglob')
     @patch('os.chmod')
     @patch('os.stat')
+    @patch('os.path.isfile')
     def test_setup_install_boot_images_efi_secure_boot(
-        self, mock_stat, mock_chmod, mock_glob,
+        self, mock_isfile, mock_stat, mock_chmod, mock_glob,
         mock_exists, mock_command, mock_supports_bios_modules
     ):
         Defaults.set_platform_name('x86_64')
         mock_supports_bios_modules.return_value = False
+        mock_isfile.return_value = False
         self.os_exists['root_dir'] = True
         self.firmware.efi_mode = Mock(
             return_value='uefi'

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -955,7 +955,7 @@ class TestBootLoaderConfigGrub2:
                 }
             )
             mock_mount_system.assert_called_once_with(
-                'rootdev', 'bootdev', None, None
+                'rootdev', 'bootdev', None, None, None
             )
             assert mock_Command_run.call_args_list == [
                 call(

--- a/test/unit/bootloader/install/grub2_test.py
+++ b/test/unit/bootloader/install/grub2_test.py
@@ -29,6 +29,7 @@ class TestBootLoaderInstallGrub2:
             'root_device': '/dev/mapper/loop0p1',
             'efi_device': '/dev/mapper/loop0p3',
             'prep_device': '/dev/mapper/loop0p2',
+            'system_root_volume': 'root',
             'system_volumes': {'boot/grub2': {
                 'volume_options': 'subvol=@/boot/grub2',
                 'volume_device': 'device'
@@ -167,7 +168,9 @@ class TestBootLoaderInstallGrub2:
         mock_mount_manager.side_effect = side_effect
 
         self.bootloader.install()
-        self.bootloader.root_mount.mount.assert_called_once_with()
+        self.bootloader.root_mount.mount.assert_called_once_with(
+            options=['subvol=root']
+        )
         self.bootloader.boot_mount.mount.assert_called_once_with()
         mock_glob.assert_called_once_with(
             'tmp_root/boot/*/grubenv'
@@ -213,7 +216,9 @@ class TestBootLoaderInstallGrub2:
         mock_mount_manager.side_effect = side_effect
 
         self.bootloader.install()
-        self.bootloader.root_mount.mount.assert_called_once_with()
+        self.bootloader.root_mount.mount.assert_called_once_with(
+            options=['subvol=root']
+        )
         self.bootloader.boot_mount.mount.assert_called_once_with()
         assert mock_command.call_args_list == [
             call(
@@ -258,7 +263,9 @@ class TestBootLoaderInstallGrub2:
         mock_mount_manager.side_effect = side_effect
 
         self.bootloader.install()
-        self.bootloader.root_mount.mount.assert_called_once_with()
+        self.bootloader.root_mount.mount.assert_called_once_with(
+            options=['subvol=root']
+        )
         self.bootloader.boot_mount.mount.assert_called_once_with()
         mock_wipe.assert_called_once_with(
             'tmp_root/boot/grub2/grubenv'
@@ -297,7 +304,9 @@ class TestBootLoaderInstallGrub2:
         mock_mount_manager.side_effect = side_effect
 
         self.bootloader.install()
-        self.bootloader.root_mount.mount.assert_called_once_with()
+        self.bootloader.root_mount.mount.assert_called_once_with(
+            options=['subvol=root']
+        )
         self.bootloader.boot_mount.mount.assert_called_once_with()
         mock_wipe.assert_called_once_with(
             'tmp_root/boot/grub2/grubenv'
@@ -338,7 +347,9 @@ class TestBootLoaderInstallGrub2:
         self.bootloader.target_removable = True
 
         self.bootloader.install()
-        self.root_mount.mount.assert_called_once_with()
+        self.root_mount.mount.assert_called_once_with(
+            options=['subvol=root']
+        )
         self.volume_mount.mount.assert_called_once_with(
             options=['subvol=@/boot/grub2']
         )
@@ -398,7 +409,9 @@ class TestBootLoaderInstallGrub2:
                 '/usr/sbin/grub2-install'
             ])
         ]
-        self.root_mount.mount.assert_called_once_with()
+        self.root_mount.mount.assert_called_once_with(
+            options=['subvol=root']
+        )
         self.volume_mount.mount.assert_called_once_with(
             options=['subvol=@/boot/grub2']
         )
@@ -421,7 +434,9 @@ class TestBootLoaderInstallGrub2:
         mock_mount_manager.side_effect = side_effect
 
         self.bootloader.secure_boot_install()
-        self.root_mount.mount.assert_called_once_with()
+        self.root_mount.mount.assert_called_once_with(
+            options=['subvol=root']
+        )
         self.volume_mount.mount.assert_called_once_with(
             options=['subvol=@/boot/grub2']
         )

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -1224,6 +1224,7 @@ class TestDiskBuilder:
         filesystem = Mock()
         mock_fs.return_value = filesystem
         self.disk_builder.volume_manager_name = 'btrfs'
+        self.disk_builder.btrfs_set_default_volume = False
 
         with patch('builtins.open'):
             self.disk_builder.create_disk()

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -1203,6 +1203,41 @@ class TestDiskBuilder:
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     @patch('kiwi.builder.disk.ImageSystem')
     @patch('os.path.exists')
+    def test_create_disk_btrfs_managed_root(
+        self, mock_exists, mock_ImageSystem, mock_grub_dir, mock_command,
+        mock_volume_manager, mock_fs
+    ):
+        mock_exists.return_value = True
+        volume_manager = Mock()
+        volume_manager.get_device = Mock(
+            return_value={
+                'root': MappedDevice('root', Mock())
+            }
+        )
+        volume_manager.get_fstab = Mock(
+            return_value=['fstab_volume_entries']
+        )
+        volume_manager.get_root_volume_name = Mock(
+            return_value='@'
+        )
+        mock_volume_manager.return_value = volume_manager
+        filesystem = Mock()
+        mock_fs.return_value = filesystem
+        self.disk_builder.volume_manager_name = 'btrfs'
+
+        with patch('builtins.open'):
+            self.disk_builder.create_disk()
+
+        assert [
+            call('UUID=blkid_result / blkid_result_fs ro,defaults,subvol=@ 0 0')
+        ] in self.disk_builder.fstab.add_entry.call_args_list
+
+    @patch('kiwi.builder.disk.FileSystem.new')
+    @patch('kiwi.builder.disk.VolumeManager.new')
+    @patch('kiwi.builder.disk.Command.run')
+    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
+    @patch('kiwi.builder.disk.ImageSystem')
+    @patch('os.path.exists')
     def test_create_disk_volume_managed_root(
         self, mock_exists, mock_ImageSystem, mock_grub_dir, mock_command,
         mock_volume_manager, mock_fs

--- a/test/unit/mount_manager_test.py
+++ b/test/unit/mount_manager_test.py
@@ -25,6 +25,9 @@ class TestMountManager:
     def setup_method(self, cls, mock_path_create):
         self.setup()
 
+    def test_get_attributes(self):
+        assert self.mount_manager.get_attributes() == {}
+
     @patch('kiwi.mount_manager.Temporary')
     def test_setup_empty_mountpoint(self, mock_Temporary):
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -53,6 +53,9 @@ class TestVolumeManagerBase:
     def setup_method(self, cls, mock_path):
         self.setup()
 
+    def test_get_root_volume_name(self):
+        assert self.volume_manager.get_root_volume_name() == '/'
+
     @patch('os.path.exists')
     def test_init_custom_args(self, mock_exists):
         mock_exists.return_value = True

--- a/test/unit/volume_manager/btrfs_test.py
+++ b/test/unit/volume_manager/btrfs_test.py
@@ -27,22 +27,22 @@ class TestVolumeManagerBtrfs:
     def setup(self, mock_path):
         self.volumes = [
             volume_type(
-                name='@', size='freespace:100', realpath='/',
+                name='@', parent='', size='freespace:100', realpath='/',
                 mountpoint=None, fullsize=False, label=None,
                 attributes=[], is_root_volume=True
             ),
             volume_type(
-                name='etc', size='freespace:200', realpath='/etc',
+                name='etc', parent='', size='freespace:200', realpath='/etc',
                 mountpoint='/etc', fullsize=False, label=None,
                 attributes=[], is_root_volume=False
             ),
             volume_type(
-                name='myvol', size='size:500', realpath='/data',
+                name='myvol', parent='', size='size:500', realpath='/data',
                 mountpoint='LVdata', fullsize=False, label=None,
                 attributes=[], is_root_volume=False
             ),
             volume_type(
-                name='home', size=None, realpath='/home',
+                name='home', parent='', size=None, realpath='/home',
                 mountpoint='/home', fullsize=True, label=None,
                 attributes=[], is_root_volume=False
             )
@@ -60,19 +60,23 @@ class TestVolumeManagerBtrfs:
         self.volume_manager = VolumeManagerBtrfs(
             self.device_map, 'root_dir', self.volumes
         )
+        self.volume_manager.mountpoint = '/var/tmp/kiwi_volumes.XXX'
 
     @patch('os.path.exists')
     def setup_method(self, cls, mock_path):
         self.setup()
 
+    def test_get_root_volume_name(self):
+        assert self.volume_manager.get_root_volume_name() == '@'
+
     def test_post_init(self):
         self.volume_manager.post_init({'some-arg': 'some-val'})
         assert self.volume_manager.custom_args['some-arg'] == 'some-val'
 
-    def test_post_init_root_is_snapshot_without_toplevel_volume(self):
+    def test_post_init_root_is_snapshot_without_root_volume(self):
         self.volume_manager.volumes = [
             volume_type(
-                name='/', size='freespace:100', realpath='/',
+                name='/', parent='', size='freespace:100', realpath='/',
                 mountpoint=None, fullsize=False, label=None,
                 attributes=[], is_root_volume=True
             )
@@ -138,7 +142,14 @@ class TestVolumeManagerBtrfs:
 
         assert mock_mount.call_args_list == [
             call(device='/dev/storage', mountpoint='tmpdir'),
-            call(device='/dev/storage', mountpoint='tmpdir/@/.snapshots/1/snapshot/.snapshots')
+            call(
+                device='/dev/storage',
+                attributes={
+                    'subvol_path': '@/.snapshots',
+                    'subvol_name': '@/.snapshots'
+                },
+                mountpoint='tmpdir/@/.snapshots/1/snapshot/.snapshots'
+            )
         ]
         toplevel_mount.mount.assert_called_once_with([])
         assert mock_command.call_args_list == [
@@ -175,7 +186,7 @@ class TestVolumeManagerBtrfs:
     @patch('kiwi.volume_manager.btrfs.MountManager')
     @patch('kiwi.volume_manager.btrfs.Path.create')
     @patch('kiwi.volume_manager.base.VolumeManagerBase.apply_attributes_on_volume')
-    def test_create_volumes_no_toplevel_volume(
+    def test_create_volumes_no_root_volume(
         self, mock_attrs, mock_path, mock_mount, mock_command, mock_os_exists
     ):
         volume_mount = Mock()
@@ -187,12 +198,12 @@ class TestVolumeManagerBtrfs:
         self.volume_manager.root_volume_name = '/'
         self.volume_manager.volumes = [
             volume_type(
-                name='/', size='freespace:100', realpath='/',
+                name='/', parent='', size='freespace:100', realpath='/',
                 mountpoint=None, fullsize=False, label=None,
                 attributes=[], is_root_volume=True
             ),
             volume_type(
-                name='home', size=None, realpath='/home',
+                name='home', parent='/', size=None, realpath='/home',
                 mountpoint='/home', fullsize=True, label=None,
                 attributes=[], is_root_volume=False
             )
@@ -208,7 +219,13 @@ class TestVolumeManagerBtrfs:
             ['btrfs', 'subvolume', 'create', 'tmpdir/home']
         )
         mock_mount.assert_called_once_with(
-            device='/dev/storage', mountpoint='tmpdir/home'
+            device='/dev/storage',
+            attributes={
+                'parent': '/',
+                'subvol_path': 'home',
+                'subvol_name': 'home'
+            },
+            mountpoint='tmpdir/home'
         )
 
     @patch('os.path.exists')
@@ -229,24 +246,24 @@ class TestVolumeManagerBtrfs:
 
         assert mock_attrs.call_args_list == [
             call(
-                'tmpdir/@/', volume_type(
-                    name='myvol', size='size:500', realpath='/data',
+                'tmpdir/@', volume_type(
+                    name='myvol', parent='', size='size:500', realpath='/data',
                     mountpoint='LVdata', fullsize=False, label=None,
                     attributes=[],
                     is_root_volume=False
                 )
             ),
             call(
-                'tmpdir/@/', volume_type(
-                    name='etc', size='freespace:200', realpath='/etc',
+                'tmpdir/@', volume_type(
+                    name='etc', parent='', size='freespace:200', realpath='/etc',
                     mountpoint='/etc', fullsize=False, label=None,
                     attributes=[],
                     is_root_volume=False
                 )
             ),
             call(
-                'tmpdir/@/', volume_type(
-                    name='home', size=None, realpath='/home',
+                'tmpdir/@', volume_type(
+                    name='home', parent='', size=None, realpath='/home',
                     mountpoint='/home', fullsize=True, label=None,
                     attributes=[],
                     is_root_volume=False
@@ -269,15 +286,27 @@ class TestVolumeManagerBtrfs:
         assert mock_mount.call_args_list == [
             call(
                 device='/dev/storage',
-                mountpoint='tmpdir/@/.snapshots/1/snapshot/data'
+                mountpoint='tmpdir/@/.snapshots/1/snapshot/data',
+                attributes={
+                    'subvol_path': '@/data',
+                    'subvol_name': '@/data'
+                }
             ),
             call(
                 device='/dev/storage',
-                mountpoint='tmpdir/@/.snapshots/1/snapshot/etc'
+                mountpoint='tmpdir/@/.snapshots/1/snapshot/etc',
+                attributes={
+                    'subvol_path': '@/etc',
+                    'subvol_name': '@/etc'
+                }
             ),
             call(
                 device='/dev/storage',
-                mountpoint='tmpdir/@/.snapshots/1/snapshot/home'
+                mountpoint='tmpdir/@/.snapshots/1/snapshot/home',
+                attributes={
+                    'subvol_path': '@/home',
+                    'subvol_name': '@/home'
+                }
             )
         ]
 
@@ -286,7 +315,9 @@ class TestVolumeManagerBtrfs:
         volume_mount.mountpoint = \
             '/var/tmp/kiwi_volumes.xx/@/.snapshots/1/snapshot/boot/grub2'
         volume_mount.device = 'device'
-        self.volume_manager.toplevel_volume = '@/.snapshots/1/snapshot'
+        volume_mount.get_attributes.return_value = {
+            'subvol_path': '@/boot/grub2'
+        }
         self.volume_manager.subvol_mount_list = [volume_mount]
         self.volume_manager.custom_args['root_is_snapshot'] = True
         assert self.volume_manager.get_volumes() == {
@@ -305,14 +336,19 @@ class TestVolumeManagerBtrfs:
         volume_mount.mountpoint = \
             '/var/tmp/kiwi_volumes.XXX/@/.snapshots/1/snapshot/var/tmp'
         volume_mount.device = 'device'
-        self.volume_manager.toplevel_volume = '@/.snapshots/1/snapshot'
+        volume_mount.get_attributes.return_value = {
+            'subvol_path': '@/var/tmp',
+            'parent': 'subvol_takes_precedence'
+        }
         self.volume_manager.subvol_mount_list = [volume_mount]
+        self.volume_manager.custom_args['root_is_snapshot'] = True
         assert self.volume_manager.get_fstab() == [
             'LABEL=id /var/tmp btrfs defaults,subvol=@/var/tmp 0 0'
         ]
         self.volumes.append(
             volume_type(
                 name='device',
+                parent='',
                 size='freespace:100',
                 realpath='/var/tmp',
                 mountpoint=volume_mount.mountpoint,
@@ -337,7 +373,9 @@ class TestVolumeManagerBtrfs:
         volume_mount = Mock()
         volume_mount.mountpoint = \
             '/var/tmp/kiwi_volumes.xx/@/.snapshots/1/snapshot/var/tmp'
-        self.volume_manager.toplevel_volume = '@/.snapshots/1/snapshot'
+        volume_mount.get_attributes.return_value = {
+            'subvol_path': '@/var/tmp'
+        }
         self.volume_manager.custom_args['root_is_snapshot'] = True
         self.volume_manager.subvol_mount_list = [volume_mount]
 
@@ -383,6 +421,9 @@ class TestVolumeManagerBtrfs:
         volume_mount = Mock()
         volume_mount.mountpoint = \
             '/var/tmp/kiwi_volumes.xx/@/.snapshots/1/snapshot/var/tmp'
+        volume_mount.get_attributes.return_value = {
+            'subvol_path': '@/var/tmp'
+        }
         self.volume_manager.subvol_mount_list = [volume_mount]
 
         self.volume_manager.mount_volumes()

--- a/test/unit/volume_manager/lvm_test.py
+++ b/test/unit/volume_manager/lvm_test.py
@@ -22,27 +22,27 @@ class TestVolumeManagerLVM:
     def setup(self, mock_path):
         self.volumes = [
             volume_type(
-                name='LVRoot', size='freespace:100', realpath='/',
+                name='LVRoot', parent='', size='freespace:100', realpath='/',
                 mountpoint=None, fullsize=False, label=None, attributes=[],
                 is_root_volume=True
             ),
             volume_type(
-                name='LVSwap', size='size:100', realpath='swap',
+                name='LVSwap', parent='', size='size:100', realpath='swap',
                 mountpoint=None, fullsize=False, label='SWAP', attributes=[],
                 is_root_volume=False
             ),
             volume_type(
-                name='LVetc', size='freespace:200', realpath='/etc',
+                name='LVetc', parent='', size='freespace:200', realpath='/etc',
                 mountpoint='/etc', fullsize=False, label='etc', attributes=[],
                 is_root_volume=False
             ),
             volume_type(
-                name='myvol', size='size:500', realpath='/data',
+                name='myvol', parent='', size='size:500', realpath='/data',
                 mountpoint='LVdata', fullsize=False, label=None, attributes=[],
                 is_root_volume=False
             ),
             volume_type(
-                name='LVhome', size=None, realpath='/home',
+                name='LVhome', parent='', size=None, realpath='/home',
                 mountpoint='/home', fullsize=True, label=None, attributes=[],
                 is_root_volume=False
             ),
@@ -178,28 +178,28 @@ class TestVolumeManagerLVM:
         assert mock_attrs.call_args_list == [
             call(
                 'root_dir', volume_type(
-                    name='LVSwap', size='size:100', realpath='swap',
+                    name='LVSwap', parent='', size='size:100', realpath='swap',
                     mountpoint=None, fullsize=False, label='SWAP',
                     attributes=[], is_root_volume=False
                 )
             ),
             call(
                 'root_dir', volume_type(
-                    name='LVRoot', size='freespace:100', realpath='/',
+                    name='LVRoot', parent='', size='freespace:100', realpath='/',
                     mountpoint=None, fullsize=False, label=None,
                     attributes=[], is_root_volume=True
                 )
             ),
             call(
                 'root_dir', volume_type(
-                    name='myvol', size='size:500', realpath='/data',
+                    name='myvol', parent='', size='size:500', realpath='/data',
                     mountpoint='LVdata', fullsize=False, label=None,
                     attributes=[], is_root_volume=False
                 )
             ),
             call(
                 'root_dir', volume_type(
-                    name='LVetc', size='freespace:200', realpath='/etc',
+                    name='LVetc', parent='', size='freespace:200', realpath='/etc',
                     mountpoint='/etc', fullsize=False, label='etc',
                     attributes=[], is_root_volume=False
                 )
@@ -342,6 +342,7 @@ class TestVolumeManagerLVM:
         self.volumes.append(
             volume_type(
                 name='device',
+                parent='',
                 size='freespace:100',
                 realpath='/var/tmp',
                 mountpoint=volume_mount.mountpoint,

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -386,6 +386,7 @@ class TestXMLState:
         volume_type = namedtuple(
             'volume_type', [
                 'name',
+                'parent',
                 'size',
                 'realpath',
                 'mountpoint',
@@ -397,7 +398,7 @@ class TestXMLState:
         )
         assert state.get_volumes() == [
             volume_type(
-                name='myroot', size='freespace:500',
+                name='myroot', parent='', size='freespace:500',
                 realpath='/',
                 mountpoint=None, fullsize=False,
                 label=None,
@@ -413,6 +414,7 @@ class TestXMLState:
         volume_type = namedtuple(
             'volume_type', [
                 'name',
+                'parent',
                 'size',
                 'realpath',
                 'mountpoint',
@@ -424,7 +426,7 @@ class TestXMLState:
         )
         assert state.get_volumes() == [
             volume_type(
-                name='usr_lib', size='size:1024',
+                name='usr_lib', parent='', size='size:1024',
                 realpath='usr/lib',
                 mountpoint='usr/lib',
                 fullsize=False,
@@ -433,7 +435,7 @@ class TestXMLState:
                 is_root_volume=False
             ),
             volume_type(
-                name='LVRoot', size='freespace:500',
+                name='LVRoot', parent='', size='freespace:500',
                 realpath='/',
                 mountpoint=None, fullsize=False,
                 label=None,
@@ -441,7 +443,7 @@ class TestXMLState:
                 is_root_volume=True
             ),
             volume_type(
-                name='etc_volume', size='freespace:30',
+                name='etc_volume', parent='', size='freespace:30',
                 realpath='etc',
                 mountpoint='etc', fullsize=False,
                 label=None,
@@ -449,7 +451,7 @@ class TestXMLState:
                 is_root_volume=False
             ),
             volume_type(
-                name='bin_volume', size=None,
+                name='bin_volume', parent='', size=None,
                 realpath='/usr/bin',
                 mountpoint='/usr/bin', fullsize=True,
                 label=None,
@@ -457,7 +459,7 @@ class TestXMLState:
                 is_root_volume=False
             ),
             volume_type(
-                name='LVSwap', size='size:128',
+                name='LVSwap', parent='', size='size:128',
                 realpath='swap',
                 mountpoint=None, fullsize=False,
                 label='SWAP',
@@ -473,6 +475,7 @@ class TestXMLState:
         volume_type = namedtuple(
             'volume_type', [
                 'name',
+                'parent',
                 'size',
                 'realpath',
                 'mountpoint',
@@ -484,14 +487,14 @@ class TestXMLState:
         )
         assert state.get_volumes() == [
             volume_type(
-                name='LVRoot', size=None, realpath='/',
+                name='LVRoot', parent='', size=None, realpath='/',
                 mountpoint=None, fullsize=True,
                 label=None,
                 attributes=[],
                 is_root_volume=True
             ),
             volume_type(
-                name='LVSwap', size='size:128',
+                name='LVSwap', parent='', size='size:128',
                 realpath='swap',
                 mountpoint=None, fullsize=False,
                 label='SWAP',
@@ -509,6 +512,7 @@ class TestXMLState:
         volume_type = namedtuple(
             'volume_type', [
                 'name',
+                'parent',
                 'size',
                 'realpath',
                 'mountpoint',
@@ -520,21 +524,21 @@ class TestXMLState:
         )
         assert state.get_volumes() == [
             volume_type(
-                name='usr', size=None, realpath='usr',
+                name='usr', parent='', size=None, realpath='usr',
                 mountpoint='usr', fullsize=True,
                 label=None,
                 attributes=[],
                 is_root_volume=False
             ),
             volume_type(
-                name='LVRoot', size='freespace:30', realpath='/',
+                name='LVRoot', parent='', size='freespace:30', realpath='/',
                 mountpoint=None, fullsize=False,
                 label=None,
                 attributes=[],
                 is_root_volume=True
             ),
             volume_type(
-                name='LVSwap', size='size:128',
+                name='LVSwap', parent='', size='size:128',
                 realpath='swap',
                 mountpoint=None, fullsize=False,
                 label='SWAP',

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1132,3 +1132,7 @@ class TestXMLState:
         assert state.get_bootloader_config_options() == [
             '--joe', '-x'
         ]
+
+    def test_get_btrfs_create_toplevel_subvolume(self):
+        assert self.state.build_type.get_btrfs_create_toplevel_subvolume() is \
+            None

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1137,6 +1137,6 @@ class TestXMLState:
             '--joe', '-x'
         ]
 
-    def test_get_btrfs_create_toplevel_subvolume(self):
-        assert self.state.build_type.get_btrfs_create_toplevel_subvolume() is \
+    def test_get_btrfs_root_is_subvolume(self):
+        assert self.state.build_type.get_btrfs_root_is_subvolume() is \
             None


### PR DESCRIPTION
In a volume setup the special volume declaration
```<volume name="@root=identifier"/>``` was only evaluated for the LVM volume manager. In case of btrfs a hardcoded root volume name '@' was used. This commit allows to specify a custom name for the root volume for btrfs as well and also allows to specify that there should be no such root volume. Example:

```xml
<volume name="@root=@"/>
```

Name the root volume '@'. If not specified this stays as the default to stay compatible

```xml
<volume name="@root=/"/>
```

Indicate no root volume is wanted. All subvolumes resides below root (/)

```xml
<volume name="@root=foo"/>
```

Name the root volume 'foo'

This is related to Issue #2316 and a first patch to address the requested changes


