### PR TITLE
Remove tox envdir

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -237,4 +237,5 @@ commands =
 
 [testenv:devel]
 passenv = *
+allowlist_externals = *
 commands = {posargs} []

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@
 #
 
 [tox]
-minversion = 2.9.1
+minversion = 3.3.0
+isolated_build = True
 skip_missing_interpreters = True
 skipsdist = True
 envlist =
@@ -39,19 +40,11 @@ allowlist_externals =
     python
     pytest
 basepython =
-    {check,devel,packagedoc,doc,doc_gh_pages,doc_suse,doc_man,scripts,}: python3
     unit_py3_10: python3.10
     unit_py3_9: python3.9
     unit_py3_8: python3.8
     unit_py3_6: python3.6
     release: python3.6
-envdir =
-    {check,devel,packagedoc,doc,doc_gh_pages,doc_suse,doc_man,scripts,}: {toxworkdir}/3
-    unit_py3_10: {toxworkdir}/3.10
-    unit_py3_9: {toxworkdir}/3.9
-    unit_py3_8: {toxworkdir}/3.8
-    unit_py3_6: {toxworkdir}/3.6
-    release: {toxworkdir}/3.6
 passenv =
     *
 usedevelop = True


### PR DESCRIPTION
Changes proposed in this pull request:
* use tox' `isolated_build` instead of hardcoding `envdir`
* allow to run all external commands in `devel` toxenv, as it is used for running arbitrary scripts in the venv
