### PR TITLE
Fix failure when booting KIS via NBD

### DIFF
--- a/dracut/modules.d/90kiwi-overlay/parse-kiwi-overlay.sh
+++ b/dracut/modules.d/90kiwi-overlay/parse-kiwi-overlay.sh
@@ -57,7 +57,7 @@ case "${overlayroot}" in
     ;;
     overlay:nbd=*) \
         root="${root#overlay:nbd=}"
-        root="block:/dev/${root}"
+        root="block:/dev/nbd0"
         need_network=1
         rootok=1
     ;;


### PR DESCRIPTION
In the NBD booting case, the function initGlobalDevices in kiwi-overlay-root.sh runs the command ndb-client to connect the remote NBD share to the device /dev/nbd0. The script parse-kiwi-overlay.sh, on the other hand, incorrectly parses overlay:nbd=ip:export to /dev/ip/export, leading to the system waiting for /dev/ip/export to appear. This commit corrects the problem.

With this change NDB booting of KIS images now succeeds, although only if the ndb package is added to the appliance description.