### PR TITLE
Delete (py)xattr module requirement

### DIFF
--- a/kiwi/utils/sync.py
+++ b/kiwi/utils/sync.py
@@ -16,10 +16,10 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import errno
 import logging
 from stat import ST_MODE
 from typing import List
-import xattr
 
 # project
 from kiwi.command import Command
@@ -134,9 +134,8 @@ class DataSync:
         :rtype: bool
         """
         try:
-            xattr.getxattr(self.target_dir, 'user.mime_type')
-        except Exception as e:
-            if format(e).startswith('[Errno 95]'):
-                # libc interface [Errno 95] Operation not supported:
+            os.getxattr(self.target_dir, 'user.mime_type')
+        except OSError as e:
+            if e.errno not in (errno.EPERM, errno.ENOTSUP, errno.ENODATA):
                 return False
         return True

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -374,11 +374,6 @@ Requires:       python%{python3_pkgversion}-docopt
 Requires:       python%{python3_pkgversion}-lxml
 Requires:       python%{python3_pkgversion}-requests
 Requires:       python%{python3_pkgversion}-setuptools
-%if (0%{?suse_version} && 0%{?suse_version} < 1550)
-Requires:       python%{python3_pkgversion}-xattr
-%else
-Requires:       python%{python3_pkgversion}-pyxattr
-%endif
 %if ! (0%{?rhel} && 0%{?rhel} < 8)
 Recommends:     kiwi-man-pages
 %endif
@@ -619,11 +614,6 @@ Provides manual pages to describe the kiwi commands
 # Drop shebang for kiwi/xml_parse.py, as we don't intend to use it
 # as an independent script
 sed -e "s|#!/usr/bin/env python||" -i kiwi/xml_parse.py
-
-%if 0%{?suse_version} && 0%{?suse_version} < 1550
-# For older SUSE distributions, use the other xattr Python module
-sed -e "s|pyxattr|xattr|" -i setup.py
-%endif
 
 %build
 # Build C-Tools

--- a/test/unit/utils/sync_test.py
+++ b/test/unit/utils/sync_test.py
@@ -57,14 +57,14 @@ class TestDataSync:
             ['rsync', 'source_dir/', 'target_dir']
         )
 
-    @patch('xattr.getxattr')
+    @patch('os.getxattr')
     def test_target_supports_extended_attributes(self, mock_getxattr):
         assert self.sync.target_supports_extended_attributes() is True
         mock_getxattr.assert_called_once_with(
             'target_dir', 'user.mime_type'
         )
 
-    @patch('xattr.getxattr')
+    @patch('os.getxattr')
     def test_target_does_not_support_extended_attributes(self, mock_getxattr):
         mock_getxattr.side_effect = OSError(
             """[Errno 95] Operation not supported: b'/boot/efi"""


### PR DESCRIPTION
The required functionality is provided by the core os library

