### PR TITLE
Add volid to profile for all ISO based image types

### DIFF
--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -184,7 +184,7 @@ class Profile:
         # kiwi_install_volid
         if self.xml_state.is_xen_server():
             self.dot_profile['kiwi_xendomain'] = 'dom0'
-        if 'oem' in self.xml_state.get_build_type_name():
+        if self.xml_state.get_build_type_name() in ['oem', 'iso']:
             install_volid = self.xml_state.build_type.get_volid() or \
                 Defaults.get_install_volume_id()
             self.dot_profile['kiwi_install_volid'] = install_volid


### PR DESCRIPTION
Add provided volume id (or the default value) to the profile environment file for all ISO based image types. So far this was only done for installation ISO media but not for simple live ISO images.


