### PR TITLE
Fixed writing keyfile path to etc/crypttab

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -370,10 +370,11 @@ class DiskBuilder:
                 True if self.boot_is_crypto or self.luks == '' else False
             luks_root.create_crypto_luks(
                 passphrase=self.luks,
-                os=self.luks_os,
+                osname=self.luks_os,
                 options=self.luks_format_options,
-                keyfile=self.luks_boot_keyfile if luks_need_keyfile else '',
-                randomize=self.luks_randomize
+                keyfile=self.luks_boot_keyname if luks_need_keyfile else '',
+                randomize=self.luks_randomize,
+                root_dir=self.root_dir
             )
             if luks_need_keyfile:
                 self.luks_boot_keyfile_setup = ''.join(

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -1045,9 +1045,10 @@ class TestDiskBuilder:
             self.disk_builder.create_disk()
 
         self.luks_root.create_crypto_luks.assert_called_once_with(
-            passphrase='passphrase', os=None,
-            options=[], keyfile='root_dir/root/.root.keyfile',
-            randomize=True
+            passphrase='passphrase', osname=None,
+            options=[], keyfile='/root/.root.keyfile',
+            randomize=True,
+            root_dir='root_dir'
         )
         self.luks_root.create_crypttab.assert_called_once_with(
             'root_dir/etc/crypttab'
@@ -1089,9 +1090,10 @@ class TestDiskBuilder:
             self.disk_builder.create_disk()
 
         self.luks_root.create_crypto_luks.assert_called_once_with(
-            passphrase='passphrase', os=None,
-            options=[], keyfile='root_dir/root/.root.keyfile',
-            randomize=True
+            passphrase='passphrase', osname=None,
+            options=[], keyfile='/root/.root.keyfile',
+            randomize=True,
+            root_dir='root_dir'
         )
         self.luks_root.create_crypttab.assert_called_once_with(
             'root_dir/etc/crypttab'


### PR DESCRIPTION
The keyfile path was not correctly set in etc/crypttab which caused systemd not being able to read the keyfile, consequently asking for a passphrase. This commit fixes the writing of the crypttab and also fixes a python name clash with the "os" namespace.

