### PR TITLE
Fixed check for extended attributes

### DIFF
--- a/kiwi/utils/sync.py
+++ b/kiwi/utils/sync.py
@@ -136,6 +136,9 @@ class DataSync:
         try:
             os.getxattr(self.target_dir, 'user.mime_type')
         except OSError as e:
-            if e.errno not in (errno.EPERM, errno.ENOTSUP, errno.ENODATA):
+            log.debug(
+                f'Check for extended attributes on {self.target_dir} said: {e}'
+            )
+            if e.errno == errno.ENOTSUP:
                 return False
         return True

--- a/test/unit/utils/sync_test.py
+++ b/test/unit/utils/sync_test.py
@@ -1,4 +1,5 @@
 import os
+import errno
 import logging
 from pytest import fixture
 from stat import ST_MODE
@@ -66,7 +67,7 @@ class TestDataSync:
 
     @patch('os.getxattr')
     def test_target_does_not_support_extended_attributes(self, mock_getxattr):
-        mock_getxattr.side_effect = OSError(
-            """[Errno 95] Operation not supported: b'/boot/efi"""
-        )
+        effect = OSError()
+        effect.errno = errno.ENOTSUP
+        mock_getxattr.side_effect = effect
         assert self.sync.target_supports_extended_attributes() is False


### PR DESCRIPTION
Only if libc reports errno 95 Operation not supported the method should return that extended attributes are not supported. Also add a debug information about the result of the call to get further information in the log file

