### PR TITLE
allow value of GRUB_TERMINAL to be empty

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -95,8 +95,10 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         if self.custom_args and 'config_options' in self.custom_args:
             self.config_options = self.custom_args['config_options']
 
-        self.terminal = self.xml_state.get_build_type_bootloader_console() \
-            or 'gfxterm'
+        self.terminal = self.xml_state.get_build_type_bootloader_console()
+        if self.terminal is None:
+            self.terminal = 'gfxterm'
+
         self.gfxmode = self.get_gfxmode('grub2')
         self.theme = self.get_boot_theme()
         self.timeout = self.get_boot_timeout_seconds()

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -103,6 +103,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         self.terminal = self.xml_state.get_build_type_bootloader_console()
         if self.terminal is None:
             self.terminal = 'gfxterm'
+        else:
+            self.terminal = self.terminal.replace('none', '').lstrip()
 
         self.gfxmode = self.get_gfxmode('grub2')
         self.theme = self.get_boot_theme()

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -37,7 +37,7 @@ vhd-tag-type = xsd:token {pattern = "[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}"}
 groups-list = xsd:token {pattern = "[a-zA-Z0-9_\-\.:]+(,[a-zA-Z0-9_\-\.:]+)*"}
 arch-name = xsd:token {pattern = "(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x|riscv64)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x|riscv64))*"}
 portnum-type = xsd:token {pattern = "(\d+|\d+/(udp|tcp))"}
-grub_console = xsd:token {pattern = "(\s*|console|gfxterm|serial)( (console|gfxterm|serial))*"}
+grub_console = xsd:token {pattern = "(none|console|gfxterm|serial)( (console|gfxterm|serial))*"}
 fs_attributes = xsd:token {pattern = "(no-copy-on-write|synchronous-updates)(,(no-copy-on-write|synchronous-updates))*"}
 package-version-type =  xsd:token {pattern = "(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){3}"}
 simple-uri-type = xsd:token {pattern = "(file:|https:|http:|ftp:).*"}

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -37,7 +37,7 @@ vhd-tag-type = xsd:token {pattern = "[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}"}
 groups-list = xsd:token {pattern = "[a-zA-Z0-9_\-\.:]+(,[a-zA-Z0-9_\-\.:]+)*"}
 arch-name = xsd:token {pattern = "(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x|riscv64)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x|riscv64))*"}
 portnum-type = xsd:token {pattern = "(\d+|\d+/(udp|tcp))"}
-grub_console = xsd:token {pattern = "(console|gfxterm|serial)( (console|gfxterm|serial))*"}
+grub_console = xsd:token {pattern = "(\s*|console|gfxterm|serial)( (console|gfxterm|serial))*"}
 fs_attributes = xsd:token {pattern = "(no-copy-on-write|synchronous-updates)(,(no-copy-on-write|synchronous-updates))*"}
 package-version-type =  xsd:token {pattern = "(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){3}"}
 simple-uri-type = xsd:token {pattern = "(file:|https:|http:|ftp:).*"}

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -88,7 +88,7 @@
   </define>
   <define name="grub_console">
     <data type="token">
-      <param name="pattern">(\s*|console|gfxterm|serial)( (console|gfxterm|serial))*</param>
+      <param name="pattern">(none|console|gfxterm|serial)( (console|gfxterm|serial))*</param>
     </data>
   </define>
   <define name="fs_attributes">

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -88,7 +88,7 @@
   </define>
   <define name="grub_console">
     <data type="token">
-      <param name="pattern">(console|gfxterm|serial)( (console|gfxterm|serial))*</param>
+      <param name="pattern">(\s*|console|gfxterm|serial)( (console|gfxterm|serial))*</param>
     </data>
   </define>
   <define name="fs_attributes">

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -5606,7 +5606,7 @@ class bootloader(GeneratedsSuper):
             if not self.gds_validate_simple_patterns(
                     self.validate_grub_console_patterns_, value):
                 warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_grub_console_patterns_, ))
-    validate_grub_console_patterns_ = [['^(\s*|console|gfxterm|serial)( (console|gfxterm|serial))*$']]
+    validate_grub_console_patterns_ = [['^(none|console|gfxterm|serial)( (console|gfxterm|serial))*$']]
     def hasContent_(self):
         if (
             self.bootloadersettings is not None

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -100,7 +100,7 @@ except ImportError:
 try:
     from generatedssuper import GeneratedsSuper
 except ImportError as exp:
-    
+
     class GeneratedsSuper(object):
         tzoff_pattern = re_.compile(r'(\+|-)((0\d|1[0-3]):[0-5]\d|14:00)$')
         class _FixedOffsetTZ(datetime_.tzinfo):
@@ -426,7 +426,7 @@ except ImportError as exp:
             return self.__dict__ == other.__dict__
         def __ne__(self, other):
             return not self.__eq__(other)
-    
+
     def getSubclassFromModule_(module, class_):
         '''Get the subclass of a class from a specific module.'''
         name = class_.__name__ + 'Sub'
@@ -5606,7 +5606,7 @@ class bootloader(GeneratedsSuper):
             if not self.gds_validate_simple_patterns(
                     self.validate_grub_console_patterns_, value):
                 warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_grub_console_patterns_, ))
-    validate_grub_console_patterns_ = [['^(console|gfxterm|serial)( (console|gfxterm|serial))*$']]
+    validate_grub_console_patterns_ = [['^(\s*|console|gfxterm|serial)( (console|gfxterm|serial))*$']]
     def hasContent_(self):
         if (
             self.bootloadersettings is not None


### PR DESCRIPTION
Fixes # 
https://github.com/OSInside/kiwi/issues/2261

Changes proposed in this pull request:
Allow value of GRUB_TERMINAL to be an empty string
(As of this moment) setting GRUB_TERMINAL to console causes garbage rendering on Apple Silicon systems. So GRUB_TERMINAL needs to contain a blank value (or not be set at all) if you want a properly rendered grub boot menu on Apple Silicon systems. 
