### PR TITLE
Fix double grub entries in hybrid ISO images

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -92,6 +92,11 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         else:
             self.boot_directory_name = 'grub'
 
+        if self.custom_args and 'grub_load_command' in self.custom_args:
+            self.grub_load = self.custom_args['grub_load_command']
+        else:
+            self.grub_load = 'source'
+
         if self.custom_args and 'config_options' in self.custom_args:
             self.config_options = self.custom_args['config_options']
 
@@ -321,7 +326,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             'theme': self.theme,
             'boot_timeout': self.timeout,
             'boot_timeout_style': self.timeout_style or 'menu',
-            'serial_line_setup': self.serial_line_setup or 'serial',
+            'serial_line_setup': self.serial_line_setup or '',
             'title': self.get_menu_entry_install_title(),
             'bootpath': self.get_boot_path('iso'),
             'boot_directory_name': self.boot_directory_name,
@@ -386,7 +391,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             'theme': self.theme,
             'boot_timeout': self.timeout,
             'boot_timeout_style': self.timeout_style or 'menu',
-            'serial_line_setup': self.serial_line_setup or 'serial',
+            'serial_line_setup': self.serial_line_setup or '',
             'title': self.get_menu_entry_title(plain=True),
             'bootpath': self.get_boot_path('iso'),
             'boot_directory_name': self.boot_directory_name,
@@ -1093,8 +1098,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 )
             )
             early_boot.write(
-                'source ($root){0}/{1}/grub.cfg{2}'.format(
-                    self.get_boot_path(), self.boot_directory_name, os.linesep
+                '{0} ($root){1}/{2}/grub.cfg{3}'.format(
+                    self.grub_load, self.get_boot_path(),
+                    self.boot_directory_name, os.linesep
                 )
             )
 
@@ -1114,8 +1120,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 )
             )
             early_boot.write(
-                'source ($root)/boot/{0}/grub.cfg{1}'.format(
-                    self.boot_directory_name, os.linesep
+                '{0} ($root)/boot/{1}/grub.cfg{2}'.format(
+                    self.grub_load, self.boot_directory_name, os.linesep
                 )
             )
 

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -213,7 +213,9 @@ class InstallImageBuilder:
                 'grub2', self.xml_state, root_dir=self.root_dir,
                 boot_dir=self.media_dir.name, custom_args={
                     'grub_directory_name':
-                        Defaults.get_grub_boot_directory_name(self.root_dir)
+                        Defaults.get_grub_boot_directory_name(self.root_dir),
+                    'grub_load_command':
+                        'configfile'
                 }
             )
             bootloader_config.setup_install_boot_images(

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -149,7 +149,9 @@ class LiveImageBuilder:
                 'grub2', self.xml_state, root_dir=self.root_dir,
                 boot_dir=self.media_dir.name, custom_args={
                     'grub_directory_name':
-                        Defaults.get_grub_boot_directory_name(self.root_dir)
+                        Defaults.get_grub_boot_directory_name(self.root_dir),
+                    'grub_load_command':
+                        'configfile'
                 }
             )
             bootloader_config.setup_live_boot_images(

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -112,6 +112,7 @@ class TestBootLoaderConfigGrub2:
         self.bootloader = BootLoaderConfigGrub2(
             self.state, 'root_dir', None, {
                 'grub_directory_name': 'grub2',
+                'grub_load_command': 'source',
                 'boot_is_crypto': True,
                 'crypto_disk': True,
                 'targetbase': 'rootdev',
@@ -138,6 +139,17 @@ class TestBootLoaderConfigGrub2:
         mock_which.return_value = None
         bootloader = BootLoaderConfigGrub2(xml_state, 'root_dir')
         assert bootloader.boot_directory_name == 'grub'
+
+    @patch('kiwi.bootloader.config.grub2.Path.which')
+    def test_post_init_grub2_load_command(self, mock_which):
+        Defaults.set_platform_name('i686')
+        xml_state = MagicMock()
+        xml_state.build_type.get_firmware = Mock(
+            return_value=None
+        )
+        mock_which.return_value = None
+        bootloader = BootLoaderConfigGrub2(xml_state, 'root_dir')
+        assert bootloader.grub_load == 'source'
 
     def test_post_init_invalid_platform(self):
         Defaults.set_platform_name('unsupported-arch')

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -189,7 +189,8 @@ class TestInstallImageBuilder:
         mock_BootLoaderConfig.assert_called_once_with(
             'grub2', self.xml_state, root_dir='root_dir',
             boot_dir='temp_media_dir', custom_args={
-                'grub_directory_name': mock_grub_dir.return_value
+                'grub_directory_name': mock_grub_dir.return_value,
+                'grub_load_command': 'configfile'
             }
         )
         bootloader_config.setup_install_boot_images.assert_called_once_with(

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -243,7 +243,8 @@ class TestLiveImageBuilder:
         kiwi.builder.live.BootLoaderConfig.new.assert_called_once_with(
             'grub2', self.xml_state, root_dir='root_dir',
             boot_dir='temp_media_dir', custom_args={
-                'grub_directory_name': 'grub2'
+                'grub_directory_name': 'grub2',
+                'grub_load_command': 'configfile'
             }
         )
         self.bootloader.setup_live_boot_images.assert_called_once_with(


### PR DESCRIPTION
As consequence of using the "source" grub command instead of the "configfile" command to load the grub config we now see double loading of the same file on ISO media. The reason here is that kiwi ISO media is always hybrid which means it embeds an MBR into the ISO for which the "source" command now can read the same file through two different device paths. This does not happen with the "configfile" grub command. Thus this patch uses "configfile" if we produce an ISO image and "source" for all other image types. The commit also fixes the custom grub template used for ISO images in a way that we only set the "serial" command if there is a serial configuration provided along with the image description.

