### PR TITLE
Fix bsc#1209302: add some hints about KIWI extensions and dependencies for SLES

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -96,10 +96,10 @@ Fedora/Rawhide:
 
 
 
-Installation for SUSE Linux Enterprise Server
----------------------------------------------
+Installation for SUSE Linux Enterprise
+--------------------------------------
 
-{kiwi} is available and supported for SUSE Linux Enterprise Server (SLES).
+{kiwi} is available and supported for SUSE Linux Enterprise (SLE).
 The recommended and supported way is to install {kiwi} by using zypper.
 
 However, if you rely on some plugins for {kiwi}, either the plugin
@@ -107,13 +107,13 @@ itself or any dependencies might not be available for your service pack.
 
 If you want to proceed anyway, keep these things in mind:
 
-* Plugins that are not provided by SLES are not supported.
+* Plugins that are not provided by SLE are not supported.
 * You probably need to install dependencies via :command:`pip`.
   The :command:`pip` command installs these dependencies from PyPI
   (the Python Package Index).
   However, this approach will not update the RPM database.
 * Depending on your security concerns, installing Python packages
-  outside the secured SLES installation may not be desirable.
+  outside the secured SLE installation may not be desirable.
 * Python packages installed from PyPI won't contain any SUSE
   customizations.
 * Depending on your extension and its dependencies, you might even need

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -94,6 +94,32 @@ Fedora/Rawhide:
 
      $ sudo dnf install kiwi-cli
 
+
+
+Installation for SUSE Linux Enterprise Server
+---------------------------------------------
+
+{kiwi} is available and supported for SUSE Linux Enterprise Server (SLES).
+The recommended and supported way is to install {kiwi} by using zypper.
+
+However, if your rely on some extensions for {kiwi}, either the extension
+itself or any dependencies might not be available for your service pack.
+
+If you want to proceed anyway, keep these things in mind:
+
+* Extensions that are not provided by SLES are not supported.
+* You probably need to install dependencies via :command:`pip`.
+  The :command:`pip` command installs these dependencies from PyPI
+  (the Python Package Index).
+  However, this approach will not update the RPM database.
+* Depending on your security concerns, installing Python packages
+  outside the secured SLES installation may not be desirable.
+* Python packages installed from PyPI won't contain any SUSE
+  customizations.
+* Depending on your extension and its dependencies, you might even need
+  a more recent Python version.
+
+
 .. _example-descriptions:
 
 Example Appliance Descriptions

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -102,12 +102,12 @@ Installation for SUSE Linux Enterprise Server
 {kiwi} is available and supported for SUSE Linux Enterprise Server (SLES).
 The recommended and supported way is to install {kiwi} by using zypper.
 
-However, if your rely on some extensions for {kiwi}, either the extension
+However, if you rely on some plugins for {kiwi}, either the plugin
 itself or any dependencies might not be available for your service pack.
 
 If you want to proceed anyway, keep these things in mind:
 
-* Extensions that are not provided by SLES are not supported.
+* Plugins that are not provided by SLES are not supported.
 * You probably need to install dependencies via :command:`pip`.
   The :command:`pip` command installs these dependencies from PyPI
   (the Python Package Index).


### PR DESCRIPTION
SUSE Linux Enterprise Server (SLES) has KIWI as a package. However, some KIWI extensions and their dependencies can be unavailable.

This commit introduces a new section which deals with this aspect.

Fixes bsc#1209302.

Changes proposed in this pull request:
* Add new section about "Installation for SUSE Linux Enterprise Server"
* Describe the general issue when using KIWI extensions on SLES.
  Keep in mind, this was deliberately kept general to fit all extensions.
