### PR TITLE
Add kiwi_live_volid variable to profile

### DIFF
--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -184,10 +184,14 @@ class Profile:
         # kiwi_install_volid
         if self.xml_state.is_xen_server():
             self.dot_profile['kiwi_xendomain'] = 'dom0'
-        if self.xml_state.get_build_type_name() in ['oem', 'iso']:
+        if self.xml_state.get_build_type_name() == 'oem':
             install_volid = self.xml_state.build_type.get_volid() or \
                 Defaults.get_install_volume_id()
             self.dot_profile['kiwi_install_volid'] = install_volid
+        if self.xml_state.get_build_type_name() == 'iso':
+            live_iso_volid = self.xml_state.build_type.get_volid() or \
+                Defaults.get_volume_id()
+            self.dot_profile['kiwi_live_volid'] = live_iso_volid
 
     def _strip_to_profile(self):
         # kiwi_strip_delete

--- a/test/data/example_dot_profile_live_config.xml
+++ b/test/data/example_dot_profile_live_config.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="7.6" name="LiveImage" displayname="Live">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>bob@example.com</contact>
+        <specification>
+            Test dot profile env for Live images
+        </specification>
+    </description>
+    <preferences>
+        <version>1.1.0</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <type image="iso" flags="overlay" firmware="bios" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="true"/>
+    </preferences>
+    <users>
+        <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+    </users>
+    <repository>
+        <source path="obsrepositories:/"/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-openSUSE-base"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+    </packages>
+</image>

--- a/test/unit/system/profile_test.py
+++ b/test/unit/system/profile_test.py
@@ -15,12 +15,67 @@ class TestProfile:
         self.profile = Profile(
             XMLState(description.load())
         )
+        live_description = XMLDescription(
+            '../data/example_dot_profile_live_config.xml'
+        )
+        self.live_profile = Profile(
+            XMLState(live_description.load())
+        )
 
     def setup_method(self, cls):
         self.setup()
 
     @patch('kiwi.path.Path.which')
-    def test_create(self, mock_which):
+    def test_create_live(self, mock_which):
+        mock_which.return_value = 'cp'
+        self.live_profile.create(self.profile_file)
+        os.remove(self.profile_file)
+        assert self.live_profile.dot_profile == {
+            'kiwi_iname': 'LiveImage',
+            'kiwi_displayname': 'Live',
+            'kiwi_profiles': '',
+            'kiwi_delete': '',
+            'kiwi_type': 'iso',
+            'kiwi_compressed': None,
+            'kiwi_boot_timeout': None,
+            'kiwi_wwid_wait_timeout': None,
+            'kiwi_hybridpersistent': True,
+            'kiwi_hybridpersistent_filesystem': 'ext4',
+            'kiwi_initrd_system': 'dracut',
+            'kiwi_ramonly': None,
+            'kiwi_target_blocksize': None,
+            'kiwi_target_removable': None,
+            'kiwi_cmdline': 'console=ttyS0',
+            'kiwi_firmware': 'bios',
+            'kiwi_bootloader': 'grub2',
+            'kiwi_bootloader_console': None,
+            'kiwi_btrfs_root_is_snapshot': None,
+            'kiwi_gpt_hybrid_mbr': None,
+            'kiwi_devicepersistency': None,
+            'kiwi_installboot': None,
+            'kiwi_bootkernel': None,
+            'kiwi_fsmountoptions': None,
+            'kiwi_bootprofile': None,
+            'kiwi_vga': None,
+            'kiwi_startsector': 2048,
+            'kiwi_luks_empty_passphrase': False,
+            'kiwi_live_volid': 'CDROM',
+            'kiwi_iversion': '1.1.0',
+            'kiwi_showlicense': None,
+            'kiwi_keytable': 'us.map.gz',
+            'kiwi_timezone': 'Europe/Berlin',
+            'kiwi_language': 'en_US',
+            'kiwi_splash_theme': None,
+            'kiwi_loader_theme': None,
+            'kiwi_strip_delete': '',
+            'kiwi_strip_tools': '',
+            'kiwi_strip_libs': '',
+            'kiwi_drivers': '',
+            'kiwi_rootpartuuid': None
+        }
+
+    @patch('kiwi.path.Path.which')
+    def test_create_oem(self, mock_which):
         mock_which.return_value = 'cp'
         self.profile.create(self.profile_file)
         os.remove(self.profile_file)


### PR DESCRIPTION
As part of the profile environment only the kiwi_install_volid variable existed with the default value 'INSTALL'. This information is correct when building an oem image with installiso set to true. The resulting .install.iso image has the configured volid or the mentioned default 'INSTALL'. However, when building a live ISO image the default volid value is set to 'CDROM' but the profile environment contains kiwi_install_volid which is misleading and in case no volid is provided in the configuration file, the default value would also be a wrong information. This commit cleans up the mess and provides kiwi_install_volid for install ISO media and kiwi_live_volid for Live ISO media with their respective default values


