### PR TITLE
Require DNF 5 in Fedora >= 41, not Fedora > 38

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -102,7 +102,7 @@ Recommends:     dnf
 Provides:       kiwi-packagemanager:microdnf
 Requires:       microdnf
 %endif
-%if 0%{?fedora} >= 39
+%if 0%{?fedora} >= 41
 Requires:       dnf5
 Requires:       dnf5-plugins
 Provides:       kiwi-packagemanager:dnf5


### PR DESCRIPTION
Hi, as you may be aware, the switch to DNF 5 has been postponed, likely to Fedora 41. In Fedora 39, the `dnf` command will be provided by the `dnf` package, and DNF 5 will not be installed by default.

DNF 5 will be available in the Fedora 39 repositories, but KIWI should still require DNF 4 since it will be the default package manager. Sorry for the flip-flop.

FYI, in the meantime, we have set up a testing [COPR repository](https://copr.fedorainfracloud.org/coprs/rpmsoftwaremanagement/dnf5-testing/) that provides a version of DNF 5 that obsoletes DNF 4. It can be used to test software in an environment similar to the future release of Fedora (whichever that will be) when DNF 5 replaces DNF 4:

```
sudo dnf-3 copr enable rpmsoftwaremanagement/dnf5-testing
```

Enabling the COPR and upgrading your system should replace DNF 4 (the `dnf` package) with DNF 5 (`dnf5`), and `/usr/bin/dnf` will be DNF 5.
