### PR TITLE
Make verity metadata always readonly

### DIFF
--- a/kiwi/utils/veritysetup.py
+++ b/kiwi/utils/veritysetup.py
@@ -173,7 +173,7 @@ class VeritySetup:
         |header_string|0xFF|dm_verity_credentials|0xFF|0x0|
 
         header_string:
-            '{version} {fstype} {ro|rw} verity'
+            '{version} {fstype} ro verity'
 
         dm_verity_credentials:
             '{hash_type} {data_blksize} {hash_blksize}
@@ -186,10 +186,8 @@ class VeritySetup:
         metadata_format_version = defaults.DM_METADATA_FORMAT_VERSION
         filesystem = self.get_block_storage_filesystem()
         if filesystem and self.verity_dict:
-            filesystem_mode = 'ro' if filesystem == 'squashfs' else 'rw'
-
-            header_string = '{0} {1} {2} verity'.format(
-                metadata_format_version, filesystem, filesystem_mode
+            header_string = '{0} {1} ro verity'.format(
+                metadata_format_version, filesystem
             )
 
             hash_start_block = int(

--- a/test/unit/utils/veritysetup_test.py
+++ b/test/unit/utils/veritysetup_test.py
@@ -162,7 +162,7 @@ class TestVeritySetup:
             file_handle = mock_open.return_value.__enter__.return_value
             self.veritysetup.create_verity_verification_metadata()
         assert file_handle.write.call_args_list == [
-            call(b'1 ext4 rw verity'),
+            call(b'1 ext4 ro verity'),
             call(b'\xff'),
             call(b'1 4096 4096 10 1 sha256 e2728628377... fb074d1db50...'),
             call(b'\xff'),


### PR DESCRIPTION
If a partition is verity protected, it can never be writable, since verity is by-definition read-only.

