### PR TITLE
Fixed mounting of subvolumes for data sync

### DIFF
--- a/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
@@ -34,6 +34,7 @@
             <systemdisk name="fedora">
                 <volume name="@root=root"/>
                 <volume name="home" parent="/"/>
+                <volume name="var" parent="/"/>
             </systemdisk>
             <oemconfig>
                 <oem-resize>false</oem-resize>

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -229,6 +229,7 @@ class VolumeManagerBtrfs(VolumeManagerBase):
                 )
 
                 volume_mountpoint = toplevel
+                root_is_snapshot = self.custom_args['root_is_snapshot']
 
                 attributes = {
                     'parent': volume.parent or '',
@@ -239,7 +240,7 @@ class VolumeManagerBtrfs(VolumeManagerBase):
                     ).lstrip(os.sep),
                     'subvol_name': volume.name
                 }
-                if self.custom_args['root_is_snapshot']:
+                if root_is_snapshot:
                     volume_mountpoint = self.mountpoint + \
                         f'/{self.root_volume_name}/.snapshots/1/snapshot/'
                     attributes = {
@@ -255,7 +256,13 @@ class VolumeManagerBtrfs(VolumeManagerBase):
                     device=self.device,
                     attributes=attributes,
                     mountpoint=os.path.normpath(
-                        volume_mountpoint + os.sep + volume.realpath
+                        os.sep.join(
+                            [
+                                volume_mountpoint,
+                                self.root_volume_name if not root_is_snapshot else '',
+                                volume.realpath
+                            ]
+                        )
                     )
                 )
                 self.subvol_mount_list.append(


### PR DESCRIPTION
The subvolumes must be mounted below the root of the filesystem tree such that the sync mechanism correctly shuffles the data to the correct volumes.
This Fixes #2356


