### PR TITLE
Drop hybrid boot snippets from the GRUB 2 configuration template

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -678,8 +678,6 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         * SUSE_REMOVE_LINUX_ROOT_PARAM
         * GRUB_BACKGROUND
         * GRUB_THEME
-        * GRUB_USE_LINUXEFI
-        * GRUB_USE_INITRDEFI
         * GRUB_SERIAL_COMMAND
         * GRUB_CMDLINE_LINUX
         * GRUB_CMDLINE_LINUX_DEFAULT
@@ -744,18 +742,6 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
             if os.path.exists(os.sep.join([self.root_dir, theme_background])):
                 grub_default_entries['GRUB_BACKGROUND'] = theme_background
-        if self.firmware.efi_mode():
-            # linuxefi/initrdefi only exist on x86, others always use efi
-            if self.arch == 'ix86' or self.arch == 'x86_64':
-                use_linuxefi_implemented = Command.run(
-                    [
-                        'grep', '-q', 'GRUB_USE_LINUXEFI',
-                        self._get_grub2_mkconfig_tool()
-                    ], raise_on_error=False
-                )
-                if use_linuxefi_implemented.returncode == 0:
-                    grub_default_entries['GRUB_USE_LINUXEFI'] = 'true'
-                    grub_default_entries['GRUB_USE_INITRDEFI'] = 'true'
         if self.xml_state.build_type.get_btrfs_root_is_snapshot():
             grub_default_entries['SUSE_BTRFS_SNAPSHOT_BOOTING'] = 'true'
         if self.custom_args.get('crypto_disk'):

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -16,7 +16,6 @@ from kiwi.defaults import grub_loader_type
 from kiwi.xml_state import XMLState
 from kiwi.xml_description import XMLDescription
 from kiwi.bootloader.config.grub2 import BootLoaderConfigGrub2
-from kiwi.bootloader.template.grub2 import BootLoaderTemplateGrub2
 from kiwi.utils.sysconfig import SysConfig
 
 from kiwi.exceptions import (
@@ -598,8 +597,6 @@ class TestBootLoaderConfigGrub2:
             'GRUB_THEME': '/boot/grub2/themes/openSUSE/theme.txt',
             'GRUB_TIMEOUT': 10,
             'GRUB_TIMEOUT_STYLE': 'countdown',
-            'GRUB_USE_INITRDEFI': 'true',
-            'GRUB_USE_LINUXEFI': 'true',
             'SUSE_BTRFS_SNAPSHOT_BOOTING': 'true',
             'GRUB_DEFAULT': 'saved'
         }
@@ -987,18 +984,6 @@ class TestBootLoaderConfigGrub2:
             assert file_handle_grub.write.call_args_list == [
                 # first write of grub.cfg, adapting to linux/initrd as variables
                 call(
-                    'set linux=linux\n'
-                    'set initrd=initrd\n'
-                    'if [ "${grub_cpu}" = "x86_64" -o '
-                    '"${grub_cpu}" = "i386" ]; then\n'
-                    '    if [ "${grub_platform}" = "efi" ]; then\n'
-                    '        set linux=linuxefi\n'
-                    '        set initrd=initrdefi\n'
-                    '    fi\n'
-                    'fi\n'
-                    'export linux initrd\n'
-                ),
-                call(
                     'root=rootdev nomodeset console=ttyS0 console=tty0'
                     '\n'
                     'root=PARTUUID=xx'
@@ -1041,12 +1026,8 @@ class TestBootLoaderConfigGrub2:
             file_handle = mock_open.return_value.__enter__.return_value
             file_handle.read.return_value = os.linesep.join(
                 [
-                    '\tlinuxefi ${rel_dirname}/${basename} ...',
                     '\tlinux ${rel_dirname}/${basename} ...',
-                    '\tlinux16 ${rel_dirname}/${basename} ...',
-                    '\tinitrdefi ${rel_dirname}/${initrd}',
                     '\tinitrd ${rel_dirname}/${initrd}',
-                    '\tinitrd16 ${rel_dirname}/${initrd}'
                 ]
             )
             self.bootloader.setup_disk_image_config(
@@ -1056,24 +1037,8 @@ class TestBootLoaderConfigGrub2:
             )
             assert file_handle.write.call_args_list == [
                 call(
-                    'set linux=linux\n'
-                    'set initrd=initrd\n'
-                    'if [ "${grub_cpu}" = "x86_64" -o '
-                    '"${grub_cpu}" = "i386" ]; then\n'
-                    '    if [ "${grub_platform}" = "efi" ]; then\n'
-                    '        set linux=linuxefi\n'
-                    '        set initrd=initrdefi\n'
-                    '    fi\n'
-                    'fi\n'
-                    'export linux initrd\n'
-                ),
-                call(
-                    '\t$linux ${rel_dirname}/${basename} ...\n'
-                    '\t$linux ${rel_dirname}/${basename} ...\n'
-                    '\t$linux ${rel_dirname}/${basename} ...\n'
-                    '\t$initrd ${rel_dirname}/${initrd}\n'
-                    '\t$initrd ${rel_dirname}/${initrd}\n'
-                    '\t$initrd ${rel_dirname}/${initrd}'
+                    '\tlinux ${rel_dirname}/${basename} ...\n'
+                    '\tinitrd ${rel_dirname}/${initrd}\n'
                 )
             ]
 

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -87,9 +87,7 @@ class TestBootLoaderConfigGrub2:
             return_value='0xffffffff'
         )
 
-        grub_template = BootLoaderTemplateGrub2()
         self.grub2 = Mock()
-        self.grub2.header_hybrid = grub_template.header_hybrid
         kiwi.bootloader.config.grub2.BootLoaderTemplateGrub2 = Mock(
             return_value=self.grub2
         )


### PR DESCRIPTION
Sometime between GRUB 2.04 and GRUB 2.06, it became no longer necessary to use `linuxefi`+`initrdefi` for UEFI boot. The standard `linux`+`initrd` stanzas work for both legacy BIOS boot and modern UEFI boot.

Some distributions no longer support `linuxefi`+`initrdefi` at all anymore, so let's just use `linux`+`initrd` for everything now.

Fixes #2354.