### PR TITLE
use os.path.join to create path

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -984,7 +984,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 '-O', Defaults.get_efi_module_directory_name(self.arch),
                 '-o', root_efi_image,
                 '-c', root_efi_path + 'earlyboot.cfg',
-                '-p', self.get_boot_path() + '/' + self.boot_directory_name,
+                '-p', os.path.join(self.get_boot_path(), self.boot_directory_name),
                 '-d', module_path.replace(self.root_dir, '')
             ] + module_list
         )
@@ -1097,15 +1097,14 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 'search --fs-uuid --set=root {0}{1}'.format(uuid, os.linesep)
             )
             early_boot.write(
-                'set prefix=($root){0}/{1}{2}'.format(
-                    self.get_boot_path(), self.boot_directory_name, os.linesep
+                'set prefix=($root){0}{1}'.format(
+                    os.path.join(self.get_boot_path(), self.boot_directory_name), os.linesep
                 )
             )
             early_boot.write(
-                '{0} ($root){1}/{2}/grub.cfg{3}'.format(
-                    self.grub_load, self.get_boot_path(),
-                    self.boot_directory_name, os.linesep
-                )
+                '{0} ($root){1}/grub.cfg{2}'.format(self.grub_load, os.path.join(
+                    self.get_boot_path(), self.boot_directory_name
+                ), os.linesep)
             )
 
     def _create_early_boot_script_for_mbrid_search(self, filename, mbrid):

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -1279,8 +1279,8 @@ class TestBootLoaderConfigGrub2:
                 call('cryptomount -u 0815\n'),
                 call('set root="cryptouuid/0815"\n'),
                 call('search --fs-uuid --set=root 0815\n'),
-                call('set prefix=($root)//grub2\n'),
-                call('source ($root)//grub2/grub.cfg\n')
+                call('set prefix=($root)/grub2\n'),
+                call('source ($root)/grub2/grub.cfg\n')
             ]
         assert mock_command.call_args_list == [
             call(
@@ -1295,7 +1295,7 @@ class TestBootLoaderConfigGrub2:
                     '-O', 'x86_64-efi',
                     '-o', '/boot/efi/EFI/BOOT/bootx64.efi',
                     '-c', '/boot/efi/EFI/BOOT/earlyboot.cfg',
-                    '-p', '//grub2',
+                    '-p', '/grub2',
                     '-d', '/usr/share/grub2/x86_64-efi',
                     'ext2', 'iso9660', 'linux', 'echo', 'configfile',
                     'search_label', 'search_fs_file', 'search',
@@ -1338,8 +1338,8 @@ class TestBootLoaderConfigGrub2:
                 call('cryptomount -u 0815\n'),
                 call('set root="cryptouuid/0815"\n'),
                 call('search --fs-uuid --set=root 0815\n'),
-                call('set prefix=($root)//grub2\n'),
-                call('source ($root)//grub2/grub.cfg\n')
+                call('set prefix=($root)/grub2\n'),
+                call('source ($root)/grub2/grub.cfg\n')
             ]
             mock_open.assert_called_once_with(
                 'root_dir/boot/efi/EFI/BOOT/grub.cfg', 'w'


### PR DESCRIPTION
`self.get_boot_path()` can potentially return a '/'

so when these functions run 
```
            early_boot.write(
                'set prefix=($root){0}{1}'.format(
                    os.path.join(self.get_boot_path(), self.boot_directory_name), os.linesep
                )
            )
            early_boot.write(
                '{0} ($root){1}/grub.cfg{2}'.format(self.grub_load,
                    os.path.join(self.get_boot_path(), self.boot_directory_name),
                    os.linesep
                )
```
....they could potentially return paths that contains double slashes `//`
```
set prefix=($root)//grub2
source ($root)//grub2/grub.cfg
```

So this PR utilizes `os.path.join` to prevent this from happening. 
I understand that `//` in paths are still functional -- but it's just not aesthetically pleasing to look at. Feel free to drop this PR if you feel it's too trivial. 