### PR TITLE
use / prefix when boot partition is used

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -1459,11 +1459,18 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         for menu_entry_file in glob.iglob(loader_entries_pattern):
             with open(menu_entry_file) as grub_menu_entry_file:
                 menu_entry = grub_menu_entry_file.read()
-                menu_entry = re.sub(
-                    r'(linux|initrd) .*(/boot.*)',
-                    r'\1 \2',
-                    menu_entry
-                )
+                if self.xml_state.build_type.get_bootpartition():
+                    menu_entry = re.sub(
+                        r'(linux|initrd) .*/boot(.*)',
+                        r'\1 \2',
+                        menu_entry
+                    )
+                else:
+                    menu_entry = re.sub(
+                        r'(linux|initrd) .*(/boot.*)',
+                        r'\1 \2',
+                        menu_entry
+                    )
             with open(menu_entry_file, 'w') as grub_menu_entry_file:
                 grub_menu_entry_file.write(menu_entry)
 


### PR DESCRIPTION
The `/boot/loader/entries/*.conf` files generated by kiwi currently contain a prefixed /boot dir
```
linux /boot/vmlinuz-6.4.11-401.asahi.fc38.aarch64+16k
initrd /boot/initramfs-6.4.11-401.asahi.fc38.aarch64+16k.img
```

However, this is not needed if a `/boot` partition is specified as this path should be relative to said `/boot` partition. This PR resolves that -- and will create 
```
linux /vmlinuz-6.4.11-401.asahi.fc38.aarch64+16k
initrd /initramfs-6.4.11-401.asahi.fc38.aarch64+16k.img
```
...if a `/boot` partition is specified. 