### PR TITLE
Fixed root entry in fstab for btrfs layout

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -413,12 +413,16 @@ btrfs_quota_groups="true|false":
   the filesystem is `btrfs`. By default quotas are inactive.
 
 btrfs_set_default_volume="true|false":
-  Tell kiwi to explicitly make a volume the default volume
-  This can be either `/` or the root subvolume or the root
-  snapshot depending on the specified btrfs configuration
-  attributes. By default btrfs_set_default_volume is set to: true
-  If no default volume should be set, this attribute can be
-  used to turn it off
+  For oem disk images using the btrfs filesystem, requests to
+  set a default volume for the rootfs which is used when the
+  filesystem gets mounted. In case a `true` value is provided or
+  the attribute is not specified at all, kiwi will make a volume
+  the default volume. This can be either `/` or the configured
+  root subvolume or the configured root snapshot. In addition
+  no entry for the rootfs will be added to the `/etc/fstab` file.
+  In case a `false` value is provided, kiwi will not set any
+  default volume which also means an entry for the rootfs is
+  required and will be placed to the `/etc/fstab` file.
 
 btrfs_root_is_subvolume="true|false":
   Tell kiwi to create a root volume to host (/) inside.

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -148,8 +148,8 @@ class DiskBuilder:
         self.target_removable = xml_state.build_type.get_target_removable()
         self.root_filesystem_is_multipath = \
             xml_state.get_oemconfig_oem_multipath_scan()
-        self.btrfs_set_default_volume = \
-            xml_state.build_type.get_btrfs_set_default_volume()
+        self.btrfs_default_volume_requested = \
+            xml_state.btrfs_default_volume_requested()
         self.oem_systemsize = xml_state.get_oemconfig_oem_systemsize()
         self.oem_resize = xml_state.get_oemconfig_oem_resize()
         self.disk_resize_requested = \
@@ -422,8 +422,8 @@ class DiskBuilder:
                 'root_is_subvolume':
                     self.xml_state.build_type.
                     get_btrfs_root_is_subvolume(),
-                'set_default_volume':
-                    self.btrfs_set_default_volume,
+                'btrfs_default_volume_requested':
+                    self.btrfs_default_volume_requested,
                 'quota_groups':
                     self.xml_state.build_type.get_btrfs_quota_groups(),
                 'resize_on_boot':
@@ -1125,7 +1125,8 @@ class DiskBuilder:
             custom_root_mount_args += ['ro']
             fs_check_interval = '0 0'
 
-        if self.volume_manager_name and self.volume_manager_name == 'btrfs':
+        if self.volume_manager_name and self.volume_manager_name == 'btrfs' \
+           and not self.btrfs_default_volume_requested:
             root_volume_name = system.get_root_volume_name()
             if root_volume_name != '/':
                 custom_root_mount_args += [
@@ -1259,7 +1260,7 @@ class DiskBuilder:
                 boot_options.append('rd.auto')
             if self.volume_manager_name \
                and self.volume_manager_name == 'btrfs' \
-               and self.btrfs_set_default_volume is False \
+               and not self.btrfs_default_volume_requested \
                and system.get_root_volume_name() != '/':
                 boot_options.append(
                     f'rootflags=subvol={system.get_root_volume_name()}'

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -67,8 +67,8 @@ class VolumeManagerBtrfs(VolumeManagerBase):
             self.custom_args['root_label'] = 'ROOT'
         if 'root_is_snapshot' not in self.custom_args:
             self.custom_args['root_is_snapshot'] = False
-        if 'set_default_volume' not in self.custom_args:
-            self.custom_args['set_default_volume'] = True
+        if 'btrfs_default_volume_requested' not in self.custom_args:
+            self.custom_args['btrfs_default_volume_requested'] = True
         if 'root_is_readonly_snapshot' not in self.custom_args:
             self.custom_args['root_is_readonly_snapshot'] = False
         if 'root_is_subvolume' not in self.custom_args:
@@ -488,7 +488,7 @@ class VolumeManagerBtrfs(VolumeManagerBase):
                 volume_id = id_search.group(1)
                 volume_path = id_search.group(2)
                 if volume_path == default_volume:
-                    if self.custom_args['set_default_volume'] is not False:
+                    if self.custom_args['btrfs_default_volume_requested']:
                         Command.run(
                             [
                                 'btrfs', 'subvolume', 'set-default',

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -168,6 +168,18 @@ class XMLState:
         """
         return self.build_type.get_image()
 
+    def btrfs_default_volume_requested(self) -> bool:
+        """
+        Check if setting a default volume for btrfs is requested
+        """
+        if self.build_type.get_btrfs_set_default_volume() is False:
+            # Setting a default volume is explicitly switched off
+            return False
+        else:
+            # In any other case (True | None) a default volume
+            # is wanted and will be set
+            return True
+
     def get_image_version(self) -> str:
         """
         Image version from preferences section.

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -1224,7 +1224,7 @@ class TestDiskBuilder:
         filesystem = Mock()
         mock_fs.return_value = filesystem
         self.disk_builder.volume_manager_name = 'btrfs'
-        self.disk_builder.btrfs_set_default_volume = False
+        self.disk_builder.btrfs_default_volume_requested = False
 
         with patch('builtins.open'):
             self.disk_builder.create_disk()

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1140,3 +1140,14 @@ class TestXMLState:
     def test_get_btrfs_root_is_subvolume(self):
         assert self.state.build_type.get_btrfs_root_is_subvolume() is \
             None
+
+    @patch('kiwi.xml_parse.type_.get_btrfs_set_default_volume')
+    def test_btrfs_default_volume_requested(
+        self, mock_get_btrfs_set_default_volume
+    ):
+        mock_get_btrfs_set_default_volume.return_value = True
+        assert self.state.btrfs_default_volume_requested() is True
+        mock_get_btrfs_set_default_volume.return_value = False
+        assert self.state.btrfs_default_volume_requested() is False
+        mock_get_btrfs_set_default_volume.return_value = None
+        assert self.state.btrfs_default_volume_requested() is True


### PR DESCRIPTION
A root (/) entry in fstab for btrfs is only required if no default volume is configured. This commit adapts the code path which adds an fstab entry for (/) to be called only if btrfs_set_default_volume is set to false.
This Fixes #2366

