### PR TITLE
Remove community repository

### DIFF
--- a/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
+++ b/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
@@ -68,9 +68,6 @@
     <repository components="Virtualization_Appliances_Images_Testing_x86_archlinux_standard">
         <source path="obs://Virtualization:Appliances:Images:Testing_x86:archlinux/standard"/>
     </repository>
-    <repository components="Arch_Community_standard">
-        <source path="obs://Arch:Community/standard"/>
-    </repository>
     <repository components="Arch_Extra_standard">
         <source path="obs://Arch:Extra/standard"/>
     </repository>


### PR DESCRIPTION
Community repository is no longer needed for the test image. OBS does not pull any package from this repository and in Arch linux there is not the concept of empty repositories, so the build fails in an OBS context if this repository is included within the build stack.
