### PR TITLE
Fix typo in 'image results' doc section

### DIFF
--- a/doc/source/image_types_and_results.rst
+++ b/doc/source/image_types_and_results.rst
@@ -124,7 +124,7 @@ image="oem"
   An image representing an expandable disk image. {kiwi} can also produce an
   installation ISO for this disk image by setting `installiso="true"` in
   the :ref:`\<preferences\>\<type\><sec.preferences>`) section or a tarball
-  including the artifacts for a network deployment by setting `installiso="true"`.
+  including the artifacts for a network deployment by setting `installpxe="true"`.
   For further details see :ref:`expandable_disk`. The results for `oem`
   can be:
 


### PR DESCRIPTION
I seems to me there is a typo and it should be installpxe instead of installiso in the second instance.
