### PR TITLE
Support TOML markup

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -11,6 +11,9 @@ lxml
 # YAML file parsing
 PyYAML
 
+# TOML file parsing
+toml
+
 # Python wrapper for extended filesystem attributes
 xattr==0.9.3
 

--- a/kiwi/markup/any.py
+++ b/kiwi/markup/any.py
@@ -70,6 +70,25 @@ class MarkupAny(MarkupBase):
             self.description_markup_processed.name
         )
 
+    def get_toml_description(self) -> str:
+        """
+        Return TOML description file name
+
+        :return: file path name
+
+        :rtype: str
+        """
+        xml_description_xslt_transformed = self.apply_xslt_stylesheets(
+            self.description_markup_processed.name
+        )
+        markup = self.anymarkup.parse_file(
+            xml_description_xslt_transformed, force_types=None
+        )
+        self.anymarkup.serialize_file(
+            markup, xml_description_xslt_transformed, format='toml'
+        )
+        return xml_description_xslt_transformed
+
     def get_yaml_description(self) -> str:
         """
         Return YAML description file name

--- a/kiwi/tasks/image_info.py
+++ b/kiwi/tasks/image_info.py
@@ -21,7 +21,7 @@ usage: kiwi-ng image info -h | --help
            [--resolve-package-list]
            [--ignore-repos]
            [--add-repo=<source,type,alias,priority>...]
-           [--print-xml|--print-yaml]
+           [--print-xml|--print-yaml|--print-toml]
        kiwi-ng image info help
 
 commands:
@@ -40,7 +40,7 @@ options:
         solve package dependencies and return a list of all
         packages including their attributes e.g size,
         shasum, etc...
-    --print-xml|--print-yaml
+    --print-xml|--print-yaml|--print-toml
         print image description in specified format
 """
 import os
@@ -140,6 +140,11 @@ class ImageInfoTask(CliTask):
             DataOutput.display_file(
                 self.description.markup.get_yaml_description(),
                 'Description(YAML):'
+            )
+        elif self.command_args['--print-toml']:
+            DataOutput.display_file(
+                self.description.markup.get_toml_description(),
+                'Description(TOML):'
             )
 
     def _setup_solver(self):

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -370,6 +370,7 @@ Requires:       python%{python3_pkgversion}-typing-extensions
 %else
 Requires:       python%{python3_pkgversion}-PyYAML
 %endif
+Requires:       python%{python3_pkgversion}-toml
 Requires:       python%{python3_pkgversion}-simplejson
 Requires:       python%{python3_pkgversion}-docopt
 Requires:       python%{python3_pkgversion}-lxml

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ config = {
         'lxml',
         'requests',
         'PyYAML',
+        'toml',
         'simplejson',
         'typing_extensions; python_version < "3.8"',
     ],

--- a/test/unit/markup/any_test.py
+++ b/test/unit/markup/any_test.py
@@ -33,3 +33,6 @@ class TestMarkupXML:
 
     def test_get_yaml_description(self):
         assert 'xslt-' in self.markup.get_yaml_description()
+
+    def test_get_toml_description(self):
+        assert 'xslt-' in self.markup.get_toml_description()

--- a/test/unit/tasks/image_info_test.py
+++ b/test/unit/tasks/image_info_test.py
@@ -94,6 +94,7 @@ class TestImageInfoTask:
         self.task.command_args['--resolve-package-list'] = False
         self.task.command_args['--print-xml'] = False
         self.task.command_args['--print-yaml'] = False
+        self.task.command_args['--print-toml'] = False
 
     @patch('kiwi.tasks.image_info.DataOutput')
     def test_process_image_info(self, mock_out):
@@ -203,3 +204,12 @@ class TestImageInfoTask:
         tmpfile, message = mock_out.display_file.call_args.args
         assert tmpfile.startswith('/var/tmp/kiwi_xslt-')
         assert message == 'Description(YAML):'
+
+    @patch('kiwi.tasks.image_info.DataOutput')
+    def test_process_image_info_print_toml(self, mock_out):
+        self._init_command_args()
+        self.task.command_args['--print-toml'] = True
+        self.task.process()
+        tmpfile, message = mock_out.display_file.call_args.args
+        assert tmpfile.startswith('/var/tmp/kiwi_xslt-')
+        assert message == 'Description(TOML):'


### PR DESCRIPTION
Allow to use TOML markup for the kiwi image description This Fixes #2372


