### PR TITLE
Switch to pyproject.toml

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -6,3 +6,5 @@ tag = True
 [bumpversion:file:kiwi/version.py]
 
 [bumpversion:file:doc/source/conf.py]
+
+[bumpversion:file:kiwi/pyproject.toml]

--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -6,6 +6,8 @@
 
 # setuptools for pypi upload
 setuptools
+build
+installer
 
 # virtualenv-based automation of test activities
 tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -37,12 +37,10 @@ include tox.ini
 include kiwi.yml
 
 recursive-include doc/build/man *
-recursive-include *.gz *.iso *.kiwi *.pf2 *.py *.txt *.xml *.xz
 
 include .bumpversion.cfg
-include .coverage*
 
 include .virtualenv.requirements.txt
 include .virtualenv.dev-requirements.txt
 
-global-exclude *.py[cod] __pycache__
+global-exclude */__pycache__/*

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -60,6 +60,11 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  gcc
 BuildRequires:  python%{python3_pkgversion}-%{develsuffix} >= 3.6
 BuildRequires:  python%{python3_pkgversion}-setuptools
+%if 0%{?fedora} || 0%{?suse_version} >= 1650 || 0%{?debian} || 0%{?ubuntu}
+BuildRequires:  python%{python3_pkgversion}-installer
+BuildRequires:  python%{python3_pkgversion}-build
+BuildRequires:  python%{python3_pkgversion}-wheel
+%endif
 %if 0%{?fedora} || 0%{?suse_version}
 BuildRequires:  fdupes
 %endif
@@ -68,6 +73,23 @@ BuildRequires:  shadow
 %endif
 %if 0%{?debian} || 0%{?ubuntu}
 BuildRequires:  passwd
+%endif
+%if 0%{?ubuntu} || 0%{?debian}
+BuildRequires:       python%{python3_pkgversion}-yaml
+BuildRequires:       python%{python3_pkgversion}-typing-extensions
+%else
+BuildRequires:       python%{python3_pkgversion}-PyYAML
+%endif
+BuildRequires:       python%{python3_pkgversion}-simplejson
+BuildRequires:       python%{python3_pkgversion}-docopt
+BuildRequires:       python%{python3_pkgversion}-lxml
+BuildRequires:       python%{python3_pkgversion}-requests
+BuildRequires:       python%{python3_pkgversion}-setuptools
+%if 0%{?rhel} || 0%{?fedora}
+BuildRequires:       (python%{python3_pkgversion}-typing-extensions if python%{python3_pkgversion} < 3.8)
+%endif
+%if 0%{?suse_version}
+BuildRequires:       (python%{python3_pkgversion}-typing_extensions if python%{python3_pkgversion} < 3.8)
 %endif
 
 %description
@@ -625,9 +647,13 @@ sed -e "s|#!/usr/bin/env python||" -i kiwi/xml_parse.py
 # Build C-Tools
 make CFLAGS="${RPM_OPT_FLAGS}" tools
 
+# Build wheel, skip on failure
+python3 -m build --no-isolation --wheel || true
+
 %install
-# Install Python 3 version
-python3 setup.py install --prefix=%{_prefix} --root=%{buildroot} %{?is_deb:--install-layout=deb}
+# Install Python 3 version from wheel, use setup.py as fallback
+python3 -m installer --destdir %{buildroot} dist/*.whl || \
+    python3 setup.py install --prefix=%{_prefix} --root=%{buildroot} %{?is_deb:--install-layout=deb}
 
 # Install C-Tools, man-pages, completion and kiwi default configuration
 make buildroot=%{buildroot}/ install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "kiwi"
+version = "9.25.21"
+authors = [
+    { name="Marcus Schäfer", email="marcus.schaefer@gmail.com" },
+]
+description = "KIWI - Appliance Builder"
+readme = "README.rst"
+requires-python = ">=3.7"
+classifiers = [
+    # classifier: http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    'Development Status :: 5 - Production/Stable',
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: ',
+    'GNU General Public License v3 or later (GPLv3+)',
+    'Operating System :: POSIX :: Linux',
+    'Programming Language :: Python :: 3',
+    'Topic :: System :: Operating System',
+]
+dynamic = [
+    "license",
+    "entry-points",
+    "scripts"
+]
+[build-system]
+requires = [
+    "docopt",
+    "lxml",
+    "requests",
+    "PyYAML",
+    "simplejson",
+    'typing_extensions; python_version<"3.8"',
+    "setuptools"
+]
+[project.urls]
+"Homepage" = "https://osinside.github.io/kiwi"
+"Bug Tracker" = "https://github.com/OSInside/kiwi/issues"

--- a/setup.py
+++ b/setup.py
@@ -3,76 +3,51 @@
 
 from os import path
 from setuptools import setup
-from setuptools.command import sdist as setuptools_sdist
-
-import distutils
-import subprocess
-
-from kiwi.version import __version__
 
 here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as readme:
     long_description = readme.read()
 
-
-class sdist(setuptools_sdist.sdist):
-    """
-    Custom sdist command
-    Host requirements: git
-    """
-    def run(self):
-        """
-        Run first the git commit format update $Format:%H$
-        and after that the usual Python sdist
-        """
-        # git attributes
-        command = ['make', 'git_attributes']
-        self.announce(
-            'Running make git_attributes target: %s' % str(command),
-            level=distutils.log.INFO
-        )
-        self.announce(
-            subprocess.check_output(command).decode(),
-            level=distutils.log.INFO
-        )
-
-        # standard sdist process
-        setuptools_sdist.sdist.run(self)
-
-        # cleanup attributes
-        command = ['make', 'clean_git_attributes']
-        self.announce(
-            subprocess.check_output(command).decode(),
-            level=distutils.log.INFO
-        )
-
-
 config = {
     'name': 'kiwi',
     'long_description': long_description,
     'long_description_content_type': 'text/x-rst',
-    'python_requires': '>=3.6',
-    'description': 'KIWI - Appliance Builder (next generation)',
-    'author': 'Marcus Schaefer',
-    'url': 'https://osinside.github.io/kiwi',
-    'download_url':
-        'https://download.opensuse.org/repositories/'
-        'Virtualization:/Appliances:/Builder',
-    'author_email': 'ms@suse.com',
-    'version': __version__,
     'license' : 'GPLv3+',
-    'install_requires': [
-        'docopt>=0.6.2',
-        'lxml',
-        'requests',
-        'PyYAML',
-        'simplejson',
-        'typing_extensions; python_version < "3.8"',
+    'packages': [
+        'kiwi',
+        'kiwi.boot',
+        'kiwi.utils',
+        'kiwi.container.setup',
+        'kiwi.markup',
+        'kiwi.archive',
+        'kiwi.bootloader',
+        'kiwi.boot.image',
+        'kiwi.bootloader.template',
+        'kiwi.bootloader.install',
+        'kiwi.bootloader.config',
+        'kiwi.builder',
+        'kiwi.container',
+        'kiwi.filesystem',
+        'kiwi.package_manager',
+        'kiwi.partitioner',
+        'kiwi.repository',
+        'kiwi.repository.template',
+        'kiwi.schema',
+        'kiwi.storage',
+        'kiwi.storage.subformat',
+        'kiwi.storage.subformat.template',
+        'kiwi.system',
+        'kiwi.system.root_import',
+        'kiwi.volume_manager',
+        'kiwi.xsl',
+        'kiwi.schema',
+        'kiwi.config',
+        'kiwi.tasks',
+        'kiwi.solver',
+        'kiwi.solver.repository',
+        'kiwi.iso_tools',
+        'kiwi.oci_tools'
     ],
-    'packages': ['kiwi'],
-    'cmdclass': {
-        'sdist': sdist
-    },
     'entry_points': {
         'kiwi.tasks': [
             'image_info=kiwi.tasks.image_info',
@@ -88,20 +63,7 @@ config = {
             'kiwi-ng=kiwi.kiwi:main',
             'kiwicompat=kiwi.kiwi_compat:main'
         ]
-    },
-    'include_package_data': True,
-    'zip_safe': False,
-    'classifiers': [
-       # classifier: http://pypi.python.org/pypi?%3Aaction=list_classifiers
-       'Development Status :: 5 - Production/Stable',
-       'Intended Audience :: Developers',
-       'License :: OSI Approved :: '
-       'GNU General Public License v3 or later (GPLv3+)',
-       'Operating System :: POSIX :: Linux',
-       'Programming Language :: Python :: 3.6',
-       'Programming Language :: Python :: 3.7',
-       'Topic :: System :: Operating System',
-    ]
+    }
 }
 
 setup(**config)

--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,8 @@ passenv =
 deps = {[testenv]deps}
 changedir=test/unit
 commands =
-    bash -c 'cd ../../ && ./setup.py develop'
+    bash -c 'cd ../../ && test -e dist/*.whl || python -m build --wheel'
+    bash -c 'cd ../../ && test -e $VIRTUAL_ENV/bin/kiwi-ng || python -m installer dist/*.whl'
     bash -c 'cd ../../ && mypy kiwi'
     pytest --doctest-modules --no-cov-on-fail --cov=kiwi \
         --cov-report=term-missing --cov-fail-under=100 \
@@ -214,7 +215,7 @@ deps = {[testenv]deps}
 skip_install = True
 usedevelop = True
 commands =
-    python setup.py sdist
+    python -m build
 
 
 [testenv:scripts]


### PR DESCRIPTION
setup.py is marked obsolete for a long time and with this commit pyproject.toml is introduced and used for the development environment setup.

To be more clear, calling setup.py as a tool is deprecated:

* https://packaging.python.org/en/latest/discussions/setup-py-deprecated/#what-commands-should-be-used-instead

The changes here refactors kiwi to no longer call setup.py in any way
