### PR TITLE
Fix incorrect prefix setting in BLS grub menu entries

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -1459,11 +1459,18 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         for menu_entry_file in glob.iglob(loader_entries_pattern):
             with open(menu_entry_file) as grub_menu_entry_file:
                 menu_entry = grub_menu_entry_file.read()
-                menu_entry = re.sub(
-                    r'(linux|initrd) .*(/boot.*)',
-                    r'\1 \2',
-                    menu_entry
-                )
+                if self.xml_state.build_type.get_bootpartition():
+                    menu_entry = re.sub(
+                        r'(linux|initrd) .*/boot(.*)',
+                        r'\1 \2',
+                        menu_entry
+                    )
+                else:
+                    menu_entry = re.sub(
+                        r'(linux|initrd) .*(/boot.*)',
+                        r'\1 \2',
+                        menu_entry
+                    )
             with open(menu_entry_file, 'w') as grub_menu_entry_file:
                 grub_menu_entry_file.write(menu_entry)
 

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -109,6 +109,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         self.gfxmode = self.get_gfxmode('grub2')
         self.theme = self.get_boot_theme()
         self.timeout = self.get_boot_timeout_seconds()
+        self.bootpartition = self.xml_state.build_type.get_bootpartition()
         self.timeout_style = \
             self.xml_state.get_build_type_bootloader_timeout_style()
         self.displayname = self.xml_state.xml_data.get_displayname()
@@ -1459,7 +1460,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         for menu_entry_file in glob.iglob(loader_entries_pattern):
             with open(menu_entry_file) as grub_menu_entry_file:
                 menu_entry = grub_menu_entry_file.read()
-                if self.xml_state.build_type.get_bootpartition():
+                if self.bootpartition:
                     menu_entry = re.sub(
                         r'(linux|initrd) .*/boot(.*)',
                         r'\1 \2',

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -1022,6 +1022,20 @@ class TestBootLoaderConfigGrub2:
             assert 'initrd /boot/initrd' in \
                 file_handle_menu.write.call_args_list[1][0][0].split(os.linesep)
 
+            self.bootloader.bootpartition = True
+            file_handle_menu.reset_mock()
+
+            self.bootloader.setup_disk_image_config(
+                boot_options={
+                    'root_device': 'rootdev', 'boot_device': 'bootdev'
+                }
+            )
+
+            assert 'linux /vmlinuz' in \
+                file_handle_menu.write.call_args_list[1][0][0].split(os.linesep)
+            assert 'initrd /initrd' in \
+                file_handle_menu.write.call_args_list[1][0][0].split(os.linesep)
+
     @patch.object(BootLoaderConfigGrub2, '_mount_system')
     @patch.object(BootLoaderConfigGrub2, '_copy_grub_config_to_efi_path')
     @patch('kiwi.bootloader.config.grub2.Command.run')


### PR DESCRIPTION
The generated /boot/loader/entries/*.conf files contain a prefixed /boot dir of the form:
```
    linux /boot/...
    initrd /boot/...
```

However, this is incorrect if an extra /boot partition is specified. This PR resolves that -- and will create

```
    linux /...
    initrd /...
```

if ```bootpartition="true"``` partition is specified.



