### PR TITLE
Support release version in signkey URLs

### DIFF
--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1912,9 +1912,23 @@ class XMLState:
         Get list of signing keys specified on the repositories
         """
         key_file_list: List[str] = []
+        release_version = self.get_release_version()
+        release_vars = [
+            '$releasever',
+            '${releasever}'
+        ]
         for repository in self.get_repository_sections() or []:
             for signing in repository.get_source().get_signing() or []:
-                key_file_list.append(Uri(signing.get_key()).translate())
+                normalized_key_url = Uri(signing.get_key()).translate()
+                if release_version:
+                    for release_var in release_vars:
+                        if release_var in normalized_key_url:
+                            normalized_key_url = normalized_key_url.replace(
+                                release_var, release_version
+                            )
+                key_file_list.append(
+                    normalized_key_url
+                ) if normalized_key_url not in key_file_list else key_file_list
         return key_file_list
 
     def set_repository(

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1926,9 +1926,8 @@ class XMLState:
                             normalized_key_url = normalized_key_url.replace(
                                 release_var, release_version
                             )
-                key_file_list.append(
-                    normalized_key_url
-                ) if normalized_key_url not in key_file_list else key_file_list
+                if normalized_key_url not in key_file_list:
+                    key_file_list.append(normalized_key_url)
         return key_file_list
 
     def set_repository(

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -184,6 +184,8 @@
     <repository priority="42" sourcetype="baseurl">
         <source path="iso:///image/CDs/dvd.iso">
             <signing key="file:key_a"/>
+            <signing key="file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary"/>
+            <signing key="file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-${releasever}-primary"/>
         </source>
     </repository>
     <repository type="rpm-md" imageinclude="true" customize="script">

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1078,9 +1078,12 @@ class TestXMLState:
 
     @patch('kiwi.system.uri.os.path.abspath')
     def test_get_repositories_signing_keys(self, mock_root_path):
-        mock_root_path.side_effect = lambda x: f'/some/path/{x}'
+        mock_root_path.side_effect = lambda x: f'(mock_abspath){x}'
         assert self.state.get_repositories_signing_keys() == [
-            '/some/path/key_a', '/some/path/key_b'
+            '(mock_abspath)key_a',
+            '(mock_abspath)/usr/share/distribution-gpg-keys/'
+            'fedora/RPM-GPG-KEY-fedora-15.3-primary',
+            '(mock_abspath)key_b'
         ]
 
     def test_this_path_resolver(self):


### PR DESCRIPTION
Using one of the $releasever/${releasever} variable placeholders in an URL as part of a <signing key="..."/> element did not replace the placeholder with the value of the <release-version> element. This commit fixes this and also makes sure that the result list for downloading signing keys is unique. This Fixes #2381

