### PR TITLE
Fix ramdisk install

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-disk-ramdisk/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-ramdisk/appliance.kiwi
@@ -73,5 +73,8 @@
         <package name="ca-certificates"/>
         <package name="ca-certificates-mozilla"/>
         <package name="openSUSE-release"/>
+        <package name="grep"/>
+        <package name="xz"/>
+        <package name="shadow"/>
     </packages>
 </image>

--- a/dracut/modules.d/90kiwi-dump/kiwi-ramdisk-deployment-generator.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-ramdisk-deployment-generator.sh
@@ -26,16 +26,12 @@ GENERATOR_DIR="$1"
 
 [ -e /config.bootoptions ] || exit 1
 
-# Add a space to /config.bootoptions to make sure the
-# following token based read captures all entries
-echo -n ' ' >> /config.bootoptions
-
 root_uuid=$(
-    while read -r -d ' ' opt; do echo "${opt}";done < /config.bootoptions |\
+    awk '{ for(i=1; i <= NF; i++) {print $i } }' /config.bootoptions |\
     grep root= | cut -f2- -d=
 )
 
-[ -z "${root_uuid}" ] && exit 1
+[ -z "${root_uuid}" ] && exit 2
 
 {
     echo "[Unit]"


### PR DESCRIPTION
Fixed argument processing of config.bootoptions
    
 Instead of adding an extra space to make the subsequent reading to work, use an awk script that does it without nasty workarounds. This Fixes the ramdisk deployment

