### PR TITLE
Fix spec file to require parted in dracut modules

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -466,6 +466,7 @@ Requires:       e2fsprogs
 Requires:       grep
 Requires:       lvm2
 Requires:       mdadm
+Requires:       parted
 Requires:       util-linux
 # lsblk is part of util-linux-systemd on openSUSE
 %if 0%{?suse_version}
@@ -484,7 +485,6 @@ Requires:       device-mapper
 %endif
 %ifarch s390 s390x
 Requires:       s390-tools
-Requires:       parted
 %endif
 License:        GPL-3.0-or-later
 Group:          %{sysgroup}
@@ -562,6 +562,7 @@ Requires:       device-mapper
 %endif
 Requires:       dracut
 Requires:       xorriso
+Requires:       parted
 License:        GPL-3.0-or-later
 Group:          %{sysgroup}
 


### PR DESCRIPTION
This commit fixes a regression introduced in commit 0947fce33a. Parted package must be required to all dracut modules using 'parted' tool and/or using 'partprobe' tool. Regardless if 'parted' is used as the partitioning tool, if 'partprobe' is called 'parted' package is still required.

Fixes bsc#1216465
