### PR TITLE
Fallback to partx if partprobe is not available

### DIFF
--- a/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
@@ -201,11 +201,17 @@ function preparePersistentOverlayDiskBoot {
     # used as presented
     local overlay_mount_point=$1
     local partitions_before_cow_part
+    local read_part_cmd
     mkdir -m 0755 -p "${overlay_mount_point}"
     if ! mount -L cow "${overlay_mount_point}"; then
         partitions_before_cow_part=$(_partition_count)
         echo -e "n\np\n\n\n\nw\nq" | fdisk "${isodiskdev}"
-        if ! partprobe "${isodiskdev}"; then
+        if type partprobe &> /dev/null;then
+            read_part_cmd="partprobe ${isodiskdev}"
+        else
+            read_part_cmd="partx -u ${isodiskdev}"
+        fi
+        if ! eval "${read_part_cmd}"; then
             return 1
         fi
         if [ "$(_partition_count)" -le "${partitions_before_cow_part}" ];then

--- a/dracut/modules.d/90kiwi-live/module-setup.sh
+++ b/dracut/modules.d/90kiwi-live/module-setup.sh
@@ -29,7 +29,7 @@ install() {
     inst_multiple \
         umount dmsetup blockdev blkid lsblk dd losetup \
         grep cut partprobe find wc fdisk tail mkfs.ext4 mkfs.xfs \
-        dialog cat mountpoint
+        dialog cat mountpoint partx
 
     dmsquashdir=$(find "${dracutbasedir}/modules.d" -name "*dmsquash-live")
     if [ -n "${dmsquashdir}" ] && \


### PR DESCRIPTION
This commit makes use of partx instead of partprobe if latter is not present in initrd.

This is to not force require parted in kiwi-live module. Partx is provided by util-linux.