### PR TITLE
Create live persistent storage without busy state

### DIFF
--- a/dracut/modules.d/90kiwi-live/kiwi-live-root.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-root.sh
@@ -20,17 +20,6 @@ initGlobalDevices "$1"
 # live options and their default values
 initGlobalOptions
 
-# mount ISO device
-iso_mount_point=$(mountIso)
-
-# mount squashfs compressed container
-container_mount_point=$(
-    mountCompressedContainerFromIso "${iso_mount_point}"
-)
-
-# mount readonly root filesystem from container
-mountReadOnlyRootImageFromContainer "${container_mount_point}"
-
 # prepare overlay for generated systemd LiveOS_rootfs service
 declare isodiskdev=${isodiskdev}
 if getargbool 0 rd.live.overlay.persistent && [ -n "${isodiskdev}" ]; then
@@ -42,6 +31,17 @@ if getargbool 0 rd.live.overlay.persistent && [ -n "${isodiskdev}" ]; then
 else
     prepareTemporaryOverlay
 fi
+
+# mount ISO device
+iso_mount_point=$(mountIso)
+
+# mount squashfs compressed container
+container_mount_point=$(
+    mountCompressedContainerFromIso "${iso_mount_point}"
+)
+
+# mount readonly root filesystem from container
+mountReadOnlyRootImageFromContainer "${container_mount_point}"
 
 need_shutdown
 


### PR DESCRIPTION
With the former logic the live ISO was already mounted when an eventual persistent storage partition was created. This leads to an issue on re-reading the partition table, not for all but several tools. This commit changes the order of tasks such that the setup of the persistent write storage is performed prior mounting the live ISO. In addition to this change an alternative method using blockdev to re-read the partition was added in case partprobe is not present. This also allows to get rid of the parted dependency which provides partprobe

