### PR TITLE
Rewrite loader linux/initrd entry relabelling without regex to improve reliability

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -1459,19 +1459,24 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         )
         for menu_entry_file in glob.iglob(loader_entries_pattern):
             with open(menu_entry_file) as grub_menu_entry_file:
-                menu_entry = grub_menu_entry_file.read()
-                if self.bootpartition:
-                    menu_entry = re.sub(
-                        r'(linux|initrd) .*/boot(.*)',
-                        r'\1 \2',
-                        menu_entry
-                    )
-                else:
-                    menu_entry = re.sub(
-                        r'(linux|initrd) .*(/boot.*)',
-                        r'\1 \2',
-                        menu_entry
-                    )
+                menu_entry = grub_menu_entry_file.read().split(os.linesep)
+
+            for line_number, menu_entry_line in enumerate(menu_entry):
+                if bool(re.match(r'^(linux|initrd) .*', menu_entry_line)):
+
+                    log.debug(f'Existing loader entry: {menu_entry_line}')
+                    config_path = menu_entry_line.split(' ', 1)[0]
+
+                    basename = os.path.basename(menu_entry_line)
+                    if self.bootpartition:
+                        config_path = (f'{config_path} /{basename}')
+                    else:
+                        config_path = (f'{config_path} /boot/{basename}')
+
+                    menu_entry[line_number] = config_path
+                    log.debug(f'Updated loader entry: {config_path}')
+
+            menu_entry = os.linesep.join(menu_entry)
             with open(menu_entry_file, 'w') as grub_menu_entry_file:
                 grub_menu_entry_file.write(menu_entry)
 


### PR DESCRIPTION
Replacing the regex-based loader entry fix with string parsing.

A user building RHEL images ran into issues with the initrd. It turns out that RHEL uses some patches that mean the initrd/linux files in RHEL are not installed to /boot, which trips up the original regex. The new fix doesn't rely on matching the path in boot, instead just finding the initrd/linux files and rewriting them in place.

This change also adds the pre-and-post fix loader entries to the debug logs.

Original bug report https://bugzilla.suse.com/show_bug.cgi?id=1208701

Fixes suse bsc#1208701

Changes proposed in this pull request:
* Replace loader fix regex with python string handling.