### PR TITLE
Add support for ISO boot via systemd-boot

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
@@ -14,6 +14,7 @@
         <profile name="BIOS" description="BIOS only Live Boot based on isolinux"/>
         <profile name="Standard" description="Standard EFI/BIOS Live Boot"/>
         <profile name="Secure" description="SecureBoot/BIOS Live Boot"/>
+        <profile name="SDBoot" description="EFI Boot via systemd-boot"/>
     </profiles>
     <preferences>
         <version>1.42.3</version>
@@ -29,6 +30,11 @@
     <preferences profiles="BIOS">
         <type image="iso" flags="overlay" firmware="bios" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="true">
             <bootloader name="isolinux" console="serial" timeout="10"/>
+        </type>
+    </preferences>
+    <preferences profiles="SDBoot">
+        <type image="iso" flags="overlay" firmware="efi" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="false">
+            <bootloader name="systemd_boot"/>
         </type>
     </preferences>
     <preferences profiles="Standard">
@@ -47,19 +53,27 @@
     <repository type="rpm-md">
         <source path="obsrepositories:/"/>
     </repository>
+    <packages type="image" profiles="SDBoot">
+        <package name="systemd-boot"/>
+    </packages>
+    <packages type="image" profiles="Standard,Secure">
+        <package name="grub2-branding-openSUSE"/>
+        <package name="grub2"/>
+        <package name="grub2-x86_64-efi" arch="x86_64"/>
+        <package name="grub2-i386-pc"/>
+        <package name="shim"/>
+    </packages>
+    <packages type="image" profiles="BIOS">
+        <package name="syslinux"/>
+    </packages>
     <packages type="image">
         <package name="bind-utils"/>
         <package name="patterns-openSUSE-base"/>
         <package name="systemd"/>
         <package name="plymouth-theme-breeze"/>
         <package name="plymouth-plugin-script"/>
-        <package name="grub2-branding-openSUSE"/>
         <package name="iputils"/>
         <package name="vim"/>
-        <package name="grub2"/>
-        <package name="grub2-x86_64-efi" arch="x86_64"/>
-        <package name="grub2-i386-pc"/>
-        <package name="syslinux"/>
         <package name="lvm2"/>
         <package name="plymouth"/>
         <package name="fontconfig"/>
@@ -73,7 +87,6 @@
         <package name="dhcp-client"/>
         <package name="which"/>
         <package name="kernel-default"/>
-        <package name="shim"/>
         <package name="timezone"/>
         <package name="dracut-kiwi-live"/>
     </packages>

--- a/build-tests/x86/tumbleweed/test-image-systemd-boot/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-systemd-boot/appliance.kiwi
@@ -16,7 +16,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>breeze</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="xfs" kernelcmdline="console=ttyS0" firmware="efi" efipartsize="200">
+        <type image="oem" filesystem="xfs" kernelcmdline="console=ttyS0" firmware="efi" efipartsize="512" installiso="true">
             <bootloader name="systemd_boot" timeout="10"/>
             <oemconfig>
                 <oem-resize>false</oem-resize>
@@ -30,6 +30,7 @@
         <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
+        <package name="dracut-kiwi-oem-dump"/>
         <package name="patterns-openSUSE-base"/>
         <package name="systemd"/>
         <package name="systemd-boot"/>

--- a/build-tests/x86/tumbleweed/test-image-systemd-boot/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-systemd-boot/appliance.kiwi
@@ -16,7 +16,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>breeze</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="xfs" kernelcmdline="console=ttyS0" firmware="efi" efipartsize="512" installiso="true">
+        <type image="oem" filesystem="xfs" kernelcmdline="console=ttyS0" firmware="efi" efipartsize="512">
             <bootloader name="systemd_boot" timeout="10"/>
             <oemconfig>
                 <oem-resize>false</oem-resize>

--- a/kiwi.yml
+++ b/kiwi.yml
@@ -157,3 +157,6 @@
 
 #      # check devicepersistency compatible with partition table type
 #      - check_partuuid_persistency_type_used_with_mbr
+
+#      # check efifatimagesize does not exceed the max El Torito load size
+#      - check_efi_fat_image_has_correct_size

--- a/kiwi/bootloader/config/bootloader_spec_base.py
+++ b/kiwi/bootloader/config/bootloader_spec_base.py
@@ -108,7 +108,6 @@ class BootLoaderSpecBase(BootLoaderConfigBase):
             ]
         )
         self.setup_loader(self.target.disk)
-        self.set_loader_entry(self.target.disk)
 
     def setup_install_image_config(
         self, mbrid: str, hypervisor: str = '',
@@ -124,12 +123,12 @@ class BootLoaderSpecBase(BootLoaderConfigBase):
 
         Targeted to bootloader spec interface
         """
-        self._setup_iso_image_config(mbrid, 'install(iso)', kernel, initrd)
+        pass
 
     def setup_live_image_config(
         self, mbrid: str, hypervisor: str = '',
         kernel: str = '', initrd: str = ''
-    ):
+    ) -> None:
         """
         Create boot config file to boot live ISO image
 
@@ -140,9 +139,11 @@ class BootLoaderSpecBase(BootLoaderConfigBase):
 
         Targeted to bootloader spec interface
         """
-        self._setup_iso_image_config(mbrid, 'live(iso)', kernel, initrd)
+        pass
 
-    def setup_disk_boot_images(self, boot_uuid: str, lookup_path: str = ''):
+    def setup_disk_boot_images(
+        self, boot_uuid: str, lookup_path: str = ''
+    ) -> None:
         """
         Create bootloader image(s) for disk boot
 
@@ -153,7 +154,9 @@ class BootLoaderSpecBase(BootLoaderConfigBase):
         """
         self.create_loader_image(self.target.disk)
 
-    def setup_install_boot_images(self, mbrid: str, lookup_path: str = ''):
+    def setup_install_boot_images(
+        self, mbrid: str, lookup_path: str = ''
+    ) -> None:
         """
         Create bootloader image(s) for install ISO boot
 
@@ -164,7 +167,9 @@ class BootLoaderSpecBase(BootLoaderConfigBase):
         """
         self.create_loader_image(self.target.install)
 
-    def setup_live_boot_images(self, mbrid: str, lookup_path: str = ''):
+    def setup_live_boot_images(
+        self, mbrid: str, lookup_path: str = ''
+    ) -> None:
         """
         Create bootloader image(s) for live ISO boot
 
@@ -201,22 +206,15 @@ class BootLoaderSpecBase(BootLoaderConfigBase):
         """
         raise NotImplementedError
 
-    def set_loader_entry(self, target: str) -> None:
+    def set_loader_entry(self, root_dir: str, target: str) -> None:
         """
         Setup bootloader menu entry boot/loader/entries/X.conf
 
+        :param str root_dir:
+            path to root directory tree
         :param str target:
             target identifier, one of disk, live(iso) or install(iso)
 
         Implementation in specialized loader class
         """
         raise NotImplementedError
-
-    def _setup_iso_image_config(
-        self, mbrid: str, target: str, kernel: str = '', initrd: str = ''
-    ):
-        self.custom_args['mbrid'] = mbrid
-        self.custom_args['kernel'] = kernel
-        self.custom_args['initrd'] = initrd
-
-        self.set_loader_entry(target)

--- a/kiwi/bootloader/config/bootloader_spec_base.py
+++ b/kiwi/bootloader/config/bootloader_spec_base.py
@@ -219,5 +219,4 @@ class BootLoaderSpecBase(BootLoaderConfigBase):
         self.custom_args['kernel'] = kernel
         self.custom_args['initrd'] = initrd
 
-        self.setup_loader(target)
         self.set_loader_entry(target)

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -43,6 +43,8 @@ from kiwi.exceptions import (
     KiwiDiskGeometryError
 )
 
+import kiwi.defaults as defaults
+
 log = logging.getLogger('kiwi')
 
 
@@ -929,7 +931,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         Must be called after setup_install_boot_images and write.
         """
         fat_image_mbsize = int(
-            self.xml_state.build_type.get_efifatimagesize() or 20
+            self.xml_state.build_type
+                .get_efifatimagesize() or defaults.EFI_FAT_IMAGE_SIZE
         )
         Command.run(
             ['qemu-img', 'create', path, f'{fat_image_mbsize}M']

--- a/kiwi/bootloader/config/systemd_boot.py
+++ b/kiwi/bootloader/config/systemd_boot.py
@@ -34,6 +34,8 @@ from kiwi.exceptions import (
     KiwiBootLoaderTargetError
 )
 
+import kiwi.defaults as defaults
+
 
 class BootLoaderSystemdBoot(BootLoaderSpecBase):
     def create_loader_image(self, target: str) -> None:
@@ -96,16 +98,9 @@ class BootLoaderSystemdBoot(BootLoaderSpecBase):
         Creates a EFI system partition image at the given path.
         Installs systemd-boot required EFI layout into the image
         """
-        # NOTE: limitation of El Torito boot,
-        # if the ESP size is greater than 20MB, the machine
-        # does no longer boot. I could not find a solution to
-        # this issue and bootctl install + kernel-install needs
-        # ~200MB for the ESP. I also noted that kernel-install
-        # does not fail with an exit code != if there is no
-        # space left anymore. Thus the image build completes but
-        # with incomplete data on the ESP
         fat_image_mbsize = int(
-            self.xml_state.build_type.get_efifatimagesize() or 20
+            self.xml_state.build_type
+                .get_efifatimagesize() or defaults.EFI_FAT_IMAGE_SIZE
         )
         Command.run(
             ['qemu-img', 'create', path, f'{fat_image_mbsize}M']

--- a/kiwi/bootloader/template/systemd_boot.py
+++ b/kiwi/bootloader/template/systemd_boot.py
@@ -28,12 +28,20 @@ class BootLoaderTemplateSystemdBoot:
 
         self.loader = dedent('''
             # kiwi generated loader config file
+            default main.conf
             console-mode max
             editor  no
         ''').strip() + self.cr
 
         self.timeout = dedent('''
             timeout ${boot_timeout}
+        ''').strip() + self.cr
+
+        self.entry = dedent('''
+            title ${title}
+            options ${boot_options}
+            linux ${kernel_file}
+            initrd ${initrd_file}
         ''').strip() + self.cr
 
     def get_loader_template(self) -> Template:
@@ -46,4 +54,15 @@ class BootLoaderTemplateSystemdBoot:
         """
         template_data = self.loader
         template_data += self.timeout
+        return Template(template_data)
+
+    def get_entry_template(self) -> Template:
+        """
+        Bootloader entry configuration template
+
+        :return: instance of :class:`Template`
+
+        :rtype: Template
+        """
+        template_data = self.entry
         return Template(template_data)

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -85,6 +85,7 @@ SHARED_CACHE_DIR = '/var/cache/kiwi'
 TEMP_DIR = '/var/tmp'
 CUSTOM_RUNTIME_CONFIG_FILE = None
 PLATFORM_MACHINE = platform.machine()
+EFI_FAT_IMAGE_SIZE = 20
 
 log = logging.getLogger('kiwi')
 

--- a/kiwi/iso_tools/xorriso.py
+++ b/kiwi/iso_tools/xorriso.py
@@ -97,20 +97,21 @@ class IsoToolsXorrIso(IsoToolsBase):
 
         if Defaults.is_x86_arch(self.arch):
             if efi_mode:
-                loader_file = os.sep.join(
-                    [
-                        self.boot_path, 'loader',
-                        Defaults.get_isolinux_bios_grub_loader()
-                    ]
-                )
                 mbr_file = os.sep.join(
                     [self.source_dir, self.boot_path, '/loader/boot_hybrid.img']
                 )
-                self.iso_loaders += [
-                    '-boot_image', 'grub', 'bin_path={0}'.format(loader_file),
-                    '-boot_image', 'grub', 'grub2_mbr={0}'.format(mbr_file),
-                    '-boot_image', 'grub', 'grub2_boot_info=on'
-                ]
+                if os.path.exists(mbr_file):
+                    loader_file = os.sep.join(
+                        [
+                            self.boot_path, 'loader',
+                            Defaults.get_isolinux_bios_grub_loader()
+                        ]
+                    )
+                    self.iso_loaders += [
+                        '-boot_image', 'grub', 'bin_path={0}'.format(loader_file),
+                        '-boot_image', 'grub', 'grub2_mbr={0}'.format(mbr_file),
+                        '-boot_image', 'grub', 'grub2_boot_info=on'
+                    ]
             else:
                 loader_file = self.boot_path + '/loader/isolinux.bin'
                 mbr_file_c = Path.which(

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -40,6 +40,8 @@ from kiwi.exceptions import (
     KiwiRuntimeError
 )
 
+import kiwi.defaults as defaults
+
 dracut_module_type = NamedTuple(
     'dracut_module_type', [
         ('package', str),
@@ -1041,6 +1043,26 @@ class RuntimeChecker:
                         type_export.getvalue()
                     )
                 )
+
+    def check_efi_fat_image_has_correct_size(self) -> None:
+        """
+        Verify that the efifatimagesize does not exceed the max
+        El Torito load size of 65535 * 512 bytes
+        """
+        message = dedent('''\n
+            El Torito max load size exceeded
+
+            The configured efifatimagesize of '{0}MB' exceeds
+            the El Torito max load size of 65535 * 512 bytes (~31MB).
+        ''')
+        fat_image_mbsize = int(
+            self.xml_state.build_type
+                .get_efifatimagesize() or defaults.EFI_FAT_IMAGE_SIZE
+        )
+        if fat_image_mbsize > 31:
+            raise KiwiRuntimeError(
+                message.format(fat_image_mbsize)
+            )
 
     @staticmethod
     def _get_dracut_module_version_from_pdb(

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -93,7 +93,8 @@ class CliTask:
             'check_image_type_unique': [],
             'check_include_references_unresolvable': [],
             'check_luksformat_options_valid': [],
-            'check_partuuid_persistency_type_used_with_mbr': []
+            'check_partuuid_persistency_type_used_with_mbr': [],
+            'check_efi_fat_image_has_correct_size': []
         }
         self.checks_after_command_args: Dict[str, List[str]] = {
             'check_repositories_configured': [],

--- a/test/unit/bootloader/config/bootloader_spec_base_test.py
+++ b/test/unit/bootloader/config/bootloader_spec_base_test.py
@@ -46,26 +46,22 @@ class TestBootLoaderSpecBase:
         mock_setup_loader.assert_called_once_with('disk')
         mock_set_loader_entry.assert_called_once_with('disk')
 
-    @patch.object(BootLoaderSpecBase, 'setup_loader')
     @patch.object(BootLoaderSpecBase, 'set_loader_entry')
     def test_setup_install_image_config(
-        self, mock_setup_loader, mock_set_loader_entry
+        self, mock_set_loader_entry
     ):
         self.bootloader.setup_install_image_config(
             'mbrid', 'hypervisor', 'kernel', 'initrd'
         )
-        mock_setup_loader.assert_called_once_with('install(iso)')
         mock_set_loader_entry.assert_called_once_with('install(iso)')
 
-    @patch.object(BootLoaderSpecBase, 'setup_loader')
     @patch.object(BootLoaderSpecBase, 'set_loader_entry')
     def test_setup_live_image_config(
-        self, mock_setup_loader, mock_set_loader_entry
+        self, mock_set_loader_entry
     ):
         self.bootloader.setup_live_image_config(
             'mbrid', 'hypervisor', 'kernel', 'initrd'
         )
-        mock_setup_loader.assert_called_once_with('live(iso)')
         mock_set_loader_entry.assert_called_once_with('live(iso)')
 
     @patch.object(BootLoaderSpecBase, 'create_loader_image')

--- a/test/unit/bootloader/config/bootloader_spec_base_test.py
+++ b/test/unit/bootloader/config/bootloader_spec_base_test.py
@@ -32,10 +32,7 @@ class TestBootLoaderSpecBase:
         self.setup()
 
     @patch.object(BootLoaderSpecBase, 'setup_loader')
-    @patch.object(BootLoaderSpecBase, 'set_loader_entry')
-    def test_setup_disk_image_config(
-        self, mock_setup_loader, mock_set_loader_entry
-    ):
+    def test_setup_disk_image_config(self, mock_setup_loader):
         self.bootloader.get_boot_cmdline = Mock(return_value='')
         self.bootloader.setup_disk_image_config(
             'boot_uuid', 'root_uuid', 'hypervisor',
@@ -44,25 +41,18 @@ class TestBootLoaderSpecBase:
             }
         )
         mock_setup_loader.assert_called_once_with('disk')
-        mock_set_loader_entry.assert_called_once_with('disk')
 
-    @patch.object(BootLoaderSpecBase, 'set_loader_entry')
-    def test_setup_install_image_config(
-        self, mock_set_loader_entry
-    ):
+    def test_setup_install_image_config(self):
+        # just pass
         self.bootloader.setup_install_image_config(
             'mbrid', 'hypervisor', 'kernel', 'initrd'
         )
-        mock_set_loader_entry.assert_called_once_with('install(iso)')
 
-    @patch.object(BootLoaderSpecBase, 'set_loader_entry')
-    def test_setup_live_image_config(
-        self, mock_set_loader_entry
-    ):
+    def test_setup_live_image_config(self):
+        # just pass
         self.bootloader.setup_live_image_config(
             'mbrid', 'hypervisor', 'kernel', 'initrd'
         )
-        mock_set_loader_entry.assert_called_once_with('live(iso)')
 
     @patch.object(BootLoaderSpecBase, 'create_loader_image')
     def test_setup_disk_boot_images(self, mock_create_loader_image):
@@ -85,7 +75,7 @@ class TestBootLoaderSpecBase:
 
     def test_set_loader_entry(self):
         with raises(NotImplementedError):
-            self.bootloader.set_loader_entry('target')
+            self.bootloader.set_loader_entry('root_dir', 'target')
 
     def test_create_loader_image(self):
         with raises(NotImplementedError):

--- a/test/unit/iso_tools/xorriso_test.py
+++ b/test/unit/iso_tools/xorriso_test.py
@@ -81,7 +81,9 @@ class TestIsoToolsXorrIso:
             '-boot_image', 'any', 'load_size=2048'
         ]
 
-    def test_init_iso_creation_parameters_efi(self):
+    @patch('os.path.exists')
+    def test_init_iso_creation_parameters_efi(self, mock_os_path_exists):
+        mock_os_path_exists.return_value = True
         self.iso_tool.init_iso_creation_parameters(
             {
                 'mbr_id': 'app_id',

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -312,6 +312,13 @@ class TestRuntimeChecker:
         with raises(KiwiRuntimeError):
             self.runtime_checker.check_xen_uniquely_setup_as_server_or_guest()
 
+    def test_check_efi_fat_image_has_correct_size(self):
+        self.xml_state.build_type.get_efifatimagesize = Mock(
+            return_value='200'
+        )
+        with raises(KiwiRuntimeError):
+            self.runtime_checker.check_efi_fat_image_has_correct_size()
+
     def test_check_xen_uniquely_setup_as_server_or_guest_for_xen(self):
         self.xml_state.build_type.get_firmware = Mock(
             return_value=None


### PR DESCRIPTION
Create proper EFI FAT image via bootctl to be used as alt loader in xorriso. This allows to boot the ISO via EFI e.g kvm -bios /usr/share/qemu/ovmf-x86_64.bin -cdrom file.iso Please note, hybrid boot is done via grub's hybrid MBR and as systemd-boot does not provide one, hybrid boot is out of scope yet. This Fixes #2281


