### PR TITLE
Fixed grub mbrid file search

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -1114,9 +1114,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 'set btrfs_relative_path="yes"{0}'.format(os.linesep)
             )
             early_boot.write(
-                'search --file --set=root /boot/mbrid{0}'.format(
-                    os.linesep
-                )
+                f'search --file --set=root /boot/{mbrid.get_id()}{os.linesep}'
             )
             early_boot.write(
                 'set prefix=($root)/boot/{0}{1}'.format(

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -1758,11 +1758,11 @@ class TestBootLoaderConfigGrub2:
             ]
             assert file_handle.write.call_args_list == [
                 call('set btrfs_relative_path="yes"\n'),
-                call('search --file --set=root /boot/mbrid\n'),
+                call('search --file --set=root /boot/0xffffffff\n'),
                 call('set prefix=($root)/boot/grub2\n'),
                 call('source ($root)/boot/grub2/grub.cfg\n'),
                 call('set btrfs_relative_path="yes"\n'),
-                call('search --file --set=root /boot/mbrid\n'),
+                call('search --file --set=root /boot/0xffffffff\n'),
                 call('set prefix=($root)/boot/grub2\n'),
                 call('source ($root)/boot/grub2/grub.cfg\n'),
                 call('source /boot/grub2/grub.cfg\n')
@@ -1871,7 +1871,7 @@ class TestBootLoaderConfigGrub2:
 
             assert file_handle.write.call_args_list == [
                 call('set btrfs_relative_path="yes"\n'),
-                call('search --file --set=root /boot/mbrid\n'),
+                call('search --file --set=root /boot/0xffffffff\n'),
                 call('set prefix=($root)/boot/grub2\n'),
                 call('source ($root)/boot/grub2/grub.cfg\n'),
                 call('source /boot/grub2/grub.cfg\n')
@@ -1941,7 +1941,7 @@ class TestBootLoaderConfigGrub2:
                 )
                 assert file_handle.write.call_args_list == [
                     call('set btrfs_relative_path="yes"\n'),
-                    call('search --file --set=root /boot/mbrid\n'),
+                    call('search --file --set=root /boot/0xffffffff\n'),
                     call('set prefix=($root)/boot/grub2\n'),
                     call('source ($root)/boot/grub2/grub.cfg\n'),
                     call('source /boot/grub2/grub.cfg\n')


### PR DESCRIPTION
To identify the root device for ISO images (live and install media) that boots via grub2, kiwi uses a grub2 --file search. The searched file was named /boot/mbrid, however this is not a unique name and could be found on other devices of the system as well. To connect the search to the correct media this commit changes the search to an ID based method which is unique to the image build process. This Fixes #2389


