### PR TITLE
Container installation support

### DIFF
--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -65,7 +65,7 @@ div {
         attribute xsi:schemaLocation { xsd:anyURI }
     k.image.schemaversion.attribute =
         ## The allowed Schema version (fixed value)
-        attribute schemaversion { "7.6" }
+        attribute schemaversion { "7.7" }
     k.image.id =
         ## An identification number which is represented in a file
         ## named /etc/ImageID
@@ -89,6 +89,7 @@ div {
             k.drivers* &
             k.strip* &
             k.repository* &
+            k.registry* &
             k.packages* &
             k.extension?
         }
@@ -938,6 +939,21 @@ div {
 }
 
 #==========================================
+# common element <container>
+#
+div {
+    k.container.name.attribute = k.name.attribute
+    k.container.attlist =
+        k.container.name.attribute
+    k.container =
+        ## Name of container to install in the image
+        element container {
+            k.container.attlist,
+            empty
+        }
+}
+
+#==========================================
 # common element <package>
 #
 div {
@@ -955,6 +971,22 @@ div {
         element package {
             k.package.attlist,
             empty
+        }
+}
+
+#==========================================
+# common element <containerruntime>
+#
+div {
+    k.containerruntime.content =
+        "podman"
+    k.containerruntime.attlist = empty
+    k.containerruntime =
+        ## Name of the container orchestrator
+        ## Must be installed in the image
+        element containerruntime {
+            k.containerruntime.attlist,
+            k.containerruntime.content
         }
 }
 
@@ -1035,6 +1067,23 @@ div {
         }
 }
 
+#==========================================
+# common element <registry>
+#
+div {
+    k.registry.profiles.attribute = k.profiles.attribute
+    k.registry.path.attribute = k.path.attribute
+    k.registry.attlist =
+        k.registry.profiles.attribute? &
+        k.registry.path.attribute
+
+    k.registry =
+        ## The path to an OCI container registry
+        element registry {
+            k.registry.attlist
+    }
+}
+    
 #==========================================
 # common element <repository>
 #
@@ -3516,6 +3565,7 @@ div {
             k.namedCollection* &
             k.collectionModule* &
             k.product* &
+            k.container* &
             k.package*
         }
 }
@@ -3541,6 +3591,7 @@ div {
             k.keytable? &
             k.locale? &
             k.packagemanager? &
+            k.containerruntime? &
             k.release-version? &
             k.rpm-locale-filtering? &
             k.rpm-check-signatures? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -109,7 +109,7 @@
   <!--
     ==========================================
     start with image description
-
+    
   -->
   <start>
     <ref name="k.image">
@@ -119,7 +119,7 @@
   <!--
     ==========================================
     main block: <image>
-
+    
   -->
   <div>
     <define name="k.image.name.attribute">
@@ -145,7 +145,7 @@ second the location of the XSD Schema
     <define name="k.image.schemaversion.attribute">
       <attribute name="schemaversion">
         <a:documentation>The allowed Schema version (fixed value)</a:documentation>
-        <value>7.6</value>
+        <value>7.7</value>
       </attribute>
     </define>
     <define name="k.image.id">
@@ -178,7 +178,7 @@ named /etc/ImageID</a:documentation>
     </define>
     <define name="k.image">
       <element name="image">
-        <a:documentation>The root element of the configuration file   </a:documentation>
+        <a:documentation>The root element of the configuration file</a:documentation>
         <interleave>
           <ref name="k.image.attlist"/>
           <zeroOrMore>
@@ -204,6 +204,9 @@ named /etc/ImageID</a:documentation>
             <ref name="k.repository"/>
           </zeroOrMore>
           <zeroOrMore>
+            <ref name="k.registry"/>
+          </zeroOrMore>
+          <zeroOrMore>
             <ref name="k.packages"/>
           </zeroOrMore>
           <optional>
@@ -216,7 +219,7 @@ named /etc/ImageID</a:documentation>
   <!--
     ==========================================
     common attributes
-
+    
   -->
   <define name="k.id.attribute">
     <attribute name="id">
@@ -349,7 +352,7 @@ file was fetched</a:documentation>
   <!--
     ==========================================
     common element <extension>
-
+    
   -->
   <div>
     <define name="k.extension.attlist">
@@ -368,7 +371,7 @@ file was fetched</a:documentation>
   <!--
     ==========================================
     common element <archive>
-
+    
   -->
   <div>
     <define name="k.archive.name.attribute">
@@ -407,7 +410,7 @@ file was fetched</a:documentation>
   <!--
     ==========================================
     common element <author>
-
+    
   -->
   <div>
     <define name="k.author.attlist">
@@ -424,7 +427,7 @@ file was fetched</a:documentation>
   <!--
     ==========================================
     common element <license>
-
+    
   -->
   <div>
     <define name="k.license.attlist">
@@ -441,7 +444,7 @@ file was fetched</a:documentation>
   <!--
     ==========================================
     common element <bootloader-theme>
-
+    
   -->
   <div>
     <define name="k.bootloader-theme.attlist">
@@ -458,7 +461,7 @@ file was fetched</a:documentation>
   <!--
     ==========================================
     common element <bootsplash-theme>
-
+    
   -->
   <div>
     <define name="k.bootsplash-theme.attlist">
@@ -475,7 +478,7 @@ file was fetched</a:documentation>
   <!--
     ==========================================
     common element <contact>
-
+    
   -->
   <div>
     <define name="k.contact.attlist">
@@ -492,7 +495,7 @@ file was fetched</a:documentation>
   <!--
     ==========================================
     common element <file>
-
+    
   -->
   <div>
     <define name="k.file.name.attribute">
@@ -520,7 +523,7 @@ file was fetched</a:documentation>
   <!--
     ==========================================
     common element <ignore>
-
+    
   -->
   <div>
     <define name="k.ignore.name.attribute">
@@ -548,7 +551,7 @@ file was fetched</a:documentation>
   <!--
     ==========================================
     common element <keytable>
-
+    
   -->
   <div>
     <define name="k.keytable.attlist">
@@ -565,7 +568,7 @@ file was fetched</a:documentation>
   <!--
     ==========================================
     common element <locale>
-
+    
   -->
   <div>
     <!-- locale -->
@@ -583,7 +586,7 @@ file was fetched</a:documentation>
   <!--
     ==========================================
     common element <rpm-locale-filtering>
-
+    
   -->
   <div>
     <define name="k.rpm-locale-filtering.content">
@@ -610,7 +613,7 @@ file was fetched</a:documentation>
   <!--
     ==========================================
     common element <namedCollection>
-
+    
   -->
   <div>
     <define name="k.namedCollection.name.attribute">
@@ -638,7 +641,7 @@ file was fetched</a:documentation>
   <!--
     ==========================================
     common element <collectionModule>
-
+    
   -->
   <div>
     <sch:pattern id="collection_module_scope">
@@ -693,7 +696,7 @@ given stream) or disabled.</a:documentation>
   <!--
     ==========================================
     common element <oem-boot-title>
-
+    
   -->
   <div>
     <define name="k.oem-boot-title.attlist">
@@ -712,7 +715,7 @@ of the OEM image</a:documentation>
   <!--
     ==========================================
     common element <oem-bootwait>
-
+    
   -->
   <div>
     <define name="k.oem-bootwait.content">
@@ -732,7 +735,7 @@ of the OEM image</a:documentation>
   <!--
     ==========================================
     common element <oem-resize>
-
+    
   -->
   <div>
     <define name="k.oem-resize.content">
@@ -757,7 +760,7 @@ of the kiwi oem dracut module that implements the resize</a:documentation>
   <!--
     ==========================================
     common element <oem-resize-once>
-
+    
   -->
   <div>
     <define name="k.oem-resize-once.content">
@@ -781,7 +784,7 @@ operation happens only once and then never again</a:documentation>
   <!--
     ==========================================
     common element <oem-device-filter>
-
+    
   -->
   <div>
     <define name="k.oem-device-filter.content">
@@ -803,7 +806,7 @@ operator</a:documentation>
   <!--
     ==========================================
     common element <oem-nic-filter>
-
+    
   -->
   <div>
     <define name="k.oem-nic-filter.content">
@@ -828,7 +831,7 @@ line in a netboot deployment</a:documentation>
   <!--
     ==========================================
     common element <oem-inplace-recovery>
-
+    
   -->
   <div>
     <define name="k.oem-inplace-recovery.content">
@@ -851,7 +854,7 @@ of the oem image</a:documentation>
   <!--
     ==========================================
     common element <oem-kiwi-initrd>
-
+    
   -->
   <div>
     <define name="k.oem-kiwi-initrd.content">
@@ -872,7 +875,7 @@ and don't replace it with mkinitrd created initrd</a:documentation>
   <!--
     ==========================================
     common element <oem-partition-install>
-
+    
   -->
   <div>
     <define name="k.oem-partition-install.content">
@@ -895,7 +898,7 @@ will not have any effect</a:documentation>
   <!--
     ==========================================
     common element <oem-reboot>
-
+    
   -->
   <div>
     <define name="k.oem-reboot.content">
@@ -915,7 +918,7 @@ will not have any effect</a:documentation>
   <!--
     ==========================================
     common element <oem-reboot-interactive>
-
+    
   -->
   <div>
     <define name="k.oem-reboot-interactive.content">
@@ -936,7 +939,7 @@ with an interactive dialog true/false</a:documentation>
   <!--
     ==========================================
     common element <oem-recovery>
-
+    
   -->
   <div>
     <define name="k.oem-recovery.content">
@@ -956,7 +959,7 @@ with an interactive dialog true/false</a:documentation>
   <!--
     ==========================================
     common element <oem-recoveryID>
-
+    
   -->
   <div>
     <define name="k.oem-recoveryID.attlist">
@@ -974,7 +977,7 @@ recovery partition. Default value is 83 (Linux)</a:documentation>
   <!--
     ==========================================
     common element <oem-recovery-part-size>
-
+    
   -->
   <div>
     <define name="k.oem-recovery-part-size.attlist">
@@ -992,7 +995,7 @@ recovery partition. Value is interpreted as MB</a:documentation>
   <!--
     ==========================================
     common element <oem-shutdown>
-
+    
   -->
   <div>
     <define name="k.oem-shutdown.content">
@@ -1013,7 +1016,7 @@ true/false</a:documentation>
   <!--
     ==========================================
     common element <oem-shutdown-interactive>
-
+    
   -->
   <div>
     <define name="k.oem-shutdown-interactive.content">
@@ -1034,7 +1037,7 @@ true/false</a:documentation>
   <!--
     ==========================================
     common element <oem-silent-boot>
-
+    
   -->
   <div>
     <define name="k.oem-silent-boot.content">
@@ -1055,7 +1058,7 @@ true/false</a:documentation>
   <!--
     ==========================================
     common element <oem-silent-install>
-
+    
   -->
   <div>
     <define name="k.oem-silent-install.content">
@@ -1076,7 +1079,7 @@ dump process, true/false</a:documentation>
   <!--
     ==========================================
     common element <oem-skip-verify>
-
+    
   -->
   <div>
     <define name="k.oem-skip-verify.content">
@@ -1097,7 +1100,7 @@ verification process, true/false</a:documentation>
   <!--
     ==========================================
     common element <oem-vmcp-parmfile>
-
+    
   -->
   <div>
     <define name="k.oem-vmcp-parmfile.content">
@@ -1119,7 +1122,7 @@ is set to: PARM-S11</a:documentation>
   <!--
     ==========================================
     common element <oem-multipath-scan>
-
+    
   -->
   <div>
     <define name="k.oem-multipath-scan.content">
@@ -1140,7 +1143,7 @@ for multipath devices: true/false (default is true)</a:documentation>
   <!--
     ==========================================
     common element <oem-silent-verify>
-
+    
   -->
   <div>
     <define name="k.oem-silent-verify.content">
@@ -1161,7 +1164,7 @@ verification process, true/false</a:documentation>
   <!--
     ==========================================
     common element <oem-swap>
-
+    
   -->
   <div>
     <define name="k.oem-swap.content">
@@ -1181,7 +1184,7 @@ verification process, true/false</a:documentation>
   <!--
     ==========================================
     common element <oem-swapsize>
-
+    
   -->
   <div>
     <define name="k.oem-swapsize.attlist">
@@ -1199,7 +1202,7 @@ partition in MB</a:documentation>
   <!--
     ==========================================
     common element <oem-swapname>
-
+    
   -->
   <div>
     <define name="k.oem-swapname.attlist">
@@ -1221,7 +1224,7 @@ no effect.</a:documentation>
   <!--
     ==========================================
     common element <oem-systemsize>
-
+    
   -->
   <div>
     <define name="k.oem-systemsize.attlist">
@@ -1240,7 +1243,7 @@ will grow to the maximum available free space on the disk</a:documentation>
   <!--
     ==========================================
     common element <oem-unattended>
-
+    
   -->
   <div>
     <define name="k.oem-unattended.content">
@@ -1261,7 +1264,7 @@ true/false</a:documentation>
   <!--
     ==========================================
     common element <oem-unattended-id>
-
+    
   -->
   <div>
     <define name="k.oem-unattended-id.attlist">
@@ -1279,7 +1282,7 @@ the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
   <!--
     ==========================================
     common element <product>
-
+    
   -->
   <div>
     <define name="k.product.name.attribute">
@@ -1307,7 +1310,7 @@ the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
   <!--
     ==========================================
     common element <option>
-
+    
   -->
   <div>
     <define name="k.option.name.attribute">
@@ -1335,7 +1338,7 @@ the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
   <!--
     ==========================================
     common element <shimoption>
-
+    
   -->
   <div>
     <define name="k.shimoption.name.attribute">
@@ -1363,7 +1366,7 @@ the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
   <!--
     ==========================================
     common element <installoption>
-
+    
   -->
   <div>
     <define name="k.installoption.name.attribute">
@@ -1391,7 +1394,7 @@ the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
   <!--
     ==========================================
     common element <configoption>
-
+    
   -->
   <div>
     <define name="k.configoption.name.attribute">
@@ -1418,8 +1421,28 @@ the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
   </div>
   <!--
     ==========================================
+    common element <container>
+    
+  -->
+  <div>
+    <define name="k.container.name.attribute">
+      <ref name="k.name.attribute"/>
+    </define>
+    <define name="k.container.attlist">
+      <ref name="k.container.name.attribute"/>
+    </define>
+    <define name="k.container">
+      <element name="container">
+        <a:documentation>Name of container to install in the image</a:documentation>
+        <ref name="k.container.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
     common element <package>
-
+    
   -->
   <div>
     <define name="k.package.name.attribute">
@@ -1458,8 +1481,29 @@ the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
   </div>
   <!--
     ==========================================
+    common element <containerruntime>
+    
+  -->
+  <div>
+    <define name="k.containerruntime.content">
+      <value>podman</value>
+    </define>
+    <define name="k.containerruntime.attlist">
+      <empty/>
+    </define>
+    <define name="k.containerruntime">
+      <element name="containerruntime">
+        <a:documentation>Name of the container orchestrator
+Must be installed in the image</a:documentation>
+        <ref name="k.containerruntime.attlist"/>
+        <ref name="k.containerruntime.content"/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
     common element <packagemanager>
-
+    
   -->
   <div>
     <define name="k.packagemanager.content">
@@ -1486,7 +1530,7 @@ the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
   <!--
     ==========================================
     common element <release-version>
-
+    
   -->
   <div>
     <define name="k.release-version.content">
@@ -1506,7 +1550,7 @@ the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
   <!--
     ==========================================
     common element <profile>
-
+    
   -->
   <div>
     <define name="k.profile.name.attribute">
@@ -1555,7 +1599,7 @@ packages.</a:documentation>
   <!--
     ==========================================
     common element <requires>
-
+    
   -->
   <div>
     <define name="k.requires.profile.attribute">
@@ -1578,8 +1622,35 @@ definition can be composed by other existing profiles.</a:documentation>
   </div>
   <!--
     ==========================================
+    common element <registry>
+    
+  -->
+  <div>
+    <define name="k.registry.profiles.attribute">
+      <ref name="k.profiles.attribute"/>
+    </define>
+    <define name="k.registry.path.attribute">
+      <ref name="k.path.attribute"/>
+    </define>
+    <define name="k.registry.attlist">
+      <interleave>
+        <optional>
+          <ref name="k.registry.profiles.attribute"/>
+        </optional>
+        <ref name="k.registry.path.attribute"/>
+      </interleave>
+    </define>
+    <define name="k.registry">
+      <element name="registry">
+        <a:documentation>The path to an OCI container registry</a:documentation>
+        <ref name="k.registry.attlist"/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
     common element <repository>
-
+    
   -->
   <div>
     <sch:pattern abstract="true" id="repo_type">
@@ -1779,7 +1850,7 @@ last one is picked.</a:documentation>
   <!--
     ==========================================
     common element <signing>
-
+    
   -->
   <div>
     <define name="k.signing.key.attribute">
@@ -1803,7 +1874,7 @@ repo/package signing keys</a:documentation>
   <!--
     ==========================================
     common element <source>
-
+    
   -->
   <div>
     <define name="k.source.path.attribute">
@@ -1826,7 +1897,7 @@ as well as a path specification</a:documentation>
   <!--
     ==========================================
     common element <rpm-check-signatures>
-
+    
   -->
   <div>
     <define name="k.rpm-check-signatures.content">
@@ -1851,7 +1922,7 @@ The default value is false.</a:documentation>
   <!--
     ==========================================
     common element <rpm-excludedocs>
-
+    
   -->
   <div>
     <define name="k.rpm-excludedocs.content">
@@ -1873,7 +1944,7 @@ according to the used package manager.</a:documentation>
   <!--
     ==========================================
     common element <showlicense>
-
+    
   -->
   <div>
     <define name="k.showlicense.attlist">
@@ -1891,7 +1962,7 @@ will be displayed in a dialog window on boot.</a:documentation>
   <!--
     ==========================================
     common element <size>
-
+    
   -->
   <div>
     <define name="k.size.unit.attribute">
@@ -1947,7 +2018,7 @@ to the required size of the image</a:documentation>
   <!--
     ==========================================
     common element <specification>
-
+    
   -->
   <div>
     <define name="k.specification.attlist">
@@ -1965,7 +2036,7 @@ can be used for.</a:documentation>
   <!--
     ==========================================
     common element <systemdisk>
-
+    
   -->
   <div>
     <define name="k.systemdisk.name.attribute">
@@ -2007,7 +2078,7 @@ volume management system</a:documentation>
   <!--
     ==========================================
     common element <timezone>
-
+    
   -->
   <div>
     <define name="k.timezone.attlist">
@@ -2024,7 +2095,7 @@ volume management system</a:documentation>
   <!--
     ==========================================
     common element <type>
-
+    
   -->
   <div>
     <sch:pattern abstract="true" id="image_type">
@@ -3458,7 +3529,7 @@ kiwi-ng result bundle ...</a:documentation>
   <!--
     ==========================================
     common element <user>
-
+    
   -->
   <div>
     <define name="k.user.name.attribute">
@@ -3543,7 +3614,7 @@ to the user according to he specifing toolchain behaviour.</a:documentation>
   <!--
     ==========================================
     common element <version>
-
+    
   -->
   <div>
     <define name="k.version.attlist">
@@ -3551,7 +3622,7 @@ to the user according to he specifing toolchain behaviour.</a:documentation>
     </define>
     <define name="k.version">
       <element name="version">
-        <a:documentation>A Version Number for the Image, Consists of Major.Minor.Release </a:documentation>
+        <a:documentation>A Version Number for the Image, Consists of Major.Minor.Release</a:documentation>
         <interleave>
           <ref name="k.version.attlist"/>
           <text/>
@@ -3562,7 +3633,7 @@ to the user according to he specifing toolchain behaviour.</a:documentation>
   <!--
     ==========================================
     common element <vmconfig-entry>
-
+    
   -->
   <div>
     <define name="k.vmconfig-entry.attlist">
@@ -3581,7 +3652,7 @@ to the user according to he specifing toolchain behaviour.</a:documentation>
   <!--
     ==========================================
     common element <vmdisk>
-
+    
   -->
   <div>
     <define name="k.vmdisk.disktype.attribute">
@@ -3658,7 +3729,7 @@ by the VM (ova only)</a:documentation>
   <!--
     ==========================================
     common element <vmdvd>
-
+    
   -->
   <div>
     <define name="k.vmdvd.controller.attribute">
@@ -3696,7 +3767,7 @@ scsi CD or an ide CD drive</a:documentation>
   <!--
     ==========================================
     common element <vmnic>
-
+    
   -->
   <div>
     <define name="k.vmnic.driver.attribute">
@@ -3747,7 +3818,7 @@ scsi CD or an ide CD drive</a:documentation>
   <!--
     ==========================================
     common element <partition>
-
+    
   -->
   <div>
     <sch:pattern abstract="true" id="partition_name_type">
@@ -3851,7 +3922,7 @@ Allowed values are: t.linux</a:documentation>
   <!--
     ==========================================
     common element <volume>
-
+    
   -->
   <div>
     <define name="k.volume.freespace.attribute">
@@ -3954,7 +4025,7 @@ on an extra volume.</a:documentation>
   <!--
     ==========================================
     main block: <include>
-
+    
   -->
   <div>
     <define name="k.include.from.attribute">
@@ -3975,7 +4046,7 @@ statement with its contents</a:documentation>
   <!--
     ==========================================
     main block: <description>
-
+    
   -->
   <div>
     <define name="k.description.type.attribute">
@@ -4015,7 +4086,7 @@ a standard image description created by a kiwi user.</a:documentation>
   <!--
     ==========================================
     main block: <drivers>
-
+    
   -->
   <div>
     <define name="k.drivers.profiles.attribute">
@@ -4028,7 +4099,7 @@ a standard image description created by a kiwi user.</a:documentation>
     </define>
     <define name="k.drivers">
       <element name="drivers">
-        <a:documentation>A Collection of Driver Files </a:documentation>
+        <a:documentation>A Collection of Driver Files</a:documentation>
         <interleave>
           <ref name="k.drivers.attlist"/>
           <oneOrMore>
@@ -4041,7 +4112,7 @@ a standard image description created by a kiwi user.</a:documentation>
   <!--
     ==========================================
     main block: <strip>
-
+    
   -->
   <div>
     <define name="k.strip.type.attribute">
@@ -4083,7 +4154,7 @@ references file names in linux lib directories to keep.</a:documentation>
   <!--
     ==========================================
     main block: <bootloader>
-
+    
   -->
   <div>
     <sch:pattern abstract="true" id="bootloader_image_type">
@@ -4252,7 +4323,7 @@ and to provide configuration parameters for it</a:documentation>
   <!--
     ==========================================
     main block: <containerconfig>
-
+    
   -->
   <div>
     <sch:pattern abstract="true" id="container_type">
@@ -4379,7 +4450,7 @@ section provides globally useful container information.</a:documentation>
   <!--
     ==========================================
     main block: <entrypoint>
-
+    
   -->
   <div>
     <define name="k.entrypoint.execute.attribute">
@@ -4410,7 +4481,7 @@ can be optionally specified</a:documentation>
   <!--
     ==========================================
     main block: <subcommand>
-
+    
   -->
   <div>
     <define name="k.subcommand.execute.attribute">
@@ -4445,7 +4516,7 @@ execution command</a:documentation>
   <!--
     ==========================================
     main block: <argument>
-
+    
   -->
   <div>
     <define name="k.argument.name.attribute">
@@ -4469,7 +4540,7 @@ execution command</a:documentation>
   <!--
     ==========================================
     main block: <expose>
-
+    
   -->
   <div>
     <define name="k.expose.attlist">
@@ -4492,7 +4563,7 @@ be configured</a:documentation>
   <!--
     ==========================================
     main block: <port>
-
+    
   -->
   <div>
     <define name="k.port.number.attribute">
@@ -4518,7 +4589,7 @@ If no protocol is defined OCI defaults are applied.</a:documentation>
   <!--
     ==========================================
     main block: <volumes>
-
+    
   -->
   <div>
     <define name="k.volumes.attlist">
@@ -4540,7 +4611,7 @@ At least one volume must be configured</a:documentation>
   <!--
     ==========================================
     main block: <partitions>
-
+    
   -->
   <div>
     <define name="k.partitions.attlist">
@@ -4562,7 +4633,7 @@ of the storage device</a:documentation>
   <!--
     ==========================================
     main block: <luksformat>
-
+    
   -->
   <div>
     <sch:pattern id="luks_requirement">
@@ -4588,7 +4659,7 @@ of the storage device</a:documentation>
   <!--
     ==========================================
     main block: <bootloadersettings>
-
+    
   -->
   <div>
     <define name="k.bootloadersettings.attlist">
@@ -4615,7 +4686,7 @@ of the storage device</a:documentation>
   <!--
     ==========================================
     main block: <environment>
-
+    
   -->
   <div>
     <define name="k.environment.attlist">
@@ -4637,7 +4708,7 @@ At least one environment variable must be configured</a:documentation>
   <!--
     ==========================================
     main block: <env>
-
+    
   -->
   <div>
     <define name="k.env.name.attribute">
@@ -4669,7 +4740,7 @@ At least one environment variable must be configured</a:documentation>
   <!--
     ==========================================
     main block: <labels>
-
+    
   -->
   <div>
     <define name="k.labels.attlist">
@@ -4691,7 +4762,7 @@ At least one label must be configured</a:documentation>
   <!--
     ==========================================
     main block: <label>
-
+    
   -->
   <div>
     <define name="k.label.name.attribute">
@@ -4723,7 +4794,7 @@ At least one label must be configured</a:documentation>
   <!--
     ==========================================
     main block: <history>
-
+    
   -->
   <div>
     <define name="k.history.created_by.attribute">
@@ -4787,7 +4858,7 @@ the 'comment' entry.</a:documentation>
   <!--
     ==========================================
     main block: <oemconfig>
-
+    
   -->
   <div>
     <define name="k.oemconfig.attlist">
@@ -4891,7 +4962,7 @@ and setup the system disk.</a:documentation>
   <!--
     ==========================================
     main block: <vagrantconfig>
-
+    
   -->
   <div>
     <sch:pattern abstract="true" id="vagrant_provider">
@@ -4967,7 +5038,7 @@ configuration options which are used inside a vagrant box</a:documentation>
   <!--
     ==========================================
     main block: <installmedia>
-
+    
   -->
   <div>
     <sch:pattern id="installation_media">
@@ -4994,7 +5065,7 @@ for the installation media of OEM images.</a:documentation>
   <!--
     ==========================================
     main block: <initrd>
-
+    
   -->
   <div>
     <define name="k.initrd.action.attribute">
@@ -5028,7 +5099,7 @@ for the installation media.</a:documentation>
   <!--
     ==========================================
     main block: <dracut>
-
+    
   -->
   <div>
     <define name="k.dracut.module.attribute">
@@ -5049,7 +5120,7 @@ for the installation media.</a:documentation>
   <!--
     ==========================================
     main block: <machine>
-
+    
   -->
   <div>
     <define name="k.machine.ovftype.attribute">
@@ -5201,7 +5272,7 @@ running the image.</a:documentation>
   <!--
     ==========================================
     main block: <packages>
-
+    
   -->
   <div>
     <sch:pattern abstract="true" id="packages_type">
@@ -5299,6 +5370,9 @@ alternative bootstrap method for debootstrap</a:documentation>
             <ref name="k.product"/>
           </zeroOrMore>
           <zeroOrMore>
+            <ref name="k.container"/>
+          </zeroOrMore>
+          <zeroOrMore>
             <ref name="k.package"/>
           </zeroOrMore>
         </interleave>
@@ -5308,7 +5382,7 @@ alternative bootstrap method for debootstrap</a:documentation>
   <!--
     ==========================================
     main block: <preferences>
-
+    
   -->
   <div>
     <define name="k.preferences.profiles.attribute">
@@ -5351,6 +5425,9 @@ definition</a:documentation>
             <ref name="k.packagemanager"/>
           </optional>
           <optional>
+            <ref name="k.containerruntime"/>
+          </optional>
+          <optional>
             <ref name="k.release-version"/>
           </optional>
           <optional>
@@ -5381,7 +5458,7 @@ definition</a:documentation>
   <!--
     ==========================================
     main block: <profiles>
-
+    
   -->
   <div>
     <define name="k.profiles.attlist">
@@ -5403,7 +5480,7 @@ drivers can bind itself to one of the listed namespaces.</a:documentation>
   <!--
     ==========================================
     main block: <users>
-
+    
   -->
   <div>
     <define name="k.users.profiles.attribute">

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.29.24.
-# Python 3.11.3 (main, Jun 03 2023, 22:12:18) [GCC]
+# Python 3.6.15 (default, Sep 23 2021, 15:41:43) [GCC]
 #
 # Command line options:
 #   ('-f', '')
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/ms/Project/kiwi/.tox/unit_py3_11/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /work/rjschwei/devel/kiwi/.tox/unit_py3_6/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -100,7 +100,7 @@ except ImportError:
 try:
     from generatedssuper import GeneratedsSuper
 except ImportError as exp:
-
+    
     class GeneratedsSuper(object):
         tzoff_pattern = re_.compile(r'(\+|-)((0\d|1[0-3]):[0-5]\d|14:00)$')
         class _FixedOffsetTZ(datetime_.tzinfo):
@@ -426,7 +426,7 @@ except ImportError as exp:
             return self.__dict__ == other.__dict__
         def __ne__(self, other):
             return not self.__eq__(other)
-
+    
     def getSubclassFromModule_(module, class_):
         '''Get the subclass of a class from a specific module.'''
         name = class_.__name__ + 'Sub'
@@ -725,6 +725,10 @@ def _cast(typ, value):
 #
 
 
+class k_containerruntime_content(object):
+    PODMAN='podman'
+
+
 class k_packagemanager_content(object):
     APT='apt'
     ZYPPER='zypper'
@@ -812,7 +816,7 @@ class image(GeneratedsSuper):
     """The root element of the configuration file"""
     subclass = None
     superclass = None
-    def __init__(self, name=None, displayname=None, id=None, schemaversion=None, noNamespaceSchemaLocation=None, schemaLocation=None, include=None, description=None, preferences=None, profiles=None, users=None, drivers=None, strip=None, repository=None, packages=None, extension=None):
+    def __init__(self, name=None, displayname=None, id=None, schemaversion=None, noNamespaceSchemaLocation=None, schemaLocation=None, include=None, description=None, preferences=None, profiles=None, users=None, drivers=None, strip=None, repository=None, registry=None, packages=None, extension=None):
         self.original_tagname_ = None
         self.name = _cast(None, name)
         self.displayname = _cast(None, displayname)
@@ -852,6 +856,10 @@ class image(GeneratedsSuper):
             self.repository = []
         else:
             self.repository = repository
+        if registry is None:
+            self.registry = []
+        else:
+            self.registry = registry
         if packages is None:
             self.packages = []
         else:
@@ -911,6 +919,11 @@ class image(GeneratedsSuper):
     def add_repository(self, value): self.repository.append(value)
     def insert_repository_at(self, index, value): self.repository.insert(index, value)
     def replace_repository_at(self, index, value): self.repository[index] = value
+    def get_registry(self): return self.registry
+    def set_registry(self, registry): self.registry = registry
+    def add_registry(self, value): self.registry.append(value)
+    def insert_registry_at(self, index, value): self.registry.insert(index, value)
+    def replace_registry_at(self, index, value): self.registry[index] = value
     def get_packages(self): return self.packages
     def set_packages(self, packages): self.packages = packages
     def add_packages(self, value): self.packages.append(value)
@@ -950,6 +963,7 @@ class image(GeneratedsSuper):
             self.drivers or
             self.strip or
             self.repository or
+            self.registry or
             self.packages or
             self.extension
         ):
@@ -1017,6 +1031,8 @@ class image(GeneratedsSuper):
             strip_.export(outfile, level, namespaceprefix_, name_='strip', pretty_print=pretty_print)
         for repository_ in self.repository:
             repository_.export(outfile, level, namespaceprefix_, name_='repository', pretty_print=pretty_print)
+        for registry_ in self.registry:
+            registry_.export(outfile, level, namespaceprefix_, name_='registry', pretty_print=pretty_print)
         for packages_ in self.packages:
             packages_.export(outfile, level, namespaceprefix_, name_='packages', pretty_print=pretty_print)
         for extension_ in self.extension:
@@ -1097,6 +1113,11 @@ class image(GeneratedsSuper):
             obj_.build(child_)
             self.repository.append(obj_)
             obj_.original_tagname_ = 'repository'
+        elif nodeName_ == 'registry':
+            obj_ = registry.factory()
+            obj_.build(child_)
+            self.registry.append(obj_)
+            obj_.original_tagname_ = 'registry'
         elif nodeName_ == 'packages':
             obj_ = packages.factory()
             obj_.build(child_)
@@ -2083,6 +2104,76 @@ class configoption(GeneratedsSuper):
 # end class configoption
 
 
+class container(GeneratedsSuper):
+    """Name of container to install in the image"""
+    subclass = None
+    superclass = None
+    def __init__(self, name=None):
+        self.original_tagname_ = None
+        self.name = _cast(None, name)
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, container)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if container.subclass:
+            return container.subclass(*args_, **kwargs_)
+        else:
+            return container(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_name(self): return self.name
+    def set_name(self, name): self.name = name
+    def hasContent_(self):
+        if (
+
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', name_='container', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('container')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='container')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='container', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='container'):
+        if self.name is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='container', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('name', node)
+        if value is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            self.name = value
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        pass
+# end class container
+
+
 class package(GeneratedsSuper):
     """Name of an image Package"""
     subclass = None
@@ -2406,6 +2497,86 @@ class requires(GeneratedsSuper):
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class requires
+
+
+class registry(GeneratedsSuper):
+    """The path to an OCI container registry"""
+    subclass = None
+    superclass = None
+    def __init__(self, profiles=None, path=None):
+        self.original_tagname_ = None
+        self.profiles = _cast(None, profiles)
+        self.path = _cast(None, path)
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, registry)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if registry.subclass:
+            return registry.subclass(*args_, **kwargs_)
+        else:
+            return registry(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_profiles(self): return self.profiles
+    def set_profiles(self, profiles): self.profiles = profiles
+    def get_path(self): return self.path
+    def set_path(self, path): self.path = path
+    def hasContent_(self):
+        if (
+
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', name_='registry', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('registry')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='registry')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='registry', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='registry'):
+        if self.profiles is not None and 'profiles' not in already_processed:
+            already_processed.add('profiles')
+            outfile.write(' profiles=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.profiles), input_name='profiles')), ))
+        if self.path is not None and 'path' not in already_processed:
+            already_processed.add('path')
+            outfile.write(' path=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.path), input_name='path')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='registry', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('profiles', node)
+        if value is not None and 'profiles' not in already_processed:
+            already_processed.add('profiles')
+            self.profiles = value
+        value = find_attr_value_('path', node)
+        if value is not None and 'path' not in already_processed:
+            already_processed.add('path')
+            self.path = value
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        pass
+# end class registry
 
 
 class repository(k_source):
@@ -8564,7 +8735,7 @@ class packages(GeneratedsSuper):
     """Specifies Packages/Patterns Used in Different Stages"""
     subclass = None
     superclass = None
-    def __init__(self, type_=None, profiles=None, patternType=None, bootstrap_package=None, archive=None, ignore=None, namedCollection=None, collectionModule=None, product=None, package=None):
+    def __init__(self, type_=None, profiles=None, patternType=None, bootstrap_package=None, archive=None, ignore=None, namedCollection=None, collectionModule=None, product=None, container=None, package=None):
         self.original_tagname_ = None
         self.type_ = _cast(None, type_)
         self.profiles = _cast(None, profiles)
@@ -8590,6 +8761,10 @@ class packages(GeneratedsSuper):
             self.product = []
         else:
             self.product = product
+        if container is None:
+            self.container = []
+        else:
+            self.container = container
         if package is None:
             self.package = []
         else:
@@ -8630,6 +8805,11 @@ class packages(GeneratedsSuper):
     def add_product(self, value): self.product.append(value)
     def insert_product_at(self, index, value): self.product.insert(index, value)
     def replace_product_at(self, index, value): self.product[index] = value
+    def get_container(self): return self.container
+    def set_container(self, container): self.container = container
+    def add_container(self, value): self.container.append(value)
+    def insert_container_at(self, index, value): self.container.insert(index, value)
+    def replace_container_at(self, index, value): self.container[index] = value
     def get_package(self): return self.package
     def set_package(self, package): self.package = package
     def add_package(self, value): self.package.append(value)
@@ -8650,6 +8830,7 @@ class packages(GeneratedsSuper):
             self.namedCollection or
             self.collectionModule or
             self.product or
+            self.container or
             self.package
         ):
             return True
@@ -8704,6 +8885,8 @@ class packages(GeneratedsSuper):
             collectionModule_.export(outfile, level, namespaceprefix_, name_='collectionModule', pretty_print=pretty_print)
         for product_ in self.product:
             product_.export(outfile, level, namespaceprefix_, name_='product', pretty_print=pretty_print)
+        for container_ in self.container:
+            container_.export(outfile, level, namespaceprefix_, name_='container', pretty_print=pretty_print)
         for package_ in self.package:
             package_.export(outfile, level, namespaceprefix_, name_='package', pretty_print=pretty_print)
     def build(self, node):
@@ -8758,6 +8941,11 @@ class packages(GeneratedsSuper):
             obj_.build(child_)
             self.product.append(obj_)
             obj_.original_tagname_ = 'product'
+        elif nodeName_ == 'container':
+            obj_ = container.factory()
+            obj_.build(child_)
+            self.container.append(obj_)
+            obj_.original_tagname_ = 'container'
         elif nodeName_ == 'package':
             obj_ = package.factory()
             obj_.build(child_)
@@ -8772,7 +8960,7 @@ class preferences(GeneratedsSuper):
     sections based on profiles combine to create on vaild definition"""
     subclass = None
     superclass = None
-    def __init__(self, profiles=None, arch=None, bootsplash_theme=None, bootloader_theme=None, keytable=None, locale=None, packagemanager=None, release_version=None, rpm_locale_filtering=None, rpm_check_signatures=None, rpm_excludedocs=None, showlicense=None, timezone=None, type_=None, version=None):
+    def __init__(self, profiles=None, arch=None, bootsplash_theme=None, bootloader_theme=None, keytable=None, locale=None, packagemanager=None, containerruntime=None, release_version=None, rpm_locale_filtering=None, rpm_check_signatures=None, rpm_excludedocs=None, showlicense=None, timezone=None, type_=None, version=None):
         self.original_tagname_ = None
         self.profiles = _cast(None, profiles)
         self.arch = _cast(None, arch)
@@ -8796,6 +8984,10 @@ class preferences(GeneratedsSuper):
             self.packagemanager = []
         else:
             self.packagemanager = packagemanager
+        if containerruntime is None:
+            self.containerruntime = []
+        else:
+            self.containerruntime = containerruntime
         if release_version is None:
             self.release_version = []
         else:
@@ -8864,6 +9056,11 @@ class preferences(GeneratedsSuper):
     def add_packagemanager(self, value): self.packagemanager.append(value)
     def insert_packagemanager_at(self, index, value): self.packagemanager.insert(index, value)
     def replace_packagemanager_at(self, index, value): self.packagemanager[index] = value
+    def get_containerruntime(self): return self.containerruntime
+    def set_containerruntime(self, containerruntime): self.containerruntime = containerruntime
+    def add_containerruntime(self, value): self.containerruntime.append(value)
+    def insert_containerruntime_at(self, index, value): self.containerruntime.insert(index, value)
+    def replace_containerruntime_at(self, index, value): self.containerruntime[index] = value
     def get_release_version(self): return self.release_version
     def set_release_version(self, release_version): self.release_version = release_version
     def add_release_version(self, value): self.release_version.append(value)
@@ -8922,6 +9119,7 @@ class preferences(GeneratedsSuper):
             self.keytable or
             self.locale or
             self.packagemanager or
+            self.containerruntime or
             self.release_version or
             self.rpm_locale_filtering or
             self.rpm_check_signatures or
@@ -8982,6 +9180,9 @@ class preferences(GeneratedsSuper):
         for packagemanager_ in self.packagemanager:
             showIndent(outfile, level, pretty_print)
             outfile.write('<packagemanager>%s</packagemanager>%s' % (self.gds_encode(self.gds_format_string(quote_xml(packagemanager_), input_name='packagemanager')), eol_))
+        for containerruntime_ in self.containerruntime:
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<containerruntime>%s</containerruntime>%s' % (self.gds_encode(self.gds_format_string(quote_xml(containerruntime_), input_name='containerruntime')), eol_))
         for release_version_ in self.release_version:
             showIndent(outfile, level, pretty_print)
             outfile.write('<release-version>%s</release-version>%s' % (self.gds_encode(self.gds_format_string(quote_xml(release_version_), input_name='release-version')), eol_))
@@ -9052,6 +9253,14 @@ class preferences(GeneratedsSuper):
                 packagemanager_ = ""
             packagemanager_ = self.gds_validate_string(packagemanager_, node, 'packagemanager')
             self.packagemanager.append(packagemanager_)
+        elif nodeName_ == 'containerruntime':
+            containerruntime_ = child_.text
+            if containerruntime_:
+                containerruntime_ = re_.sub(String_cleanup_pat_, " ", containerruntime_).strip()
+            else:
+                containerruntime_ = ""
+            containerruntime_ = self.gds_validate_string(containerruntime_, node, 'containerruntime')
+            self.containerruntime.append(containerruntime_)
         elif nodeName_ == 'release-version':
             release_version_ = child_.text
             release_version_ = self.gds_validate_string(release_version_, node, 'release_version')
@@ -9411,6 +9620,7 @@ __all__ = [
     "bootloadersettings",
     "collectionModule",
     "configoption",
+    "container",
     "containerconfig",
     "description",
     "dracut",
@@ -9445,6 +9655,7 @@ __all__ = [
     "product",
     "profile",
     "profiles",
+    "registry",
     "repository",
     "requires",
     "shimoption",

--- a/kiwi/xsl/convert76to77.xsl
+++ b/kiwi/xsl/convert76to77.xsl
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv76to77">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv76to77"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>7.6</literal> to <literal>7.7</literal>.
+</para>
+<xsl:template match="image" mode="conv76to77">
+    <xsl:choose>
+        <!-- nothing to do if already at 7.7 -->
+        <xsl:when test="@schemaversion > 7.6">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="7.7">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv75to76"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/kiwi/xsl/master.xsl
+++ b/kiwi/xsl/master.xsl
@@ -48,6 +48,7 @@
 <xsl:import href="convert73to74.xsl"/>
 <xsl:import href="convert74to75.xsl"/>
 <xsl:import href="convert75to76.xsl"/>
+<xsl:import href="convert76to77.xsl"/>
 <xsl:import href="pretty.xsl"/>
 
 <xsl:output encoding="utf-8"/>
@@ -225,8 +226,12 @@
         <xsl:apply-templates select="exslt:node-set($v75)" mode="conv75to76"/>
     </xsl:variable>
 
+    <xsl:variable name="v77">
+        <xsl:apply-templates select="exslt:node-set($v76)" mode="conv76to77"/>
+    </xsl:variable>
+
     <xsl:apply-templates
-        select="exslt:node-set($v76)" mode="pretty"
+        select="exslt:node-set($v77)" mode="pretty"
     />
 </xsl:template>
 

--- a/test/data/example_apt_config.xml
+++ b/test/data/example_apt_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="apt-testing">
+<image schemaversion="7.7" name="apt-testing">
     <description type="system">
         <author>Bob</author>
         <contact>user@example.com</contact>

--- a/test/data/example_arm_disk_size_config.xml
+++ b/test/data/example_arm_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_btrfs_config.xml
+++ b/test/data/example_btrfs_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS" displayname="Bob">
+<image schemaversion="7.7" name="LimeJeOS" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>
@@ -86,6 +86,7 @@
         </type>
     </preferences>
     <preferences profiles="ec2Flavour">
+        <containerruntime>podman</containerruntime>
         <type image="oem" filesystem="ext3" bootprofile="ec2" bootkernel="ec2k" kernelcmdline="xencons=xvc0 console=xvc0 multipath=off splash" firmware="ec2">
             <oemconfig>
                 <oem-resize>false</oem-resize>
@@ -196,6 +197,7 @@
             <signing key="file:key_b"/>
         </source>
     </repository>
+    <registry profiles="ec2Flavour" path="https://registry.opensuse.org"/>
     <packages type="image" patternType="plusRecommended">
         <namedCollection name="base"/>
         <product name="openSUSE"/>
@@ -215,7 +217,9 @@
         <package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
     </packages>
     <packages type="image" profiles="ec2Flavour">
+        <container name="distrobox"/>
         <package name="kernel-ec2"/>
+        <package name="podman"/>
         <package name="xen-tools" arch="x86_64"/>
         <package name="xen" arch="x86_64"/>
     </packages>

--- a/test/data/example_config_target_dir.xml
+++ b/test/data/example_config_target_dir.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS" displayname="Bob">
+<image schemaversion="7.7" name="LimeJeOS" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>

--- a/test/data/example_disk_config.xml
+++ b/test/data/example_disk_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_config.xml
+++ b/test/data/example_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_empty_vol_config.xml
+++ b/test/data/example_disk_size_empty_vol_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_oem_volume_config.xml
+++ b/test/data/example_disk_size_oem_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_partition_too_small_config.xml
+++ b/test/data/example_disk_size_partition_too_small_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="TestPartitions">
+<image schemaversion="7.7" name="TestPartitions">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_partitions_config.xml
+++ b/test/data/example_disk_size_partitions_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="TestPartitions">
+<image schemaversion="7.7" name="TestPartitions">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_vol_root_config.xml
+++ b/test/data/example_disk_size_vol_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_volume_config.xml
+++ b/test/data/example_disk_size_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_volume_too_small_config.xml
+++ b/test/data/example_disk_size_volume_too_small_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="JeOS">
+<image schemaversion="7.7" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_dot_profile_config.xml
+++ b/test/data/example_dot_profile_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_dot_profile_live_config.xml
+++ b/test/data/example_dot_profile_live_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LiveImage" displayname="Live">
+<image schemaversion="7.7" name="LiveImage" displayname="Live">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>bob@example.com</contact>

--- a/test/data/example_include_config.xml
+++ b/test/data/example_include_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS">
+<image schemaversion="7.7" name="LimeJeOS">
     <description type="system">
         <author>Marcus</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_include_config_from_description_dir.xml
+++ b/test/data/example_include_config_from_description_dir.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS">
+<image schemaversion="7.7" name="LimeJeOS">
     <description type="system">
         <author>Marcus</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_include_config_missing_reference.xml
+++ b/test/data/example_include_config_missing_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="JeOS">
+<image schemaversion="7.7" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_custom_rootvol_config.xml
+++ b/test/data/example_lvm_custom_rootvol_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="custom-root-volume-setup">
+<image schemaversion="7.7" name="custom-root-volume-setup">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_default_config.xml
+++ b/test/data/example_lvm_default_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_config.xml
+++ b/test/data/example_lvm_no_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_full_usr_config.xml
+++ b/test/data/example_lvm_no_root_full_usr_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_preferred_config.xml
+++ b/test/data/example_lvm_preferred_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_multiple_users_config.xml
+++ b/test/data/example_multiple_users_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_default_type.xml
+++ b/test/data/example_no_default_type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_image_packages_config.xml
+++ b/test/data/example_no_image_packages_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_imageinclude_config.xml
+++ b/test/data/example_no_imageinclude_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_partitions_config.xml
+++ b/test/data/example_partitions_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="TestPartitions">
+<image schemaversion="7.7" name="TestPartitions">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_ppc_disk_size_config.xml
+++ b/test/data/example_ppc_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_pxe_config.xml
+++ b/test/data/example_pxe_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_boot_desc_not_found.xml
+++ b/test/data/example_runtime_checker_boot_desc_not_found.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="JeOS">
+<image schemaversion="7.7" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.7" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>

--- a/test/data/example_runtime_checker_conflicting_types.xml
+++ b/test/data/example_runtime_checker_conflicting_types.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="TypeConflict">
+<image schemaversion="7.7" name="TypeConflict">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/test/data/example_runtime_checker_include_nested_reference.xml
+++ b/test/data/example_runtime_checker_include_nested_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="JeOS">
+<image schemaversion="7.7" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_no_boot_reference.xml
+++ b/test/data/example_runtime_checker_no_boot_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="JeOS">
+<image schemaversion="7.7" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_no_initrd_system_reference.xml
+++ b/test/data/example_runtime_checker_no_initrd_system_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="JeOS">
+<image schemaversion="7.7" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_this_path_config.xml
+++ b/test/data/example_this_path_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="JeOS">
+<image schemaversion="7.7" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/isoboot/example-distribution-no-delete-section/config.xml
+++ b/test/data/isoboot/example-distribution-no-delete-section/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="initrd-isoboot-suse-13.2">
+<image schemaversion="7.7" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/isoboot/example-distribution/config.xml
+++ b/test/data/isoboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="initrd-isoboot-suse-13.2">
+<image schemaversion="7.7" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/oemboot/example-distribution/config.xml
+++ b/test/data/oemboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.6" name="initrd-oemboot-suse-13.2">
+<image schemaversion="7.7" name="initrd-oemboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>


### PR DESCRIPTION
As systems become leaner and functionality moves from system installed packages (RPM, deb or other) to containers it is important that kiwi can pre-install conatiners from specified registries to build system images.


Changes proposed in this pull request:
* Schema support for container installation with podman
*
