### PR TITLE
Support install disk overwrite per cmdline

### DIFF
--- a/doc/source/building_images/build_expandable_disk.rst
+++ b/doc/source/building_images/build_expandable_disk.rst
@@ -393,6 +393,15 @@ oemconfig.oem-unattended Element
   possible target devices are discovered the image is deployed to
   the first device. ``kiwi_oemunattended`` in the initrd
 
+oemconfig.oem-unattended-id Element
+  The target disk device for the installation is selected according
+  to the specified device ID. The device ID corresponds to the name of
+  the device as it exists for the configured `devicepersistency`. By
+  default this is the `by-uuid` device name. If no such representation
+  exist e.g for ramdisk devices, the unix device node can be used
+  to select. The given name must be present in the device list detected
+  by kiwi.
+
 oemconfig.oem-skip-verify Element
   Do not perform the checksum verification process after install
   of the image to the target disk. The verification process computes

--- a/doc/source/concept_and_workflow/customize_the_boot_process.rst
+++ b/doc/source/concept_and_workflow/customize_the_boot_process.rst
@@ -210,6 +210,19 @@ the available kernel boot parameters for this modules:
   OS deployment is `/dev/sdj`. With `rd.kiwi.oem.maxdisk=500G` the
   deployment will land on that RAID disk.
 
+``rd.kiwi.oem.installdevice``
+  Configures the disk device that should be used in an OEM
+  installation. This overwrites/resets any other oem device specific
+  settings, e.g oem-device-filter, oem-unattended-id or rd.kiwi.oem.maxdisk
+  from the cmdline and just continues the installation on the given
+  device. However, the device must exist and must be a block special.
+
+.. note:: Non interactive mode activated by rd.kiwi.oem.installdevice
+
+   When setting rd.kiwi.oem.installdevice explicitly on the
+   kernel commandline, {kiwi} will not ask for confirmation
+   of the device and just use it !
+
 ``rd.live.overlay.size``
   Tells a live ISO image the size for the `tmpfs` filesystem that is used
   for the `overlayfs` mount process. If the write area of the overlayfs


### PR DESCRIPTION
Allow install disk overwrite from cmdline
    
Add rd.kiwi.oem.installdevice=DEVICE. Configures the disk device that should be used in an OEM installation. This oerwrites any other oem device setting, e.g device filter or maxdisk and just  continues the installation on the given device. However, the device must exist and must be a block special.
