### PR TITLE
Set kpartx as default mapper tool for s390

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1791,6 +1791,9 @@ class Defaults:
 
         :rtype: str
         """
+        host_architecture = Defaults.get_platform_name()
+        if 's390' in host_architecture:
+            return 'kpartx'
         return 'partx'
 
     @staticmethod

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -78,7 +78,11 @@ class TestRuntimeConfig:
         ]
 
     @patch('kiwi.runtime_checker.Defaults.is_buildservice_worker')
-    def test_config_sections_defaults(self, mock_is_buildservice_worker):
+    @patch('kiwi.runtime_checker.Defaults.get_platform_name')
+    def test_config_sections_defaults(
+        self, mock_get_platform_name, mock_is_buildservice_worker
+    ):
+        mock_get_platform_name.return_value = 's390x'
         mock_is_buildservice_worker.return_value = True
         with patch.dict('os.environ', {'HOME': '../data/kiwi_config/defaults'}):
             runtime_config = RuntimeConfig(reread=True)
@@ -93,10 +97,15 @@ class TestRuntimeConfig:
         assert runtime_config.get_container_compression() is True
         assert runtime_config.get_iso_tool_category() == 'xorriso'
         assert runtime_config.get_oci_archive_tool() == 'umoci'
-        assert runtime_config.get_mapper_tool() == 'partx'
+        assert runtime_config.get_mapper_tool() == 'kpartx'
         assert runtime_config.get_package_changes() is False
         assert runtime_config.\
             get_credentials_verification_metadata_signing_key_file() == ''
+
+        mock_get_platform_name.return_value = 'x86_64'
+        with patch.dict('os.environ', {'HOME': '../data/kiwi_config/defaults'}):
+            runtime_config = RuntimeConfig(reread=True)
+        assert runtime_config.get_mapper_tool() == 'partx'
 
     def test_config_sections_invalid(self):
         with patch.dict('os.environ', {'HOME': '../data/kiwi_config/invalid'}):


### PR DESCRIPTION
Some time ago we moved the default partition mapper from kpartx to partx to reduce a package dependencies. Some months and issues later this change will now be reverted for the following reason. partx exists in util-linux in different versions and with different feature sets for different distributions. This makes it very hard to provide a consistently working partition mapper utility across the distributions in the way we had it with kpartx before. Changing the default for a tool that has issues and less support as the one before is a bad move and causes trouble to our users.
This Fixes #2277

