### PR TITLE
package: Drop unused xorriso dep on dracut-kiwi-live subpackage

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -561,7 +561,6 @@ Requires:       dracut-network
 Requires:       device-mapper
 %endif
 Requires:       dracut
-Requires:       xorriso
 License:        GPL-3.0-or-later
 Group:          %{sysgroup}
 


### PR DESCRIPTION
We do not actually use xorriso anywhere inside of the dracut module, nor do we pull in any utilities from the xorriso package into the generated initramfs anyway.

Fixes #2404
