### PR TITLE
Allow target_blocksize to be available for kis image

### DIFF
--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1486,7 +1486,7 @@ div {
         attribute target_blocksize { xsd:nonNegativeInteger }
         >> sch:pattern [ id = "target_blocksize" is-a = "image_type"
             sch:param [ name = "attr" value = "target_blocksize" ]
-            sch:param [ name = "types" value = "oem" ]
+            sch:param [ name = "types" value = "oem kis" ]
         ]
     k.type.target_removable.attribute =
         ## Indicate if the target disk for oem images is deployed

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2160,7 +2160,7 @@ desired target by calling: blockdev --report device</a:documentation>
       </attribute>
       <sch:pattern id="target_blocksize" is-a="image_type">
         <sch:param name="attr" value="target_blocksize"/>
-        <sch:param name="types" value="oem"/>
+        <sch:param name="types" value="oem kis"/>
       </sch:pattern>
     </define>
     <define name="k.type.target_removable.attribute">


### PR DESCRIPTION
target_blocksize attribute shouble be also avaliable for kis image, so add kis to target_blocksize match pattern.
