### PR TITLE
Ensure setfiles is detected inside the image-root

### DIFF
--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -549,7 +549,7 @@ class SystemSetup:
         """
         security_context = '/etc/selinux/targeted/contexts/files/file_contexts'
         if os.path.exists(self.root_dir + security_context):
-            if Path.which(filename='setfiles', access_mode=os.X_OK):
+            if Path.which(filename='setfiles', access_mode=os.X_OK, root_dir=self.root_dir):
                 self.set_selinux_file_contexts(security_context)
             else:
                 log.warning(


### PR DESCRIPTION
We do not actually use setfiles from the host, we use it from the image root we create for the image build. Thus, we should look in the image root instead of on the host system.

This prevents us from incorrectly detecting that setfiles is not available for setting SELinux contexts.

Fixes: 2a22901ddd11ae23b6724b5e1aaa4261f219ccb6

Fixes #2414
