### PR TITLE
Move LoopDevice class to context manager

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 9.25.22
+current_version = 10.0.0
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 9.25.21
+current_version = 9.25.22
 commit = True
 tag = True
 

--- a/.github/workflows/ci-code-style.yml
+++ b/.github/workflows/ci-code-style.yml
@@ -3,7 +3,7 @@ name: CI-Code-Style
 on:
   push:
     branches:
-      - "master"
+      - "main"
   pull_request:
 
 jobs:
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-config-functions.yml
+++ b/.github/workflows/ci-config-functions.yml
@@ -4,7 +4,7 @@ name: CI-Config-Functions
 on:
   push:
     branches:
-      - "master"
+      - "main"
     paths:
       - "kiwi/config/functions.sh"
       - ".github/workflows/**"

--- a/.github/workflows/ci-differential-shellcheck.yml
+++ b/.github/workflows/ci-differential-shellcheck.yml
@@ -1,7 +1,7 @@
 name: CI-Differential-ShellCheck
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/ci-documentation.yml
+++ b/.github/workflows/ci-documentation.yml
@@ -3,7 +3,7 @@ name: CI-Documentation
 on:
   push:
     branches:
-      - "master"
+      - "main"
   pull_request:
 
 jobs:

--- a/.github/workflows/ci-kiwi-9-compliant.yml
+++ b/.github/workflows/ci-kiwi-9-compliant.yml
@@ -1,0 +1,14 @@
+name: CI-Compliant-To-Kiwi-9
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  compliance_test:
+    name: Capable for Rebase to kiwi v9.x.x
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run rebase
+        run: git fetch --all; git config user.email rebase@action.com; git config user.name git_action; git checkout master; git cherry-pick "origin/main..origin/${GITHUB_HEAD_REF}"

--- a/.github/workflows/ci-units-types.yml
+++ b/.github/workflows/ci-units-types.yml
@@ -3,7 +3,7 @@ name: CI-Unit-And-Types
 on:
   push:
     branches:
-      - "master"
+      - "main"
   pull_request:
 
 jobs:

--- a/.github/workflows/ci-update-build-tests.yml
+++ b/.github/workflows/ci-update-build-tests.yml
@@ -3,7 +3,7 @@ name: CI-Update-Build-Tests
 on:
   push:
     branches:
-      - "master"
+      - "main"
     paths:
       - "build-tests/**"
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -139,7 +139,7 @@ author = 'Marcus Schäfer'
 # built documents.
 #
 # The short X.Y version.
-version = '9.25.22'
+version = '10.0.0'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -139,7 +139,7 @@ author = 'Marcus Schäfer'
 # built documents.
 #
 # The short X.Y version.
-version = '9.25.21'
+version = '9.25.22'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/doc/source/contributing/kiwi_from_python.rst
+++ b/doc/source/contributing/kiwi_from_python.rst
@@ -56,15 +56,15 @@ which contains your host `tmp` directory.
     from kiwi.storage.loop_device import LoopDevice
     from kiwi.filesystem import FileSystem
 
-    loop_provider = LoopDevice(
+    with LoopDevice(
         filename='my_tmp.ext4', filesize_mbytes=100
-    )
-    loop_provider.create()
+    ) as loop_provider:
+        loop_provider.create()
 
-    filesystem = FileSystem.new(
-        'ext4', loop_provider, '/tmp/'
-    )
-    filesystem.create_on_device(
-        label='TMP'
-    )
-    filesystem.sync_data()
+        filesystem = FileSystem.new(
+            'ext4', loop_provider, '/tmp/'
+        )
+        filesystem.create_on_device(
+            label='TMP'
+        )
+        filesystem.sync_data()

--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -170,26 +170,26 @@ class FileSystemBuilder:
 
     def _operate_on_loop(self) -> None:
         filesystem = None
-        loop_provider = LoopDevice(
+        with LoopDevice(
             self.filename,
             self.filesystem_setup.get_size_mbytes(),
             self.blocksize
-        )
-        loop_provider.create()
-        filesystem = FileSystem.new(
-            self.requested_filesystem, loop_provider,
-            self.root_dir + os.sep, self.filesystem_custom_parameters
-        )
-        filesystem.create_on_device(self.label)
-        self.root_uuid = loop_provider.get_uuid(loop_provider.get_device())
-        log.info(
-            f'--> Syncing data to filesystem on {loop_provider.get_device()}'
-        )
-        filesystem.sync_data(
-            Defaults.
-            get_exclude_list_for_root_data_sync() + Defaults.
-            get_exclude_list_from_custom_exclude_files(self.root_dir)
-        )
+        ) as loop_provider:
+            loop_provider.create()
+            filesystem = FileSystem.new(
+                self.requested_filesystem, loop_provider,
+                self.root_dir + os.sep, self.filesystem_custom_parameters
+            )
+            filesystem.create_on_device(self.label)
+            self.root_uuid = loop_provider.get_uuid(loop_provider.get_device())
+            log.info(
+                f'--> Syncing data to filesystem on {loop_provider.get_device()}'
+            )
+            filesystem.sync_data(
+                Defaults.
+                get_exclude_list_for_root_data_sync() + Defaults.
+                get_exclude_list_from_custom_exclude_files(self.root_dir)
+            )
 
     def _operate_on_file(self) -> None:
         default_provider = DeviceProvider()

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -255,28 +255,28 @@ class LiveImageBuilder:
             self.xml_state, self.root_dir
         )
         root_image = Temporary().new_file()
-        loop_provider = LoopDevice(
+        with LoopDevice(
             root_image.name,
             filesystem_setup.get_size_mbytes(root_filesystem),
             self.xml_state.build_type.get_target_blocksize()
-        )
-        loop_provider.create()
-        live_filesystem = FileSystem.new(
-            name=root_filesystem,
-            device_provider=loop_provider,
-            root_dir=self.root_dir + os.sep,
-            custom_args=filesystem_custom_parameters
-        )
-        live_filesystem.create_on_device()
-        log.info(
-            '--> Syncing data to {0} root image'.format(root_filesystem)
-        )
-        live_filesystem.sync_data(
-            Defaults.
-            get_exclude_list_for_root_data_sync() + Defaults.
-            get_exclude_list_from_custom_exclude_files(self.root_dir)
-        )
-        live_filesystem.umount()
+        ) as loop_provider:
+            loop_provider.create()
+            live_filesystem = FileSystem.new(
+                name=root_filesystem,
+                device_provider=loop_provider,
+                root_dir=self.root_dir + os.sep,
+                custom_args=filesystem_custom_parameters
+            )
+            live_filesystem.create_on_device()
+            log.info(
+                '--> Syncing data to {0} root image'.format(root_filesystem)
+            )
+            live_filesystem.sync_data(
+                Defaults.
+                get_exclude_list_for_root_data_sync() + Defaults.
+                get_exclude_list_from_custom_exclude_files(self.root_dir)
+            )
+            live_filesystem.umount()
 
         log.info('--> Creating squashfs container for root image')
         self.live_container_dir = Temporary(

--- a/kiwi/filesystem/clicfs.py
+++ b/kiwi/filesystem/clicfs.py
@@ -65,27 +65,27 @@ class FileSystemClicFs(FileSystemBase):
         self.filename = filename
         container_dir = Temporary(prefix='kiwi_clicfs.').new_dir()
         clicfs_container_filesystem = container_dir.name + '/fsdata.ext4'
-        loop_provider = LoopDevice(
+        with LoopDevice(
             clicfs_container_filesystem,
             self._get_container_filesystem_size_mbytes()
-        )
-        loop_provider.create()
-        filesystem = FileSystemExt4(
-            loop_provider, self.root_dir
-        )
-        filesystem.create_on_device()
-        filesystem.sync_data()
-        Command.run(
-            ['resize2fs', '-f', loop_provider.get_device(), '-M']
-        )
+        ) as loop_provider:
+            loop_provider.create()
+            filesystem = FileSystemExt4(
+                loop_provider, self.root_dir
+            )
+            filesystem.create_on_device()
+            filesystem.sync_data()
+            Command.run(
+                ['resize2fs', '-f', loop_provider.get_device(), '-M']
+            )
 
-        # force cleanup and umount of container filesystem
-        # before mkclicfs is called
-        del filesystem
+            # force cleanup and umount of container filesystem
+            # before mkclicfs is called
+            del filesystem
 
-        Command.run(
-            ['mkclicfs', clicfs_container_filesystem, self.filename]
-        )
+            Command.run(
+                ['mkclicfs', clicfs_container_filesystem, self.filename]
+            )
 
     def _get_container_filesystem_size_mbytes(self):
         size = SystemSize(self.root_dir)

--- a/kiwi/storage/loop_device.py
+++ b/kiwi/storage/loop_device.py
@@ -101,7 +101,7 @@ class LoopDevice(DeviceProvider):
         )
         self.node_name = loop_call.output.rstrip(os.linesep)
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, exc_type, exc_value, exc_traceback):
         if self.node_name:
             try:
                 Command.run(['losetup', '-d', self.node_name])

--- a/kiwi/tasks/image_resize.py
+++ b/kiwi/tasks/image_resize.py
@@ -120,13 +120,12 @@ class ImageResizeTask(CliTask):
 
         # resize raw disk partition table
         firmware = FirmWare(self.xml_state)
-        loop_provider = LoopDevice(image_format.diskname)
-        loop_provider.create(overwrite=False)
-        partitioner = Partitioner.new(
-            firmware.get_partition_table_type(), loop_provider
-        )
-        partitioner.resize_table()
-        del loop_provider
+        with LoopDevice(image_format.diskname) as loop_provider:
+            loop_provider.create(overwrite=False)
+            partitioner = Partitioner.new(
+                firmware.get_partition_table_type(), loop_provider
+            )
+            partitioner.resize_table()
 
         # resize disk format from resized raw disk
         if disk_format and resize_result is True:

--- a/kiwi/version.py
+++ b/kiwi/version.py
@@ -18,5 +18,5 @@
 """
 Global version information used in kiwi and the package
 """
-__version__ = '9.25.21'
+__version__ = '9.25.22'
 __githash__ = '$Format:%H$'

--- a/kiwi/version.py
+++ b/kiwi/version.py
@@ -18,5 +18,5 @@
 """
 Global version information used in kiwi and the package
 """
-__version__ = '9.25.22'
+__version__ = '10.0.0'
 __githash__ = '$Format:%H$'

--- a/test/unit/filesystem/clicfs_test.py
+++ b/test/unit/filesystem/clicfs_test.py
@@ -1,6 +1,7 @@
 from mock import patch
-from mock import call
-import mock
+from mock import (
+    call, Mock
+)
 
 from kiwi.filesystem.clicfs import FileSystemClicFs
 
@@ -9,7 +10,7 @@ class TestFileSystemClicFs:
     @patch('os.path.exists')
     def setup(self, mock_exists):
         mock_exists.return_value = True
-        self.clicfs = FileSystemClicFs(mock.Mock(), 'root_dir')
+        self.clicfs = FileSystemClicFs(Mock(), 'root_dir')
 
     @patch('os.path.exists')
     def setup_method(self, cls, mock_exists):
@@ -21,28 +22,28 @@ class TestFileSystemClicFs:
     @patch('kiwi.filesystem.clicfs.FileSystemExt4')
     @patch('kiwi.filesystem.clicfs.SystemSize')
     def test_create_on_file(
-        self, mock_size, mock_ext4, mock_loop,
+        self, mock_size, mock_ext4, mock_LoopDevice,
         mock_Temporary, mock_command
     ):
-        size = mock.Mock()
-        size.customize = mock.Mock(
+        size = Mock()
+        size.customize = Mock(
             return_value=42
         )
-        size.accumulate_mbyte_file_sizes = mock.Mock(
+        size.accumulate_mbyte_file_sizes = Mock(
             return_value=42
         )
         mock_size.return_value = size
-        filesystem = mock.Mock()
+        filesystem = Mock()
         mock_ext4.return_value = filesystem
-        loop_provider = mock.Mock()
-        mock_loop.return_value = loop_provider
+        loop_provider = Mock()
+        mock_LoopDevice.return_value.__enter__.return_value = loop_provider
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
 
         self.clicfs.create_on_file('myimage', 'label')
 
         size.accumulate_mbyte_file_sizes.assert_called_once_with()
         size.customize.assert_called_once_with(42, 'ext4')
-        mock_loop.assert_called_once_with(
+        mock_LoopDevice.assert_called_once_with(
             'tmpdir/fsdata.ext4', 42
         )
         loop_provider.create.assert_called_once_with()

--- a/test/unit/tasks/image_resize_test.py
+++ b/test/unit/tasks/image_resize_test.py
@@ -41,13 +41,13 @@ class TestImageResizeTask:
         self.firmware.get_partition_table_type = Mock(
             return_value='gpt'
         )
-        self.loop_provider = Mock()
+#        self.loop_provider = Mock()
         kiwi.tasks.image_resize.FirmWare = Mock(
             return_value=self.firmware
         )
-        kiwi.tasks.image_resize.LoopDevice = Mock(
-            return_value=self.loop_provider
-        )
+#        kiwi.tasks.image_resize.LoopDevice = Mock(
+#            return_value=self.loop_provider
+#        )
 
         self.task = ImageResizeTask()
 
@@ -94,9 +94,14 @@ class TestImageResizeTask:
         with raises(KiwiSizeError):
             self.task.process()
 
+    @patch('kiwi.tasks.image_resize.LoopDevice')
     @patch('kiwi.tasks.image_resize.DiskFormat.new')
     @patch('kiwi.tasks.image_resize.Partitioner.new')
-    def test_process_image_resize_gb(self, mock_Partitioner, mock_DiskFormat):
+    def test_process_image_resize_gb(
+        self, mock_Partitioner, mock_DiskFormat, mock_LoopDevice
+    ):
+        loop_provider = Mock()
+        mock_LoopDevice.return_value.__enter__.return_value = loop_provider
         partitioner = Mock()
         mock_Partitioner.return_value = partitioner
         image_format = Mock()
@@ -105,16 +110,21 @@ class TestImageResizeTask:
         self._init_command_args()
         self.task.command_args['resize'] = True
         self.task.process()
-        self.loop_provider.create.assert_called_once_with(overwrite=False)
+        loop_provider.create.assert_called_once_with(overwrite=False)
         partitioner.resize_table.assert_called_once_with()
         image_format.resize_raw_disk.assert_called_once_with(
             42 * 1024 * 1024 * 1024
         )
         image_format.create_image_format.assert_called_once_with()
 
+    @patch('kiwi.tasks.image_resize.LoopDevice')
     @patch('kiwi.tasks.image_resize.DiskFormat.new')
     @patch('kiwi.tasks.image_resize.Partitioner.new')
-    def test_process_image_resize_mb(self, mock_Partitioner, mock_DiskFormat):
+    def test_process_image_resize_mb(
+        self, mock_Partitioner, mock_DiskFormat, mock_LoopDevice
+    ):
+        loop_provider = Mock()
+        mock_LoopDevice.return_value.__enter__.return_value = loop_provider
         partitioner = Mock()
         mock_Partitioner.return_value = partitioner
         image_format = Mock()
@@ -124,18 +134,21 @@ class TestImageResizeTask:
         self.task.command_args['resize'] = True
         self.task.command_args['--size'] = '42m'
         self.task.process()
-        self.loop_provider.create.assert_called_once_with(overwrite=False)
+        loop_provider.create.assert_called_once_with(overwrite=False)
         partitioner.resize_table.assert_called_once_with()
         image_format.resize_raw_disk.assert_called_once_with(
             42 * 1024 * 1024
         )
         image_format.create_image_format.assert_called_once_with()
 
+    @patch('kiwi.tasks.image_resize.LoopDevice')
     @patch('kiwi.tasks.image_resize.DiskFormat.new')
     @patch('kiwi.tasks.image_resize.Partitioner.new')
     def test_process_image_resize_bytes(
-        self, mock_Partitioner, mock_DiskFormat
+        self, mock_Partitioner, mock_DiskFormat, mock_LoopDevice
     ):
+        loop_provider = Mock()
+        mock_LoopDevice.return_value.__enter__.return_value = loop_provider
         partitioner = Mock()
         mock_Partitioner.return_value = partitioner
         image_format = Mock()
@@ -145,18 +158,21 @@ class TestImageResizeTask:
         self.task.command_args['resize'] = True
         self.task.command_args['--size'] = '42'
         self.task.process()
-        self.loop_provider.create.assert_called_once_with(overwrite=False)
+        loop_provider.create.assert_called_once_with(overwrite=False)
         partitioner.resize_table.assert_called_once_with()
         image_format.resize_raw_disk.assert_called_once_with(
             42
         )
         image_format.create_image_format.assert_called_once_with()
 
+    @patch('kiwi.tasks.image_resize.LoopDevice')
     @patch('kiwi.tasks.image_resize.DiskFormat.new')
     @patch('kiwi.tasks.image_resize.Partitioner.new')
     def test_process_image_resize_not_needed(
-        self, mock_Partitioner, mock_DiskFormat
+        self, mock_Partitioner, mock_DiskFormat, mock_LoopDevice
     ):
+        loop_provider = Mock()
+        mock_LoopDevice.return_value.__enter__.return_value = loop_provider
         partitioner = Mock()
         mock_Partitioner.return_value = partitioner
         image_format = Mock()
@@ -167,7 +183,7 @@ class TestImageResizeTask:
         self.task.command_args['--size'] = '42'
         with self._caplog.at_level(logging.INFO):
             self.task.process()
-            self.loop_provider.create.assert_called_once_with(overwrite=False)
+            loop_provider.create.assert_called_once_with(overwrite=False)
             partitioner.resize_table.assert_called_once_with()
             image_format.resize_raw_disk.assert_called_once_with(
                 42


### PR DESCRIPTION
Change the LoopDevice class to be a context manager. All code using LoopDevice was updated to the following with statement:

```python
with LoopDevice(...) as loop_provider:
    loop_provider.some_member()
```

This is related to Issue #2412

