### PR TITLE
Fix overwrite of kiwi_oemunattended

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -129,19 +129,6 @@ function get_disk_list {
         )
         device_size=$(echo "${device_meta}" | cut -f2 -d:)
         list_items="${device} ${device_size}"
-        # activate unattended mode. In case a user explicitly
-        # provides the device name to deploy the image to via
-        # the kernel commandline, no further questions if this
-        # is wanted should appear
-        message="rd.kiwi.oem.installdevice set via cmdline to: ${device}"
-        message="${message} The following OEM device settings will be ignored:"
-        message="${message} oem-unattended,"
-        message="${message} oem-unattended-id,"
-        message="${message} oem-device-filter"
-        export kiwi_oemunattended="true"
-        export kiwi_oemunattended_id=""
-        export kiwi_oemdevicefilter=""
-        info "${message}" >&2
     fi
     if [ -z "${list_items}" ];then
         local no_device_text="No device(s) for installation found"

--- a/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
@@ -176,10 +176,29 @@ function initialize {
     # The method will exit from the initrd if the profile
     # file does not exist
     # """
+    local kiwi_oem_installdevice
     local profile=/.profile
 
     test -f ${profile} || \
         report_and_quit "No profile setup found"
 
     import_file ${profile}
+
+    # Handle overwrites
+    kiwi_oem_installdevice=$(getarg rd.kiwi.oem.installdevice=)
+    if [ -n "${kiwi_oem_installdevice}" ];then
+        # activate unattended mode. In case a user explicitly
+        # provides the device name to deploy the image to via
+        # the kernel commandline, no further questions if this
+        # is wanted should appear
+        message="rd.kiwi.oem.installdevice explicitly set via cmdline."
+        message="${message} The following OEM device settings will be ignored:"
+        message="${message} oem-unattended,"
+        message="${message} oem-unattended-id,"
+        message="${message} oem-device-filter"
+        export kiwi_oemunattended="true"
+        export kiwi_oemunattended_id=""
+        export kiwi_oemdevicefilter=""
+        info "${message}" >&2
+    fi
 }

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ allowlist_externals =
     python
     pytest
 basepython =
+    unit_py3_12: python3.12
     unit_py3_11: python3.11
     unit_py3_10: python3.10
     unit_py3_9: python3.9
@@ -79,6 +80,7 @@ setenv =
 changedir=test/unit
 commands =
     {[testenv:unit]commands}
+
 
 # Unit Test run with basepython set to 3.12
 [testenv:unit_py3_12]


### PR DESCRIPTION
In case rd.kiwi.oem.installdevice is set, there is an overwrite of the kiwi_oemunattended setting. However the variable was set in local scope of a function and therefore the change was not effective in other methods which also evaluates this variable. This commit fixes it such that the overwrite happens in the early initialize method which provides the environment for all code running in the dracut module. This is related to jira#PED-7180


