### PR TITLE
Move loop device to context manager

### DIFF
--- a/doc/source/contributing/kiwi_from_python.rst
+++ b/doc/source/contributing/kiwi_from_python.rst
@@ -56,15 +56,15 @@ which contains your host `tmp` directory.
     from kiwi.storage.loop_device import LoopDevice
     from kiwi.filesystem import FileSystem
 
-    loop_provider = LoopDevice(
+    with LoopDevice(
         filename='my_tmp.ext4', filesize_mbytes=100
-    )
-    loop_provider.create()
+    ) as loop_provider:
+        loop_provider.create()
 
-    filesystem = FileSystem.new(
-        'ext4', loop_provider, '/tmp/'
-    )
-    filesystem.create_on_device(
-        label='TMP'
-    )
-    filesystem.sync_data()
+        filesystem = FileSystem.new(
+            'ext4', loop_provider, '/tmp/'
+        )
+        filesystem.create_on_device(
+            label='TMP'
+        )
+        filesystem.sync_data()

--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -170,26 +170,26 @@ class FileSystemBuilder:
 
     def _operate_on_loop(self) -> None:
         filesystem = None
-        loop_provider = LoopDevice(
+        with LoopDevice(
             self.filename,
             self.filesystem_setup.get_size_mbytes(),
             self.blocksize
-        )
-        loop_provider.create()
-        filesystem = FileSystem.new(
-            self.requested_filesystem, loop_provider,
-            self.root_dir + os.sep, self.filesystem_custom_parameters
-        )
-        filesystem.create_on_device(self.label)
-        self.root_uuid = loop_provider.get_uuid(loop_provider.get_device())
-        log.info(
-            f'--> Syncing data to filesystem on {loop_provider.get_device()}'
-        )
-        filesystem.sync_data(
-            Defaults.
-            get_exclude_list_for_root_data_sync() + Defaults.
-            get_exclude_list_from_custom_exclude_files(self.root_dir)
-        )
+        ) as loop_provider:
+            loop_provider.create()
+            filesystem = FileSystem.new(
+                self.requested_filesystem, loop_provider,
+                self.root_dir + os.sep, self.filesystem_custom_parameters
+            )
+            filesystem.create_on_device(self.label)
+            self.root_uuid = loop_provider.get_uuid(loop_provider.get_device())
+            log.info(
+                f'--> Syncing data to filesystem on {loop_provider.get_device()}'
+            )
+            filesystem.sync_data(
+                Defaults.
+                get_exclude_list_for_root_data_sync() + Defaults.
+                get_exclude_list_from_custom_exclude_files(self.root_dir)
+            )
 
     def _operate_on_file(self) -> None:
         default_provider = DeviceProvider()

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -255,28 +255,28 @@ class LiveImageBuilder:
             self.xml_state, self.root_dir
         )
         root_image = Temporary().new_file()
-        loop_provider = LoopDevice(
+        with LoopDevice(
             root_image.name,
             filesystem_setup.get_size_mbytes(root_filesystem),
             self.xml_state.build_type.get_target_blocksize()
-        )
-        loop_provider.create()
-        live_filesystem = FileSystem.new(
-            name=root_filesystem,
-            device_provider=loop_provider,
-            root_dir=self.root_dir + os.sep,
-            custom_args=filesystem_custom_parameters
-        )
-        live_filesystem.create_on_device()
-        log.info(
-            '--> Syncing data to {0} root image'.format(root_filesystem)
-        )
-        live_filesystem.sync_data(
-            Defaults.
-            get_exclude_list_for_root_data_sync() + Defaults.
-            get_exclude_list_from_custom_exclude_files(self.root_dir)
-        )
-        live_filesystem.umount()
+        ) as loop_provider:
+            loop_provider.create()
+            live_filesystem = FileSystem.new(
+                name=root_filesystem,
+                device_provider=loop_provider,
+                root_dir=self.root_dir + os.sep,
+                custom_args=filesystem_custom_parameters
+            )
+            live_filesystem.create_on_device()
+            log.info(
+                '--> Syncing data to {0} root image'.format(root_filesystem)
+            )
+            live_filesystem.sync_data(
+                Defaults.
+                get_exclude_list_for_root_data_sync() + Defaults.
+                get_exclude_list_from_custom_exclude_files(self.root_dir)
+            )
+            live_filesystem.umount()
 
         log.info('--> Creating squashfs container for root image')
         self.live_container_dir = Temporary(

--- a/kiwi/tasks/image_resize.py
+++ b/kiwi/tasks/image_resize.py
@@ -120,13 +120,12 @@ class ImageResizeTask(CliTask):
 
         # resize raw disk partition table
         firmware = FirmWare(self.xml_state)
-        loop_provider = LoopDevice(image_format.diskname)
-        loop_provider.create(overwrite=False)
-        partitioner = Partitioner.new(
-            firmware.get_partition_table_type(), loop_provider
-        )
-        partitioner.resize_table()
-        del loop_provider
+        with LoopDevice(image_format.diskname) as loop_provider:
+            loop_provider.create(overwrite=False)
+            partitioner = Partitioner.new(
+                firmware.get_partition_table_type(), loop_provider
+            )
+            partitioner.resize_table()
 
         # resize disk format from resized raw disk
         if disk_format and resize_result is True:

--- a/test/unit/storage/loop_device_test.py
+++ b/test/unit/storage/loop_device_test.py
@@ -1,5 +1,7 @@
 import logging
-from mock import patch
+from mock import (
+    patch, call
+)
 from pytest import (
     raises, fixture
 )
@@ -64,12 +66,16 @@ class TestLoopDevice:
         self.loop.node_name = None
 
     @patch('kiwi.storage.loop_device.Command.run')
-    def test_destructor(self, mock_command):
-        self.loop.node_name = '/dev/loop0'
-        mock_command.side_effect = Exception
-        self.loop.__del__()
-        with self._caplog.at_level(logging.WARNING):
-            mock_command.assert_called_once_with(
-                ['losetup', '-d', '/dev/loop0']
-            )
-        self.loop.node_name = None
+    @patch('os.path.exists')
+    def test_context_manager_exit(self, mock_os_path_exists, mock_command_run):
+        mock_os_path_exists.return_value = True
+        mock_command_run.side_effect = Exception
+        with self._caplog.at_level(logging.ERROR):
+            with LoopDevice('loop-file', 20) as loop_provider:
+                loop_provider.node_name = '/dev/loop0'
+                with raises(Exception):
+                    loop_provider.create(overwrite=False)
+            assert mock_command_run.call_args_list == [
+                call(['losetup', '-f', '--show', 'loop-file']),
+                call(['losetup', '-d', '/dev/loop0'])
+            ]

--- a/test/unit/tasks/image_resize_test.py
+++ b/test/unit/tasks/image_resize_test.py
@@ -41,12 +41,8 @@ class TestImageResizeTask:
         self.firmware.get_partition_table_type = Mock(
             return_value='gpt'
         )
-        self.loop_provider = Mock()
         kiwi.tasks.image_resize.FirmWare = Mock(
             return_value=self.firmware
-        )
-        kiwi.tasks.image_resize.LoopDevice = Mock(
-            return_value=self.loop_provider
         )
 
         self.task = ImageResizeTask()
@@ -94,9 +90,14 @@ class TestImageResizeTask:
         with raises(KiwiSizeError):
             self.task.process()
 
+    @patch('kiwi.tasks.image_resize.LoopDevice')
     @patch('kiwi.tasks.image_resize.DiskFormat.new')
     @patch('kiwi.tasks.image_resize.Partitioner.new')
-    def test_process_image_resize_gb(self, mock_Partitioner, mock_DiskFormat):
+    def test_process_image_resize_gb(
+        self, mock_Partitioner, mock_DiskFormat, mock_LoopDevice
+    ):
+        loop_provider = Mock()
+        mock_LoopDevice.return_value.__enter__.return_value = loop_provider
         partitioner = Mock()
         mock_Partitioner.return_value = partitioner
         image_format = Mock()
@@ -105,16 +106,21 @@ class TestImageResizeTask:
         self._init_command_args()
         self.task.command_args['resize'] = True
         self.task.process()
-        self.loop_provider.create.assert_called_once_with(overwrite=False)
+        loop_provider.create.assert_called_once_with(overwrite=False)
         partitioner.resize_table.assert_called_once_with()
         image_format.resize_raw_disk.assert_called_once_with(
             42 * 1024 * 1024 * 1024
         )
         image_format.create_image_format.assert_called_once_with()
 
+    @patch('kiwi.tasks.image_resize.LoopDevice')
     @patch('kiwi.tasks.image_resize.DiskFormat.new')
     @patch('kiwi.tasks.image_resize.Partitioner.new')
-    def test_process_image_resize_mb(self, mock_Partitioner, mock_DiskFormat):
+    def test_process_image_resize_mb(
+        self, mock_Partitioner, mock_DiskFormat, mock_LoopDevice
+    ):
+        loop_provider = Mock()
+        mock_LoopDevice.return_value.__enter__.return_value = loop_provider
         partitioner = Mock()
         mock_Partitioner.return_value = partitioner
         image_format = Mock()
@@ -124,18 +130,21 @@ class TestImageResizeTask:
         self.task.command_args['resize'] = True
         self.task.command_args['--size'] = '42m'
         self.task.process()
-        self.loop_provider.create.assert_called_once_with(overwrite=False)
+        loop_provider.create.assert_called_once_with(overwrite=False)
         partitioner.resize_table.assert_called_once_with()
         image_format.resize_raw_disk.assert_called_once_with(
             42 * 1024 * 1024
         )
         image_format.create_image_format.assert_called_once_with()
 
+    @patch('kiwi.tasks.image_resize.LoopDevice')
     @patch('kiwi.tasks.image_resize.DiskFormat.new')
     @patch('kiwi.tasks.image_resize.Partitioner.new')
     def test_process_image_resize_bytes(
-        self, mock_Partitioner, mock_DiskFormat
+        self, mock_Partitioner, mock_DiskFormat, mock_LoopDevice
     ):
+        loop_provider = Mock()
+        mock_LoopDevice.return_value.__enter__.return_value = loop_provider
         partitioner = Mock()
         mock_Partitioner.return_value = partitioner
         image_format = Mock()
@@ -145,18 +154,21 @@ class TestImageResizeTask:
         self.task.command_args['resize'] = True
         self.task.command_args['--size'] = '42'
         self.task.process()
-        self.loop_provider.create.assert_called_once_with(overwrite=False)
+        loop_provider.create.assert_called_once_with(overwrite=False)
         partitioner.resize_table.assert_called_once_with()
         image_format.resize_raw_disk.assert_called_once_with(
             42
         )
         image_format.create_image_format.assert_called_once_with()
 
+    @patch('kiwi.tasks.image_resize.LoopDevice')
     @patch('kiwi.tasks.image_resize.DiskFormat.new')
     @patch('kiwi.tasks.image_resize.Partitioner.new')
     def test_process_image_resize_not_needed(
-        self, mock_Partitioner, mock_DiskFormat
+        self, mock_Partitioner, mock_DiskFormat, mock_LoopDevice
     ):
+        loop_provider = Mock()
+        mock_LoopDevice.return_value.__enter__.return_value = loop_provider
         partitioner = Mock()
         mock_Partitioner.return_value = partitioner
         image_format = Mock()
@@ -167,7 +179,7 @@ class TestImageResizeTask:
         self.task.command_args['--size'] = '42'
         with self._caplog.at_level(logging.INFO):
             self.task.process()
-            self.loop_provider.create.assert_called_once_with(overwrite=False)
+            loop_provider.create.assert_called_once_with(overwrite=False)
             partitioner.resize_table.assert_called_once_with()
             image_format.resize_raw_disk.assert_called_once_with(
                 42


### PR DESCRIPTION
Change the LoopDevice class to be a context manager. All code using LoopDevice was updated to the following
with statement:
   
```python
with LoopDevice(...) as loop_provider:
    loop_provider.some_member()
```
    
This is related to Issue #2412
