### PR TITLE
Use obsrepositories for the CentOS 9 image

### DIFF
--- a/build-tests/x86/centos/test-image-live-disk-v9/appliance.kiwi
+++ b/build-tests/x86/centos/test-image-live-disk-v9/appliance.kiwi
@@ -51,23 +51,8 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" alias="kiwi-next-generation" priority="1">
-        <source path="obs://Virtualization:Appliances:Staging/CentOS_9"/>
-    </repository>
-    <repository type="rpm-md">
-        <source path="obs://Fedora:EPEL:9/next"/>
-    </repository>
-    <repository type="rpm-md">
-        <source path="obs://Fedora:EPEL:9/standard"/>
-    </repository>
-    <repository type="rpm-md">
-        <source path="obs://CentOS:CentOS-9:Stream/crb"/>
-    </repository>
-    <repository type="rpm-md">
-        <source path="obs://CentOS:CentOS-9:Stream/appstream"/>
-    </repository>
-    <repository type="rpm-md">
-        <source path="obs://CentOS:CentOS-9:Stream/baseos"/>
+    <repository type="rpm-md" priority="1">
+        <source path='obsrepositories:/'/>
     </repository>
     <packages type="image">
         <package name="syslinux"/>


### PR DESCRIPTION
We were relying on the repos being parsed from the kiwi description but this can cause problems and gives us less flexibility when it comes to fixing repository setup issues.

This fixes https://github.com/OSInside/kiwi/issues/2335
