### PR TITLE
Move FileSystem to context manager

### DIFF
--- a/.github/workflows/ci-kiwi-9-compliant.yml
+++ b/.github/workflows/ci-kiwi-9-compliant.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run rebase
-        run: git fetch --all; git config user.email rebase@action.com; git config user.name git_action; git checkout master; git cherry-pick "origin/main..origin/${GITHUB_HEAD_REF}"
+        run: git fetch --all; git config user.email cherrypick@action.com; git config user.name git_action; git checkout master; git log --pretty=oneline --no-merges "origin/master..origin/${GITHUB_HEAD_REF}" | cut -f1 -d " " | head -n -1 > commit.list; git cherry-pick $(tac commit.list | tr "\n" " ")

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -129,7 +129,8 @@ class DiskBuilder:
         self.use_disk_password = \
             xml_state.get_build_type_bootloader_use_disk_password()
         self.integrity_root = xml_state.build_type.get_standalone_integrity()
-        self.integrity_legacy_hmac = xml_state.build_type.get_integrity_legacy_hmac()
+        self.integrity_legacy_hmac = \
+            xml_state.build_type.get_integrity_legacy_hmac()
         self.integrity_keyfile = xml_state.build_type.get_integrity_keyfile()
         self.integrity_key_description = \
             xml_state.build_type.get_integrity_metadata_key_description()
@@ -444,144 +445,65 @@ class DiskBuilder:
                     self.requested_filesystem
                 )
                 volume_manager.mount_volumes()
-                system = volume_manager
                 device_map['root'] = volume_manager.get_device().get('root')
                 device_map['swap'] = volume_manager.get_device().get('swap')
+                system = volume_manager
             else:
                 if not self.root_filesystem_is_overlay or \
                    self.root_filesystem_has_write_partition is not False:
                     log.info(
-                        'Creating root(%s) filesystem on %s',
-                        self.requested_filesystem, device_map['root'].get_device()
+                        'Creating root({0}) filesystem on {1}'.format(
+                            self.requested_filesystem,
+                            device_map['root'].get_device()
+                        )
                     )
                     filesystem_custom_parameters = {
                         'mount_options': self.custom_root_mount_args,
                         'create_options': self.custom_root_creation_args
                     }
-                    filesystem = FileSystem.new(
+                    with FileSystem.new(
                         self.requested_filesystem, device_map['root'],
                         self.root_dir + '/',
                         filesystem_custom_parameters
-                    )
-                    if self.root_filesystem_embed_integrity_metadata:
-                        filesystem.create_on_device(
-                            label=self.disk_setup.get_root_label(),
-                            size=-defaults.DM_METADATA_OFFSET,
-                            unit=defaults.UNIT.byte
-                        )
-                    else:
-                        filesystem.create_on_device(
-                            label=self.disk_setup.get_root_label(),
-                        )
-                    system = filesystem
+                    ) as filesystem:
+                        if self.root_filesystem_embed_integrity_metadata:
+                            filesystem.create_on_device(
+                                label=self.disk_setup.get_root_label(),
+                                size=-defaults.DM_METADATA_OFFSET,
+                                unit=defaults.UNIT.byte
+                            )
+                        else:
+                            filesystem.create_on_device(
+                                label=self.disk_setup.get_root_label(),
+                            )
+                        system = filesystem
 
-            # create swap on current root device if requested
-            if self.swap_mbytes:
-                swap = FileSystem.new(
-                    'swap', device_map['swap']
+            # sync system data, configure system, setup loader and initrd
+            try:
+                self._build_main_system(
+                    device_map,
+                    disk,
+                    system,
+                    system_boot,
+                    system_efi,
+                    system_spare,
+                    system_custom_parts,
+                    luks_root,
+                    raid_root
                 )
-                swap.create_on_device(
-                    label='SWAP'
-                )
-
-            # store root partition/filesystem uuid for profile
-            self._preserve_root_partition_uuid(device_map)
-            self._preserve_root_filesystem_uuid(device_map)
-
-            # create a random image identifier
-            self.mbrid = SystemIdentifier()
-            self.mbrid.calculate_id()
-
-            # create first stage metadata to boot image
-            self._write_partition_id_config_to_boot_image(disk)
-
-            self._write_recovery_metadata_to_boot_image()
-
-            self._write_raid_config_to_boot_image(raid_root)
-
-            self._write_generic_fstab_to_boot_image(device_map, system)
-
-            self.system_setup.export_modprobe_setup(
-                self.boot_image.boot_root_directory
-            )
-
-            # create first stage metadata to system image
-            self._write_image_identifier_to_system_image()
-
-            self._write_crypttab_to_system_image(luks_root)
-
-            self._write_integritytab_to_system_image(self.integrity_root)
-
-            self._write_generic_fstab_to_system_image(device_map, system)
-
-            if self.initrd_system == 'dracut':
-                if self.root_filesystem_is_multipath is False:
-                    self.boot_image.omit_module('multipath')
-                if self.root_filesystem_is_overlay:
-                    self.boot_image.include_module('kiwi-overlay')
-                    self.boot_image.write_system_config_file(
-                        config={'modules': ['kiwi-overlay']}
-                    )
-                if self.disk_resize_requested:
-                    self.boot_image.include_module('kiwi-repart')
-
-            # create initrd
-            if self.boot_image.has_initrd_support():
-                self.boot_image.create_initrd(self.mbrid)
-
-            # create second stage metadata to system image
-            self._copy_first_boot_files_to_system_image()
-
-            self._write_bootloader_meta_data_to_system_image(
-                device_map, disk, system
-            )
-
-            self.mbrid.write_to_disk(
-                disk.storage_provider
-            )
-
-            # run pre sync script hook
-            if self.system_setup.script_exists(
-                defaults.PRE_DISK_SYNC_SCRIPT
-            ):
-                disk_system = SystemSetup(
-                    self.xml_state, self.root_dir
-                )
-                disk_system.call_pre_disk_script()
-
-            # syncing system data to disk image
-            self._sync_system_to_image(
-                device_map, system, system_boot, system_efi, system_spare,
-                system_custom_parts
-            )
-
-            # run post sync script hook
-            if self.system_setup.script_exists(
-                defaults.POST_DISK_SYNC_SCRIPT
-            ):
-                image_system = ImageSystem(
-                    device_map, self.root_dir,
-                    system.get_volumes() if self.volume_manager_name else {}
-                )
-                image_system.mount()
-                disk_system = SystemSetup(
-                    self.xml_state, image_system.mountpoint()
-                )
-                try:
-                    disk_system.call_disk_script()
-                finally:
-                    image_system.umount()
-
-            # install boot loader
-            self._install_bootloader(device_map, disk, system)
-
-            # set root filesystem properties
-            self._setup_property_root_is_readonly_snapshot(system)
-
-            Result.verify_image_size(
-                self.runtime_config.get_max_size_constraint(),
-                self.diskname
-            )
+            finally:
+                for map_name in sorted(system_custom_parts.keys()):
+                    system_custom_parts[map_name].umount()
+                if system_efi:
+                    system_efi.umount()
+                if system_spare:
+                    system_spare.umount()
+                if system_boot:
+                    system_boot.umount()
+                if self.volume_manager_name:
+                    system.umount_volumes()
+                elif system:
+                    system.umount()
 
         # store image bundle_format in result
         if self.bundle_format:
@@ -718,6 +640,121 @@ class DiskBuilder:
 
         return result_instance
 
+    def _build_main_system(
+        self,
+        device_map: Dict,
+        disk: Disk,
+        system: Any,
+        system_boot: Optional[FileSystemBase],
+        system_efi: Optional[FileSystemBase],
+        system_spare: Optional[FileSystemBase],
+        system_custom_parts: Dict[str, FileSystemBase],
+        luks_root: Optional[LuksDevice] = None,
+        raid_root: Optional[RaidDevice] = None
+    ) -> None:
+        # create swap on current root device if requested
+        if self.swap_mbytes:
+            with FileSystem.new(
+                'swap', device_map['swap']
+            ) as swap:
+                swap.create_on_device(
+                    label='SWAP'
+                )
+
+        # store root partition/filesystem uuid for profile
+        self._preserve_root_partition_uuid(device_map)
+        self._preserve_root_filesystem_uuid(device_map)
+
+        # create a random image identifier
+        self.mbrid = SystemIdentifier()
+        self.mbrid.calculate_id()
+
+        # create first stage metadata to boot image
+        self._write_partition_id_config_to_boot_image(disk)
+
+        self._write_recovery_metadata_to_boot_image()
+
+        self._write_raid_config_to_boot_image(raid_root)
+
+        self._write_generic_fstab_to_boot_image(device_map, system)
+
+        self.system_setup.export_modprobe_setup(
+            self.boot_image.boot_root_directory
+        )
+
+        # create first stage metadata to system image
+        self._write_image_identifier_to_system_image()
+
+        self._write_crypttab_to_system_image(luks_root)
+
+        self._write_integritytab_to_system_image(self.integrity_root)
+
+        self._write_generic_fstab_to_system_image(device_map, system)
+
+        if self.initrd_system == 'dracut':
+            if self.root_filesystem_is_multipath is False:
+                self.boot_image.omit_module('multipath')
+            if self.root_filesystem_is_overlay:
+                self.boot_image.include_module('kiwi-overlay')
+                self.boot_image.write_system_config_file(
+                    config={'modules': ['kiwi-overlay']}
+                )
+            if self.disk_resize_requested:
+                self.boot_image.include_module('kiwi-repart')
+
+        # create initrd
+        if self.boot_image.has_initrd_support():
+            self.boot_image.create_initrd(self.mbrid)
+
+        # create second stage metadata to system image
+        self._copy_first_boot_files_to_system_image()
+
+        self._write_bootloader_meta_data_to_system_image(
+            device_map, disk, system
+        )
+
+        self.mbrid.write_to_disk(
+            disk.storage_provider
+        )
+
+        # run pre sync script hook
+        if self.system_setup.script_exists(
+            defaults.PRE_DISK_SYNC_SCRIPT
+        ):
+            disk_system = SystemSetup(
+                self.xml_state, self.root_dir
+            )
+            disk_system.call_pre_disk_script()
+
+        # syncing system data to disk image
+        self._sync_system_to_image(
+            device_map, system, system_boot, system_efi, system_spare,
+            system_custom_parts
+        )
+
+        # run post sync script hook
+        if self.system_setup.script_exists(
+            defaults.POST_DISK_SYNC_SCRIPT
+        ):
+            image_system = ImageSystem(
+                device_map, self.root_dir,
+                system.get_volumes() if self.volume_manager_name else {}
+            )
+            image_system.mount()
+            disk_system = SystemSetup(
+                self.xml_state, image_system.mountpoint()
+            )
+            try:
+                disk_system.call_disk_script()
+            finally:
+                image_system.umount()
+
+        # install boot loader
+        self._install_bootloader(device_map, disk, system)
+
+        # set root filesystem properties
+        self._setup_property_root_is_readonly_snapshot(system)
+
     def _install_image_requested(self) -> bool:
         return bool(
             self.install_iso or self.install_stick or self.install_pxe
@@ -768,39 +805,39 @@ class DiskBuilder:
                 if map_name in device_map:
                     ptable_entry = custom_partitions[map_name]
                     if ptable_entry.filesystem:
-                        filesystem = FileSystem.new(
+                        with FileSystem.new(
                             ptable_entry.filesystem,
                             device_map[map_name],
                             f'{self.root_dir}{ptable_entry.mountpoint}/'
-                        )
-                        if ptable_entry.filesystem == 'squashfs':
-                            squashed_root_file = Temporary().new_file()
-                            filesystem.create_on_file(
-                                filename=squashed_root_file.name,
-                                exclude=[Defaults.get_shared_cache_location()]
-                            )
-                            readonly_target = device_map[map_name].get_device()
-                            readonly_target_bytesize = device_map[map_name].get_byte_size(
-                                readonly_target
-                            )
-                            log.info(
-                                '--> Dumping {0!r} file({1} bytes) -> {2}({3} bytes)'.format(
-                                    map_name, os.path.getsize(squashed_root_file.name),
-                                    readonly_target, readonly_target_bytesize
+                        ) as filesystem:
+                            if ptable_entry.filesystem == 'squashfs':
+                                squashed_root_file = Temporary().new_file()
+                                filesystem.create_on_file(
+                                    filename=squashed_root_file.name,
+                                    exclude=[Defaults.get_shared_cache_location()]
                                 )
-                            )
-                            Command.run(
-                                [
-                                    'dd',
-                                    'if=%s' % squashed_root_file.name,
-                                    'of=%s' % readonly_target
-                                ]
-                            )
-                        else:
-                            filesystem.create_on_device(
-                                label=map_name.upper()
-                            )
-                        filesystem_dict[map_name] = filesystem
+                                readonly_target = device_map[map_name].get_device()
+                                readonly_target_bytesize = device_map[map_name].get_byte_size(
+                                    readonly_target
+                                )
+                                log.info(
+                                    '--> Dumping {0!r} file({1} bytes) -> {2}({3} bytes)'.format(
+                                        map_name, os.path.getsize(squashed_root_file.name),
+                                        readonly_target, readonly_target_bytesize
+                                    )
+                                )
+                                Command.run(
+                                    [
+                                        'dd',
+                                        'if=%s' % squashed_root_file.name,
+                                        'of=%s' % readonly_target
+                                    ]
+                                )
+                            else:
+                                filesystem.create_on_device(
+                                    label=map_name.upper()
+                                )
+                            filesystem_dict[map_name] = filesystem
         return filesystem_dict
 
     def _build_spare_filesystem(self, device_map: Dict) -> Optional[FileSystemBase]:
@@ -814,16 +851,16 @@ class DiskBuilder:
                 spare_part_data_path = self.root_dir + '{0}/'.format(
                     self.spare_part_mountpoint
                 )
-            filesystem = FileSystem.new(
+            with FileSystem.new(
                 self.spare_part_fs,
                 device_map['spare'],
                 spare_part_data_path,
                 spare_part_custom_parameters
-            )
-            filesystem.create_on_device(
-                label='SPARE'
-            )
-            return filesystem
+            ) as filesystem:
+                filesystem.create_on_device(
+                    label='SPARE'
+                )
+                return filesystem
         return None
 
     def _build_boot_filesystems(
@@ -836,13 +873,13 @@ class DiskBuilder:
                 'Creating EFI(fat16) filesystem on %s',
                 device_map['efi'].get_device()
             )
-            filesystem = FileSystem.new(
+            with FileSystem.new(
                 'fat16', device_map['efi'], self.root_dir + '/boot/efi/'
-            )
-            filesystem.create_on_device(
-                label=self.disk_setup.get_efi_label()
-            )
-            system_efi = filesystem
+            ) as filesystem:
+                filesystem.create_on_device(
+                    label=self.disk_setup.get_efi_label()
+                )
+                system_efi = filesystem
 
         if 'boot' in device_map:
             boot_filesystem = self.requested_boot_filesystem
@@ -855,13 +892,13 @@ class DiskBuilder:
                 'Creating boot(%s) filesystem on %s',
                 boot_filesystem, device_map['boot'].get_device()
             )
-            filesystem = FileSystem.new(
+            with FileSystem.new(
                 boot_filesystem, device_map['boot'], boot_directory
-            )
-            filesystem.create_on_device(
-                label=self.disk_setup.get_boot_label()
-            )
-            system_boot = filesystem
+            ) as filesystem:
+                filesystem.create_on_device(
+                    label=self.disk_setup.get_boot_label()
+                )
+                system_boot = filesystem
         return system_boot, system_efi
 
     def _build_and_map_disk_partitions(
@@ -934,17 +971,17 @@ class DiskBuilder:
             squashed_rootfs_mbsize = self.root_filesystem_read_only_partsize
             if not self.root_filesystem_read_only_partsize:
                 squashed_root_file = Temporary().new_file()
-                squashed_root = FileSystemSquashFs(
+                with FileSystemSquashFs(
                     device_provider=DeviceProvider(), root_dir=self.root_dir,
                     custom_args={
                         'compression':
                             self.xml_state.build_type.get_squashfscompression()
                     }
-                )
-                squashed_root.create_on_file(
-                    filename=squashed_root_file.name,
-                    exclude=[Defaults.get_shared_cache_location()]
-                )
+                ) as squashed_root:
+                    squashed_root.create_on_file(
+                        filename=squashed_root_file.name,
+                        exclude=[Defaults.get_shared_cache_location()]
+                    )
                 squashed_rootfs_mbsize = int(
                     os.path.getsize(squashed_root_file.name) / 1048576
                 ) + Defaults.get_min_partition_mbytes()
@@ -1367,52 +1404,54 @@ class DiskBuilder:
         log.info('--> Syncing root filesystem data')
         if self.root_filesystem_is_overlay:
             squashed_root_file = Temporary().new_file()
-            squashed_root = FileSystemSquashFs(
+            with FileSystemSquashFs(
                 device_provider=DeviceProvider(), root_dir=self.root_dir,
                 custom_args={
                     'compression':
                         self.xml_state.build_type.get_squashfscompression()
                 }
-            )
-            exclude_list = self._get_exclude_list_for_root_data_sync(device_map)
-            # To allow running custom scripts in a read-only root
-            # it's required to keep the /image mountpoint directory
-            # such that it can be bind mounted from the unpacked
-            # root tree
-            exclude_list.remove('image')
-            exclude_list.append('image/*')
-            squashed_root.create_on_file(
-                filename=squashed_root_file.name,
-                exclude=exclude_list
-            )
-
-            if self.root_filesystem_verity_blocks:
-                squashed_root.create_verity_layer(
-                    self.root_filesystem_verity_blocks if
-                    self.root_filesystem_verity_blocks != 'all' else None
+            ) as squashed_root:
+                exclude_list = self._get_exclude_list_for_root_data_sync(
+                    device_map
+                )
+                # To allow running custom scripts in a read-only root
+                # it's required to keep the /image mountpoint directory
+                # such that it can be bind mounted from the unpacked
+                # root tree
+                exclude_list.remove('image')
+                exclude_list.append('image/*')
+                squashed_root.create_on_file(
+                    filename=squashed_root_file.name,
+                    exclude=exclude_list
                 )
 
-            readonly_target = device_map['readonly'].get_device()
-            readonly_target_bytesize = device_map['readonly'].get_byte_size(
-                readonly_target
-            )
-            log.info(
-                '--> Dumping rootfs file({0} bytes) -> {1}({2} bytes)'.format(
-                    os.path.getsize(squashed_root_file.name),
-                    readonly_target, readonly_target_bytesize
-                )
-            )
-            Command.run(
-                [
-                    'dd',
-                    'if=%s' % squashed_root_file.name,
-                    'of=%s' % readonly_target
-                ]
-            )
-            if self.root_filesystem_embed_verity_metadata:
-                squashed_root.create_verification_metadata(
+                if self.root_filesystem_verity_blocks:
+                    squashed_root.create_verity_layer(
+                        self.root_filesystem_verity_blocks if
+                        self.root_filesystem_verity_blocks != 'all' else None
+                    )
+
+                readonly_target = device_map['readonly'].get_device()
+                readonly_target_bytesize = device_map['readonly'].get_byte_size(
                     readonly_target
                 )
+                log.info(
+                    '--> Dumping rootfs file({0} bytes) -> {1}({2} bytes)'.format(
+                        os.path.getsize(squashed_root_file.name),
+                        readonly_target, readonly_target_bytesize
+                    )
+                )
+                Command.run(
+                    [
+                        'dd',
+                        'if=%s' % squashed_root_file.name,
+                        'of=%s' % readonly_target
+                    ]
+                )
+                if self.root_filesystem_embed_verity_metadata:
+                    squashed_root.create_verification_metadata(
+                        readonly_target
+                    )
             if device_map.get('rootclone1'):
                 log.info(
                     '--> Dumping readonly root clone data at extra partition'
@@ -1441,24 +1480,24 @@ class DiskBuilder:
                     'mount_options': self.custom_root_mount_args,
                     'create_options': self.custom_root_creation_args
                 }
-                filesystem = FileSystem.new(
+                with FileSystem.new(
                     self.requested_filesystem, loop_provider,
                     self.root_dir + '/',
                     filesystem_custom_parameters
-                )
-                filesystem.create_on_device(
-                    label=self.disk_setup.get_root_label(),
-                    uuid=BlockID(root_target).get_uuid()
-                )
-                filesystem.sync_data(
-                    self._get_exclude_list_for_root_data_sync(device_map)
-                )
-                filesystem.umount()
+                ) as filesystem:
+                    filesystem.create_on_device(
+                        label=self.disk_setup.get_root_label(),
+                        uuid=BlockID(root_target).get_uuid()
+                    )
+                    filesystem.sync_data(
+                        self._get_exclude_list_for_root_data_sync(device_map)
+                    )
                 filesystem.create_verity_layer(
                     self.root_filesystem_verity_blocks if
                     self.root_filesystem_verity_blocks != 'all' else None,
                     verity_root_file.name
                 )
+
             log.info(
                 '--> Dumping rootfs file({0} bytes) -> {1}({2} bytes)'.format(
                     os.path.getsize(verity_root_file.name),

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -191,15 +191,15 @@ class InstallImageBuilder:
                 self.target_dir, '/', self.squashed_diskname, '.squashfs'
             ]
         )
-        squashed_image = FileSystemSquashFs(
+        with FileSystemSquashFs(
             device_provider=DeviceProvider(),
             root_dir=self.squashed_contents.name,
             custom_args={
                 'compression':
                     self.xml_state.build_type.get_squashfscompression()
             }
-        )
-        squashed_image.create_on_file(squashed_image_file)
+        ) as squashed_image:
+            squashed_image.create_on_file(squashed_image_file)
         Command.run(
             ['mv', squashed_image_file, self.media_dir.name]
         )
@@ -261,11 +261,11 @@ class InstallImageBuilder:
 
         # create iso filesystem from media_dir
         log.info('Creating ISO filesystem')
-        iso_image = FileSystemIsoFs(
+        with FileSystemIsoFs(
             device_provider=DeviceProvider(), root_dir=self.media_dir.name,
             custom_args=self.custom_iso_args
-        )
-        iso_image.create_on_file(self.isoname)
+        ) as iso_image:
+            iso_image.create_on_file(self.isoname)
         self.boot_image_task.cleanup()
 
     def create_install_pxe_archive(self) -> None:

--- a/kiwi/filesystem/base.py
+++ b/kiwi/filesystem/base.py
@@ -76,6 +76,9 @@ class FileSystemBase:
         self.post_init(custom_args)
         self.veritysetup: Optional[VeritySetup] = None
 
+    def __enter__(self):
+        return self
+
     def post_init(self, custom_args: Dict):
         """
         Post initialization method
@@ -174,7 +177,7 @@ class FileSystemBase:
 
     def sync_data(self, exclude: List[str] = []):
         """
-        Copy root data tree into filesystem
+        Copy data tree into filesystem
 
         :param list exclude: list of exclude dirs/files
         """
@@ -345,6 +348,5 @@ class FileSystemBase:
                     ]
                 )
 
-    def __del__(self):
-        log.info('Cleaning up %s instance', type(self).__name__)
+    def __exit__(self, exc_type, exc_value, traceback):
         self.umount()

--- a/kiwi/filesystem/base.py
+++ b/kiwi/filesystem/base.py
@@ -265,6 +265,56 @@ class FileSystemBase:
             log.info('umount %s instance', type(self).__name__)
             self.filesystem_mount.umount()
 
+    def umount_volumes(self) -> None:
+        """
+        Consistency layer with regards to VolumeManager classes
+
+        Invokes umount
+        """
+        self.umount()
+
+    def mount_volumes(self) -> None:
+        """
+        Consistency layer with regards to VolumeManager classes
+
+        Invokes mount
+        """
+        self.mount()
+
+    def get_volumes(self) -> Dict:
+        """
+        Consistency layer with regards to VolumeManager classes
+
+        Raises
+        """
+        raise NotImplementedError
+
+    def get_root_volume_name(self) -> None:
+        """
+        Consistency layer with regards to VolumeManager classes
+
+        Raises
+        """
+        raise NotImplementedError
+
+    def get_fstab(
+        self, persistency_type: str = 'by-label', filesystem_name: str = ''
+    ) -> List[str]:
+        """
+        Consistency layer with regards to VolumeManager classes
+
+        Raises
+        """
+        raise NotImplementedError
+
+    def set_property_readonly_root(self) -> None:
+        """
+        Consistency layer with regards to VolumeManager classes
+
+        Raises
+        """
+        raise NotImplementedError
+
     def _map_size(self, size: float, from_unit: str, to_unit: str) -> float:
         """
         Return byte size value for given size and unit

--- a/kiwi/storage/clone_device.py
+++ b/kiwi/storage/clone_device.py
@@ -65,9 +65,8 @@ class CloneDevice(DeviceProvider):
             if target_filesystem in Defaults.get_filesystem_image_types():
                 # Simple filesystem clones needs to be unique on the UUID
                 # to avoid conflicts on the running system
-                FileSystem.new(
-                    target_filesystem, target_device
-                ).set_uuid()
+                with FileSystem.new(target_filesystem, target_device) as fs:
+                    fs.set_uuid()
             elif target_filesystem == 'LVM2_member':
                 # Volume Group clones requires to be unique on the vgroup
                 # name to avoid conflicts on the running system
@@ -104,10 +103,11 @@ class CloneDevice(DeviceProvider):
                             md_name, md_device, target_device.get_device()
                         ]
                     )
-                    FileSystem.new(
+                    with FileSystem.new(
                         BlockID(md_device).get_filesystem(),
                         MappedDevice(md_device, target_device)
-                    ).set_uuid()
+                    ) as fs:
+                        fs.set_uuid()
                     Command.run(
                         ['mdadm', '--stop', md_device]
                     )

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -187,6 +187,22 @@ class VolumeManagerBase(DeviceProvider):
         """
         raise NotImplementedError
 
+    def umount(self):
+        """
+        Consistency layer with regards to FileSystem classes
+
+        Invokes umount_volumes
+        """
+        self.umount_volumes()
+
+    def mount(self):
+        """
+        Consistency layer with regards to FileSystem classes
+
+        Invokes mount_volumes
+        """
+        self.mount_volumes()
+
     def is_loop(self):
         """
         Check if storage provider is loop based

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -269,7 +269,9 @@ class VolumeManagerBtrfs(VolumeManagerBase):
                     volume_mount
                 )
 
-    def get_fstab(self, persistency_type='by-label', filesystem_name=None):
+    def get_fstab(
+        self, persistency_type: str = 'by-label', filesystem_name: str = ''
+    ) -> List[str]:
         """
         Implements creation of the fstab entries. The method
         returns a list of fstab compatible entries

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -109,16 +109,16 @@ class VolumeManagerBtrfs(VolumeManagerBase):
         """
         self.setup_mountpoint()
 
-        filesystem = FileSystem.new(
+        with FileSystem.new(
             name='btrfs',
             device_provider=MappedDevice(
                 device=self.device, device_provider=self.device_provider_root
             ),
             custom_args=self.custom_filesystem_args
-        )
-        filesystem.create_on_device(
-            label=self.custom_args['root_label']
-        )
+        ) as filesystem:
+            filesystem.create_on_device(
+                label=self.custom_args['root_label']
+            )
         self.toplevel_mount = MountManager(
             device=self.device, mountpoint=self.mountpoint
         )

--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -17,6 +17,9 @@
 #
 import os
 import logging
+from typing import (
+    Dict, List
+)
 
 # project
 import kiwi.defaults as defaults
@@ -228,7 +231,9 @@ class VolumeManagerLVM(VolumeManagerBase):
         for mount_path in Path.sort_by_hierarchy(sorted(volume_paths.keys())):
             self.mount_list.append(volume_paths[mount_path])
 
-    def get_fstab(self, persistency_type, filesystem_name):
+    def get_fstab(
+        self, persistency_type: str = 'by-label', filesystem_name: str = ''
+    ) -> List[str]:
         """
         Implements creation of the fstab entries. The method
         returns a list of fstab compatible entries
@@ -266,7 +271,7 @@ class VolumeManagerLVM(VolumeManagerBase):
 
         return fstab_entries
 
-    def get_volumes(self):
+    def get_volumes(self) -> Dict:
         """
         Return dict of volumes
 

--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -327,16 +327,16 @@ class VolumeManagerLVM(VolumeManagerBase):
             # perform a second lookup of a label specified via the
             # rootfs_label from the type setup
             volume_label = self.custom_args['root_label']
-        filesystem = FileSystem.new(
+        with FileSystem.new(
             name=filesystem_name,
             device_provider=MappedDevice(
                 device=device_node, device_provider=self.device_provider_root
             ),
             custom_args=self.custom_filesystem_args
-        )
-        filesystem.create_on_device(
-            label=volume_label
-        )
+        ) as filesystem:
+            filesystem.create_on_device(
+                label=volume_label
+            )
 
     def _add_to_mount_list(self, volume_name, realpath):
         device_node = self.volume_map[volume_name]

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -302,7 +302,7 @@ class TestDiskBuilder:
         mock_path.return_value = True
         mock_rand.return_value = 15
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.volume_manager_name = None
         self.disk_builder.initrd_system = 'kiwi'
 
@@ -448,7 +448,7 @@ class TestDiskBuilder:
         mock_path.return_value = True
         filesystem = Mock()
         filesystem.filename = ''
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.custom_partitions = {
             'var': ptable_entry_type(
                 mbsize=100,
@@ -513,7 +513,7 @@ class TestDiskBuilder:
         mock_path.return_value = True
         filesystem = Mock()
         filesystem.filename = ''
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.custom_partitions = {
             'var': ptable_entry_type(
                 mbsize=100,
@@ -609,7 +609,7 @@ class TestDiskBuilder:
         )
         mock_path.return_value = True
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.integrity_root = True
         self.disk_builder.integrity_legacy_hmac = True
         self.disk_builder.root_filesystem_embed_integrity_metadata = True
@@ -667,7 +667,7 @@ class TestDiskBuilder:
         mock_path.return_value = True
         mock_rand.return_value = 15
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.root_filesystem_verity_blocks = 10
         self.disk_builder.root_filesystem_embed_verity_metadata = True
         self.disk_builder.root_filesystem_is_overlay = False
@@ -864,7 +864,7 @@ class TestDiskBuilder:
         self.disk_builder.root_filesystem_embed_integrity_metadata = True
         self.disk_builder.volume_manager_name = None
         squashfs = Mock()
-        mock_squashfs.return_value = squashfs
+        mock_squashfs.return_value.__enter__.return_value = squashfs
         mock_getsize.return_value = 1048576
         tempfile = Mock()
         tempfile.name = 'kiwi-tempname'
@@ -953,7 +953,7 @@ class TestDiskBuilder:
         self, mock_command, mock_fs
     ):
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.volume_manager_name = None
         self.disk_builder.xen_server = True
         self.firmware.efi_mode = Mock(
@@ -975,7 +975,7 @@ class TestDiskBuilder:
     ):
         self.disk_builder.arch = 's390x'
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.volume_manager_name = None
         self.firmware.efi_mode = Mock(
             return_value=False
@@ -994,7 +994,7 @@ class TestDiskBuilder:
         self, mock_grub_dir, mock_command, mock_fs
     ):
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.volume_manager_name = None
         self.firmware.efi_mode = Mock(
             return_value='uefi'
@@ -1012,7 +1012,7 @@ class TestDiskBuilder:
         self, mock_grub_dir, mock_command, mock_fs
     ):
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.volume_manager_name = None
         self.disk_builder.mdraid = 'mirroring'
         self.disk.public_partition_id_map = self.id_map
@@ -1041,7 +1041,7 @@ class TestDiskBuilder:
         self, mock_grub_dir, mock_command, mock_fs
     ):
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.volume_manager_name = None
         self.disk_builder.luks = 'passphrase'
         self.disk_setup.need_boot_partition.return_value = False
@@ -1081,7 +1081,7 @@ class TestDiskBuilder:
         self, mock_BootLoaderInstall, mock_grub_dir, mock_command, mock_fs
     ):
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.volume_manager_name = None
         self.disk_builder.luks = 'passphrase'
         self.disk_builder.use_disk_password = True
@@ -1174,7 +1174,7 @@ class TestDiskBuilder:
         self.disk_builder.volume_manager_name = None
 
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
 
         with patch('builtins.open'):
             self.disk_builder.create_disk()
@@ -1232,7 +1232,7 @@ class TestDiskBuilder:
         )
         mock_volume_manager.return_value = volume_manager
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.volume_manager_name = 'btrfs'
         self.disk_builder.btrfs_default_volume_requested = False
 
@@ -1266,7 +1266,7 @@ class TestDiskBuilder:
         )
         mock_volume_manager.return_value = volume_manager
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.volume_manager_name = 'lvm'
 
         with patch('builtins.open'):
@@ -1305,7 +1305,7 @@ class TestDiskBuilder:
         self, mock_grub_dir, mock_command, mock_fs
     ):
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.volume_manager_name = None
         self.disk_builder.install_media = False
         self.disk_builder.hybrid_mbr = True
@@ -1322,7 +1322,7 @@ class TestDiskBuilder:
         self, mock_grub_dir, mock_command, mock_fs
     ):
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.volume_manager_name = None
         self.disk_builder.install_media = False
         self.disk_builder.force_mbr = True
@@ -1339,7 +1339,7 @@ class TestDiskBuilder:
         self, mock_grub_dir, mock_command, mock_fs
     ):
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.volume_manager_name = None
         self.disk_builder.install_media = False
         self.disk_builder.disk_start_sector = 4096
@@ -1378,7 +1378,7 @@ class TestDiskBuilder:
         self, mock_grub_dir, mock_command, mock_fs
     ):
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.volume_manager_name = None
         self.disk_builder.install_media = False
         self.disk_builder.spare_part_mbsize = 42
@@ -1451,7 +1451,7 @@ class TestDiskBuilder:
         mock_DiskFormat.return_value = disk_subformat
         result_instance = Mock()
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.disk_builder.install_media = False
         self.disk_builder.image_format = 'vmdk'
 

--- a/test/unit/builder/filesystem_test.py
+++ b/test/unit/builder/filesystem_test.py
@@ -95,7 +95,7 @@ class TestFileSystemBuilder:
     ):
         Defaults.set_platform_name('x86_64')
         mock_fs_setup.return_value = self.fs_setup
-        mock_fs.return_value = self.filesystem
+        mock_fs.return_value.__enter__.return_value = self.filesystem
         loop_provider = Mock()
         loop_provider.get_device = Mock(
             return_value='/dev/loop1'
@@ -135,7 +135,7 @@ class TestFileSystemBuilder:
         Defaults.set_platform_name('x86_64')
         provider = Mock()
         mock_provider.return_value = provider
-        mock_fs.return_value = self.filesystem
+        mock_fs.return_value.__enter__.return_value = self.filesystem
         self.xml_state.get_build_type_name = Mock(
             return_value='squashfs'
         )

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -198,7 +198,7 @@ class TestLiveImageBuilder:
         tmpdir_name = [temp_squashfs, temp_media_dir]
 
         filesystem = Mock()
-        mock_filesystem.return_value = filesystem
+        mock_filesystem.return_value.__enter__.return_value = filesystem
 
         def side_effect():
             return tmpdir_name.pop()
@@ -210,7 +210,7 @@ class TestLiveImageBuilder:
 
         iso_image = Mock()
         iso_image.create_on_file.return_value = 'offset'
-        mock_isofs.return_value = iso_image
+        mock_isofs.return_value.__enter__.return_value = iso_image
 
         rootsize = Mock()
         rootsize.accumulate_mbyte_file_sizes = Mock(

--- a/test/unit/filesystem/base_test.py
+++ b/test/unit/filesystem/base_test.py
@@ -111,11 +111,39 @@ class TestFileSystemBase:
         self.fsbase.umount()
         mount.umount.assert_called_once_with()
 
+    def test_umount_volumes(self):
+        mount = Mock()
+        self.fsbase.filesystem_mount = mount
+        self.fsbase.umount_volumes()
+        mount.umount.assert_called_once_with()
+
     def test_mount(self):
         mount = Mock()
         self.fsbase.filesystem_mount = mount
         self.fsbase.mount()
         mount.mount.assert_called_once_with([])
+
+    def test_mount_volumes(self):
+        mount = Mock()
+        self.fsbase.filesystem_mount = mount
+        self.fsbase.mount_volumes()
+        mount.mount.assert_called_once_with([])
+
+    def test_get_volumes(self):
+        with raises(NotImplementedError):
+            self.fsbase.get_volumes()
+
+    def test_get_root_volume_name(self):
+        with raises(NotImplementedError):
+            self.fsbase.get_root_volume_name()
+
+    def test_get_fstab(self):
+        with raises(NotImplementedError):
+            self.fsbase.get_fstab()
+
+    def test_set_property_readonly_root(self):
+        with raises(NotImplementedError):
+            self.fsbase.set_property_readonly_root()
 
     def test_fs_size(self):
         # size of 100k must be 100k (default unit)

--- a/test/unit/storage/clone_device_test.py
+++ b/test/unit/storage/clone_device_test.py
@@ -41,7 +41,8 @@ class TestCloneDevice:
         mock_FileSystem_new.assert_called_once_with(
             'ext3', self.target_device
         )
-        mock_FileSystem_new.return_value.set_uuid.assert_called_once_with()
+        mock_FileSystem_new.return_value.__enter__ \
+            .return_value.set_uuid.assert_called_once_with()
 
     @patch('kiwi.storage.clone_device.Command.run')
     @patch('kiwi.storage.clone_device.BlockID')
@@ -106,7 +107,8 @@ class TestCloneDevice:
             mock_BlockID.return_value.get_filesystem.return_value,
             mock_MappedDevice.return_value
         )
-        mock_FileSystem_new.return_value.set_uuid.assert_called_once_with()
+        mock_FileSystem_new.return_value.__enter__ \
+            .return_value.set_uuid.assert_called_once_with()
         assert mock_Command_run.call_args_list == [
             call(
                 ['dd', 'if=/dev/source-device', 'of=/dev/target-device']

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -213,9 +213,17 @@ class TestVolumeManagerBase:
         with raises(NotImplementedError):
             self.volume_manager.mount_volumes()
 
+    def test_mount(self):
+        with raises(NotImplementedError):
+            self.volume_manager.mount()
+
     def test_umount_volumes(self):
         with raises(NotImplementedError):
             self.volume_manager.umount_volumes()
+
+    def test_umount(self):
+        with raises(NotImplementedError):
+            self.volume_manager.umount()
 
     def test_get_volumes(self):
         with raises(NotImplementedError):

--- a/test/unit/volume_manager/lvm_test.py
+++ b/test/unit/volume_manager/lvm_test.py
@@ -161,7 +161,7 @@ class TestVolumeManagerLVM:
 
         mock_os_exists.side_effect = mock_os_exists_return
         filesystem = Mock()
-        mock_fs.return_value = filesystem
+        mock_fs.return_value.__enter__.return_value = filesystem
         self.volume_manager.mountpoint = 'tmpdir'
         mock_mapped_device.return_value = 'mapped_device'
         size = Mock()


### PR DESCRIPTION
Change the FileSystem class to be a context manager. All code using FileSystem was updated to the following with statement:

with FileSystem.new(...) as filesystem:
    filesystem.some_member()

This is related to Issue #2412

