### PR TITLE
Follow up fix for drop of hybrid boot snippets

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -174,13 +174,10 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 )
 
         if self.xml_state.is_xen_server():
-            self.hybrid_boot = False
             self.multiboot = True
         elif self.xen_guest:
-            self.hybrid_boot = False
             self.multiboot = False
         else:
-            self.hybrid_boot = True
             self.multiboot = False
 
         self.grub2 = BootLoaderTemplateGrub2()
@@ -377,9 +374,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
         else:
             log.info('--> Using standard boot install template')
-            hybrid_boot = True
             template = self.grub2.get_install_template(
-                self.failsafe_boot, hybrid_boot, has_graphics, has_serial,
+                self.failsafe_boot, has_graphics, has_serial,
                 self.continue_on_timeout
             )
         try:
@@ -449,10 +445,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
         else:
             log.info('--> Using standard boot template')
-            hybrid_boot = True
             template = self.grub2.get_iso_template(
-                self.failsafe_boot, hybrid_boot,
-                has_graphics, has_serial, self.mediacheck_boot
+                self.failsafe_boot, has_graphics, has_serial,
+                self.mediacheck_boot
             )
         try:
             self.config = template.substitute(parameters)

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -898,7 +898,7 @@ class TestBootLoaderConfigGrub2:
         self.bootloader.multiboot = False
         self.bootloader.setup_live_image_config(self.mbrid)
         self.grub2.get_iso_template.assert_called_once_with(
-            True, True, True, True, None
+            True, True, True, None
         )
         mock_copy_grub_config_to_efi_path.assert_called_once_with(
             'root_dir', 'earlyboot.cfg', 'iso'
@@ -1031,7 +1031,7 @@ class TestBootLoaderConfigGrub2:
         self.bootloader.multiboot = False
         self.bootloader.setup_install_image_config(self.mbrid)
         self.grub2.get_install_template.assert_called_once_with(
-            True, True, False, False, True
+            True, False, False, True
         )
         mock_copy_grub_config_to_efi_path.assert_called_once_with(
             'root_dir', 'earlyboot.cfg', 'iso'


### PR DESCRIPTION
The following is left over code from the drop of the hybrid boot templates.

