### PR TITLE
Refactor disk builder for use with context manager

### DIFF
--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -93,7 +93,8 @@ class BootLoaderConfigBase:
         pass
 
     def setup_disk_image_config(
-        self, boot_uuid, root_uuid, hypervisor, kernel, initrd, boot_options={}
+        self, boot_uuid=None, root_uuid=None, hypervisor=None,
+        kernel=None, initrd=None, boot_options={}
     ):
         """
         Create boot config file to boot from disk.

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -610,7 +610,7 @@ class TestDiskBuilder:
         mock_path.return_value = True
         filesystem = Mock()
         mock_fs.return_value.__enter__.return_value = filesystem
-        self.disk_builder.integrity_root = True
+        self.disk_builder.integrity = True
         self.disk_builder.integrity_legacy_hmac = True
         self.disk_builder.root_filesystem_embed_integrity_metadata = True
         self.disk_builder.root_filesystem_is_overlay = False
@@ -860,7 +860,7 @@ class TestDiskBuilder:
         self.disk_builder.root_filesystem_has_write_partition = False
         self.disk_builder.root_filesystem_verity_blocks = 10
         self.disk_builder.root_filesystem_embed_verity_metadata = True
-        self.disk_builder.integrity_root = True
+        self.disk_builder.integrity = True
         self.disk_builder.root_filesystem_embed_integrity_metadata = True
         self.disk_builder.volume_manager_name = None
         squashfs = Mock()


### PR DESCRIPTION
In preparation to further context manager related changes in VolumeManager, LuksDevice, RaidDevice and more the disk builder code which uses these classes needs to be refactored beforehand to allow switching to context manager based cascading of the storage device classes. This commit does the refactoring and is related to Issue #2412


