### PR TITLE
Support for new shellcheck

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -76,7 +76,7 @@ function get_disk_list {
             continue
         fi
         disk_size=$(echo "${disk_meta}" | cut -f2 -d:)
-        if [ ${max_disk} -gt 0 ]; then
+        if [ "${max_disk}" -gt 0 ]; then
             local disk_size_bytes
             disk_size_bytes=$(binsize_to_bytesize "${disk_size}") || \
                 disk_size_bytes=0

--- a/dracut/modules.d/99kiwi-lib/kiwi-filesystem-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-filesystem-lib.sh
@@ -112,7 +112,7 @@ function probe_filesystem {
     if [ "${fstype}" = "crypto_LUKS" ];then
         fstype=luks
     fi
-    echo ${fstype}
+    echo "${fstype}"
 }
 
 #======================================

--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -178,7 +178,7 @@ function create_dasd_partitions {
             echo >> ${partition_setup_file}
             continue
         fi
-        echo $cmd >> ${partition_setup_file}
+        echo "$cmd" >> ${partition_setup_file}
     done
     echo "w" >> ${partition_setup_file}
     echo "q" >> ${partition_setup_file}

--- a/tox.ini
+++ b/tox.ini
@@ -215,8 +215,8 @@ commands =
     flake8 --statistics -j auto --count {toxinidir}/kiwi
     flake8 --statistics -j auto --count {toxinidir}/test/unit
     flake8 --statistics -j auto --count {toxinidir}/test/scripts
-    bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174,SC1117,SC2048 {toxinidir}/dracut/modules.d/*/*.sh -s bash'
-    bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174,SC1117,SC2048 {toxinidir}/kiwi/config/functions.sh -s bash'
+    bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174,SC1117,SC2048,SC2004 {toxinidir}/dracut/modules.d/*/*.sh -s bash'
+    bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174,SC1117,SC2048,SC2004 {toxinidir}/kiwi/config/functions.sh -s bash'
 
 
 # PyPi upload


### PR DESCRIPTION
The ubuntu builders use Shellcheck 0.8.0, but 0.9.0 introduces additional errors. They are fixed/silenced via this PR.