### PR TITLE
convert BootLoaderConfig to an abstract base class

### DIFF
--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+from abc import ABC, abstractmethod
 import os
 import re
 import logging
@@ -34,7 +35,7 @@ from kiwi.exceptions import (
 log = logging.getLogger('kiwi')
 
 
-class BootLoaderConfigBase:
+class BootLoaderConfigBase(ABC):
     """
     **Base class for bootloader configuration**
 
@@ -73,13 +74,13 @@ class BootLoaderConfigBase:
         """
         self.custom_args = custom_args
 
+    @abstractmethod
     def write(self):
         """
         Write config data to config file.
 
         Implementation in specialized bootloader class required
         """
-        raise NotImplementedError
 
     def write_meta_data(
         self, root_device=None, write_device=None, boot_options=''
@@ -95,6 +96,7 @@ class BootLoaderConfigBase:
         """
         pass
 
+    @abstractmethod
     def setup_disk_image_config(
         self, boot_uuid=None, root_uuid=None, hypervisor=None,
         kernel=None, initrd=None, boot_options={}
@@ -119,8 +121,8 @@ class BootLoaderConfigBase:
 
         Implementation in specialized bootloader class required
         """
-        raise NotImplementedError
 
+    @abstractmethod
     def setup_install_image_config(
         self, mbrid, hypervisor, kernel, initrd
     ):
@@ -134,8 +136,8 @@ class BootLoaderConfigBase:
 
         Implementation in specialized bootloader class required
         """
-        raise NotImplementedError
 
+    @abstractmethod
     def setup_live_image_config(
         self, mbrid, hypervisor, kernel, initrd
     ):
@@ -149,8 +151,8 @@ class BootLoaderConfigBase:
 
         Implementation in specialized bootloader class required
         """
-        raise NotImplementedError
 
+    @abstractmethod
     def setup_disk_boot_images(self, boot_uuid, lookup_path=None):
         """
         Create bootloader images for disk boot
@@ -164,8 +166,8 @@ class BootLoaderConfigBase:
 
         Implementation in specialized bootloader class required
         """
-        raise NotImplementedError
 
+    @abstractmethod
     def setup_install_boot_images(self, mbrid, lookup_path=None):
         """
         Create bootloader images for ISO boot an install media
@@ -175,8 +177,8 @@ class BootLoaderConfigBase:
 
         Implementation in specialized bootloader class required
         """
-        raise NotImplementedError
 
+    @abstractmethod
     def setup_live_boot_images(self, mbrid, lookup_path=None):
         """
         Create bootloader images for ISO boot a live ISO image
@@ -186,8 +188,8 @@ class BootLoaderConfigBase:
 
         Implementation in specialized bootloader class required
         """
-        raise NotImplementedError
 
+    @abstractmethod
     def setup_sysconfig_bootloader(self):
         """
         Create or update etc/sysconfig/bootloader by parameters
@@ -195,7 +197,6 @@ class BootLoaderConfigBase:
 
         Implementation in specialized bootloader class required
         """
-        raise NotImplementedError
 
     def create_efi_path(self, in_sub_dir='boot/efi'):
         """

--- a/kiwi/bootloader/config/bootloader_spec_base.py
+++ b/kiwi/bootloader/config/bootloader_spec_base.py
@@ -21,6 +21,7 @@ from typing import (
 
 # project
 from kiwi.bootloader.config.base import BootLoaderConfigBase
+from kiwi.system.identifier import SystemIdentifier
 
 target_type = NamedTuple(
     'target_type', [
@@ -110,7 +111,7 @@ class BootLoaderSpecBase(BootLoaderConfigBase):
         self.setup_loader(self.target.disk)
 
     def setup_install_image_config(
-        self, mbrid: str, hypervisor: str = '',
+        self, mbrid: SystemIdentifier, hypervisor: str = '',
         kernel: str = '', initrd: str = ''
     ) -> None:
         """
@@ -126,7 +127,7 @@ class BootLoaderSpecBase(BootLoaderConfigBase):
         pass
 
     def setup_live_image_config(
-        self, mbrid: str, hypervisor: str = '',
+        self, mbrid: SystemIdentifier, hypervisor: str = '',
         kernel: str = '', initrd: str = ''
     ) -> None:
         """
@@ -155,7 +156,7 @@ class BootLoaderSpecBase(BootLoaderConfigBase):
         self.create_loader_image(self.target.disk)
 
     def setup_install_boot_images(
-        self, mbrid: str, lookup_path: str = ''
+        self, mbrid: SystemIdentifier, lookup_path: str = ''
     ) -> None:
         """
         Create bootloader image(s) for install ISO boot
@@ -168,7 +169,7 @@ class BootLoaderSpecBase(BootLoaderConfigBase):
         self.create_loader_image(self.target.install)
 
     def setup_live_boot_images(
-        self, mbrid: str, lookup_path: str = ''
+        self, mbrid: SystemIdentifier, lookup_path: str = ''
     ) -> None:
         """
         Create bootloader image(s) for live ISO boot

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -204,6 +204,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             with open(config_file, 'w') as config:
                 config.write(self.config)
 
+    def setup_sysconfig_bootloader(self):
+        raise NotImplementedError
+
     def write_meta_data(
         self, root_device=None, write_device=None, boot_options=''
     ):

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -31,6 +31,7 @@ from kiwi.defaults import Defaults
 from kiwi.exceptions import KiwiFileNotFound
 from kiwi.firmware import FirmWare
 from kiwi.path import Path
+from kiwi.system.identifier import SystemIdentifier
 from kiwi.utils.sync import DataSync
 from kiwi.utils.sysconfig import SysConfig
 
@@ -393,7 +394,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
 
     def setup_live_image_config(
-        self, mbrid, hypervisor='xen.gz', kernel='linux', initrd='initrd'
+        self, mbrid: SystemIdentifier, hypervisor='xen.gz', kernel='linux', initrd='initrd'
     ):
         """
         Create grub2 config file to boot a live media ISO image
@@ -463,7 +464,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 self.boot_dir, self.early_boot_script_efi, 'iso'
             )
 
-    def setup_install_boot_images(self, mbrid, lookup_path=None):
+    def setup_install_boot_images(self, mbrid: SystemIdentifier, lookup_path: str = None) -> None:
         """
         Create/Provide grub2 boot images and metadata
 
@@ -514,7 +515,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             loopback_file
         )
 
-    def setup_live_boot_images(self, mbrid, lookup_path=None):
+    def setup_live_boot_images(self, mbrid: SystemIdentifier, lookup_path=None):
         """
         Create/Provide grub2 boot images and metadata
 

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -36,7 +36,7 @@ from kiwi.system.mount import ImageSystem
 from kiwi.storage.disk import ptable_entry_type
 from kiwi.defaults import Defaults
 from kiwi.filesystem.base import FileSystemBase
-from kiwi.bootloader.config import BootLoaderConfig
+from kiwi.bootloader.config import create_boot_loader_config
 from kiwi.bootloader.config.base import BootLoaderConfigBase
 from kiwi.bootloader.install import BootLoaderInstall
 from kiwi.system.identifier import SystemIdentifier
@@ -514,9 +514,9 @@ class DiskBuilder:
         )
 
     def _bootloader_instance(self, disk: Disk) -> BootLoaderConfigBase:
-        return BootLoaderConfig.new(
-            self.bootloader,
-            self.xml_state,
+        return create_boot_loader_config(
+            name=self.bootloader,
+            xml_state=self.xml_state,
             root_dir=self.root_dir,
             boot_dir=self.root_dir,
             custom_args={

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -28,7 +28,7 @@ from kiwi.command import Command
 from kiwi.storage.device_provider import DeviceProvider
 from kiwi.boot.image.base import BootImageBase
 from kiwi.boot.image import BootImage
-from kiwi.bootloader.config import BootLoaderConfig
+from kiwi.bootloader.config import create_boot_loader_config
 from kiwi.filesystem.squashfs import FileSystemSquashFs
 from kiwi.filesystem.isofs import FileSystemIsoFs
 from kiwi.firmware import FirmWare
@@ -357,8 +357,9 @@ class InstallImageBuilder:
         self.boot_image_task.cleanup()
 
     def _create_bootloader_instance(self):
-        return BootLoaderConfig.new(
-            self.bootloader, self.xml_state, root_dir=self.root_dir,
+        return create_boot_loader_config(
+            name=self.bootloader, xml_state=self.xml_state,
+            root_dir=self.root_dir,
             boot_dir=self.media_dir.name, custom_args={
                 'grub_directory_name':
                     Defaults.get_grub_boot_directory_name(self.root_dir),

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -22,7 +22,7 @@ import shutil
 
 # project
 from kiwi.utils.temporary import Temporary
-from kiwi.bootloader.config import BootLoaderConfig
+from kiwi.bootloader.config import create_boot_loader_config
 from kiwi.bootloader.config.base import BootLoaderConfigBase
 from kiwi.filesystem import FileSystem
 from kiwi.filesystem.isofs import FileSystemIsoFs
@@ -344,8 +344,9 @@ class LiveImageBuilder:
         return self.result
 
     def _create_bootloader_instance(self) -> BootLoaderConfigBase:
-        return BootLoaderConfig.new(
-            self.bootloader, self.xml_state, root_dir=self.root_dir,
+        return create_boot_loader_config(
+            name=self.bootloader, xml_state=self.xml_state,
+            root_dir=self.root_dir,
             boot_dir=self.media_dir.name, custom_args={
                 'grub_directory_name':
                     Defaults.get_grub_boot_directory_name(self.root_dir),

--- a/test/unit/bootloader/config/base_test.py
+++ b/test/unit/bootloader/config/base_test.py
@@ -13,6 +13,38 @@ from kiwi.exceptions import KiwiBootLoaderTargetError
 from kiwi.bootloader.config.base import BootLoaderConfigBase
 
 
+class BootLoaderConfigTestImpl(BootLoaderConfigBase):
+    def setup_install_image_config(self, mbrid, hypervisor, kernel, initrd):
+        return super().setup_install_image_config(mbrid, hypervisor, kernel, initrd)
+
+    def setup_disk_image_config(
+            self, boot_uuid=None, root_uuid=None, hypervisor=None, kernel=None,
+            initrd=None, boot_options=...):
+        return super().setup_disk_image_config(
+            boot_uuid, root_uuid, hypervisor, kernel, initrd, boot_options
+        )
+
+    def write(self):
+        return super().write()
+
+    def setup_live_image_config(self, mbrid, hypervisor, kernel, initrd):
+        return super().setup_live_image_config(
+            mbrid, hypervisor, kernel, initrd
+        )
+
+    def setup_install_boot_images(self, mbrid, lookup_path=None):
+        return super().setup_install_boot_images(mbrid, lookup_path)
+
+    def setup_disk_boot_images(self, boot_uuid, lookup_path=None):
+        return super().setup_disk_boot_images(boot_uuid, lookup_path)
+
+    def setup_live_boot_images(self, mbrid, lookup_path=None):
+        return super().setup_live_boot_images(mbrid, lookup_path)
+
+    def setup_sysconfig_bootloader(self):
+        return super().setup_sysconfig_bootloader()
+
+
 class TestBootLoaderConfigBase:
     @fixture(autouse=True)
     def inject_fixtures(self, caplog):
@@ -26,51 +58,12 @@ class TestBootLoaderConfigBase:
         self.state = XMLState(
             description.load()
         )
-        self.bootloader = BootLoaderConfigBase(
+        self.bootloader = BootLoaderConfigTestImpl(
             self.state, 'root_dir'
         )
 
     def setup_method(self, cls):
         self.setup()
-
-    def test_write(self):
-        with raises(NotImplementedError):
-            self.bootloader.write()
-
-    def test_setup_disk_image_config(self):
-        with raises(NotImplementedError):
-            self.bootloader.setup_disk_image_config(
-                'boot_uuid', 'root_uuid', 'hypervisor',
-                'kernel', 'initrd', 'options'
-            )
-
-    def test_setup_install_image_config(self):
-        with raises(NotImplementedError):
-            self.bootloader.setup_install_image_config(
-                'mbrid', 'hypervisor', 'kernel', 'initrd'
-            )
-
-    def test_setup_live_image_config(self):
-        with raises(NotImplementedError):
-            self.bootloader.setup_live_image_config(
-                'mbrid', 'hypervisor', 'kernel', 'initrd'
-            )
-
-    def test_setup_disk_boot_images(self):
-        with raises(NotImplementedError):
-            self.bootloader.setup_disk_boot_images('uuid')
-
-    def test_setup_install_boot_images(self):
-        with raises(NotImplementedError):
-            self.bootloader.setup_install_boot_images('mbrid')
-
-    def test_setup_live_boot_images(self):
-        with raises(NotImplementedError):
-            self.bootloader.setup_live_boot_images('mbrid')
-
-    def test_setup_sysconfig_bootloader(self):
-        with raises(NotImplementedError):
-            self.bootloader.setup_sysconfig_bootloader()
 
     @patch('kiwi.path.Path.create')
     def test_create_efi_path(self, mock_path):
@@ -383,7 +376,7 @@ class TestBootLoaderConfigBase:
 
         mock_MountManager.side_effect = mount_managers_effect
 
-        with BootLoaderConfigBase(self.state, 'root_dir') as bootloader:
+        with BootLoaderConfigTestImpl(self.state, 'root_dir') as bootloader:
             bootloader.root_filesystem_is_overlay = True
             bootloader._mount_system(
                 'rootdev', 'bootdev', 'efidev', {

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -8,6 +8,7 @@ from mock import (
 from pytest import (
     raises, fixture
 )
+import pytest
 
 import kiwi
 
@@ -125,6 +126,17 @@ class TestBootLoaderConfigGrub2:
     @patch('kiwi.bootloader.config.base.BootLoaderConfigBase.get_boot_theme')
     def setup_method(self, cls, mock_theme, mock_firmware):
         self.setup()
+
+    def test_setup_sysconfig_bootloader_not_impl(self):
+        xml_state = MagicMock()
+        xml_state.build_type.get_firmware = Mock(
+            return_value=None
+        )
+
+        with pytest.raises(NotImplementedError):
+            BootLoaderConfigGrub2(
+                xml_state=xml_state, root_dir='root_dir'
+            ).setup_sysconfig_bootloader()
 
     @patch('kiwi.bootloader.config.grub2.Path.which')
     def test_post_init_grub2_boot_directory(self, mock_which):

--- a/test/unit/bootloader/config/init_test.py
+++ b/test/unit/bootloader/config/init_test.py
@@ -4,16 +4,26 @@ from mock import (
 from pytest import raises
 
 from kiwi.exceptions import KiwiBootLoaderConfigSetupError
-from kiwi.bootloader.config import BootLoaderConfig
+from kiwi.bootloader.config import create_boot_loader_config
 
 
 class TestBootLoaderConfig:
     def test_bootloader_config_not_implemented(self):
         with raises(KiwiBootLoaderConfigSetupError):
-            BootLoaderConfig.new('foo', Mock(), 'root_dir')
+            create_boot_loader_config(name='foo', xml_state=Mock(), root_dir='root_dir')
 
     @patch('kiwi.bootloader.config.grub2.BootLoaderConfigGrub2')
     def test_bootloader_config_grub2(self, mock_grub2):
         xml_state = Mock()
-        BootLoaderConfig.new('grub2', xml_state, 'root_dir')
-        mock_grub2.assert_called_once_with(xml_state, 'root_dir', None, None)
+        for name in ("grub2", "grub2_s390x_emu"):
+            create_boot_loader_config(name=name, xml_state=xml_state, root_dir='root_dir')
+            mock_grub2.assert_called_once_with(xml_state, 'root_dir', None, None)
+            mock_grub2.reset_mock()
+
+    @patch('kiwi.bootloader.config.systemd_boot.BootLoaderSystemdBoot')
+    def test_bootloader_config_systemd_boot(self, mock_systemd_boot):
+        xml_state = Mock()
+        create_boot_loader_config(name='systemd_boot', xml_state=xml_state, root_dir='root_dir', boot_dir='boot_dir')
+        mock_systemd_boot.assert_called_once_with(
+            xml_state, 'root_dir', 'boot_dir', None
+        )

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -6,7 +6,7 @@ from mock import (
 from pytest import (
     raises, fixture
 )
-import kiwi
+import kiwi.builder.disk
 
 from ..test_helper import argv_kiwi_tests
 
@@ -133,6 +133,14 @@ class TestDiskBuilder:
         self.bootloader_install = Mock()
         kiwi.builder.disk.BootLoaderInstall.new = MagicMock(
             return_value=self.bootloader_install
+        )
+        self.bootloader_config = Mock()
+        self.bootloader_config.use_disk_password = True
+        self.bootloader_config.get_boot_cmdline = Mock(
+            return_value='boot_cmdline'
+        )
+        kiwi.builder.disk.create_boot_loader_config = MagicMock(
+            return_value=self.bootloader_config
         )
         kiwi.builder.disk.DiskSetup = MagicMock(
             return_value=self.disk_setup
@@ -278,7 +286,7 @@ class TestDiskBuilder:
             {'signing_keys': ['key_file_a', 'key_file_b']}
         )
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.LoopDevice')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('random.randrange')
@@ -289,13 +297,13 @@ class TestDiskBuilder:
     def test_create_disk_standard_root_with_kiwi_initrd(
         self, mock_path, mock_ImageSystem, mock_grub_dir,
         mock_command, mock_rand, mock_fs, mock_LoopDevice,
-        mock_BootLoaderConfig
+        mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         loop_provider = Mock()
         mock_LoopDevice.return_value.__enter__.return_value = loop_provider
@@ -422,7 +430,7 @@ class TestDiskBuilder:
             'target_dir'
         )
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.VolumeManager.new')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.Command.run')
@@ -437,13 +445,13 @@ class TestDiskBuilder:
         self, mock_CloneDevice, mock_Temporary_new_file, mock_ImageSystem,
         mock_SystemSetup, mock_os_path_getsize, mock_path,
         mock_grub_dir, mock_command, mock_fs, mock_volume_manager,
-        mock_BootLoaderConfig
+        mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         tempfile = Mock()
         tempfile.name = 'tempfile'
@@ -496,7 +504,7 @@ class TestDiskBuilder:
         volume_manager.\
             umount_volumes.call_args_list[0].assert_called_once_with()
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.Command.run')
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
@@ -509,13 +517,13 @@ class TestDiskBuilder:
     def test_create_disk_standard_root_with_clone(
         self, mock_CloneDevice, mock_Temporary_new_file, mock_ImageSystem,
         mock_SystemSetup, mock_os_path_getsize, mock_path,
-        mock_grub_dir, mock_command, mock_fs, mock_BootLoaderConfig
+        mock_grub_dir, mock_command, mock_fs, mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         tempfile = Mock()
         tempfile.name = 'tempfile'
@@ -601,7 +609,7 @@ class TestDiskBuilder:
             call([self.device_map['rootclone1']])
         ]
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.Command.run')
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
@@ -613,13 +621,13 @@ class TestDiskBuilder:
     def test_create_disk_standard_root_with_dm_integrity(
         self, mock_Temporary_new_file, mock_ImageSystem,
         mock_SystemSetup, mock_os_path_getsize, mock_path,
-        mock_grub_dir, mock_command, mock_fs, mock_BootLoaderConfig
+        mock_grub_dir, mock_command, mock_fs, mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         tempfile = Mock()
         tempfile.name = 'tempfile'
@@ -659,7 +667,7 @@ class TestDiskBuilder:
             call(label='SWAP')
         ]
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.LoopDevice')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('random.randrange')
@@ -675,13 +683,13 @@ class TestDiskBuilder:
         self, mock_Temporary_new_file, mock_VeritySetup,
         mock_ImageSystem, mock_SystemSetup, mock_os_path_getsize,
         mock_path, mock_grub_dir, mock_command, mock_rand, mock_fs,
-        mock_LoopDevice, mock_BootLoaderConfig
+        mock_LoopDevice, mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         loop_provider = Mock()
         mock_LoopDevice.return_value.__enter__.return_value = loop_provider
@@ -830,7 +838,7 @@ class TestDiskBuilder:
             '/dev/root-device'
         )
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('random.randrange')
     @patch('kiwi.builder.disk.Command.run')
@@ -844,7 +852,7 @@ class TestDiskBuilder:
         self, mock_Temporary_new_file,
         mock_ImageSystem, mock_SystemSetup, mock_os_path_getsize,
         mock_path, mock_grub_dir, mock_command, mock_rand, mock_fs,
-        mock_BootLoaderConfig
+        mock_create_boot_loader_config
     ):
         self.disk_builder.root_filesystem_embed_verity_metadata = False
         self.disk_builder.root_filesystem_is_overlay = False
@@ -859,7 +867,7 @@ class TestDiskBuilder:
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
 
         m_open = mock_open()
@@ -870,7 +878,7 @@ class TestDiskBuilder:
             'clone:1024:1024', 1
         )
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.LoopDevice')
     @patch('kiwi.builder.disk.DeviceProvider')
     @patch('kiwi.builder.disk.FileSystem.new')
@@ -886,13 +894,13 @@ class TestDiskBuilder:
         self, mock_BlockID, mock_rand, mock_temp,
         mock_getsize, mock_exists, mock_grub_dir, mock_command,
         mock_squashfs, mock_fs, mock_DeviceProvider,
-        mock_LoopDevice, mock_BootLoaderConfig
+        mock_LoopDevice, mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         loop_provider = Mock()
         mock_LoopDevice.return_value.__enter__.return_value = loop_provider
@@ -992,17 +1000,17 @@ class TestDiskBuilder:
             with raises(KiwiDiskBootImageError):
                 self.disk_builder.create_disk()
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.Command.run')
     def test_create_disk_standard_root_xen_server_boot(
-        self, mock_command, mock_fs, mock_BootLoaderConfig
+        self, mock_command, mock_fs, mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         filesystem = Mock()
         mock_fs.return_value.__enter__.return_value = filesystem
@@ -1019,19 +1027,19 @@ class TestDiskBuilder:
             'root_dir', '/boot/xen.gz'
         )
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.Command.run')
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     def test_create_disk_standard_root_s390_boot(
-        self, mock_grub_dir, mock_command, mock_fs, mock_BootLoaderConfig
+        self, mock_grub_dir, mock_command, mock_fs, mock_create_boot_loader_config
     ):
         self.disk_builder.arch = 's390x'
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         filesystem = Mock()
         mock_fs.return_value.__enter__.return_value = filesystem
@@ -1046,18 +1054,18 @@ class TestDiskBuilder:
 
         bootloader_config.write.assert_called_once_with()
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.Command.run')
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     def test_create_disk_standard_root_secure_boot(
-        self, mock_grub_dir, mock_command, mock_fs, mock_BootLoaderConfig
+        self, mock_grub_dir, mock_command, mock_fs, mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         filesystem = Mock()
         mock_fs.return_value.__enter__.return_value = filesystem
@@ -1072,18 +1080,18 @@ class TestDiskBuilder:
             '0815'
         )
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.Command.run')
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     def test_create_disk_mdraid_root(
-        self, mock_grub_dir, mock_command, mock_fs, mock_BootLoaderConfig
+        self, mock_grub_dir, mock_command, mock_fs, mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         filesystem = Mock()
         mock_fs.return_value.__enter__.return_value = filesystem
@@ -1108,18 +1116,18 @@ class TestDiskBuilder:
             'kiwi_RaidDev': '/dev/md0'
         }
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.Command.run')
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     def test_create_disk_luks_root(
-        self, mock_grub_dir, mock_command, mock_fs, mock_BootLoaderConfig
+        self, mock_grub_dir, mock_command, mock_fs, mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         filesystem = Mock()
         mock_fs.return_value.__enter__.return_value = filesystem
@@ -1154,21 +1162,21 @@ class TestDiskBuilder:
             config_file='root_dir/etc/dracut.conf.d/99-luks-boot.conf'
         )
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.Command.run')
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     @patch('kiwi.builder.disk.BootLoaderInstall.new')
     def test_create_disk_luks_root_with_disk_password(
         self, mock_BootLoaderInstall, mock_grub_dir, mock_command, mock_fs,
-        mock_BootLoaderConfig
+        mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.use_disk_password = True
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         filesystem = Mock()
         mock_fs.return_value.__enter__.return_value = filesystem
@@ -1206,7 +1214,7 @@ class TestDiskBuilder:
         )
         bootloader.set_disk_password.assert_called_once_with('passphrase')
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.Command.run')
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
@@ -1214,13 +1222,13 @@ class TestDiskBuilder:
     @patch('kiwi.builder.disk.BlockID')
     def test_create_disk_uses_custom_partitions(
         self, mock_BlockID, mock_exists, mock_grub_dir, mock_command, mock_fs,
-        mock_BootLoaderConfig
+        mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         self.fstype_mock_list = [
             'ext3',
@@ -1302,7 +1310,7 @@ class TestDiskBuilder:
             call('LABEL=blkid_result /var ext3 defaults 0 0')
         ] in self.disk_builder.fstab.add_entry.call_args_list
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.VolumeManager.new')
     @patch('kiwi.builder.disk.Command.run')
@@ -1311,13 +1319,13 @@ class TestDiskBuilder:
     @patch('os.path.exists')
     def test_create_disk_btrfs_managed_root(
         self, mock_exists, mock_ImageSystem, mock_grub_dir, mock_command,
-        mock_volume_manager, mock_fs, mock_BootLoaderConfig
+        mock_volume_manager, mock_fs, mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         mock_exists.return_value = True
         volume_manager = Mock()
@@ -1345,7 +1353,7 @@ class TestDiskBuilder:
             call('UUID=blkid_result / blkid_result_fs ro,defaults,subvol=@ 0 0')
         ] in self.disk_builder.fstab.add_entry.call_args_list
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.VolumeManager.new')
     @patch('kiwi.builder.disk.Command.run')
@@ -1354,13 +1362,13 @@ class TestDiskBuilder:
     @patch('os.path.exists')
     def test_create_disk_volume_managed_root(
         self, mock_exists, mock_ImageSystem, mock_grub_dir, mock_command,
-        mock_volume_manager, mock_fs, mock_BootLoaderConfig
+        mock_volume_manager, mock_fs, mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         mock_exists.return_value = True
         volume_manager = Mock()
@@ -1407,18 +1415,18 @@ class TestDiskBuilder:
             self.disk_builder.fstab
         )
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.Command.run')
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     def test_create_disk_hybrid_gpt_requested(
-        self, mock_grub_dir, mock_command, mock_fs, mock_BootLoaderConfig
+        self, mock_grub_dir, mock_command, mock_fs, mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         filesystem = Mock()
         mock_fs.return_value.__enter__.return_value = filesystem
@@ -1431,18 +1439,18 @@ class TestDiskBuilder:
 
         self.disk.create_hybrid_mbr.assert_called_once_with()
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.Command.run')
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     def test_create_disk_force_mbr_requested(
-        self, mock_grub_dir, mock_command, mock_fs, mock_BootLoaderConfig
+        self, mock_grub_dir, mock_command, mock_fs, mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         filesystem = Mock()
         mock_fs.return_value.__enter__.return_value = filesystem
@@ -1455,18 +1463,18 @@ class TestDiskBuilder:
 
         self.disk.create_mbr.assert_called_once_with()
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.Command.run')
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     def test_create_disk_custom_start_sector_requested(
-        self, mock_grub_dir, mock_command, mock_fs, mock_BootLoaderConfig
+        self, mock_grub_dir, mock_command, mock_fs, mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         filesystem = Mock()
         mock_fs.return_value.__enter__.return_value = filesystem
@@ -1501,18 +1509,18 @@ class TestDiskBuilder:
         append_unpartitioned.assert_called_once_with()
         create_disk_format.assert_called_once_with(result)
 
-    @patch('kiwi.builder.disk.BootLoaderConfig.new')
+    @patch('kiwi.builder.disk.create_boot_loader_config')
     @patch('kiwi.builder.disk.FileSystem.new')
     @patch('kiwi.builder.disk.Command.run')
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     def test_create_disk_spare_part_requested(
-        self, mock_grub_dir, mock_command, mock_fs, mock_BootLoaderConfig
+        self, mock_grub_dir, mock_command, mock_fs, mock_create_boot_loader_config
     ):
         bootloader_config = Mock()
         bootloader_config.get_boot_cmdline = Mock(
             return_value='boot_cmdline'
         )
-        mock_BootLoaderConfig.return_value.__enter__.return_value = \
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
             bootloader_config
         filesystem = Mock()
         mock_fs.return_value.__enter__.return_value = filesystem

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -246,7 +246,7 @@ class TestInstallImageBuilder:
 
         self.boot_image_task.include_module.assert_any_call('kiwi-dump')
         self.boot_image_task.include_module.assert_any_call('kiwi-dump-reboot')
-        self.boot_image_task.omit_module.call_args_list == [
+        assert self.boot_image_task.omit_module.call_args_list == [
             call('multipath'), call('module1'), call('module2')
         ]
         self.boot_image_task.set_static_modules.assert_called_once_with(
@@ -437,7 +437,7 @@ class TestInstallImageBuilder:
 
         self.boot_image_task.include_module.assert_any_call('kiwi-dump')
         self.boot_image_task.include_module.assert_any_call('kiwi-dump-reboot')
-        self.boot_image_task.omit_module.call_args_list == [
+        assert self.boot_image_task.omit_module.call_args_list == [
             call('multipath'), call('module1'), call('module2')
         ]
         self.boot_image_task.set_static_modules.assert_called_once_with(

--- a/test/unit/shell_test.py
+++ b/test/unit/shell_test.py
@@ -7,7 +7,7 @@ from kiwi.defaults import Defaults
 
 class TestShell:
     def test_quote(self):
-        assert Shell.quote('aa\!') == 'aa\\\\\\!'
+        assert Shell.quote(r'aa\!') == 'aa\\\\\\!'
 
     @patch('kiwi.path.Path.which')
     def test_quote_key_value_file(self, mock_which):


### PR DESCRIPTION
These are mostly changes wrt style, but they allow us to have more concrete types of the `BootLoaderConfigBase` subclasses.

Changes proposed in this pull request:
* convert `BootLoaderConfig.new` to a free function. This class really has no purpose except for being having this one static method. This is very C++ pre 98 when there were no namespaces. There's no reason for replicating this style in Python
* convert `BootLoaderConfigBase` into an abstract base class. Thereby we can ensure that all methods must be implemented. This shows a few shortcomings in the current code: certain methods only make sense for certain bootloaders but have to be implemented by all bootloader-configs. It would imho make sense to further refactor the source code to remove these issues. But that probably only makes sense once #2439 is merged
* a few minor changes that showed up during refactoring (wrong type hint, missing `assert` in a test)
