### PR TITLE
Move Disk to context manager

### DIFF
--- a/kiwi/bootloader/config/systemd_boot.py
+++ b/kiwi/bootloader/config/systemd_boot.py
@@ -119,46 +119,45 @@ class BootLoaderSystemdBoot(BootLoaderSpecBase):
         )
         with LoopDevice(path) as loop_provider:
             loop_provider.create(overwrite=False)
-            disk = Disk('gpt', loop_provider)
-            disk.map_partitions()
-            disk.partitioner.partition_id = 1
-            disk._add_to_map('efi')
-            Command.run(
-                ['mkdosfs', '-n', 'BOOT', disk.partition_map['efi']]
-            )
-            Path.create(f'{self.root_dir}/boot/efi')
-            efi_mount = MountManager(
-                device=disk.partition_map['efi'],
-                mountpoint=f'{self.root_dir}/boot/efi'
-            )
-            device_mount = MountManager(
-                device='/dev',
-                mountpoint=f'{self.root_dir}/dev'
-            )
-            proc_mount = MountManager(
-                device='/proc',
-                mountpoint=f'{self.root_dir}/proc'
-            )
-            sys_mount = MountManager(
-                device='/sys',
-                mountpoint=f'{self.root_dir}/sys'
-            )
-            efi_mount.mount()
-            device_mount.bind_mount()
-            proc_mount.bind_mount()
-            sys_mount.bind_mount()
-            try:
-                self._run_bootctl(self.root_dir)
-                self.set_loader_entry(self.root_dir, self.target.live)
-            finally:
-                efi_mount.umount()
-                device_mount.umount()
-                proc_mount.umount()
-                sys_mount.umount()
-            Command.run(
-                ['dd', f'if={disk.partition_map["efi"]}', f'of={path}.img']
-            )
-            del disk
+            with Disk('gpt', loop_provider) as disk:
+                disk.map_partitions()
+                disk.partitioner.partition_id = 1
+                disk._add_to_map('efi')
+                Command.run(
+                    ['mkdosfs', '-n', 'BOOT', disk.partition_map['efi']]
+                )
+                Path.create(f'{self.root_dir}/boot/efi')
+                efi_mount = MountManager(
+                    device=disk.partition_map['efi'],
+                    mountpoint=f'{self.root_dir}/boot/efi'
+                )
+                device_mount = MountManager(
+                    device='/dev',
+                    mountpoint=f'{self.root_dir}/dev'
+                )
+                proc_mount = MountManager(
+                    device='/proc',
+                    mountpoint=f'{self.root_dir}/proc'
+                )
+                sys_mount = MountManager(
+                    device='/sys',
+                    mountpoint=f'{self.root_dir}/sys'
+                )
+                efi_mount.mount()
+                device_mount.bind_mount()
+                proc_mount.bind_mount()
+                sys_mount.bind_mount()
+                try:
+                    self._run_bootctl(self.root_dir)
+                    self.set_loader_entry(self.root_dir, self.target.live)
+                finally:
+                    efi_mount.umount()
+                    device_mount.umount()
+                    proc_mount.umount()
+                    sys_mount.umount()
+                Command.run(
+                    ['dd', f'if={disk.partition_map["efi"]}', f'of={path}.img']
+                )
 
         Command.run(
             ['mv', f'{path}.img', path]

--- a/test/unit/bootloader/config/systemd_boot_test.py
+++ b/test/unit/bootloader/config/systemd_boot_test.py
@@ -194,7 +194,7 @@ class TestBootLoaderSystemdBoot:
     ):
         target = Mock()
         self.bootloader.target = target
-        mock_Disk.return_value.partition_map = {
+        mock_Disk.return_value.__enter__.return_value.partition_map = {
             'efi': 'efi_device'
         }
         self.bootloader._create_embedded_fat_efi_image('ESP')

--- a/test/unit/storage/disk_test.py
+++ b/test/unit/storage/disk_test.py
@@ -306,50 +306,46 @@ class TestDisk:
 
     @patch('kiwi.storage.disk.Command.run')
     def test_destructor_partx_loop_cleanup_failed(self, mock_command):
-        self.disk.is_mapped = True
-        self.disk.partition_map = {'root': '/dev/loop0p1'}
         mock_command.side_effect = Exception
-        self.disk.__del__()
+        with Disk('gpt', self.storage_provider) as disk:
+            disk.is_mapped = True
+            disk.partition_map = {'root': '/dev/loop0p1'}
         with self._caplog.at_level(logging.WARNING):
             mock_command.assert_called_once_with(
                 ['partx', '--delete', '/dev/loop0']
             )
-        self.disk.is_mapped = False
 
     @patch('kiwi.storage.disk.Command.run')
     def test_destructor_dm_loop_cleanup_failed(self, mock_command):
-        self.disk.partition_mapper = 'kpartx'
-        self.disk.is_mapped = True
-        self.disk.partition_map = {'root': '/dev/mapper/loop0p1'}
         mock_command.side_effect = Exception
-        self.disk.__del__()
+        with Disk('gpt', self.storage_provider) as disk:
+            disk.partition_mapper = 'kpartx'
+            disk.is_mapped = True
+            disk.partition_map = {'root': '/dev/mapper/loop0p1'}
         with self._caplog.at_level(logging.WARNING):
             mock_command.assert_called_once_with(
                 ['dmsetup', 'remove', '/dev/mapper/loop0p1']
             )
-        self.disk.is_mapped = False
 
     @patch('kiwi.storage.disk.Command.run')
     def test_destructor_partx(self, mock_command):
-        self.disk.is_mapped = True
-        self.disk.partition_map = {'root': '/dev/loop0p1'}
-        self.disk.__del__()
+        with Disk('gpt', self.storage_provider) as disk:
+            disk.is_mapped = True
+            disk.partition_map = {'root': '/dev/loop0p1'}
         assert mock_command.call_args_list == [
             call(['partx', '--delete', '/dev/loop0'])
         ]
-        self.disk.is_mapped = False
 
     @patch('kiwi.storage.disk.Command.run')
     def test_destructor_kpartx(self, mock_command):
-        self.disk.partition_mapper = 'kpartx'
-        self.disk.is_mapped = True
-        self.disk.partition_map = {'root': '/dev/mapper/loop0p1'}
-        self.disk.__del__()
+        with Disk('gpt', self.storage_provider) as disk:
+            disk.partition_mapper = 'kpartx'
+            disk.is_mapped = True
+            disk.partition_map = {'root': '/dev/mapper/loop0p1'}
         assert mock_command.call_args_list == [
             call(['dmsetup', 'remove', '/dev/mapper/loop0p1']),
             call(['kpartx', '-d', '/dev/loop0'])
         ]
-        self.disk.is_mapped = False
 
     def test_get_public_partition_id_map(self):
         assert self.disk.get_public_partition_id_map() == {}


### PR DESCRIPTION
Change the Disk class to be a context manager. All code using Disk was updated to the following
with statement:

```python
with Disk(...) as disk:
    disk.some_member()
```

This is related to Issue #2412

