### PR TITLE
Fix reading of os-release file

### DIFF
--- a/kiwi/utils/os_release.py
+++ b/kiwi/utils/os_release.py
@@ -16,6 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import csv
+from io import TextIOWrapper
+from typing import Iterable
 
 # project
 from kiwi.exceptions import KiwiOSReleaseImportError
@@ -30,12 +32,27 @@ class OsRelease:
         os_release = root_dir + '/etc/os-release'
         try:
             with open(os_release) as osdata:
-                reader = csv.reader(osdata, delimiter='=')
+                reader = csv.reader(OsRelease._rip(osdata), delimiter='=')
                 self.data = dict(reader)
         except Exception as issue:
             raise KiwiOSReleaseImportError(
                 f'Import of {os_release} failed with {issue}'
             )
+
+    @staticmethod
+    def _is_comment(line: str) -> bool:
+        return line.startswith('#')
+
+    @staticmethod
+    def _is_whitespace(line: str) -> bool:
+        return line.isspace()
+
+    @staticmethod
+    def _rip(csvfile: TextIOWrapper) -> Iterable[str]:
+        for row in csvfile:
+            if not OsRelease._is_comment(row) \
+               and not OsRelease._is_whitespace(row):
+                yield row
 
     def get(self, key: str) -> str:
         """

--- a/test/data/etc/os-release
+++ b/test/data/etc/os-release
@@ -1,9 +1,12 @@
 NAME="openSUSE Leap"
 VERSION="15.5"
 ID="opensuse-leap"
+
+# some comment
 ID_LIKE="suse opensuse"
 VERSION_ID="15.5"
 PRETTY_NAME="openSUSE Leap 15.5"
+# some other comment
 ANSI_COLOR="0;32"
 CPE_NAME="cpe:/o:opensuse:leap:15.5"
 BUG_REPORT_URL="https://bugs.opensuse.org"


### PR DESCRIPTION
If the /etc/os-release file contains comments or spaces python's csv reader will throw an exception. Thus this data must be ripped out prior reading

