### PR TITLE
Only pass appropriate bootloader arguments

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -514,25 +514,26 @@ class DiskBuilder:
         )
 
     def _bootloader_instance(self, disk: Disk) -> BootLoaderConfigBase:
+        custom_args = {
+            'targetbase':
+                disk.storage_provider.get_device(),
+            'crypto_disk':
+                True if self.luks is not None else False,
+            'boot_is_crypto':
+                self.boot_is_crypto,
+            'config_options':
+                self.xml_state.get_bootloader_config_options()
+        }
+        if self.bootloader.startswith('grub'):
+            custom_args.update(
+                Defaults.get_grub_custom_arguments(self.root_dir)
+            )
         return create_boot_loader_config(
             name=self.bootloader,
             xml_state=self.xml_state,
             root_dir=self.root_dir,
             boot_dir=self.root_dir,
-            custom_args={
-                'targetbase':
-                    disk.storage_provider.get_device(),
-                'grub_directory_name':
-                    Defaults.get_grub_boot_directory_name(
-                        self.root_dir
-                    ),
-                'crypto_disk':
-                    True if self.luks is not None else False,
-                'boot_is_crypto':
-                    self.boot_is_crypto,
-                'config_options':
-                    self.xml_state.get_bootloader_config_options()
-            }
+            custom_args=custom_args
         )
 
     def _raid_instance(self, device_map: Dict) -> RaidDevice:

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -360,12 +360,10 @@ class InstallImageBuilder:
         return create_boot_loader_config(
             name=self.bootloader, xml_state=self.xml_state,
             root_dir=self.root_dir,
-            boot_dir=self.media_dir.name, custom_args={
-                'grub_directory_name':
-                    Defaults.get_grub_boot_directory_name(self.root_dir),
-                'grub_load_command':
-                    'configfile'
-            }
+            boot_dir=self.media_dir.name,
+            custom_args=Defaults.get_grub_custom_arguments(
+                self.root_dir
+            ) if self.bootloader.startswith('grub') else {}
         )
 
     def _create_pxe_install_kernel_and_initrd(self) -> None:

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -347,12 +347,10 @@ class LiveImageBuilder:
         return create_boot_loader_config(
             name=self.bootloader, xml_state=self.xml_state,
             root_dir=self.root_dir,
-            boot_dir=self.media_dir.name, custom_args={
-                'grub_directory_name':
-                    Defaults.get_grub_boot_directory_name(self.root_dir),
-                'grub_load_command':
-                    'configfile'
-            }
+            boot_dir=self.media_dir.name,
+            custom_args=Defaults.get_grub_custom_arguments(
+                self.root_dir
+            ) if self.bootloader.startswith('grub') else {}
         )
 
     def _setup_live_iso_kernel_and_initrd(self) -> None:

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -23,7 +23,7 @@ import platform
 import yaml
 from pkg_resources import resource_filename
 from typing import (
-    List, NamedTuple, Optional
+    List, NamedTuple, Optional, Dict
 )
 
 # project
@@ -569,6 +569,15 @@ class Defaults:
         :rtype: str
         """
         return 'grub2'
+
+    @staticmethod
+    def get_grub_custom_arguments(root_dir: str) -> Dict[str, str]:
+        return {
+            'grub_directory_name':
+                Defaults.get_grub_boot_directory_name(root_dir),
+            'grub_load_command':
+                'configfile'
+        }
 
     @staticmethod
     def get_grub_boot_directory_name(lookup_path):


### PR DESCRIPTION
When constructing a BootLoaderConfig instance only pass arguments appropriate to the selected bootloader. It does not hurt but it is bad style and unnecessary data and code points if e.g grub relevant information is passed when we actually setup systemd-boot


