### PR TITLE
Fix crypto LUKS integration test

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
@@ -16,11 +16,10 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>breeze</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="uefi" luks="linux" luks_version="luks" bootpartition="false">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0" firmware="uefi" luks="linux" luks_version="luks2" luks_pbkdf="pbkdf2" bootpartition="false">
             <luksformat>
                 <option name="--cipher" value="aes-xts-plain64"/>
                 <option name="--key-size" value="256"/>
-                <option name="--hash" value="sha1"/>
             </luksformat>
             <oemconfig>
                 <oem-resize>false</oem-resize>
@@ -75,5 +74,6 @@
         <package name="ca-certificates"/>
         <package name="ca-certificates-mozilla"/>
         <package name="openSUSE-release"/>
+        <package name="shadow"/>
     </packages>
 </image>


### PR DESCRIPTION
The integration test build also encrypts /boot which requires grub to open the LUKS pool using cryptomount. grub does not support the argonID salted password hashes. Thus the integration test description configures pbkdf2 instead

