### PR TITLE
Remove obsolete destructor from BootImageDracut

### DIFF
--- a/test/unit/boot/image/dracut_test.py
+++ b/test/unit/boot/image/dracut_test.py
@@ -177,10 +177,3 @@ class TestBootImageKiwi:
 
     def test_has_initrd_support(self):
         assert self.boot_image.has_initrd_support() is True
-
-    def test_destructor(self):
-        self.boot_image.device_mount = Mock()
-        self.boot_image.proc_mount = Mock()
-        self.boot_image.__del__()
-        self.boot_image.device_mount.umount.assert_called_once_with()
-        self.boot_image.proc_mount.umount.assert_called_once_with()


### PR DESCRIPTION
With MountManager as context manager the BootImageDracut class doesn't need a destructor anymore. This is
related to Issue #2412


