### PR TITLE
Update documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -79,13 +79,13 @@ prolog_replacements = {
     '{exc_description_live}': 'x86/leap/test-image-live',
     '{exc_description_wsl}': 'x86/tumbleweed/test-image-wsl',
     '{exc_description_docker}': 'x86/leap/test-image-docker',
-    '{exc_os_version}': '15.3',
+    '{exc_os_version}': '15.5',
     '{exc_image_version}': '1.15.3',
-    '{exc_repo_leap}': 'obs://openSUSE:Leap:15.3/standard',
+    '{exc_repo_leap}': 'obs://openSUSE:Leap:15.5/standard',
     '{exc_repo_tumbleweed}': 'http://download.opensuse.org/tumbleweed/repo/oss',
     '{exc_kiwi_repo}':
-        'obs://Virtualization:Appliances:Builder/openSUSE_Leap_15.3',
-    '{schema_version}': '7.4',
+        'obs://Virtualization:Appliances:Builder/openSUSE_Leap_15.5',
+    '{schema_version}': '8.0',
     '{kiwi}': 'KIWI NG',
     '{kiwi-product}': 'KIWI Next Generation (KIWI NG)',
     '{kiwi-legacy}': 'KIWI Legacy'

--- a/doc/source/plugins/stackbuild.rst
+++ b/doc/source/plugins/stackbuild.rst
@@ -174,7 +174,7 @@ And place the following content:
 
     <?xml version="1.0" encoding="utf-8"?>
 
-    <image schemaversion="6.8" name="Leap-VM">
+    <image schemaversion="8.0" name="Leap-VM">
         <description type="system">
             <author>The Author</author>
             <contact>user@example.org</contact>
@@ -194,8 +194,8 @@ And place the following content:
             <keytable>us</keytable>
             <timezone>UTC</timezone>
         </preferences>
-        <repository type="rpm-md" alias="Leap_15_3">
-            <source path="obs://openSUSE:Leap:15.3/standard"/>
+        <repository type="rpm-md" alias="Leap">
+            <source path="{exc_repo_leap}"/>
         </repository>
         <packages type="image">
             <package name="grub2"/>
@@ -215,7 +215,7 @@ container at SUSE, call the following `stackbuild` command:
 .. code:: bash
 
     $ sudo kiwi-ng system stackbuild \
-        --stash leap:15.3 \
+        --stash leap:{exc_os_version} \
         --from-registry registry.opensuse.org/opensuse \
         --target-dir /tmp/myLeap \
         --description container_to_VM_layer


### PR DESCRIPTION
Several examples still pointed to Leap 15.3 repos, but we are at Leap 15.5. Thus this commit shifts towards Leap 15.5

