### PR TITLE
Move OCI to context manager

### DIFF
--- a/kiwi/oci_tools/base.py
+++ b/kiwi/oci_tools/base.py
@@ -43,6 +43,9 @@ class OCIBase:
         )
         self.post_init()
 
+    def __enter__(self):
+        return self
+
     def post_init(self):
         """
         Post initialization method
@@ -172,3 +175,7 @@ class OCIBase:
             ):
                 return True
         return False
+
+    # pragma: no cover
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass

--- a/kiwi/oci_tools/buildah.py
+++ b/kiwi/oci_tools/buildah.py
@@ -42,6 +42,9 @@ class OCIBuildah(OCIBase):
         self.imported_image = None
         self.working_container = None
 
+    def __enter__(self):
+        return self
+
     def import_container_image(self, container_image_ref):
         """
         Imports container image reference to the OCI containers storage.
@@ -333,7 +336,7 @@ class OCIBuildah(OCIBase):
         """
         return "".join(random.choice(allchars) for x in range(chars_num))
 
-    def __del__(self):
+    def __exit__(self, exc_type, exc_value, traceback):
         if self.working_container:
             Command.run(['buildah', 'umount', self.working_container])
             Command.run(['buildah', 'rm', self.working_container])

--- a/test/unit/container/oci_test.py
+++ b/test/unit/container/oci_test.py
@@ -141,7 +141,7 @@ class TestContainerImageOCI:
         mock_Compress.return_value = compress
         mock_cache.return_value = 'var/cache/kiwi'
         mock_oci = Mock()
-        mock_OCI.new.return_value = mock_oci
+        mock_OCI.new.return_value.__enter__.return_value = mock_oci
 
         self.oci.archive_transport = 'oci-archive'
         self.oci.create('result.tar', '', True, True)
@@ -187,7 +187,7 @@ class TestContainerImageOCI:
     ):
         mock_cache.return_value = 'var/cache/kiwi'
         mock_oci = Mock()
-        mock_OCI.new.return_value = mock_oci
+        mock_OCI.new.return_value.__enter__.return_value = mock_oci
 
         self.runtime_config.get_container_compression.return_value = 'xz'
 

--- a/test/unit/oci_tools/umoci_test.py
+++ b/test/unit/oci_tools/umoci_test.py
@@ -247,3 +247,12 @@ class TestOCIUmoci:
         mock_Command_run.assert_called_once_with(
             ['umoci', 'gc', '--layout', 'tmpdir/oci_layout']
         )
+
+    @patch('kiwi.oci_tools.umoci.CommandCapabilities.has_option_in_help')
+    def test_context_manager_exit(
+        self, mock_CommandCapabilities_has_option_in_help
+    ):
+        mock_CommandCapabilities_has_option_in_help.return_value = True
+        with OCIUmoci():
+            pass
+            # just pass

--- a/test/unit/system/root_import/oci_test.py
+++ b/test/unit/system/root_import/oci_test.py
@@ -46,7 +46,7 @@ class TestRootImportOCI:
     @patch('kiwi.system.root_import.oci.OCI')
     def test_sync_data(self, mock_OCI, mock_path, mock_md5, mock_compress):
         oci = Mock()
-        mock_OCI.new.return_value = oci
+        mock_OCI.new.return_value.__enter__.return_value = oci
         mock_md5.return_value = Mock()
 
         uncompress = Mock()
@@ -74,7 +74,7 @@ class TestRootImportOCI:
         mock_path_create, mock_compress
     ):
         oci = Mock()
-        mock_OCI.new.return_value = oci
+        mock_OCI.new.return_value.__enter__.return_value = oci
 
         self.oci_import.overlay_data()
 
@@ -103,7 +103,7 @@ class TestRootImportOCI:
         self, mock_OCI, mock_path, mock_md5, mock_compress
     ):
         oci = Mock()
-        mock_OCI.new.return_value = oci
+        mock_OCI.new.return_value.__enter__.return_value = oci
         mock_md5.return_value = Mock()
 
         uncompress = Mock()
@@ -131,7 +131,7 @@ class TestRootImportOCI:
     ):
         mock_exists.return_value = True
         oci = Mock()
-        mock_OCI.new.return_value = oci
+        mock_OCI.new.return_value.__enter__.return_value = oci
         mock_md5.return_value = Mock()
         with patch.dict('os.environ', {'HOME': '../data'}):
             oci_import = RootImportOCI(


### PR DESCRIPTION
Change the OCI Factory to be a context manager. All code using OCI was updated to the following
with statement:

```python
with OCI(...).new as oci:
    oci.some_member()
```

This is related to Issue #2412


