### PR TITLE
Fix setup of UUID for btrfs

### DIFF
--- a/kiwi/filesystem/btrfs.py
+++ b/kiwi/filesystem/btrfs.py
@@ -67,5 +67,5 @@ class FileSystemBtrfs(FileSystemBase):
         """
         device = self.device_provider.get_device()
         Command.run(
-            ['btrfstune', '-u', device]
+            ['btrfstune', '-f', '-u', device]
         )

--- a/test/unit/filesystem/btrfs_test.py
+++ b/test/unit/filesystem/btrfs_test.py
@@ -37,5 +37,5 @@ class TestFileSystemBtrfs:
     def test_set_uuid(self, mock_command):
         self.btrfs.set_uuid()
         mock_command.assert_called_once_with(
-            ['btrfstune', '-u', '/dev/foo']
+            ['btrfstune', '-f', '-u', '/dev/foo']
         )


### PR DESCRIPTION
When setting up the UUID for a btrfs filesystem via btrfstune it could happen that the call becomes interactive asking a question and give a recommendation. All this is unwanted and can be forced via the -f switch. This Fixes #2456


