### PR TITLE
Allow specifying the filesystem for live image, also direct squashfs

### DIFF
--- a/doc/source/building_images/build_live_iso.rst
+++ b/doc/source/building_images/build_live_iso.rst
@@ -43,6 +43,18 @@ live ISO images:
   Both modules support a different set of live features.
   For details see :ref:`live_features`
 
+- `filesystem`: Specifies the root filesystem for the live system.
+
+  If set to `squashfs`, the root filesystem is written into a squashfs image.
+  This option is not compatible with device-mapper specific features of the
+  dmsquash-live dracut module. In that case, using overayfs is required.
+
+  If set to a value different from `squashfs`, the root filesystem is written
+  into a filesystem image of the specified type and that filesystem image
+  written into a squashfs image for compression.
+
+  The default value for this option is `ext4`.
+
 - `hybridpersistent`: Accepts `true` or `false`, if set to `true` then the
   resulting image will be created with a COW file to keep data persistent
   over a reboot

--- a/doc/source/building_images/build_live_iso.rst
+++ b/doc/source/building_images/build_live_iso.rst
@@ -32,14 +32,15 @@ To add a live ISO build to your appliance, create a `type` element with
 The following attributes of the `type` element are relevant when building
 live ISO images:
 
-- `flags`: Specifies the live ISO technology and dracut module to use, can
-  be set to `overlay` or to `dmsquash`.
+- `flags`: Specifies the dracut module to use.
 
-  If set to `overlay`, the kiwi-live dracut module will be used to support a
-  live ISO system based on squashfs and overlayfs.
-  If set to `dmsquash`, the dracut standard dmsquash-live module will be
-  used to support a live ISO system based on squashfs and the device
-  mapper. Note, both modules support a different set of live features.
+  If set to `overlay`, the kiwi supplied kiwi-live dracut module will used
+  for booting.
+
+  If set to `dmsquash`, the dracut supplied dmsquash-live module will be
+  used for booting.
+
+  Both modules support a different set of live features.
   For details see :ref:`live_features`
 
 - `hybridpersistent`: Accepts `true` or `false`, if set to `true` then the
@@ -78,13 +79,14 @@ deployment.
 Decision for a live ISO technology
 ----------------------------------
 
-The decision for the `overlay` vs. `dmsquash` dracut module depends on
-the features one wants to use. From a design perspective the `overlay`
-module is conceived for live ISO deployments on disk devices which
-allows the creation of a write partition or cow file. The `dmsquash`
-module is conceived as a generic mapping technology using device-mapper
-snapshots. The following list describes important live ISO features and
-their support status compared to the `overlay` and `dmsquash` modules.
+The decision for the `overlay` vs. `dmsquash` dracut module depends on the
+features one wants to use. The `overlay` module only supports overlayfs
+based overlays, but with automatic creation of a writable layer for
+persistence. The `dmsquash` module supports overlayfs as well as
+device-mapper based overlays.
+
+The following list describes important live ISO features and their support
+status compared to the `overlay` and `dmsquash` modules.
 
 ISO scan
   Usable in the same way with both dracut modules. This feature allows
@@ -100,8 +102,8 @@ ISO in RAM completely
   to setup RAM only deployments in {kiwi} see: :ref:`ramdisk_deployment`
 
 Overlay based on overlayfs
-  Usable with the `overlay` module. A squashfs compressed readonly root
-  gets overlayed with a readwrite filesystem using the kernel overlayfs
+  Usable with both dracut modules. The readonly root filesystem gets
+  overlayed with a readwrite filesystem using the kernel overlayfs
   filesystem.
 
 Overlay based on device mapper snapshots

--- a/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
@@ -134,6 +134,14 @@ function mountReadOnlyRootImageFromContainer {
     local rootfs_image="${container_mount_point}/LiveOS/rootfs.img"
     local root_mount_point="${overlay_base}/rootfsbase"
     mkdir -m 0755 -p "${root_mount_point}"
+
+    if ! [ -e "${rootfs_image}" ] && [ -d "${container_mount_point}/proc" ]; then
+        # It's the root filesystem directly, just do a bind mount
+        mount -n --bind "${container_mount_point}" "${root_mount_point}"
+        echo "${root_mount_point}"
+        return
+    fi
+
     if ! mount -n "${rootfs_image}" "${root_mount_point}"; then
         die "Failed to mount live ISO root filesystem"
     fi

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1661,7 +1661,7 @@ div {
         }
         >> sch:pattern [ id = "filesystem" is-a = "image_type"
             sch:param [ name = "attr" value = "filesystem" ]
-            sch:param [ name = "types" value = "oem pxe kis" ]
+            sch:param [ name = "types" value = "oem pxe kis iso" ]
         ]
         >> sch:pattern [
             id = "filesystem_mandatory" is-a = "image_type_requirement"

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2403,7 +2403,7 @@ structure</a:documentation>
       </attribute>
       <sch:pattern id="filesystem" is-a="image_type">
         <sch:param name="attr" value="filesystem"/>
-        <sch:param name="types" value="oem pxe kis"/>
+        <sch:param name="types" value="oem pxe kis iso"/>
       </sch:pattern>
       <sch:pattern id="filesystem_mandatory" is-a="image_type_requirement">
         <sch:param name="attr" value="filesystem"/>


### PR DESCRIPTION
By setting <type image="iso" filesystem="FSTYPE" .../> it's now possible
to specify the filesystem used for live images. By using "squashfs", the
rootfs container is skipped entirely.

Fixes https://github.com/OSInside/kiwi/issues/2447