### PR TITLE
Don't run ci-kiwi-9-compliant action on forks

### DIFF
--- a/.github/workflows/ci-kiwi-9-compliant.yml
+++ b/.github/workflows/ci-kiwi-9-compliant.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   compliance_test:
+    if: ${{ github.repository == 'OSInside/kiwi' }}
     name: Capable for Rebase to kiwi v9.x.x
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The compliant merge test does not work on forks so far, thus disable