### PR TITLE
Add support for reading .profile.extra in initrd

### DIFF
--- a/doc/source/concept_and_workflow/shell_scripts.rst
+++ b/doc/source/concept_and_workflow/shell_scripts.rst
@@ -301,6 +301,11 @@ $kiwi_type
   The image type as extracted from the `type` element in
   :file:`config.xml`.
 
+.. note:: **.profile.extra**
+
+   If there is the file :file:`/.profile.extra` available in the
+   initrd, {kiwi} will import this additional environment file
+   after the import of the :file:`/.profile` file.
 
 Configuration Tips
 ------------------

--- a/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
@@ -78,6 +78,7 @@ function _setup_interactive_service {
         echo "Wants=systemd-vconsole-setup.service"
         echo "Conflicts=emergency.service emergency.target"
         echo "[Service]"
+        echo "EnvironmentFile=/.profile.extra"
         echo "Environment=HOME=/"
         echo "Environment=DRACUT_SYSTEMD=1"
         echo "Environment=NEWROOT=/sysroot"

--- a/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
@@ -178,11 +178,17 @@ function initialize {
     # """
     local kiwi_oem_installdevice
     local profile=/.profile
+    local profile_extra=/.profile.extra
 
     test -f ${profile} || \
         report_and_quit "No profile setup found"
 
     import_file ${profile}
+
+    test -f ${profile_extra} || \
+        cat >${profile_extra}</dev/null
+
+    import_file ${profile_extra}
 
     # Handle overwrites
     kiwi_oem_installdevice=$(getarg rd.kiwi.oem.installdevice=)


### PR DESCRIPTION
If there is the file /.profile.extra available in the initrd, kiwi will import this additional environment file after the import of the standard /.profile file. This is related to bsc#1218095


