### PR TITLE
Don't use LUKS keyfile with disk password

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -644,6 +644,21 @@ class DiskBuilder:
         #
         luks_need_keyfile = \
             True if self.boot_is_crypto or self.luks == '' else False
+        if self.use_disk_password and self.luks:
+            # In case a disk password is configured, no keyfile
+            # will be used. The setup of the disk password is a
+            # method to store an insecure password into the bootloader
+            # configuration and directly call cryptomount with
+            # that password to boot into the system once. The
+            # insecure credentials will then be replaced by a
+            # secure version e.g from a TPM. This concept for
+            # non-interactive boot of an encrypted system is similar
+            # to specifying an empty luks passphrase but also
+            # works from within the bootloader and therefore allows
+            # to keep /boot encrypted. In constrast to cryptsetup
+            # cryptomount requires to input credentials even if
+            # they are empty.
+            luks_need_keyfile = False
         luks_root.create_crypto_luks(
             passphrase=self.luks or '',
             osname=self.luks_os,

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -1220,7 +1220,7 @@ class TestDiskBuilder:
 
         self.luks_root.create_crypto_luks.assert_called_once_with(
             passphrase='passphrase', osname=None,
-            options=[], keyfile='/root/.root.keyfile',
+            options=[], keyfile='',
             randomize=True,
             root_dir='root_dir'
         )
@@ -1228,14 +1228,9 @@ class TestDiskBuilder:
             'root_dir/etc/crypttab'
         )
         assert self.boot_image_task.include_file.call_args_list == [
-            call('/root/.root.keyfile'),
             call('/config.partids'),
             call('/etc/crypttab')
         ]
-        self.boot_image_task.write_system_config_file.assert_called_once_with(
-            config={'install_items': ['/root/.root.keyfile']},
-            config_file='root_dir/etc/dracut.conf.d/99-luks-boot.conf'
-        )
         bootloader.set_disk_password.assert_called_once_with('passphrase')
 
     @patch('kiwi.builder.disk.Disk')


### PR DESCRIPTION
In case a disk password is configured, no keyfile will be used. The setup of the disk password is a method to store an insecure password into the bootloader configuration and directly call cryptomount with that password to boot into the system once. The
insecure credentials will then be replaced by a secure version e.g from a TPM and a final keyfile will be placed into the luks pool. Thus there is no need for kiwi to create an initial keyfile as it's insecure and overwritten anyway.

This is related to bsc#1218181

