### PR TITLE
Refactor Command.run()

### DIFF
--- a/.github/workflows/ci-kiwi-9-compliant.yml
+++ b/.github/workflows/ci-kiwi-9-compliant.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run rebase
-        run: git fetch --all; git config user.email cherrypick@action.com; git config user.name git_action; git checkout master; git log --pretty=oneline --no-merges "origin/master..origin/${GITHUB_HEAD_REF}" | cut -f1 -d " " | head -n -1 > commit.list; git cherry-pick $(tac commit.list | tr "\n" " ")
+        run: git fetch --all; git config user.email cherrypick@action.com; git config user.name git_action; git checkout master; git log --pretty=oneline --no-merges "origin/master..origin/${GITHUB_HEAD_REF}" | cut -f1 -d " " | head -n -1 > commit.list; git cherry-pick --keep-redundant-commits $(tac commit.list | tr "\n" " ")

--- a/.github/workflows/ci-units-types.yml
+++ b/.github/workflows/ci-units-types.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-units-types.yml
+++ b/.github/workflows/ci-units-types.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-units-types.yml
+++ b/.github/workflows/ci-units-types.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -280,11 +280,9 @@ class InstallImageBuilder:
             source_filename=self.diskname,
             keep_source_on_compress=True
         )
-        compress.xz(self.xz_options)
-        # set by compress.xz
-        assert compress.compressed_filename
+        xz_archive = compress.xz(self.xz_options)
         Command.run(
-            ['mv', compress.compressed_filename, pxe_image_filename]
+            ['mv', xz_archive, pxe_image_filename]
         )
 
         # the system image transfer is checked against a checksum

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -281,6 +281,8 @@ class InstallImageBuilder:
             keep_source_on_compress=True
         )
         compress.xz(self.xz_options)
+        # set by compress.xz
+        assert compress.compressed_filename
         Command.run(
             ['mv', compress.compressed_filename, pxe_image_filename]
         )

--- a/kiwi/command.py
+++ b/kiwi/command.py
@@ -31,23 +31,19 @@ from kiwi.exceptions import (
 
 log = logging.getLogger('kiwi')
 
-command_type = NamedTuple(
-    'command_type', [
-        ('output', str),
-        ('error', str),
-        ('returncode', int)
-    ]
-)
 
-command_call_type = NamedTuple(
-    'command_call_type', [
-        ('output', str),
-        ('output_available', bool),
-        ('error', str),
-        ('error_available', bool),
-        ('process', subprocess.Popen)
-    ]
-)
+class CommandT(NamedTuple):
+    output: str
+    error: str
+    returncode: int
+
+
+class CommandCallT(NamedTuple):
+    output: IO[bytes]
+    output_available: Callable[[], bool]
+    error: IO[bytes]
+    error_available: Callable[[], bool]
+    process: subprocess.Popen
 
 
 class Command:

--- a/kiwi/command_process.py
+++ b/kiwi/command_process.py
@@ -17,6 +17,7 @@
 #
 import logging
 from collections import namedtuple
+from kiwi.command import CommandCallT
 
 # project
 from kiwi.utils.codec import Codec
@@ -37,7 +38,7 @@ class CommandProcess:
     :param subprocess command: instance of subprocess
     :param string log_topic: topic string for logging
     """
-    def __init__(self, command, log_topic='system'):
+    def __init__(self, command: CommandCallT, log_topic='system') -> None:
         self.command = CommandIterator(command)
         self.log_topic = log_topic
         self.items_processed = 0
@@ -154,7 +155,7 @@ class CommandIterator:
 
     :param subprocess command: instance of subprocess
     """
-    def __init__(self, command):
+    def __init__(self, command: CommandCallT) -> None:
         self.command = command
         self.command_error_output = bytes(b'')
         self.command_output_line = bytes(b'')
@@ -196,7 +197,7 @@ class CommandIterator:
         """
         return Codec.decode(self.command_error_output)
 
-    def get_error_code(self):
+    def get_error_code(self) -> int:
         """
         Provide return value from processed command
 
@@ -206,7 +207,7 @@ class CommandIterator:
         """
         return self.command.process.returncode
 
-    def get_pid(self):
+    def get_pid(self) -> int:
         """
         Provide process ID of command while running
 
@@ -216,7 +217,7 @@ class CommandIterator:
         """
         return self.command.process.pid
 
-    def kill(self):
+    def kill(self) -> None:
         """
         Send kill signal SIGTERM to command process
         """

--- a/kiwi/mount_manager.py
+++ b/kiwi/mount_manager.py
@@ -216,7 +216,4 @@ class MountManager:
             command=['mountpoint', '-q', self.mountpoint],
             raise_on_error=False
         )
-        if mountpoint_call.returncode == 0:
-            return True
-        else:
-            return False
+        return mountpoint_call.returncode == 0

--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -24,7 +24,7 @@ from typing import (
 )
 
 # project
-from kiwi.command import command_call_type
+from kiwi.command import CommandCallT
 from kiwi.command import Command
 from kiwi.path import Path
 from kiwi.package_manager.base import PackageManagerBase
@@ -128,7 +128,7 @@ class PackageManagerApt(PackageManagerBase):
 
     def process_install_requests_bootstrap(
         self, root_bind: RootBind = None, bootstrap_package: str = None
-    ) -> command_call_type:
+    ) -> CommandCallT:
         """
         Process package install requests for bootstrap phase (no chroot)
         Either debootstrap or a prebuilt bootstrap package can be used
@@ -155,7 +155,7 @@ class PackageManagerApt(PackageManagerBase):
 
     def _process_install_requests_bootstrap_prebuild_root(
         self, bootstrap_package: str
-    ) -> command_call_type:
+    ) -> CommandCallT:
         """
         Process bootstrap phase (no chroot) using a prebuilt bootstrap
         package. The package has to provide a tarball below the
@@ -207,7 +207,7 @@ class PackageManagerApt(PackageManagerBase):
 
     def _process_install_requests_bootstrap_debootstrap(
         self, root_bind: RootBind = None
-    ) -> command_call_type:
+    ) -> CommandCallT:
         """
         Process package install requests for bootstrap phase (no chroot)
         The debootstrap program is used to bootstrap a new system
@@ -316,7 +316,7 @@ class PackageManagerApt(PackageManagerBase):
         if root_bind:
             root_bind.mount_kernel_file_systems(delta_root)
 
-    def process_install_requests(self) -> command_call_type:
+    def process_install_requests(self) -> CommandCallT:
         """
         Process package install requests for image phase (chroot)
 
@@ -344,7 +344,7 @@ class PackageManagerApt(PackageManagerBase):
             apt_get_command, self.command_env
         )
 
-    def process_delete_requests(self, force: bool = False) -> command_call_type:
+    def process_delete_requests(self, force: bool = False) -> CommandCallT:
         """
         Process package delete requests (chroot)
 
@@ -452,7 +452,7 @@ class PackageManagerApt(PackageManagerBase):
             ]
         )
 
-    def update(self) -> command_call_type:
+    def update(self) -> CommandCallT:
         """
         Process package update requests (chroot)
 

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -243,7 +243,7 @@ class PackageManagerBase:
 
         :rtype: boolean
         """
-        return True if returncode != 0 else False
+        return returncode != 0
 
     def get_error_details(self) -> str:
         """

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -20,7 +20,7 @@ from typing import (
 )
 
 from kiwi.api_helper import decommissioned
-from kiwi.command import command_call_type
+from kiwi.command import CommandCallT
 from kiwi.system.root_bind import RootBind
 from kiwi.repository.base import RepositoryBase
 
@@ -117,7 +117,7 @@ class PackageManagerBase:
 
     def process_install_requests_bootstrap(
         self, root_bind: RootBind = None, bootstrap_package: str = None
-    ) -> command_call_type:
+    ) -> CommandCallT:
         """
         Process package install requests for bootstrap phase (no chroot)
 
@@ -125,7 +125,7 @@ class PackageManagerBase:
         """
         raise NotImplementedError
 
-    def process_install_requests(self) -> command_call_type:
+    def process_install_requests(self) -> CommandCallT:
         """
         Process package install requests for image phase (chroot)
 
@@ -133,7 +133,7 @@ class PackageManagerBase:
         """
         raise NotImplementedError
 
-    def process_delete_requests(self, force: bool = False) -> command_call_type:
+    def process_delete_requests(self, force: bool = False) -> CommandCallT:
         """
         Process package delete requests (chroot)
 
@@ -143,7 +143,7 @@ class PackageManagerBase:
         """
         raise NotImplementedError
 
-    def update(self) -> command_call_type:
+    def update(self) -> CommandCallT:
         """
         Process package update requests (chroot)
 

--- a/kiwi/package_manager/dnf.py
+++ b/kiwi/package_manager/dnf.py
@@ -20,7 +20,7 @@ from typing import (
 )
 
 # project
-from kiwi.command import command_call_type
+from kiwi.command import CommandCallT
 from kiwi.package_manager.base import PackageManagerBase
 from kiwi.system.root_bind import RootBind
 from kiwi.api_helper import decommissioned
@@ -60,22 +60,22 @@ class PackageManagerDnf(PackageManagerBase):
     @decommissioned
     def process_install_requests_bootstrap(
         self, root_bind: RootBind = None, bootstrap_package: str = None
-    ) -> command_call_type:
+    ) -> CommandCallT:
         pass  # pragma: no cover
 
     @no_type_check
     @decommissioned
-    def process_install_requests(self) -> command_call_type:
+    def process_install_requests(self) -> CommandCallT:
         pass  # pragma: no cover
 
     @no_type_check
     @decommissioned
-    def process_delete_requests(self, force: bool = False) -> command_call_type:
+    def process_delete_requests(self, force: bool = False) -> CommandCallT:
         pass  # pragma: no cover
 
     @no_type_check
     @decommissioned
-    def update(self) -> command_call_type:
+    def update(self) -> CommandCallT:
         pass  # pragma: no cover
 
     @decommissioned

--- a/kiwi/package_manager/dnf4.py
+++ b/kiwi/package_manager/dnf4.py
@@ -21,7 +21,7 @@ from typing import (
 )
 
 # project
-from kiwi.command import command_call_type
+from kiwi.command import CommandCallT
 from kiwi.command import Command
 from kiwi.utils.rpm_database import RpmDataBase
 from kiwi.utils.rpm import Rpm
@@ -136,7 +136,7 @@ class PackageManagerDnf4(PackageManagerBase):
 
     def process_install_requests_bootstrap(
         self, root_bind: RootBind = None, bootstrap_package: str = None
-    ) -> command_call_type:
+    ) -> CommandCallT:
         """
         Process package install requests for bootstrap phase (no chroot)
 
@@ -165,7 +165,7 @@ class PackageManagerDnf4(PackageManagerBase):
             dnf_command, self.command_env
         )
 
-    def process_install_requests(self) -> command_call_type:
+    def process_install_requests(self) -> CommandCallT:
         """
         Process package install requests for image phase (chroot)
 
@@ -196,7 +196,7 @@ class PackageManagerDnf4(PackageManagerBase):
             dnf_command, self.command_env
         )
 
-    def process_delete_requests(self, force: bool = False) -> command_call_type:
+    def process_delete_requests(self, force: bool = False) -> CommandCallT:
         """
         Process package delete requests (chroot)
 
@@ -245,7 +245,7 @@ class PackageManagerDnf4(PackageManagerBase):
                 dnf_command, self.command_env
             )
 
-    def update(self) -> command_call_type:
+    def update(self) -> CommandCallT:
         """
         Process package update requests (chroot)
 

--- a/kiwi/package_manager/dnf5.py
+++ b/kiwi/package_manager/dnf5.py
@@ -21,7 +21,7 @@ from typing import (
 )
 
 # project
-from kiwi.command import command_call_type
+from kiwi.command import CommandCallT
 from kiwi.command import Command
 from kiwi.utils.rpm_database import RpmDataBase
 from kiwi.utils.rpm import Rpm
@@ -136,7 +136,7 @@ class PackageManagerDnf5(PackageManagerBase):
 
     def process_install_requests_bootstrap(
         self, root_bind: RootBind = None, bootstrap_package: str = None
-    ) -> command_call_type:
+    ) -> CommandCallT:
         """
         Process package install requests for bootstrap phase (no chroot)
 
@@ -165,7 +165,7 @@ class PackageManagerDnf5(PackageManagerBase):
             dnf_command, self.command_env
         )
 
-    def process_install_requests(self) -> command_call_type:
+    def process_install_requests(self) -> CommandCallT:
         """
         Process package install requests for image phase (chroot)
 
@@ -196,7 +196,7 @@ class PackageManagerDnf5(PackageManagerBase):
             dnf_command, self.command_env
         )
 
-    def process_delete_requests(self, force: bool = False) -> command_call_type:
+    def process_delete_requests(self, force: bool = False) -> CommandCallT:
         """
         Process package delete requests (chroot)
 
@@ -245,7 +245,7 @@ class PackageManagerDnf5(PackageManagerBase):
                 dnf_command, self.command_env
             )
 
-    def update(self) -> command_call_type:
+    def update(self) -> CommandCallT:
         """
         Process package update requests (chroot)
 

--- a/kiwi/package_manager/microdnf.py
+++ b/kiwi/package_manager/microdnf.py
@@ -23,7 +23,7 @@ from typing import (
 
 
 # project
-from kiwi.command import command_call_type
+from kiwi.command import CommandCallT
 from kiwi.command import Command
 from kiwi.utils.rpm_database import RpmDataBase
 from kiwi.utils.rpm import Rpm
@@ -155,7 +155,7 @@ class PackageManagerMicroDnf(PackageManagerBase):
 
     def process_install_requests_bootstrap(
         self, root_bind: RootBind = None, bootstrap_package: str = None
-    ) -> command_call_type:
+    ) -> CommandCallT:
         """
         Process package install requests for bootstrap phase (no chroot)
 
@@ -187,7 +187,7 @@ class PackageManagerMicroDnf(PackageManagerBase):
             microdnf_command, self.command_env
         )
 
-    def process_install_requests(self) -> command_call_type:
+    def process_install_requests(self) -> CommandCallT:
         """
         Process package install requests for image phase (chroot)
 
@@ -218,7 +218,7 @@ class PackageManagerMicroDnf(PackageManagerBase):
             microdnf_command, self.command_env
         )
 
-    def process_delete_requests(self, force: bool = False) -> command_call_type:
+    def process_delete_requests(self, force: bool = False) -> CommandCallT:
         """
         Process package delete requests (chroot)
 
@@ -267,7 +267,7 @@ class PackageManagerMicroDnf(PackageManagerBase):
                 dnf_command, self.command_env
             )
 
-    def update(self) -> command_call_type:
+    def update(self) -> CommandCallT:
         """
         Process package update requests (chroot)
 

--- a/kiwi/package_manager/pacman.py
+++ b/kiwi/package_manager/pacman.py
@@ -22,7 +22,7 @@ from typing import (
 )
 
 # project
-from kiwi.command import command_call_type
+from kiwi.command import CommandCallT
 from kiwi.command import Command
 from kiwi.package_manager.base import PackageManagerBase
 from kiwi.system.root_bind import RootBind
@@ -110,7 +110,7 @@ class PackageManagerPacman(PackageManagerBase):
 
     def process_install_requests_bootstrap(
         self, root_bind: RootBind = None, bootstrap_package: str = None
-    ) -> command_call_type:
+    ) -> CommandCallT:
         """
         Process package install requests for bootstrap phase (no chroot)
 
@@ -139,7 +139,7 @@ class PackageManagerPacman(PackageManagerBase):
             pacman_command, self.command_env
         )
 
-    def process_install_requests(self) -> command_call_type:
+    def process_install_requests(self) -> CommandCallT:
         """
         Process package install requests for image phase (chroot)
 
@@ -158,7 +158,7 @@ class PackageManagerPacman(PackageManagerBase):
             pacman_command, self.command_env
         )
 
-    def process_delete_requests(self, force: bool = False) -> command_call_type:
+    def process_delete_requests(self, force: bool = False) -> CommandCallT:
         """
         Process package delete requests (chroot)
 
@@ -195,7 +195,7 @@ class PackageManagerPacman(PackageManagerBase):
             self.command_env
         )
 
-    def update(self) -> command_call_type:
+    def update(self) -> CommandCallT:
         """
         Process package update requests (chroot)
 

--- a/kiwi/package_manager/zypper.py
+++ b/kiwi/package_manager/zypper.py
@@ -23,7 +23,7 @@ from typing import (
 
 
 # project
-from kiwi.command import command_call_type
+from kiwi.command import CommandCallT
 from kiwi.command import Command
 from kiwi.package_manager.base import PackageManagerBase
 from kiwi.system.root_bind import RootBind
@@ -114,7 +114,7 @@ class PackageManagerZypper(PackageManagerBase):
 
     def process_install_requests_bootstrap(
         self, root_bind: RootBind = None, bootstrap_package: str = None
-    ) -> command_call_type:
+    ) -> CommandCallT:
         """
         Process package install requests for bootstrap phase (no chroot)
 
@@ -134,7 +134,7 @@ class PackageManagerZypper(PackageManagerBase):
             command, self.command_env
         )
 
-    def process_install_requests(self) -> command_call_type:
+    def process_install_requests(self) -> CommandCallT:
         """
         Process package install requests for image phase (chroot)
 
@@ -165,7 +165,7 @@ class PackageManagerZypper(PackageManagerBase):
             self.chroot_command_env
         )
 
-    def process_delete_requests(self, force: bool = False) -> command_call_type:
+    def process_delete_requests(self, force: bool = False) -> CommandCallT:
         """
         Process package delete requests (chroot)
 
@@ -211,7 +211,7 @@ class PackageManagerZypper(PackageManagerBase):
                 zypper_command, self.chroot_command_env
             )
 
-    def update(self) -> command_call_type:
+    def update(self) -> CommandCallT:
         """
         Process package update requests (chroot)
 

--- a/kiwi/partitioner/msdos.py
+++ b/kiwi/partitioner/msdos.py
@@ -91,7 +91,8 @@ class PartitionerMsDos(PartitionerBase):
             raise KiwiPartitionerMsDosFlagError(
                 'Unknown partition flag %s' % flag_name
             )
-        if self.flag_map[flag_name]:
+        flag_val = self.flag_map[flag_name]
+        if flag_val:
             if flag_name == 'f.active':
                 Command.run(
                     [
@@ -100,10 +101,11 @@ class PartitionerMsDos(PartitionerBase):
                     ]
                 )
             else:
+                assert isinstance(flag_val, str), f"flag {flag_name} must be a string but got a {type(flag_val)}"
                 Command.run(
                     [
                         'sfdisk', '-c', self.disk_device,
-                        format(partition_id), self.flag_map[flag_name]
+                        format(partition_id), flag_val
                     ]
                 )
         else:

--- a/kiwi/path.py
+++ b/kiwi/path.py
@@ -18,7 +18,7 @@
 import os
 import logging
 import collections
-from typing import Dict, List, Optional
+from typing import Dict, List, MutableMapping, Optional
 
 # project
 from kiwi.command import Command
@@ -224,7 +224,7 @@ class Path:
     @staticmethod
     def which(
         filename: str, alternative_lookup_paths: Optional[List[str]] = None,
-        custom_env: Optional[Dict[str, str]] = None,
+        custom_env: Optional[MutableMapping[str, str]] = None,
         access_mode: Optional[int] = None,
         root_dir: Optional[str] = None
     ) -> Optional[str]:

--- a/kiwi/storage/raid_device.py
+++ b/kiwi/storage/raid_device.py
@@ -108,6 +108,8 @@ class RaidDevice(DeviceProvider):
 
         :param string filename: config file name
         """
+        if not self.raid_device:
+            raise KiwiRaidSetupError("No raid device defined, cannot create raid config!")
         mdadm_call = Command.run(
             ['mdadm', '-Db', self.raid_device]
         )

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -23,7 +23,7 @@ import pathlib
 from collections import OrderedDict
 from collections import namedtuple
 from typing import (
-    Any, List
+    Any, List, Optional
 )
 
 # project
@@ -1154,7 +1154,7 @@ class SystemSetup:
             self.setup_selinux_file_contexts()
 
     def _call_script_no_chroot(
-        self, name, option_list, working_directory
+        self, name: str, option_list: List[str], working_directory: Optional[str]
     ):
         if not working_directory:
             working_directory = self.root_dir

--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -196,8 +196,7 @@ class ResultBundleTask(CliTask):
                 if result_file.compress:
                     log.info('--> XZ compressing')
                     compress = Compress(bundle_file)
-                    compress.xz(self.runtime_config.get_xz_options())
-                    bundle_file = compress.compressed_filename
+                    bundle_file = compress.xz(self.runtime_config.get_xz_options())
 
                 if self.command_args['--zsync-source'] and result_file.shasum:
                     # Files with a checksum are considered to be image files

--- a/kiwi/utils/command_capabilities.py
+++ b/kiwi/utils/command_capabilities.py
@@ -78,7 +78,7 @@ class CommandCapabilities:
     def check_version(
         call, version_waterline, version_flags=None,
         root=None, raise_on_error=True
-    ):
+    ) -> bool:
         """
         Checks if the given command version is equal or higher than
         the given version tuple.

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -342,6 +342,8 @@ class TestInstallImageBuilder:
         mock_md5.return_value = checksum
 
         compress = mock.Mock()
+        src = 'target_dir/result-image.x86_64-1.2.3.raw'
+        compress.xz.return_value = src
         mock_compress.return_value = compress
 
         m_open = mock_open()
@@ -349,15 +351,11 @@ class TestInstallImageBuilder:
             self.install_image.create_install_pxe_archive()
 
         mock_compress.assert_called_once_with(
-            keep_source_on_compress=True,
-            source_filename='target_dir/result-image.x86_64-1.2.3.raw'
+            keep_source_on_compress=True, source_filename=src
         )
         compress.xz.assert_called_once_with(None)
         assert mock_command.call_args_list[0] == call(
-            [
-                'mv', compress.compressed_filename,
-                'tmpdir/result-image.x86_64-1.2.3.xz'
-            ]
+            ['mv', src, 'tmpdir/result-image.x86_64-1.2.3.xz']
         )
         mock_md5.assert_called_once_with(
             'target_dir/result-image.x86_64-1.2.3.raw'

--- a/test/unit/path_test.py
+++ b/test/unit/path_test.py
@@ -134,7 +134,6 @@ class TestPath:
         mock_exists.return_value = False
         with self._caplog.at_level(logging.DEBUG):
             assert Path.which('file') is None
-            print(self._caplog.text)
             assert (
                 '"file": in paths "{0}" exists: "False" mode match: '
                 'not checked'

--- a/test/unit/path_test.py
+++ b/test/unit/path_test.py
@@ -108,7 +108,7 @@ class TestPath:
         assert Path.which('some-file') is None
         mock_env.return_value = None
         mock_exists.return_value = True
-        assert Path.which('some-file', ['alternative']) == \
+        assert Path.which('some-file', alternative_lookup_paths=['alternative']) == \
             'alternative/some-file'
         mock_access.return_value = False
         mock_env.return_value = '/usr/local/bin:/usr/bin:/bin'

--- a/test/unit/shell_test.py
+++ b/test/unit/shell_test.py
@@ -11,7 +11,7 @@ class TestShell:
 
     @patch('kiwi.path.Path.which')
     def test_quote_key_value_file(self, mock_which):
-        mock_which.return_value = 'cp'
+        mock_which.side_effect = ['cp', 'bash']
         assert Shell.quote_key_value_file('../data/key_value') == [
             "foo='bar'",
             "bar='xxx'",

--- a/test/unit/storage/raid_device_test.py
+++ b/test/unit/storage/raid_device_test.py
@@ -80,6 +80,16 @@ class TestRaidDevice:
         m_open.return_value.write.assert_called_once_with('data')
         self.raid.raid_device = None
 
+    @patch('kiwi.storage.raid_device.Command.run')
+    def test_create_raid_config_without_raid_device(self, mock_command):
+        self.raid.raid_device = None
+
+        with raises(KiwiRaidSetupError) as raid_err_ctx:
+            self.raid.create_raid_config('mdadm.conf')
+
+        assert "No raid device" in str(raid_err_ctx.value)
+        mock_command.assert_not_called()
+
     def test_is_loop(self):
         assert self.raid.is_loop() is True
 

--- a/test/unit/system/profile_test.py
+++ b/test/unit/system/profile_test.py
@@ -27,7 +27,7 @@ class TestProfile:
 
     @patch('kiwi.path.Path.which')
     def test_create_live(self, mock_which):
-        mock_which.return_value = 'cp'
+        mock_which.side_effect = ['cp', 'bash']
         self.live_profile.create(self.profile_file)
         os.remove(self.profile_file)
         assert self.live_profile.dot_profile == {
@@ -76,7 +76,7 @@ class TestProfile:
 
     @patch('kiwi.path.Path.which')
     def test_create_oem(self, mock_which):
-        mock_which.return_value = 'cp'
+        mock_which.side_effect = ['cp', 'bash']
         self.profile.create(self.profile_file)
         os.remove(self.profile_file)
         assert self.profile.dot_profile == {
@@ -159,7 +159,7 @@ class TestProfile:
 
     @patch('kiwi.path.Path.which')
     def test_create_displayname_is_image_name(self, mock_which):
-        mock_which.return_value = 'cp'
+        mock_which.side_effect = ['cp', 'bash']
         description = XMLDescription('../data/example_pxe_config.xml')
         profile = Profile(
             XMLState(description.load())
@@ -171,7 +171,7 @@ class TestProfile:
 
     @patch('kiwi.path.Path.which')
     def test_create_cpio(self, mock_which):
-        mock_which.return_value = 'cp'
+        mock_which.side_effect = ['cp', 'bash']
         description = XMLDescription('../data/example_dot_profile_config.xml')
         profile = Profile(
             XMLState(description.load(), None, 'cpio')

--- a/test/unit/tasks/result_bundle_test.py
+++ b/test/unit/tasks/result_bundle_test.py
@@ -102,7 +102,7 @@ class TestResultBundleTask:
         checksum = Mock()
         compress = Mock()
         mock_path_which.return_value = 'zsyncmake'
-        compress.compressed_filename = 'compressed_filename'
+        compress.xz.return_value = 'compressed_filename'
         mock_compress.return_value = compress
         mock_checksum.return_value = checksum
         mock_exists.return_value = False
@@ -139,7 +139,7 @@ class TestResultBundleTask:
             os.sep.join([self.abs_bundle_dir, 'test-image-1.2.3-Build_42'])
         )
         mock_checksum.assert_called_once_with(
-            compress.compressed_filename
+            'compressed_filename'
         )
         checksum.sha256.assert_called_once_with()
         m_open.return_value.write.assert_called_once_with(
@@ -168,7 +168,7 @@ class TestResultBundleTask:
         checksum = Mock()
         compress = Mock()
         mock_path_which.return_value = 'zsyncmake'
-        compress.compressed_filename = 'compressed_filename'
+        compress.xz.return_value = 'compressed_filename'
         mock_compress.return_value = compress
         mock_checksum.return_value = checksum
         mock_exists.return_value = False
@@ -303,7 +303,7 @@ class TestResultBundleTask:
         checksum = Mock()
         compress = Mock()
         mock_path_which.return_value = None
-        compress.compressed_filename = 'compressed_filename'
+        compress.xz.return_value = 'compressed_filename'
         mock_compress.return_value = compress
         mock_checksum.return_value = checksum
         mock_exists.return_value = False

--- a/test/unit/utils/compress_test.py
+++ b/test/unit/utils/compress_test.py
@@ -95,9 +95,11 @@ class TestCompress:
 
     @patch('kiwi.path.Path.which')
     def test_get_format(self, mock_which):
-        mock_which.return_value = 'ziptool'
+        mock_which.side_effect = ['xz']
         xz = Compress('../data/xz_data.xz')
         assert xz.get_format() == 'xz'
+
+        mock_which.side_effect = ['xz', 'gzip']
         gzip = Compress('../data/gz_data.gz')
         assert gzip.get_format() == 'gzip'
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,13 +22,12 @@ envlist =
     unit_py3_10,
     unit_py3_9,
     unit_py3_8,
-    unit_py3_7,
     packagedoc
 
 
 [testenv]
 description =
-    {unit_py3_7,unit_py3_8,unit_py3_9,unit_py3_10,unit_py3_11,unit_py3_12}: Unit Test run with basepython set to {basepython}
+    {unit_py3_8,unit_py3_9,unit_py3_10,unit_py3_11,unit_py3_12}: Unit Test run with basepython set to {basepython}
     devel: Test KIWI
 allowlist_externals =
     bash
@@ -47,7 +46,6 @@ basepython =
     unit_py3_10: python3.10
     unit_py3_9: python3.9
     unit_py3_8: python3.8
-    unit_py3_7: python3.7
     release: python3.10
     check: python3
     devel: python3
@@ -58,14 +56,6 @@ usedevelop = True
 deps =
     -r.virtualenv.dev-requirements.txt
 
-
-# Unit Test run with basepython set to 3.7
-[testenv:unit_py3_7]
-setenv =
-    PYTHONPATH={toxinidir}/test
-changedir=test/unit
-commands =
-    {[testenv:unit]commands}
 
 # Unit Test run with basepython set to 3.8
 [testenv:unit_py3_8]

--- a/tox.ini
+++ b/tox.ini
@@ -22,12 +22,13 @@ envlist =
     unit_py3_10,
     unit_py3_9,
     unit_py3_8,
+    unit_py3_7,
     packagedoc
 
 
 [testenv]
 description =
-    {unit_py3_8,unit_py3_9,unit_py3_10,unit_py3_11,unit_py3_12}: Unit Test run with basepython set to {basepython}
+    {unit_py3_7,unit_py3_8,unit_py3_9,unit_py3_10,unit_py3_11,unit_py3_12}: Unit Test run with basepython set to {basepython}
     devel: Test KIWI
 allowlist_externals =
     bash
@@ -46,6 +47,7 @@ basepython =
     unit_py3_10: python3.10
     unit_py3_9: python3.9
     unit_py3_8: python3.8
+    unit_py3_7: python3.7
     release: python3.10
     check: python3
     devel: python3
@@ -56,6 +58,14 @@ usedevelop = True
 deps =
     -r.virtualenv.dev-requirements.txt
 
+
+# Unit Test run with basepython set to 3.7
+[testenv:unit_py3_7]
+setenv =
+    PYTHONPATH={toxinidir}/test
+changedir=test/unit
+commands =
+    {[testenv:unit]commands}
 
 # Unit Test run with basepython set to 3.8
 [testenv:unit_py3_8]

--- a/tox.ini
+++ b/tox.ini
@@ -59,56 +59,78 @@ deps =
     -r.virtualenv.dev-requirements.txt
 
 
-# Unit Test run with basepython set to 3.7
+# Test run with basepython set to 3.7
+# Only static type checking is performed for 3.7
+# because the unit test code base requires python >= 3.8
 [testenv:unit_py3_7]
 setenv =
     PYTHONPATH={toxinidir}/test
 changedir=test/unit
 commands =
-    {[testenv:unit]commands}
+    {[testenv:mypy]commands}
 
-# Unit Test run with basepython set to 3.8
+# Test run with basepython set to 3.8
 [testenv:unit_py3_8]
 setenv =
     PYTHONPATH={toxinidir}/test
 changedir=test/unit
 commands =
+    {[testenv:mypy]commands}
     {[testenv:unit]commands}
 
-# Unit Test run with basepython set to 3.9
+# Test run with basepython set to 3.9
 [testenv:unit_py3_9]
 setenv =
     PYTHONPATH={toxinidir}/test
 changedir=test/unit
 commands =
+    {[testenv:mypy]commands}
     {[testenv:unit]commands}
 
 
-# Unit Test run with basepython set to 3.10
+# Test run with basepython set to 3.10
 [testenv:unit_py3_10]
 setenv =
     PYTHONPATH={toxinidir}/test
 changedir=test/unit
 commands =
+    {[testenv:mypy]commands}
     {[testenv:unit]commands}
 
 
-# Unit Test run with basepython set to 3.11
+# Test run with basepython set to 3.11
 [testenv:unit_py3_11]
 setenv =
     PYTHONPATH={toxinidir}/test
 changedir=test/unit
 commands =
+    {[testenv:mypy]commands}
     {[testenv:unit]commands}
 
 
-# Unit Test run with basepython set to 3.12
+# Test run with basepython set to 3.12
 [testenv:unit_py3_12]
 setenv =
     PYTHONPATH={toxinidir}/test
 changedir=test/unit
 commands =
+    {[testenv:mypy]commands}
     {[testenv:unit]commands}
+
+
+[testenv:mypy]
+description = Static Type Checking Base
+skip_install = True
+usedevelop = True
+setenv =
+    PYTHONUNBUFFERED=yes
+    WITH_COVERAGE=yes
+passenv =
+    *
+deps = {[testenv]deps}
+changedir=test/unit
+commands =
+    bash -c 'cd ../../ && mypy kiwi'
 
 
 [testenv:unit]

--- a/tox.ini
+++ b/tox.ini
@@ -21,12 +21,14 @@ envlist =
     unit_py3_11,
     unit_py3_10,
     unit_py3_9,
+    unit_py3_8,
+    unit_py3_7,
     packagedoc
 
 
 [testenv]
 description =
-    {unit_py3_9,unit_py3_10,unit_py3_11,unit_py3_12}: Unit Test run with basepython set to {basepython}
+    {unit_py3_7,unit_py3_8,unit_py3_9,unit_py3_10,unit_py3_11,unit_py3_12}: Unit Test run with basepython set to {basepython}
     devel: Test KIWI
 allowlist_externals =
     bash
@@ -44,6 +46,8 @@ basepython =
     unit_py3_11: python3.11
     unit_py3_10: python3.10
     unit_py3_9: python3.9
+    unit_py3_8: python3.8
+    unit_py3_7: python3.7
     release: python3.10
     check: python3
     devel: python3
@@ -54,6 +58,22 @@ usedevelop = True
 deps =
     -r.virtualenv.dev-requirements.txt
 
+
+# Unit Test run with basepython set to 3.7
+[testenv:unit_py3_7]
+setenv =
+    PYTHONPATH={toxinidir}/test
+changedir=test/unit
+commands =
+    {[testenv:unit]commands}
+
+# Unit Test run with basepython set to 3.8
+[testenv:unit_py3_8]
+setenv =
+    PYTHONPATH={toxinidir}/test
+changedir=test/unit
+commands =
+    {[testenv:unit]commands}
 
 # Unit Test run with basepython set to 3.9
 [testenv:unit_py3_9]


### PR DESCRIPTION
`Command.run()` currently has a bit of a confusing behavior: if `raise_on_error` is `False` and the executable is not found, then a weird `CommandT` is returned (return code is -1 and stdout+stderr is None). This makes it possible to handle command not found errors separately, but it makes that needlessly verbose. So instead, let's just return `None` in **this** special case.

That in turn uncovered, that in most cases when we set `raise_on_error=True`, we actually want an error if the command is not present but no error if the command fails to execute (e.g. because it returns -1 if you run `$cmd --version` 🙄). Hence we introduce the flag `raise_on_command_not_found`, which causes an exception to be raised if the command is not found. This makes it independent of the `raise_on_error` flag.

Additionally, we add a small optimization: if command starts with /, then we assume it's a full path and we omit the call to which (and just check whether it exists).

These changes require additional tests and a few assertions in places where mypy cannot infer that a certain value is of the correct type.
Also, add type hints in a few (mostly random) places.