### PR TITLE
Include partprobe in initrd for s390

### DIFF
--- a/dracut/modules.d/99kiwi-lib/module-setup.sh
+++ b/dracut/modules.d/99kiwi-lib/module-setup.sh
@@ -34,7 +34,7 @@ install() {
         exit 1
     fi
     if [[ "$(uname -m)" =~ s390 ]];then
-        inst_multiple fdasd parted
+        inst_multiple fdasd parted partprobe
     fi
     inst_simple \
         "${moddir}/kiwi-lib.sh" "/lib/kiwi-lib.sh"


### PR DESCRIPTION
This commit includes partprobe, in addition to parted, on s390 based systems. Otherwise partx is used and apparently it does not properly support s390.

Fixes bsc#1219798
