### PR TITLE
Allow empty cherry-picks for compliance test

### DIFF
--- a/.github/workflows/ci-kiwi-9-compliant.yml
+++ b/.github/workflows/ci-kiwi-9-compliant.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run rebase
-        run: git fetch --all; git config user.email cherrypick@action.com; git config user.name git_action; git checkout master; git log --pretty=oneline --no-merges "origin/master..origin/${GITHUB_HEAD_REF}" | cut -f1 -d " " | head -n -1 > commit.list; git cherry-pick $(tac commit.list | tr "\n" " ")
+        run: git fetch --all; git config user.email cherrypick@action.com; git config user.name git_action; git checkout master; git log --pretty=oneline --no-merges "origin/master..origin/${GITHUB_HEAD_REF}" | cut -f1 -d " " | head -n -1 > commit.list; git cherry-pick --keep-redundant-commits $(tac commit.list | tr "\n" " ")


### PR DESCRIPTION
If we cherry-pick from main to master the compliance check will notice that a commit already exists. This is not an error and we can allow to continue the picking via --allow-empty

