### PR TITLE
Move ImageSystem to context manager

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -879,18 +879,15 @@ class DiskBuilder:
             if system and self.system_setup.script_exists(
                 defaults.POST_DISK_SYNC_SCRIPT
             ):
-                image_system = ImageSystem(
+                with ImageSystem(
                     device_map, self.root_dir,
                     system.get_volumes() if self.volume_manager_name else {}
-                )
-                image_system.mount()
-                disk_system = SystemSetup(
-                    self.xml_state, image_system.mountpoint()
-                )
-                try:
+                ) as image_system:
+                    image_system.mount()
+                    disk_system = SystemSetup(
+                        self.xml_state, image_system.mountpoint()
+                    )
                     disk_system.call_disk_script()
-                finally:
-                    image_system.umount()
 
             # install boot loader
             if self.bootloader != 'custom':

--- a/kiwi/system/mount.py
+++ b/kiwi/system/mount.py
@@ -49,6 +49,9 @@ class ImageSystem:
         self.volumes = volumes
         self.mount_list: List[MountManager] = []
 
+    def __enter__(self):
+        return self
+
     def mountpoint(self) -> str:
         """
         Return image root mountpoint
@@ -175,6 +178,5 @@ class ImageSystem:
                 options=[self.volumes[volume_path]['volume_options']]
             )
 
-    def __del__(self):
-        log.info('Cleaning up %s instance', type(self).__name__)
+    def __exit__(self, exc_type, exc_value, traceback):
         self.umount()


### PR DESCRIPTION
Change the ImageSystem class to context manager.
All code using ImageSystem was updated to the following with statement:

```python
with ImageSystem(...) as image_system:
    image_system.some_member()
```

This is related to Issue #2412

