### PR TITLE
Move VolumeManager to context manager

### DIFF
--- a/kiwi/filesystem/base.py
+++ b/kiwi/filesystem/base.py
@@ -60,9 +60,7 @@ class FileSystemBase:
         # as a file there
         self.filesystem_mount: Optional[MountManager] = None
 
-        # bind the block device providing class instance to this object.
-        # This is done to guarantee the correct destructor order when
-        # the device should be released. This is only required if the
+        # the underlaying device provider. This is only required if the
         # filesystem required a block device to become created
         self.device_provider = device_provider
 

--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -68,15 +68,13 @@ class Disk(DeviceProvider):
             of that extended partition
         """
         self.partition_mapper = RuntimeConfig().get_mapper_tool()
-        # bind the underlaying block device providing class instance
-        # to this object (e.g loop) if present. This is done to guarantee
-        # the correct destructor order when the device should be released.
+        #: the underlaying device provider
         self.storage_provider = storage_provider
 
-        # list of protected map ids. If used in a custom partitions
-        # setup this will lead to a raise conditition in order to
-        # avoid conflicts with the existing partition layout and its
-        # customizaton capabilities
+        #: list of protected map ids. If used in a custom partitions
+        #: setup this will lead to a raise conditition in order to
+        #: avoid conflicts with the existing partition layout and its
+        #: customizaton capabilities
         self.protected_map_ids = [
             'root',
             'readonly',

--- a/kiwi/storage/integrity_device.py
+++ b/kiwi/storage/integrity_device.py
@@ -61,9 +61,7 @@ class IntegrityDevice(DeviceProvider):
         self, storage_provider: DeviceProvider, integrity_algorithm: str,
         credentials: integrity_credentials_type = None
     ) -> None:
-        # bind the underlaying block device providing class instance
-        # to this object (e.g loop) if present. This is done to guarantee
-        # the correct destructor order when the device should be released.
+        #: the underlaying device provider
         self.storage_provider = storage_provider
 
         self.integrity_device: Optional[str] = None

--- a/kiwi/storage/luks_device.py
+++ b/kiwi/storage/luks_device.py
@@ -40,9 +40,7 @@ class LuksDevice(DeviceProvider):
     :param object storage_provider: Instance of class based on DeviceProvider
     """
     def __init__(self, storage_provider: DeviceProvider) -> None:
-        # bind the underlaying block device providing class instance
-        # to this object (e.g loop) if present. This is done to guarantee
-        # the correct destructor order when the device should be released.
+        #: the underlaying device provider
         self.storage_provider = storage_provider
 
         self.luks_device: Optional[str] = None

--- a/kiwi/storage/raid_device.py
+++ b/kiwi/storage/raid_device.py
@@ -38,9 +38,7 @@ class RaidDevice(DeviceProvider):
     :param object storage_provider: Instance of class based on DeviceProvider
     """
     def __init__(self, storage_provider: DeviceProvider):
-        # bind the underlaying block device providing class instance
-        # to this object (e.g loop) if present. This is done to guarantee
-        # the correct destructor order when the device should be released.
+        #: the underlaying device provider
         self.storage_provider = storage_provider
 
         self.raid_level_map = {

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -105,10 +105,7 @@ class SystemPrepare:
         self.profiles = xml_state.profiles
         self.root_bind = root_bind
 
-        # A list of Uri references is stored inside of the System instance
-        # in order to delay the Uri destructors until the System instance
-        # dies. This is needed to keep bind mounted Uri locations alive
-        # for System operations
+        #: A list of Uri references
         self.uri_list: List[Uri] = []
 
     def setup_repositories(

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -61,18 +61,15 @@ class VolumeManagerBase(DeviceProvider):
     ) -> None:
 
         self.temp_directories: List[Temporary] = []
-        # all volumes are combined into one mountpoint. This is
-        # needed at sync_data time. How to mount the volumes is
-        # special to the volume management class
-        #: root mountpoint for volumes
+        #: all volumes are combined into one mountpoint. This is
+        #: needed at sync_data time. How to mount the volumes is
+        #: special to the volume management class
         self.mountpoint: Optional[str] = None
 
         #: dictionary of mapped DeviceProviders
         self.device_map = device_map
 
-        # bind the device providing class instance to this object.
-        # This is done to guarantee the correct destructor order when
-        # the device should be released.
+        #: the underlaying device provider
         self.device_provider_root = device_map['root']
 
         #: An indicator for the mount of the filesystem and its volumes
@@ -98,10 +95,12 @@ class VolumeManagerBase(DeviceProvider):
                 'given root directory %s does not exist' % root_dir
             )
 
+        #: custom arguments passed to setup the volumes
         self.custom_args: Dict[str, Any] = {}
 
         #: custom filesystem creation and mount arguments, subset of the
-        #: custom_args information suitable to be passed to a FileSystem instance
+        #: custom_args information suitable to be passed to a
+        #: FileSystem instance
         self.custom_filesystem_args: Dict[str, Any] = {
             'create_options': [],
             'mount_options': []
@@ -120,6 +119,9 @@ class VolumeManagerBase(DeviceProvider):
                 custom_args['fs_create_options']
 
         self.post_init(custom_args)
+
+    def __enter__(self):
+        return self
 
     def post_init(self, custom_args):
         """
@@ -164,7 +166,9 @@ class VolumeManagerBase(DeviceProvider):
                     ]
                 )
 
-    def get_fstab(self, persistency_type: str, filesystem_name: str) -> List[str]:
+    def get_fstab(
+        self, persistency_type: str, filesystem_name: str
+    ) -> List[str]:
         """
         Implements setup of the fstab entries. The method should
         return a list of fstab compatible entries
@@ -370,7 +374,9 @@ class VolumeManagerBase(DeviceProvider):
         """
         return '/'
 
-    def sync_data(self, exclude: Optional[List[str]] = None) -> Optional[MountManager]:
+    def sync_data(
+        self, exclude: Optional[List[str]] = None
+    ) -> Optional[MountManager]:
         """
         Implements sync of root directory to mounted volumes
 
@@ -421,3 +427,6 @@ class VolumeManagerBase(DeviceProvider):
         self.mountpoint_tempdir = Temporary(prefix='kiwi_volumes.').new_dir()
         self.mountpoint = self.mountpoint_tempdir.name
         self.temp_directories.append(self.mountpoint_tempdir)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -134,13 +134,13 @@ class TestCli:
     def test_set_target_arch(self):
         sys.argv = [
             sys.argv[0],
-            '--target-arch', 'artificial', 'system', 'build',
+            '--target-arch', 'x86_64', 'system', 'build',
             '--description', 'description',
             '--target-dir', 'directory'
         ]
         cli = Cli()
         cli.get_global_args()
-        assert Defaults.get_platform_name() == 'artificial'
+        assert Defaults.get_platform_name() == 'x86_64'
 
     def test_get_servicename_image(self):
         sys.argv = [

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -291,3 +291,10 @@ class TestVolumeManagerBase:
         mock_command.assert_called_once_with(
             ['chattr', '+C', 'toplevel/etc']
         )
+
+    @patch('os.path.exists')
+    def test_context_manager_exit(self, mock_os_path_exists):
+        mock_os_path_exists.return_value = True
+        with VolumeManagerBase(self.device_map, 'root_dir', Mock()):
+            pass
+            # just pass


### PR DESCRIPTION
Change the VolumeManager Factory to be a context manager. All code using VolumeManager was
updated to the following with statement:

```python
with VolumeManager(...).new as volume_manager:
    volume_manager.some_member()
```

This is related to Issue #2412