### PR TITLE
Fixed implementation for oem-shutdown

### DIFF
--- a/dracut/modules.d/99kiwi-dump-reboot/kiwi-dump-reboot-system.sh
+++ b/dracut/modules.d/99kiwi-dump-reboot/kiwi-dump-reboot-system.sh
@@ -30,7 +30,7 @@ function boot_installed_system {
         ask_and_shutdown "${ask_shutdown_text}"
     fi
     if [ "${kiwi_oemshutdown}" = "true" ];then
-        reboot -f -p
+        systemctl halt
     fi
 
     # if rd.kiwi.install.pass.bootparam is given, pass on most

--- a/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
@@ -152,6 +152,6 @@ function ask_and_shutdown {
     if ! run_dialog --yesno "\"${text_message}\"" 7 80; then
         die "${text_message}"
     else
-        reboot -f -p
+        systemctl halt
     fi
 }


### PR DESCRIPTION
If specified oem-shutdown caused a reboot -f -p which is a powerdown but not a graceful shutdown. This commit fixes this by using systemctl halt for a clean shutdown. This Fixes #2474

