### PR TITLE
Allow terminal emulation setup from the cmdline

### DIFF
--- a/doc/source/concept_and_workflow/customize_the_boot_process.rst
+++ b/doc/source/concept_and_workflow/customize_the_boot_process.rst
@@ -181,6 +181,14 @@ A dracut generated initrd in a {kiwi} image build process includes one or
 more of the {kiwi} provided dracut modules. The following list documents
 the available kernel boot parameters for this modules:
 
+``rd.kiwi.term``
+  Exports the TERM variable into the initrd environment. In case
+  the default value for the terminal emulation is not appropriate
+  `rd.kiwi.term` can be used to overwrite the default. The
+  environment is also passed to the systemd unit which calls
+  dialog based programs in {kiwi} dracut code, such that the
+  TERM setting will be effective there too.
+
 ``rd.kiwi.debug``
   Activates the debug log file for the {kiwi} part of
   the boot process at :file:`/run/initramfs/log/boot.kiwi`.

--- a/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
@@ -176,21 +176,28 @@ function initialize {
     # The method will exit from the initrd if the profile
     # file does not exist
     # """
+    local term
     local kiwi_oem_installdevice
     local profile=/.profile
     local profile_extra=/.profile.extra
 
+    # Read and import mandatory image profile to env
     test -f ${profile} || \
         report_and_quit "No profile setup found"
-
     import_file ${profile}
 
+    # Optional env TERM setup
+    term=$(getarg "rd.kiwi.term=")
+    [ -n "${term}" ] && export TERM="${term}"
+
+    # Source optional profile.extra to env
     test -f ${profile_extra} && source ${profile_extra}
 
+    # Create dialog profile from current env
     # Used in the systemd dialog unit
     env >/dialog_profile
 
-    # Handle overwrites
+    # Handle kiwi specific env overwrites
     kiwi_oem_installdevice=$(getarg rd.kiwi.oem.installdevice=)
     if [ -n "${kiwi_oem_installdevice}" ];then
         # activate unattended mode. In case a user explicitly


### PR DESCRIPTION
Using rd.kiwi.term will export the TERM variable into the initrd environment. In case the default value for the terminal emulation is not appropriate rd.kiwi.term can be used to overwrite the default. The environment is also passed to the systemd unit which calls dialog based programs in kiwi dracut code, such that the TERM setting will be effective there too. For example:

```
rd.kiwi.term=vt100
```

This is related to bsc#1218095

