### PR TITLE
Move Repository to context manager

### DIFF
--- a/kiwi/repository/base.py
+++ b/kiwi/repository/base.py
@@ -44,6 +44,9 @@ class RepositoryBase:
 
         self.post_init(custom_args or [])
 
+    def __enter__(self):
+        return self
+
     def post_init(self, custom_args: List = []) -> None:
         """
         Post initialization method
@@ -166,3 +169,6 @@ class RepositoryBase:
         Command.run(
             ['bash', '--norc', script_path, repo_file]
         )
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass  # pragma: no cover

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -450,7 +450,9 @@ class RepositoryZypper(RepositoryBase):
         """
         self._move_package_cache(restore=True)
 
-    def _move_package_cache(self, backup: bool = False, restore: bool = False) -> None:
+    def _move_package_cache(
+        self, backup: bool = False, restore: bool = False
+    ) -> None:
         package_cache = self.shared_location + '/packages'
         package_cache_moved = package_cache + '.moved'
         if backup and os.path.exists(package_cache):
@@ -462,5 +464,5 @@ class RepositoryZypper(RepositoryBase):
                 ['mv', '-f', package_cache_moved, package_cache]
             )
 
-    def __del__(self) -> None:
+    def __exit__(self, exc_type, exc_value, traceback):
         self._restore_package_cache()

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -374,7 +374,7 @@ class SystemPrepare:
                 )
 
     def pinch_system(
-        self, manager: PackageManagerBase = None, force: bool = False
+        self, manager: Optional[PackageManagerBase] = None, force: bool = False
     ) -> None:
         """
         Delete packages marked for deletion in the XML description. If force

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -139,52 +139,52 @@ class SystemSetup:
         root = RootInit(
             root_dir=self.root_dir, allow_existing=True
         )
-        repo = Repository.new(
+        with Repository.new(
             RootBind(root), self.xml_state.get_package_manager()
-        )
-        repo.use_default_location()
-        for xml_repo in repository_sections:
-            repo_type = xml_repo.get_type()
-            repo_source = xml_repo.get_source().get_path()
-            repo_user = xml_repo.get_username()
-            repo_secret = xml_repo.get_password()
-            repo_alias = xml_repo.get_alias()
-            repo_priority = xml_repo.get_priority()
-            repo_dist = xml_repo.get_distribution()
-            repo_components = xml_repo.get_components()
-            repo_repository_gpgcheck = xml_repo.get_repository_gpgcheck()
-            repo_package_gpgcheck = xml_repo.get_package_gpgcheck()
-            repo_customization_script = self._get_repo_customization_script(
-                xml_repo
-            )
-            repo_sourcetype = xml_repo.get_sourcetype()
-            repo_use_for_bootstrap = False
-            uri = Uri(repo_source, repo_type)
-            repo_source_translated = uri.translate(
-                check_build_environment=False
-            )
-            if not repo_alias:
-                repo_alias = uri.alias()
-            log.info(
-                'Setting up image repository {0}'.format(
-                    Uri.print_sensitive(repo_source)
+        ) as repo:
+            repo.use_default_location()
+            for xml_repo in repository_sections:
+                repo_type = xml_repo.get_type()
+                repo_source = xml_repo.get_source().get_path()
+                repo_user = xml_repo.get_username()
+                repo_secret = xml_repo.get_password()
+                repo_alias = xml_repo.get_alias()
+                repo_priority = xml_repo.get_priority()
+                repo_dist = xml_repo.get_distribution()
+                repo_components = xml_repo.get_components()
+                repo_repository_gpgcheck = xml_repo.get_repository_gpgcheck()
+                repo_package_gpgcheck = xml_repo.get_package_gpgcheck()
+                repo_customization_script = self._get_repo_customization_script(
+                    xml_repo
                 )
-            )
-            log.info('--> Type: {0}'.format(repo_type))
-            log.info(
-                '--> Translated: {0}'.format(
-                    Uri.print_sensitive(repo_source_translated)
+                repo_sourcetype = xml_repo.get_sourcetype()
+                repo_use_for_bootstrap = False
+                uri = Uri(repo_source, repo_type)
+                repo_source_translated = uri.translate(
+                    check_build_environment=False
                 )
-            )
-            log.info('--> Alias: {0}'.format(repo_alias))
-            repo.add_repo(
-                repo_alias, repo_source_translated,
-                repo_type, repo_priority, repo_dist, repo_components,
-                repo_user, repo_secret, uri.credentials_file_name(),
-                repo_repository_gpgcheck, repo_package_gpgcheck,
-                repo_sourcetype, repo_use_for_bootstrap,
-                repo_customization_script
-            )
+                if not repo_alias:
+                    repo_alias = uri.alias()
+                log.info(
+                    'Setting up image repository {0}'.format(
+                        Uri.print_sensitive(repo_source)
+                    )
+                )
+                log.info('--> Type: {0}'.format(repo_type))
+                log.info(
+                    '--> Translated: {0}'.format(
+                        Uri.print_sensitive(repo_source_translated)
+                    )
+                )
+                log.info('--> Alias: {0}'.format(repo_alias))
+                repo.add_repo(
+                    repo_alias, repo_source_translated,
+                    repo_type, repo_priority, repo_dist, repo_components,
+                    repo_user, repo_secret, uri.credentials_file_name(),
+                    repo_repository_gpgcheck, repo_package_gpgcheck,
+                    repo_sourcetype, repo_use_for_bootstrap,
+                    repo_customization_script
+                )
 
     def import_cdroot_files(self, target_dir: str) -> None:
         """

--- a/test/unit/repository/zypper_test.py
+++ b/test/unit/repository/zypper_test.py
@@ -426,9 +426,10 @@ class TestRepositoryZypper:
 
     @patch('kiwi.command.Command.run')
     @patch('os.path.exists')
-    def test_destructor(self, mock_exists, mock_command):
-        mock_exists.return_value = True
-        self.repo.__del__()
-        mock_command.assert_called_once_with(
+    def test_context_manager_exit(self, mock_os_path_exists, mock_command_run):
+        mock_os_path_exists.return_value = True
+        with RepositoryZypper(self.root_bind):
+            pass
+        mock_command_run.assert_called_once_with(
             ['mv', '-f', '/shared-dir/packages.moved', '/shared-dir/packages']
         )

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -254,7 +254,7 @@ class TestSystemPrepare:
             return_value='credentials-file'
         )
         repo = Mock()
-        mock_repo.return_value = repo
+        mock_repo.return_value.__enter__.return_value = repo
 
         self.system.setup_repositories(
             clear_cache=True,
@@ -324,7 +324,7 @@ class TestSystemPrepare:
             return_value='uri-alias'
         )
         repo = Mock()
-        mock_repo.return_value = repo
+        mock_repo.return_value.__enter__.return_value = repo
         with self._caplog.at_level(logging.WARNING):
             self.system.setup_repositories()
 

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -1591,7 +1591,7 @@ class TestSystemSetup:
         )
         mock_uri.return_value = uri
         repo = Mock()
-        mock_repo.return_value = repo
+        mock_repo.return_value.__enter__.return_value = repo
         self.setup_with_real_xml.import_repositories_marked_as_imageinclude()
         assert repo.add_repo.call_args_list[0] == call(
             'uri-alias', 'uri', 'rpm-md', None, None, None, None, None,


### PR DESCRIPTION
Change the Repository Factory to be a context manager. All code using Repository was updated to the following with statement:

```python
with Repository(...).new as repo:
    repo.some_member()
```

This is related to Issue #2412