### PR TITLE
Added requirement for xmltodict to spec

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -371,6 +371,7 @@ Requires:       python%{python3_pkgversion}-docopt
 Requires:       python%{python3_pkgversion}-lxml
 Requires:       python%{python3_pkgversion}-requests
 Requires:       python%{python3_pkgversion}-setuptools
+Requires:       python%{python3_pkgversion}-xmltodict
 %if 0%{?rhel} || 0%{?fedora}
 Requires:       (python%{python3_pkgversion}-typing-extensions if python%{python3_pkgversion} < 3.8)
 %endif


### PR DESCRIPTION
Actually the real issue to this defect seems to live in the anymarkup source code. It seems that the import of xmltodict at the beginning of the core module is optional, but later on when handling XML xmltodict seems to be mandatory, see here: https://github.com/bkabrda/anymarkup-core/blob/08896a8215819edcc413e3f2588518046 9a4c2ed/anymarkup_core/__init__.py#L210-L229. Because this issue can result in a "ImportError: Can't parse xml: xmltodict not installed" turning kiwi into a bad exit condition I propose to add this python requirement to the kiwi spec as a workaround and try fixing the anymarkup packaging and module setup upstream in addition. To my knowledge all relevant distributions provides xmltodict


