### PR TITLE
Move DiskFormat to context manager

### DIFF
--- a/kiwi/storage/subformat/base.py
+++ b/kiwi/storage/subformat/base.py
@@ -60,6 +60,9 @@ class DiskFormatBase:
 
         self.post_init(custom_args or {})
 
+    def __enter__(self):
+        return self
+
     def post_init(self, custom_args: dict) -> None:
         """
         Post initialization method
@@ -198,7 +201,6 @@ class DiskFormatBase:
             shasum=True
         )
 
-    def __del__(self):
+    def __exit__(self, exc_type, exc_value, traceback):
         if self.temp_image_dir and os.path.exists(self.temp_image_dir):
-            log.info('Cleaning up %s instance', type(self).__name__)
             Path.wipe(self.temp_image_dir)

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -1647,7 +1647,7 @@ class TestDiskBuilder:
         partitioner = Mock()
         mock_partitioner.return_value = partitioner
         disk_format = Mock()
-        mock_diskformat.return_value = disk_format
+        mock_diskformat.return_value.__enter__.return_value = disk_format
         self.disk_builder.unpartitioned_bytes = 1024
         self.disk_builder.append_unpartitioned_space()
         disk_format.resize_raw_disk.assert_called_once_with(
@@ -1661,7 +1661,7 @@ class TestDiskBuilder:
     @patch('kiwi.builder.disk.DiskFormat.new')
     def test_create_disk_format(self, mock_DiskFormat, mock_command, mock_fs):
         disk_subformat = Mock()
-        mock_DiskFormat.return_value = disk_subformat
+        mock_DiskFormat.return_value.__enter__.return_value = disk_subformat
         result_instance = Mock()
         filesystem = Mock()
         mock_fs.return_value.__enter__.return_value = filesystem

--- a/test/unit/storage/integrity_device_test.py
+++ b/test/unit/storage/integrity_device_test.py
@@ -228,7 +228,7 @@ class TestIntegrityDevice:
 
     @patch('kiwi.storage.integrity_device.Command.run')
     @patch('kiwi.storage.integrity_device.log.warning')
-    def test_destructor(self, mock_log_warn, mock_Command_run):
+    def test_context_manager_exit(self, mock_log_warn, mock_Command_run):
         mock_Command_run.side_effect = Exception
         with self._caplog.at_level(logging.ERROR):
             with IntegrityDevice(

--- a/test/unit/storage/subformat/base_test.py
+++ b/test/unit/storage/subformat/base_test.py
@@ -145,9 +145,10 @@ class TestDiskFormatBase:
 
     @patch('kiwi.storage.subformat.base.Path.wipe')
     @patch('os.path.exists')
-    def test_destructor(self, mock_exists, mock_wipe):
+    def test_context_manager_exit(self, mock_exists, mock_wipe):
         mock_exists.return_value = True
-        self.disk_format.temp_image_dir = 'tmpdir'
-        self.disk_format.__del__()
-        self.disk_format.temp_image_dir = None
+        with DiskFormatBase(
+            self.xml_state, 'root_dir', 'target_dir'
+        ) as disk_format:
+            disk_format.temp_image_dir = 'tmpdir'
         mock_wipe.assert_called_once_with('tmpdir')

--- a/test/unit/tasks/image_resize_test.py
+++ b/test/unit/tasks/image_resize_test.py
@@ -73,7 +73,7 @@ class TestImageResizeTask:
     def test_process_no_raw_disk_found(self, mock_DiskFormat):
         image_format = Mock()
         image_format.has_raw_disk.return_value = False
-        mock_DiskFormat.return_value = image_format
+        mock_DiskFormat.return_value.__enter__.return_value = image_format
         self._init_command_args()
         self.task.command_args['resize'] = True
         with raises(KiwiImageResizeError):
@@ -83,7 +83,7 @@ class TestImageResizeTask:
     def test_process_unsupported_size_format(self, mock_DiskFormat):
         image_format = Mock()
         image_format.has_raw_disk.return_value = True
-        mock_DiskFormat.return_value = image_format
+        mock_DiskFormat.return_value.__enter__.return_value = image_format
         self._init_command_args()
         self.task.command_args['--size'] = '20x'
         self.task.command_args['resize'] = True
@@ -102,7 +102,7 @@ class TestImageResizeTask:
         mock_Partitioner.return_value = partitioner
         image_format = Mock()
         image_format.resize_raw_disk.return_value = True
-        mock_DiskFormat.return_value = image_format
+        mock_DiskFormat.return_value.__enter__.return_value = image_format
         self._init_command_args()
         self.task.command_args['resize'] = True
         self.task.process()
@@ -125,7 +125,7 @@ class TestImageResizeTask:
         mock_Partitioner.return_value = partitioner
         image_format = Mock()
         image_format.resize_raw_disk.return_value = True
-        mock_DiskFormat.return_value = image_format
+        mock_DiskFormat.return_value.__enter__.return_value = image_format
         self._init_command_args()
         self.task.command_args['resize'] = True
         self.task.command_args['--size'] = '42m'
@@ -149,7 +149,7 @@ class TestImageResizeTask:
         mock_Partitioner.return_value = partitioner
         image_format = Mock()
         image_format.resize_raw_disk.return_value = True
-        mock_DiskFormat.return_value = image_format
+        mock_DiskFormat.return_value.__enter__.return_value = image_format
         self._init_command_args()
         self.task.command_args['resize'] = True
         self.task.command_args['--size'] = '42'
@@ -173,7 +173,7 @@ class TestImageResizeTask:
         mock_Partitioner.return_value = partitioner
         image_format = Mock()
         image_format.resize_raw_disk.return_value = False
-        mock_DiskFormat.return_value = image_format
+        mock_DiskFormat.return_value.__enter__.return_value = image_format
         self._init_command_args()
         self.task.command_args['resize'] = True
         self.task.command_args['--size'] = '42'


### PR DESCRIPTION
Change the DiskFormat Factory to be a context manager. All code using DiskFormat was updated to the following with statement:

```python
    with DiskFormat(...).new as disk_format:
        disk_format.some_member()
```

This is related to Issue #2412

