### PR TITLE
Move SystemPrepare to context manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,6 @@ htmlcov/
 .tox/
 .coverage
 .cache
-nosetests.xml
 coverage.xml
 
 # Translations
@@ -74,9 +73,6 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 doc/xml/
-
-# PyBuilder
-target/
 
 # man pages
 *.1.gz

--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -85,44 +85,42 @@ class BootImageKiwi(BootImageBase):
             self.import_system_description_elements()
 
             log.info('Preparing boot image')
-            system = SystemPrepare(
+            with SystemPrepare(
                 xml_state=self.boot_xml_state,
                 root_dir=self.boot_root_directory,
                 allow_existing=True
-            )
-            manager = system.setup_repositories(
-                signing_keys=self.signing_keys, target_arch=self.target_arch
-            )
-            system.install_bootstrap(
-                manager
-            )
-            system.install_system(
-                manager
-            )
+            ) as system:
+                manager = system.setup_repositories(
+                    signing_keys=self.signing_keys, target_arch=self.target_arch
+                )
+                system.install_bootstrap(
+                    manager
+                )
+                system.install_system(
+                    manager
+                )
 
-            profile = Profile(self.boot_xml_state)
-            profile.add('kiwi_initrdname', boot_image_name)
+                profile = Profile(self.boot_xml_state)
+                profile.add('kiwi_initrdname', boot_image_name)
 
-            defaults = Defaults()
-            defaults.to_profile(profile)
+                defaults = Defaults()
+                defaults.to_profile(profile)
 
-            self.setup = SystemSetup(
-                self.boot_xml_state, self.boot_root_directory
-            )
-            profile.create(
-                Defaults.get_profile_file(self.boot_root_directory)
-            )
-            self.setup.import_description()
-            self.setup.import_overlay_files(
-                follow_links=True
-            )
-            self.setup.call_config_script()
+                self.setup = SystemSetup(
+                    self.boot_xml_state, self.boot_root_directory
+                )
+                profile.create(
+                    Defaults.get_profile_file(self.boot_root_directory)
+                )
+                self.setup.import_description()
+                self.setup.import_overlay_files(
+                    follow_links=True
+                )
+                self.setup.call_config_script()
 
-            system.pinch_system(
-                manager=manager, force=True
-            )
-            # make sure system instance is cleaned up before setting up
-            del system
+                system.pinch_system(
+                    manager=manager, force=True
+                )
 
             self.setup.call_image_script()
             self.setup.create_init_link_from_linuxrc()

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -109,6 +109,9 @@ class SystemPrepare:
         #: A list of Uri references
         self.uri_list: List[Uri] = []
 
+    def __enter__(self):
+        return self
+
     def setup_repositories(
         self, clear_cache: bool = False,
         signing_keys: List[str] = None, target_arch: Optional[str] = None
@@ -611,20 +614,8 @@ class SystemPrepare:
             )
         return script_path
 
-    def __del__(self):
-        log.info('Cleaning up {:s} instance'.format(type(self).__name__))
-        try:
-            if hasattr(self, 'root_bind'):
-                self.root_bind.cleanup()
-            if self.root_import:
-                self.root_import.overlay_finalize(self.xml_state)
-        except Exception as exc:
-            log.info(
-                'Cleaning up {self_name:s} instance failed, got an exception '
-                'of type {exc_type:s}: {exc:s}'
-                .format(
-                    self_name=type(self).__name__,
-                    exc_type=type(exc).__name__,
-                    exc=str(exc)
-                )
-            )
+    def __exit__(self, exc_type, exc_value, traceback):
+        if hasattr(self, 'root_bind'):
+            self.root_bind.cleanup()
+        if self.root_import:
+            self.root_import.overlay_finalize(self.xml_state)

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -219,90 +219,81 @@ class SystemBuildTask(CliTask):
         self.run_checks(self.checks_after_command_args)
 
         log.info('Preparing new root system')
-        system = SystemPrepare(
+        with SystemPrepare(
             self.xml_state,
             image_root,
             self.command_args['--allow-existing-root']
-        )
-        manager = system.setup_repositories(
-            self.command_args['--clear-cache'],
-            self.command_args[
-                '--signing-key'
-            ] + self.xml_state.get_repositories_signing_keys(),
-            self.global_args['--target-arch']
-        )
-        system.install_bootstrap(
-            manager, self.command_args['--add-bootstrap-package']
-        )
-
-        setup = SystemSetup(
-            self.xml_state, image_root
-        )
-        setup.import_description()
-
-        # call post_bootstrap.sh script if present
-        setup.call_post_bootstrap_script()
-
-        system.install_system(
-            manager
-        )
-        if self.command_args['--add-package']:
-            system.install_packages(
-                manager, self.command_args['--add-package']
+        ) as system:
+            manager = system.setup_repositories(
+                self.command_args['--clear-cache'],
+                self.command_args[
+                    '--signing-key'
+                ] + self.xml_state.get_repositories_signing_keys(),
+                self.global_args['--target-arch']
             )
-        if self.command_args['--delete-package']:
-            system.delete_packages(
-                manager, self.command_args['--delete-package']
+            system.install_bootstrap(
+                manager, self.command_args['--add-bootstrap-package']
             )
 
-        profile = Profile(self.xml_state)
+            setup = SystemSetup(
+                self.xml_state, image_root
+            )
+            setup.import_description()
 
-        defaults = Defaults()
-        defaults.to_profile(profile)
-        profile.create(
-            Defaults.get_profile_file(image_root)
-        )
+            # call post_bootstrap.sh script if present
+            setup.call_post_bootstrap_script()
 
-        setup.import_overlay_files()
-        setup.import_image_identifier()
-        setup.setup_groups()
-        setup.setup_users()
-        setup.setup_keyboard_map()
-        setup.setup_locale()
-        setup.setup_plymouth_splash()
-        setup.setup_timezone()
-        setup.setup_permissions()
+            system.install_system(
+                manager
+            )
+            if self.command_args['--add-package']:
+                system.install_packages(
+                    manager, self.command_args['--add-package']
+                )
+            if self.command_args['--delete-package']:
+                system.delete_packages(
+                    manager, self.command_args['--delete-package']
+                )
 
-        # make sure manager instance is cleaned up now
-        del manager
+            profile = Profile(self.xml_state)
 
-        # setup permanent image repositories after cleanup
-        setup.import_repositories_marked_as_imageinclude()
+            defaults = Defaults()
+            defaults.to_profile(profile)
+            profile.create(
+                Defaults.get_profile_file(image_root)
+            )
 
-        # call config.sh script if present
-        setup.call_config_script()
+            setup.import_overlay_files()
+            setup.import_image_identifier()
+            setup.setup_groups()
+            setup.setup_users()
+            setup.setup_keyboard_map()
+            setup.setup_locale()
+            setup.setup_plymouth_splash()
+            setup.setup_timezone()
+            setup.setup_permissions()
 
-        # if configured, assign SELinux labels
-        setup.setup_selinux_file_contexts()
+            # setup permanent image repositories after cleanup
+            setup.import_repositories_marked_as_imageinclude()
 
-        # handle uninstall package requests, gracefully uninstall
-        # with dependency cleanup
-        system.pinch_system(force=False)
+            # call config.sh script if present
+            setup.call_config_script()
 
-        # handle delete package requests, forced uninstall without
-        # any dependency resolution
-        system.pinch_system(force=True)
+            # if configured, assign SELinux labels
+            setup.setup_selinux_file_contexts()
 
-        # delete any custom rpm macros created
-        system.clean_package_manager_leftovers()
+            # handle uninstall package requests, gracefully uninstall
+            # with dependency cleanup
+            system.pinch_system(force=False)
 
-        # make sure system instance is cleaned up now
-        del system
+            # handle delete package requests, forced uninstall without
+            # any dependency resolution
+            system.pinch_system(force=True)
+
+            # delete any custom rpm macros created
+            system.clean_package_manager_leftovers()
 
         setup.call_image_script()
-
-        # make sure setup instance is cleaned up now
-        del setup
 
         log.info('Creating system image')
         self.run_checks(

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -204,105 +204,101 @@ class SystemPrepareTask(CliTask):
         self.run_checks(self.checks_after_command_args)
 
         log.info('Preparing system')
-        system = SystemPrepare(
+        with SystemPrepare(
             self.xml_state,
             abs_root_path,
             self.command_args['--allow-existing-root']
-        )
-        manager = system.setup_repositories(
-            self.command_args['--clear-cache'],
-            self.command_args[
-                '--signing-key'
-            ] + self.xml_state.get_repositories_signing_keys(),
-            self.global_args['--target-arch']
-        )
-        run_bootstrap = True
-        if self.xml_state.get_package_manager() == 'apt' and \
-           self.command_args['--allow-existing-root']:
-            # try to call apt-get inside of the existing root.
-            # If the call succeeds we skip calling debootstrap again
-            # and assume the root to be ok to proceed with apt-get
-            # if it fails, treat the root as dirty and give the
-            # bootstrap a try
-            try:
-                Command.run(['chroot', abs_root_path, 'apt-get', '--version'])
-                run_bootstrap = False
-                log.warning(
-                    'debootstrap will only be called once, skipped'
+        ) as system:
+            manager = system.setup_repositories(
+                self.command_args['--clear-cache'],
+                self.command_args[
+                    '--signing-key'
+                ] + self.xml_state.get_repositories_signing_keys(),
+                self.global_args['--target-arch']
+            )
+            run_bootstrap = True
+            if self.xml_state.get_package_manager() == 'apt' and \
+               self.command_args['--allow-existing-root']:
+                # try to call apt-get inside of the existing root.
+                # If the call succeeds we skip calling debootstrap again
+                # and assume the root to be ok to proceed with apt-get
+                # if it fails, treat the root as dirty and give the
+                # bootstrap a try
+                try:
+                    Command.run(
+                        ['chroot', abs_root_path, 'apt-get', '--version']
+                    )
+                    run_bootstrap = False
+                    log.warning(
+                        'debootstrap will only be called once, skipped'
+                    )
+                except Exception:
+                    run_bootstrap = True
+
+            if run_bootstrap:
+                system.install_bootstrap(
+                    manager, self.command_args['--add-bootstrap-package']
                 )
-            except Exception:
-                run_bootstrap = True
 
-        if run_bootstrap:
-            system.install_bootstrap(
-                manager, self.command_args['--add-bootstrap-package']
+            setup = SystemSetup(
+                self.xml_state, abs_root_path
+            )
+            setup.import_description()
+
+            # call post_bootstrap.sh script if present
+            setup.call_post_bootstrap_script()
+
+            system.install_system(
+                manager
             )
 
-        setup = SystemSetup(
-            self.xml_state, abs_root_path
-        )
-        setup.import_description()
+            if self.command_args['--add-package']:
+                system.install_packages(
+                    manager, self.command_args['--add-package']
+                )
+            if self.command_args['--delete-package']:
+                system.delete_packages(
+                    manager, self.command_args['--delete-package']
+                )
 
-        # call post_bootstrap.sh script if present
-        setup.call_post_bootstrap_script()
+            profile = Profile(self.xml_state)
 
-        system.install_system(
-            manager
-        )
+            defaults = Defaults()
+            defaults.to_profile(profile)
 
-        if self.command_args['--add-package']:
-            system.install_packages(
-                manager, self.command_args['--add-package']
-            )
-        if self.command_args['--delete-package']:
-            system.delete_packages(
-                manager, self.command_args['--delete-package']
+            profile.create(
+                Defaults.get_profile_file(abs_root_path)
             )
 
-        profile = Profile(self.xml_state)
+            setup.import_overlay_files()
+            setup.import_image_identifier()
+            setup.setup_groups()
+            setup.setup_users()
+            setup.setup_keyboard_map()
+            setup.setup_locale()
+            setup.setup_plymouth_splash()
+            setup.setup_timezone()
+            setup.setup_permissions()
 
-        defaults = Defaults()
-        defaults.to_profile(profile)
+            # setup permanent image repositories after cleanup
+            setup.import_repositories_marked_as_imageinclude()
 
-        profile.create(
-            Defaults.get_profile_file(abs_root_path)
-        )
+            # call config.sh script if present
+            setup.call_config_script()
 
-        setup.import_overlay_files()
-        setup.import_image_identifier()
-        setup.setup_groups()
-        setup.setup_users()
-        setup.setup_keyboard_map()
-        setup.setup_locale()
-        setup.setup_plymouth_splash()
-        setup.setup_timezone()
-        setup.setup_permissions()
+            # if configured, assign SELinux labels
+            setup.setup_selinux_file_contexts()
 
-        # make sure manager instance is cleaned up now
-        del manager
+            # handle uninstall package requests, gracefully uninstall
+            # with dependency cleanup
+            system.pinch_system(force=False)
 
-        # setup permanent image repositories after cleanup
-        setup.import_repositories_marked_as_imageinclude()
+            # handle delete package requests, forced uninstall without
+            # any dependency resolution
+            system.pinch_system(force=True)
 
-        # call config.sh script if present
-        setup.call_config_script()
-
-        # if configured, assign SELinux labels
-        setup.setup_selinux_file_contexts()
-
-        # handle uninstall package requests, gracefully uninstall
-        # with dependency cleanup
-        system.pinch_system(force=False)
-
-        # handle delete package requests, forced uninstall without
-        # any dependency resolution
-        system.pinch_system(force=True)
-
-        # delete any custom rpm macros created
-        system.clean_package_manager_leftovers()
-
-        # make sure system instance is cleaned up now
-        del system
+            # delete any custom rpm macros created
+            system.clean_package_manager_leftovers()
 
     def _help(self):
         if self.command_args['help']:

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -122,6 +122,8 @@ from kiwi.defaults import Defaults
 from kiwi.system.profile import Profile
 from kiwi.command import Command
 
+from kiwi.exceptions import KiwiCommandError
+
 log = logging.getLogger('kiwi')
 
 
@@ -232,7 +234,7 @@ class SystemPrepareTask(CliTask):
                     log.warning(
                         'debootstrap will only be called once, skipped'
                     )
-                except Exception:
+                except KiwiCommandError:
                     run_bootstrap = True
 
             if run_bootstrap:

--- a/kiwi/tasks/system_update.py
+++ b/kiwi/tasks/system_update.py
@@ -84,26 +84,26 @@ class SystemUpdateTask(CliTask):
             package_requests = True
 
         log.info('Updating system')
-        self.system = SystemPrepare(
+        with SystemPrepare(
             self.xml_state,
             abs_root_path,
             allow_existing=True
-        )
-        manager = self.system.setup_repositories(
-            target_arch=self.global_args['--target-arch']
-        )
+        ) as system:
+            manager = system.setup_repositories(
+                target_arch=self.global_args['--target-arch']
+            )
 
-        if not package_requests:
-            self.system.update_system(manager)
-        else:
-            if self.command_args['--add-package']:
-                self.system.install_packages(
-                    manager, self.command_args['--add-package']
-                )
-            if self.command_args['--delete-package']:
-                self.system.delete_packages(
-                    manager, self.command_args['--delete-package']
-                )
+            if not package_requests:
+                system.update_system(manager)
+            else:
+                if self.command_args['--add-package']:
+                    system.install_packages(
+                        manager, self.command_args['--add-package']
+                    )
+                if self.command_args['--delete-package']:
+                    system.delete_packages(
+                        manager, self.command_args['--delete-package']
+                    )
 
     def _help(self):
         if self.command_args['help']:

--- a/test/unit/tasks/system_create_test.py
+++ b/test/unit/tasks/system_create_test.py
@@ -1,5 +1,7 @@
 import sys
-import unittest.mock as mock
+from unittest.mock import (
+    Mock, MagicMock
+)
 import os
 
 import kiwi
@@ -19,36 +21,35 @@ class TestSystemCreateTask:
         self.abs_root_dir = os.path.abspath('../data/root-dir')
         self.abs_target_dir = os.path.abspath('some-target')
 
-        kiwi.tasks.system_create.Path = mock.Mock()
-        kiwi.tasks.system_create.Privileges = mock.Mock()
-        kiwi.tasks.system_create.Path = mock.Mock()
+        kiwi.tasks.system_create.Path = Mock()
+        kiwi.tasks.system_create.Privileges = Mock()
 
-        kiwi.tasks.system_create.Help = mock.Mock(
-            return_value=mock.Mock()
+        kiwi.tasks.system_create.Help = Mock(
+            return_value=Mock()
         )
 
-        self.runtime_checker = mock.Mock()
-        kiwi.tasks.base.RuntimeChecker = mock.Mock(
+        self.runtime_checker = Mock()
+        kiwi.tasks.base.RuntimeChecker = Mock(
             return_value=self.runtime_checker
         )
 
-        self.runtime_config = mock.Mock()
+        self.runtime_config = Mock()
         self.runtime_config.get_disabled_runtime_checks.return_value = []
-        kiwi.tasks.base.RuntimeConfig = mock.Mock(
+        kiwi.tasks.base.RuntimeConfig = Mock(
             return_value=self.runtime_config
         )
 
-        self.setup = mock.Mock()
-        kiwi.tasks.system_create.SystemSetup = mock.Mock(
+        self.setup = Mock()
+        kiwi.tasks.system_create.SystemSetup = Mock(
             return_value=self.setup
         )
 
-        self.result = mock.Mock()
-        self.builder = mock.MagicMock()
-        self.builder.create = mock.Mock(
+        self.result = Mock()
+        self.builder = MagicMock()
+        self.builder.create = Mock(
             return_value=self.result
         )
-        kiwi.tasks.system_create.ImageBuilder.new = mock.Mock(
+        kiwi.tasks.system_create.ImageBuilder.new = Mock(
             return_value=self.builder
         )
 

--- a/test/unit/tasks/system_prepare_test.py
+++ b/test/unit/tasks/system_prepare_test.py
@@ -9,6 +9,8 @@ import kiwi
 
 from ..test_helper import argv_kiwi_tests
 
+from kiwi.exceptions import KiwiCommandError
+
 from kiwi.tasks.system_prepare import SystemPrepareTask
 
 
@@ -191,7 +193,7 @@ class TestSystemPrepareTask:
         self.task.command_args['--allow-existing-root'] = True
 
         # debootstrap must be called if chroot with apt-get failed
-        self.command.run.side_effect = Exception
+        self.command.run.side_effect = KiwiCommandError('error')
         self.task.process()
         assert system_prepare.install_bootstrap.called
 

--- a/test/unit/tasks/system_update_test.py
+++ b/test/unit/tasks/system_update_test.py
@@ -1,5 +1,8 @@
 import sys
-import unittest.mock as mock
+import os
+from unittest.mock import (
+    patch, Mock
+)
 
 import kiwi
 
@@ -16,17 +19,13 @@ class TestSystemUpdateTask:
             sys.argv[0], '--profile', 'vmxFlavour', 'system', 'update',
             '--root', '../data/root-dir'
         ]
-        self.manager = mock.Mock()
-        self.system_prepare = mock.Mock()
-        kiwi.tasks.system_update.Privileges = mock.Mock()
-        self.system_prepare.setup_repositories = mock.Mock(
-            return_value=self.manager
-        )
-        kiwi.tasks.system_update.SystemPrepare = mock.Mock(
-            return_value=self.system_prepare
-        )
-        kiwi.tasks.system_update.Help = mock.Mock(
-            return_value=mock.Mock()
+        self.abs_target_dir = os.path.abspath('some-target')
+
+        kiwi.tasks.system_update.Privileges = Mock()
+        kiwi.tasks.system_update.Path = Mock()
+
+        kiwi.tasks.system_update.Help = Mock(
+            return_value=Mock()
         )
         self.task = SystemUpdateTask()
 
@@ -47,37 +46,58 @@ class TestSystemUpdateTask:
         self.task.command_args['--delete-package'] = []
         self.task.command_args['--root'] = '../data/root-dir'
 
-    def test_process_system_update(self):
+    @patch('kiwi.tasks.system_update.SystemPrepare')
+    def test_process_system_update(self, mock_SystemPrepare):
+        manager = Mock()
+        system_prepare = Mock()
+        system_prepare.setup_repositories = Mock(
+            return_value=manager
+        )
+        mock_SystemPrepare.return_value.__enter__.return_value = system_prepare
         self._init_command_args()
         self.task.command_args['update'] = True
         self.task.process()
-        self.task.system.setup_repositories.assert_called_once_with(
+        system_prepare.setup_repositories.assert_called_once_with(
             target_arch=None
         )
-        self.task.system.update_system.assert_called_once_with(self.manager)
+        system_prepare.update_system.assert_called_once_with(manager)
 
-    def test_process_system_update_add_package(self):
+    @patch('kiwi.tasks.system_update.SystemPrepare')
+    def test_process_system_update_add_package(self, mock_SystemPrepare):
+        manager = Mock()
+        system_prepare = Mock()
+        system_prepare.setup_repositories = Mock(
+            return_value=manager
+        )
+        mock_SystemPrepare.return_value.__enter__.return_value = system_prepare
         self._init_command_args()
         self.task.command_args['update'] = True
         self.task.command_args['--add-package'] = ['vim']
         self.task.process()
-        self.task.system.setup_repositories.assert_called_once_with(
+        system_prepare.setup_repositories.assert_called_once_with(
             target_arch=None
         )
-        self.task.system.install_packages.assert_called_once_with(
-            self.manager, ['vim']
+        system_prepare.install_packages.assert_called_once_with(
+            manager, ['vim']
         )
 
-    def test_process_system_update_delete_package(self):
+    @patch('kiwi.tasks.system_update.SystemPrepare')
+    def test_process_system_update_delete_package(self, mock_SystemPrepare):
+        manager = Mock()
+        system_prepare = Mock()
+        system_prepare.setup_repositories = Mock(
+            return_value=manager
+        )
+        mock_SystemPrepare.return_value.__enter__.return_value = system_prepare
         self._init_command_args()
         self.task.command_args['update'] = True
         self.task.command_args['--delete-package'] = ['vim']
         self.task.process()
-        self.task.system.setup_repositories.assert_called_once_with(
+        system_prepare.setup_repositories.assert_called_once_with(
             target_arch=None
         )
-        self.task.system.delete_packages.assert_called_once_with(
-            self.manager, ['vim']
+        system_prepare.delete_packages.assert_called_once_with(
+            manager, ['vim']
         )
 
     def test_process_system_update_help(self):


### PR DESCRIPTION
Change the SystemPrepare class to context manager. All code using SystemPrepare was updated to the following with statement:

```python
with SystemPrepare(...) as system_prepare:
    system_prepare.some_member()
```

This completes the refactoring from finalizers to
context managers and Fixes #2412


