### PR TITLE
Set default output console to gfxterm for grub

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -122,9 +122,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         ]
 
         self.terminal_output = \
-            terminal_output if terminal_output in terminal_output_grub else ''
+            terminal_output if terminal_output in terminal_output_grub else 'gfxterm'
         self.terminal_input = \
-            terminal_input if terminal_input in terminal_input_grub else ''
+            terminal_input if terminal_input in terminal_input_grub else 'console'
 
         self.gfxmode = self.get_gfxmode('grub2')
         self.theme = self.get_boot_theme()

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -894,7 +894,7 @@ class TestBootLoaderConfigGrub2:
         self.bootloader.multiboot = True
         self.bootloader.setup_live_image_config(self.mbrid)
         self.grub2.get_multiboot_iso_template.assert_called_once_with(
-            True, False, False, None
+            True, True, False, None
         )
 
     @patch.object(BootLoaderConfigGrub2, '_copy_grub_config_to_efi_path')
@@ -1043,7 +1043,7 @@ class TestBootLoaderConfigGrub2:
         self.bootloader.multiboot = False
         self.bootloader.setup_install_image_config(self.mbrid)
         self.grub2.get_install_template.assert_called_once_with(
-            True, False, False, True
+            True, True, False, True
         )
         mock_copy_grub_config_to_efi_path.assert_called_once_with(
             'root_dir', 'earlyboot.cfg', 'iso'


### PR DESCRIPTION
If no console setting is done in the image description for grub the default output console is set to: gfxterm and the default input console is set to: console. This Fixes bsc#1219074

