### PR TITLE
Add support for BLS zipl

### DIFF
--- a/build-tests/s390/rawhide/test-image-disk/appliance.kiwi
+++ b/build-tests/s390/rawhide/test-image-disk/appliance.kiwi
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- The line below is required in order to use the multibuild OBS features -->
+<!-- OBS-Profiles: @BUILD_FLAVOR@ -->
+
+<image schemaversion="7.5" name="kiwi-test-image-disk">
+    <description type="system">
+        <author>Marcus Schaefer</author>
+        <contact>marcus.schaefer@suse.com</contact>
+        <specification>Virtual and Physical disk image test</specification>
+    </description>
+    <profiles>
+        <profile name="Virtual" description="Image for use with kvm"/>
+        <profile name="Physical" description="Image for physical storage disk CDL mode"/>
+    </profiles>
+    <preferences>
+        <version>1.42.1</version>
+        <packagemanager>dnf5</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>false</rpm-check-signatures>
+    </preferences>
+    <preferences profiles="Virtual">
+        <type image="oem" filesystem="ext4" bootpartition="false" kernelcmdline="console=ttyS0" format="qcow2">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+            <bootloader name="zipl" timeout="10"/>
+        </type>
+    </preferences>
+    <preferences profiles="Physical">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0 dasd_mod.dasd=ipldev" bootpartition="false" target_blocksize="4096">
+            <bootloader name="zipl" targettype="CDL" timeout="10"/>
+            <oemconfig>
+                <oem-swap>true</oem-swap>
+                <oem-swapsize>512</oem-swapsize>
+            </oemconfig>
+        </type>
+    </preferences>
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
+    </users>
+    <repository type="rpm-md" alias="kiwi-next-generation" priority="1">
+        <source path="obs://Virtualization:Appliances:Staging/Fedora_Rawhide"/>
+    </repository>
+    <repository type="rpm-md" alias="Fedora_Rawhide">
+        <source path="obs://Fedora:Rawhide/standard"/>
+    </repository>
+    <packages type="image">
+        <package name="s390utils"/>
+        <package name="mariadb-connector-c-config"/>
+        <package name="kernel"/>
+        <package name="selinux-policy-targeted"/>
+        <package name="dhclient"/>
+        <package name="glibc-all-langpacks"/>
+        <package name="vim"/>
+        <package name="tzdata"/>
+        <package name="NetworkManager"/>
+        <package name="dracut-kiwi-oem-repart"/>
+        <package name="btrfs-progs"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="filesystem"/>
+        <package name="basesystem"/>
+        <package name="fedora-release"/>
+    </packages>
+</image>

--- a/build-tests/s390/rawhide/test-image-disk/config.sh
+++ b/build-tests/s390/rawhide/test-image-disk/config.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# shellcheck disable=SC1091
+test -f /.kconfig && . /.kconfig
+
+declare kiwi_iname=${kiwi_iname}
+
+#======================================
+# Greeting...
+#--------------------------------------
+echo "Configure image: [${kiwi_iname}]..."
+
+#======================================
+# Activate services
+#--------------------------------------
+baseInsertService dbus-broker
+baseInsertService NetworkManager
+
+#======================================
+# Setup default target, multi-user
+#--------------------------------------
+baseSetRunlevel 3

--- a/doc/source/api/kiwi.bootloader.config.rst
+++ b/doc/source/api/kiwi.bootloader.config.rst
@@ -22,6 +22,22 @@ Submodules
     :undoc-members:
     :show-inheritance:
 
+`kiwi.bootloader.config.systemd_boot` Module
+--------------------------------------------
+
+.. automodule:: kiwi.bootloader.config.systemd_boot
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+`kiwi.bootloader.config.zipl` Module
+------------------------------------
+
+.. automodule:: kiwi.bootloader.config.zipl
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 .. _db_kiwi_bootloader_config_contents:
 
 Module Contents

--- a/doc/source/api/kiwi.bootloader.install.rst
+++ b/doc/source/api/kiwi.bootloader.install.rst
@@ -22,6 +22,22 @@ Submodules
     :undoc-members:
     :show-inheritance:
 
+`kiwi.bootloader.install.systemd_boot` Module
+---------------------------------------------
+
+.. automodule:: kiwi.bootloader.install.systemd_boot
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+`kiwi.bootloader.install.zipl` Module
+-------------------------------------
+
+.. automodule:: kiwi.bootloader.install.zipl
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 .. _db_kiwi_bootloader_install_contents:
 
 Module Contents

--- a/helper/build_status.sh
+++ b/helper/build_status.sh
@@ -15,6 +15,7 @@ for project in \
     Virtualization:Appliances:Images:Testing_arm:ubuntu \
     Virtualization:Appliances:Images:Testing_x86:debian \
     Virtualization:Appliances:Images:Testing_s390:tumbleweed \
+    Virtualization:Appliances:Images:Testing_s390:rawhide \
     Virtualization:Appliances:Images:Testing_arm:tumbleweed \
     Virtualization:Appliances:Images:Testing_arm:fedora \
     Virtualization:Appliances:Images:Testing_ppc:tumbleweed \

--- a/kiwi/bootloader/config/__init__.py
+++ b/kiwi/bootloader/config/__init__.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:  # pragma: nocover
     from kiwi.bootloader.config.grub2 import BootLoaderConfigGrub2
     from kiwi.bootloader.config.systemd_boot import BootLoaderSystemdBoot
     from kiwi.bootloader.config.custom import BootLoaderConfigCustom
+    from kiwi.bootloader.config.zipl import BootLoaderZipl
 
 
 @overload
@@ -59,16 +60,24 @@ def create_boot_loader_config(
 
 @overload
 def create_boot_loader_config(
+    *, name: Literal["zipl"], xml_state: object, root_dir: str,
+    boot_dir: str = None, custom_args: Dict = None
+) -> "BootLoaderZipl":
+    ...  # pragma: nocover
+
+
+@overload
+def create_boot_loader_config(
     *, name: str, xml_state: object, root_dir: str,
     boot_dir: str = None, custom_args: Dict = None
-) -> "Union[BootLoaderConfigGrub2, BootLoaderSystemdBoot]":
+) -> "Union[BootLoaderConfigGrub2, BootLoaderSystemdBoot, BootLoaderZipl]":
     ...  # pragma: nocover
 
 
 def create_boot_loader_config(
     *, name: str, xml_state: object, root_dir: str,
     boot_dir: str = None, custom_args: Dict = None
-) -> "Union[BootLoaderConfigGrub2, BootLoaderSystemdBoot, BootLoaderConfigCustom]":
+) -> "Union[BootLoaderConfigGrub2, BootLoaderSystemdBoot, BootLoaderZipl, BootLoaderConfigCustom]":
 
     if name in ("grub2", "grub2_s390x_emu"):
         from kiwi.bootloader.config.grub2 import BootLoaderConfigGrub2
@@ -76,6 +85,9 @@ def create_boot_loader_config(
     if name == "systemd_boot":
         from kiwi.bootloader.config.systemd_boot import BootLoaderSystemdBoot
         return BootLoaderSystemdBoot(xml_state, root_dir, boot_dir, custom_args)
+    if name == "zipl":
+        from kiwi.bootloader.config.zipl import BootLoaderZipl
+        return BootLoaderZipl(xml_state, root_dir, boot_dir, custom_args)
     if name == "custom":
         from kiwi.bootloader.config.custom import BootLoaderConfigCustom
         return BootLoaderConfigCustom(xml_state, root_dir, boot_dir, custom_args)

--- a/kiwi/bootloader/config/bootloader_spec_base.py
+++ b/kiwi/bootloader/config/bootloader_spec_base.py
@@ -20,6 +20,7 @@ from typing import (
 )
 
 # project
+from kiwi.firmware import FirmWare
 from kiwi.bootloader.config.base import BootLoaderConfigBase
 from kiwi.system.identifier import SystemIdentifier
 
@@ -62,6 +63,9 @@ class BootLoaderSpecBase(BootLoaderConfigBase):
         )
         self.custom_args = custom_args
         self.timeout = self.get_boot_timeout_seconds()
+        self.disk_type = self.xml_state.get_build_type_bootloader_targettype()
+        self.disk_blocksize = self.xml_state.build_type.get_target_blocksize()
+        self.firmware = FirmWare(self.xml_state)
         self.cmdline = ''
 
     def write(self) -> None:

--- a/kiwi/bootloader/install/__init__.py
+++ b/kiwi/bootloader/install/__init__.py
@@ -48,7 +48,8 @@ class BootLoaderInstall(metaclass=ABCMeta):
         name_map = {
             'grub2': {'grub2': 'BootLoaderInstallGrub2'},
             'grub2_s390x_emu': {'grub2': 'BootLoaderInstallGrub2'},
-            'systemd_boot': {'systemd_boot': 'BootLoaderInstallSystemdBoot'}
+            'systemd_boot': {'systemd_boot': 'BootLoaderInstallSystemdBoot'},
+            'zipl': {'zipl': 'BootLoaderInstallZipl'}
         }
         try:
             (bootloader_namespace, bootloader_name) = \

--- a/kiwi/bootloader/install/zipl.py
+++ b/kiwi/bootloader/install/zipl.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2024 SUSE Software Solutions Germany GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import logging
+from typing import Dict
+
+# project
+from kiwi.bootloader.install.base import BootLoaderInstallBase
+
+log = logging.getLogger('kiwi')
+
+
+class BootLoaderInstallZipl(BootLoaderInstallBase):
+    """
+    **zipl bootloader installation**
+    """
+    def post_init(self, custom_args: Dict):
+        """
+        zipl post initialization method
+
+        :param dict custom_args: unused
+        """
+        self.custom_args = custom_args
+
+    def install_required(self) -> bool:
+        """
+        Check if zipl needs to install boot code
+
+        zipl requires boot code installation, but it is done as
+        part of the BLS implementation in bootloader/config/zipl.py
+        Thus this method always returns: False
+
+        :return: False
+
+        :rtype: bool
+        """
+        return False
+
+    def secure_boot_install(self):
+        """
+        Run shim installation for secure boot setup
+
+        For zipl this is skipped since details for
+        secure boot are not yet clear.
+        """
+        pass

--- a/kiwi/bootloader/template/zipl.py
+++ b/kiwi/bootloader/template/zipl.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2024 SUSE Software Solutions Germany GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+from string import Template
+from textwrap import dedent
+
+
+class BootLoaderTemplateZipl:
+    """
+    **zipl configuraton file templates**
+    """
+    def __init__(self):
+        self.cr = '\n'
+
+        self.main_conf = dedent('''
+            [defaultboot]
+            defaultauto
+            prompt=1
+            target=${bootpath}
+            ${targetbase}
+            targettype=${targettype}
+            targetblocksize=${targetblocksize}
+            targetoffset=${targetoffset}
+            ${targetgeometry}
+            timeout=${boot_timeout}
+            secure=auto
+        ''').strip() + self.cr
+
+        self.entry = dedent('''
+            title ${title}
+            options ${boot_options}
+            linux ${kernel_file}
+            initrd ${initrd_file}
+        ''').strip() + self.cr
+
+    def get_loader_template(self) -> Template:
+        """
+        Bootloader main configuration template
+
+        :return: instance of :class:`Template`
+
+        :rtype: Template
+        """
+        template_data = self.main_conf
+        return Template(template_data)
+
+    def get_entry_template(self) -> Template:
+        """
+        Bootloader entry configuration template
+
+        :return: instance of :class:`Template`
+
+        :rtype: Template
+        """
+        template_data = self.entry
+        return Template(template_data)

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2731,14 +2731,15 @@ div {
     ]
     k.bootloader.name.attribute =
         ## Specifies the bootloader used for booting the image.
-        ## At the moment grub2, systemd_boot(EFI only), and the
-        ## combination of zipl plus userspace grub2(grub2_s390x_emu) are supported.
+        ## At the moment grub2, systemd_boot(EFI only), zipl and the
+        ## combination of zipl plus userspace grub2(grub2_s390x_emu)
+        ## are supported.
         ## The special custom entry allows to skip the bootloader
         ## configuration and installation and leaves this up to the
         ## user which can be done by using the editbootinstall and
         ## editbootconfig custom scripts
         attribute name {
-            "grub2" | "grub2_s390x_emu" | "systemd_boot" | "custom"
+            "grub2" | "grub2_s390x_emu" | "systemd_boot" | "custom" | "zipl"
         }
         >> sch:pattern [ id = "loader_name" is-a = "bootloader_image_type"
             sch:param [ name = "attr" value = "name" ]
@@ -2780,7 +2781,7 @@ div {
         attribute timeout { xsd:nonNegativeInteger }
         >> sch:pattern [ id = "timeout" is-a = "bootloader_name_type"
             sch:param [ name = "attr" value = "timeout" ]
-            sch:param [ name = "types" value = "grub2 grub2_s390x_emu systemd_boot" ]
+            sch:param [ name = "types" value = "grub2 grub2_s390x_emu systemd_boot zipl" ]
         ]
     k.bootloader.timeout_style.attribute =
         ## Specifies the boot timeout style to control the way in which
@@ -2804,7 +2805,7 @@ div {
         }
         >> sch:pattern [ id = "targettype" is-a = "bootloader_name_type"
             sch:param [ name = "attr" value = "targettype" ]
-            sch:param [ name = "types" value = "grub2_s390x_emu" ]
+            sch:param [ name = "types" value = "grub2_s390x_emu zipl" ]
         ]
     k.bootloader.use_disk_password.attribute =
         ## When /boot is encrypted, make the boot loader store the

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -4095,8 +4095,9 @@ references file names in linux lib directories to keep.</a:documentation>
     <define name="k.bootloader.name.attribute">
       <attribute name="name">
         <a:documentation>Specifies the bootloader used for booting the image.
-At the moment grub2, systemd_boot(EFI only), and the
-combination of zipl plus userspace grub2(grub2_s390x_emu) are supported.
+At the moment grub2, systemd_boot(EFI only), zipl and the
+combination of zipl plus userspace grub2(grub2_s390x_emu)
+are supported.
 The special custom entry allows to skip the bootloader
 configuration and installation and leaves this up to the
 user which can be done by using the editbootinstall and
@@ -4106,6 +4107,7 @@ editbootconfig custom scripts</a:documentation>
           <value>grub2_s390x_emu</value>
           <value>systemd_boot</value>
           <value>custom</value>
+          <value>zipl</value>
         </choice>
       </attribute>
       <sch:pattern id="loader_name" is-a="bootloader_image_type">
@@ -4158,7 +4160,7 @@ to 10sec</a:documentation>
       </attribute>
       <sch:pattern id="timeout" is-a="bootloader_name_type">
         <sch:param name="attr" value="timeout"/>
-        <sch:param name="types" value="grub2 grub2_s390x_emu systemd_boot"/>
+        <sch:param name="types" value="grub2 grub2_s390x_emu systemd_boot zipl"/>
       </sch:pattern>
     </define>
     <define name="k.bootloader.timeout_style.attribute">
@@ -4192,7 +4194,7 @@ for 4k DASD devices use CDL</a:documentation>
       </attribute>
       <sch:pattern id="targettype" is-a="bootloader_name_type">
         <sch:param name="attr" value="targettype"/>
-        <sch:param name="types" value="grub2_s390x_emu"/>
+        <sch:param name="types" value="grub2_s390x_emu zipl"/>
       </sch:pattern>
     </define>
     <define name="k.bootloader.use_disk_password.attribute">

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -232,9 +232,6 @@ Recommends:     gfxboot
 Requires:       grub2-efi-x64
 %endif
 %endif
-%if ! (0%{?debian} || 0%{?ubuntu})
-Requires:       grub2
-%endif
 %ifarch %arm aarch64
 %if 0%{?fedora} || 0%{?rhel}
 Requires:       uboot-tools
@@ -244,7 +241,14 @@ Requires:       u-boot-tools
 %endif
 %endif
 %ifarch s390 s390x
+%if 0%{?fedora} || 0%{?rhel}
+Requires:       s390utils
+%else
 Requires:       s390-tools
+%if ! (0%{?debian} || 0%{?ubuntu})
+Requires:       grub2
+%endif
+%endif
 %endif
 Requires:       kiwi-systemdeps-core = %{version}-%{release}
 
@@ -486,7 +490,11 @@ Requires:       xz
 Requires:       device-mapper
 %endif
 %ifarch s390 s390x
+%if 0%{?fedora} || 0%{?rhel}
+Requires:       s390utils
+%else
 Requires:       s390-tools
+%endif
 Requires:       parted
 %endif
 License:        GPL-3.0-or-later

--- a/test/unit/bootloader/config/bootloader_spec_base_test.py
+++ b/test/unit/bootloader/config/bootloader_spec_base_test.py
@@ -16,7 +16,8 @@ class TestBootLoaderSpecBase:
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
-    def setup(self):
+    @patch('kiwi.bootloader.config.bootloader_spec_base.FirmWare')
+    def setup(self, mock_FirmWare):
         Defaults.set_platform_name('x86_64')
         description = XMLDescription(
             '../data/example_config.xml'
@@ -28,7 +29,8 @@ class TestBootLoaderSpecBase:
             self.state, 'root_dir'
         )
 
-    def setup_method(self, cls):
+    @patch('kiwi.bootloader.config.bootloader_spec_base.FirmWare')
+    def setup_method(self, cls, mock_FirmWare):
         self.setup()
 
     @patch.object(BootLoaderSpecBase, 'setup_loader')

--- a/test/unit/bootloader/config/custom_test.py
+++ b/test/unit/bootloader/config/custom_test.py
@@ -27,6 +27,9 @@ class TestBootLoaderConfigCustom:
             Mock(), 'root_dir'
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_setup_disk_boot_images(self):
         with raises(NotImplementedError):
             self.bootloader.setup_disk_boot_images('0815')

--- a/test/unit/bootloader/config/init_test.py
+++ b/test/unit/bootloader/config/init_test.py
@@ -37,6 +37,18 @@ class TestBootLoaderConfig:
             xml_state, 'root_dir', 'boot_dir', None
         )
 
+    @patch('kiwi.bootloader.config.zipl.BootLoaderZipl')
+    @patch('kiwi.bootloader.config.bootloader_spec_base.FirmWare')
+    def test_bootloader_config_zipl(self, mock_FirmWare, mock_zipl):
+        xml_state = Mock()
+        create_boot_loader_config(
+            name='zipl', xml_state=xml_state,
+            root_dir='root_dir', boot_dir='boot_dir'
+        )
+        mock_zipl.assert_called_once_with(
+            xml_state, 'root_dir', 'boot_dir', None
+        )
+
     @patch('kiwi.bootloader.config.custom.BootLoaderConfigCustom')
     def test_bootloader_config_custom(self, mock_custom):
         xml_state = Mock()

--- a/test/unit/bootloader/config/systemd_boot_test.py
+++ b/test/unit/bootloader/config/systemd_boot_test.py
@@ -13,7 +13,8 @@ from kiwi.exceptions import (
 
 
 class TestBootLoaderSystemdBoot:
-    def setup(self):
+    @patch('kiwi.bootloader.config.bootloader_spec_base.FirmWare')
+    def setup(self, mock_FirmWare):
         self.state = Mock()
         self.state.xml_data.get_name.return_value = 'image-name'
         self.state.get_image_version.return_value = 'image-version'
@@ -34,7 +35,8 @@ class TestBootLoaderSystemdBoot:
             return_value='title'
         )
 
-    def setup_method(self, cls):
+    @patch('kiwi.bootloader.config.bootloader_spec_base.FirmWare')
+    def setup_method(self, cls, mock_FirmWare):
         self.setup()
 
     def test_setup_loader_raises_invalid_target(self):

--- a/test/unit/bootloader/config/zipl_test.py
+++ b/test/unit/bootloader/config/zipl_test.py
@@ -1,0 +1,269 @@
+import io
+from pytest import raises
+from unittest.mock import (
+    Mock, patch, call, MagicMock
+)
+from kiwi.bootloader.config.zipl import BootLoaderZipl
+from kiwi.command import CommandT
+
+from kiwi.exceptions import (
+    KiwiTemplateError,
+    KiwiBootLoaderTargetError,
+    KiwiKernelLookupError,
+    KiwiDiskGeometryError
+)
+
+
+class TestBootLoaderZipl:
+    @patch('kiwi.bootloader.config.bootloader_spec_base.FirmWare')
+    def setup(self, mock_FirmWare):
+        self.firmware = Mock()
+        mock_FirmWare.return_value = self.firmware
+        self.state = Mock()
+        self.state.get_build_type_bootloader_targettype.return_value = 'CDL'
+        self.state.build_type.get_target_blocksize.return_value = 4096
+        self.state.xml_data.get_name.return_value = 'image-name'
+        self.state.get_image_version.return_value = 'image-version'
+        self.state.build_type.get_efifatimagesize.return_value = None
+        self.bootloader = BootLoaderZipl(self.state, 'root_dir')
+        self.bootloader.custom_args['kernel'] = None
+        self.bootloader.custom_args['initrd'] = None
+        self.bootloader.custom_args['boot_options'] = {}
+        self.bootloader.custom_args['targetbase'] = '/dev/disk'
+        self.bootloader.root_mount = Mock(
+            mountpoint='system_root_mount'
+        )
+        self.bootloader._mount_system = Mock()
+        self.bootloader.create_efi_path = Mock()
+        self.bootloader.get_boot_path = Mock(
+            return_value='bootpath'
+        )
+        self.bootloader.get_menu_entry_title = Mock(
+            return_value='title'
+        )
+
+    @patch('kiwi.bootloader.config.bootloader_spec_base.FirmWare')
+    def setup_method(self, cls, mock_FirmWare):
+        self.setup()
+
+    def test_setup_loader_raises_invalid_target(self):
+        with raises(KiwiBootLoaderTargetError):
+            self.bootloader.setup_loader('iso')
+
+    @patch('os.path.exists')
+    @patch('kiwi.bootloader.config.zipl.OsRelease')
+    @patch('kiwi.bootloader.config.zipl.glob.iglob')
+    @patch('kiwi.bootloader.config.zipl.BootImageBase.get_boot_names')
+    @patch('kiwi.bootloader.config.zipl.Path.wipe')
+    @patch('kiwi.bootloader.config.zipl.Path.create')
+    @patch('kiwi.bootloader.config.zipl.Command.run')
+    @patch('kiwi.bootloader.config.zipl.BootLoaderTemplateZipl')
+    @patch.object(BootLoaderZipl, '_write_config_file')
+    @patch.object(BootLoaderZipl, '_get_template_parameters')
+    def test_setup_loader(
+        self, mock_get_template_parameters, mock_write_config_file,
+        mock_BootLoaderTemplateZipl, mock_Command_run,
+        mock_Path_create, mock_Path_wipe, mock_BootImageBase_get_boot_names,
+        mock_iglob,
+        mock_OsRelease,
+        mock_os_path_exists
+    ):
+        mock_get_template_parameters.return_value = {
+            'targetbase': '/dev/loop'
+        }
+        mock_iglob.return_value = ['/lib/modules/5.3.18-59.10-default']
+        os_release = Mock()
+        os_release.get.return_value = 'opensuse-leap'
+        mock_OsRelease.return_value = os_release
+        kernel_info = Mock()
+        kernel_info.kernel_version = 'kernel-version'
+        kernel_info.kernel_filename = 'kernel-filename'
+        kernel_info.initrd_name = 'initrd-name'
+        mock_os_path_exists.return_value = True
+        mock_BootImageBase_get_boot_names.return_value = kernel_info
+        self.bootloader.setup_loader('disk')
+        assert mock_write_config_file.call_args_list == [
+            call(
+                mock_BootLoaderTemplateZipl.
+                return_value.get_loader_template.return_value,
+                'system_root_mount/etc/zipl.conf',
+                mock_get_template_parameters.return_value
+            ),
+            call(
+                mock_BootLoaderTemplateZipl.
+                return_value.get_entry_template.return_value,
+                'system_root_mount/boot/loader/entries/'
+                'opensuse-leap-5.3.18-59.10-default.conf',
+                mock_get_template_parameters.return_value
+            ),
+            call(
+                mock_BootLoaderTemplateZipl.
+                return_value.get_loader_template.return_value,
+                'system_root_mount/etc/zipl.conf',
+                {'targetbase': ''}
+            )
+        ]
+        assert self.bootloader._mount_system.called
+        mock_Command_run.assert_called_once_with(
+            [
+                'chroot', 'system_root_mount', 'zipl',
+                '--noninteractive',
+                '--config', '/etc/zipl.conf',
+                '--blsdir', '/boot/loader/entries',
+                '--verbose'
+            ]
+        )
+
+    @patch('kiwi.bootloader.config.zipl.OsRelease')
+    @patch('kiwi.bootloader.config.zipl.glob.iglob')
+    def test_set_loader_entry_kernel_lookup_raises(
+        self, mock_iglob, mock_OsRelease
+    ):
+        mock_iglob.return_value = None
+        with raises(KiwiKernelLookupError):
+            self.bootloader.set_loader_entry('root_dir', 'disk')
+
+    @patch.object(BootLoaderZipl, '_get_disk_geometry')
+    @patch.object(BootLoaderZipl, '_get_partition_start')
+    def test_get_template_parameters(
+        self, mock_get_partition_start, mock_get_disk_geometry
+    ):
+        mock_get_partition_start.return_value = '42'
+        mock_get_disk_geometry.return_value = '123,53,9'
+        self.bootloader.timeout = 0
+        self.bootloader.disk_type = 'CDL'
+        self.bootloader.disk_blocksize = 4096
+        assert self.bootloader._get_template_parameters() == {
+            'kernel_file': 'vmlinuz',
+            'initrd_file': 'initrd',
+            'boot_options': '',
+            'boot_timeout': 0,
+            'bootpath': 'bootpath',
+            'targetbase': 'targetbase=/dev/disk',
+            'targettype': 'CDL',
+            'targetblocksize': '4096',
+            'targetoffset': '42',
+            'targetgeometry': 'targetgeometry=123,53,9',
+            'title': 'title',
+            'default_entry': ''
+        }
+
+    @patch('kiwi.bootloader.config.zipl.Path.create')
+    @patch.object(BootLoaderZipl, '_get_template_parameters')
+    def test_write_config_file(
+        self, mock_get_template_parameters, mock_Path_create
+    ):
+        template = Mock()
+        template.substitute.return_value = 'data'
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            self.bootloader._write_config_file(template, 'path/some-file', {})
+            mock_Path_create.assert_called_once_with('path')
+            mock_open.assert_called_once_with('path/some-file', 'w')
+            file_handle.write.assert_called_once_with('data')
+
+    def test_write_config_file_raises(self):
+        template = Mock()
+        template.substitute.side_effect = Exception
+        with raises(KiwiTemplateError):
+            self.bootloader._write_config_file(template, 'some-file', {})
+
+    @patch('kiwi.bootloader.config.zipl.Command.run')
+    def test_get_disk_geometry(self, mock_Command_run):
+        command_return_values = [
+            CommandT(
+                output='  cylinders ............: 10017\n',
+                error='', returncode=0
+            ),
+            CommandT(
+                output='  tracks per cylinder ..: 15\n',
+                error='', returncode=0
+            ),
+            CommandT(
+                output='  blocks per track .....: 12\n',
+                error='', returncode=0
+            )
+        ]
+
+        def command_run(arg):
+            return command_return_values.pop(0)
+
+        self.firmware.get_partition_table_type.return_value = 'dasd'
+        mock_Command_run.side_effect = command_run
+        assert self.bootloader._get_disk_geometry() == '10017,15,12'
+
+    @patch('kiwi.bootloader.config.zipl.Command.run')
+    def test_get_partition_start_dasd(self, mock_Command_run):
+        self.firmware.get_partition_table_type.return_value = 'dasd'
+        command_return_values = [
+            CommandT(
+                output='  blocks per track .....: 12\n',
+                error='', returncode=0
+            ),
+            CommandT(
+                output=' /dev/loop01 2 6401 6400 1 Linux native\n',
+                error='', returncode=0
+            )
+        ]
+
+        def command_run(arg):
+            return command_return_values.pop(0)
+
+        mock_Command_run.side_effect = command_run
+        assert self.bootloader._get_partition_start() == '24'
+        assert mock_Command_run.call_args_list == [
+            call(
+                [
+                    'bash', '-c',
+                    'fdasd -f -p /dev/disk | grep "blocks per track"'
+                ]
+            ),
+            call(
+                [
+                    'bash', '-c',
+                    'fdasd -f -s -p /dev/disk | grep "^ " |'
+                    ' head -n 1 | tr -s " "'
+                ]
+            )
+        ]
+
+    @patch('kiwi.bootloader.config.zipl.Command.run')
+    def test_get_partition_start_not_dasd(self, mock_Command_run):
+        self.firmware.get_partition_table_type.return_value = 'msdos'
+        command = Mock()
+        command.output = '  2048'
+        mock_Command_run.return_value = command
+        assert self.bootloader._get_partition_start() == '2048'
+        mock_Command_run.assert_called_once_with(
+            [
+                'bash', '-c',
+                'sfdisk --dump /dev/disk | grep "1 :" |'
+                ' cut -f1 -d, | cut -f2 -d='
+            ]
+        )
+
+    @patch('kiwi.bootloader.config.zipl.Command.run')
+    @patch.object(BootLoaderZipl, '_get_dasd_disk_geometry_element')
+    def test_get_partition_start_raises(
+        self, mock_get_dasd_disk_geometry_element, mock_Command_run
+    ):
+        self.firmware.get_partition_table_type.return_value = 'dasd'
+        mock_Command_run.return_value = CommandT(
+            output='bogus data', error='', returncode=0
+        )
+        with raises(KiwiDiskGeometryError):
+            self.bootloader._get_partition_start()
+
+    @patch('kiwi.bootloader.config.zipl.Command.run')
+    def test_get_dasd_disk_geometry_element_raises(
+        self, mock_Command_run
+    ):
+        self.bootloader.target_table_type = 'dasd'
+        mock_Command_run.return_value = CommandT(
+            output='bogus data', error='', returncode=0
+        )
+        with raises(KiwiDiskGeometryError):
+            self.bootloader._get_dasd_disk_geometry_element(
+                '/dev/disk', 'tracks per cylinder'
+            )

--- a/test/unit/bootloader/install/zipl_test.py
+++ b/test/unit/bootloader/install/zipl_test.py
@@ -1,0 +1,25 @@
+from unittest.mock import Mock
+from pytest import raises
+
+from kiwi.bootloader.install.zipl import BootLoaderInstallZipl
+
+
+class TestBootLoaderInstallZipl:
+    def setup(self):
+        self.bootloader = BootLoaderInstallZipl(
+            'root_dir', Mock()
+        )
+
+    def setup_method(self, cls):
+        self.setup()
+
+    def test_install(self):
+        with raises(NotImplementedError):
+            self.bootloader.install()
+
+    def test_install_required(self):
+        assert self.bootloader.install_required() is False
+
+    def test_secure_boot_install(self):
+        # just pass
+        self.bootloader.secure_boot_install()

--- a/test/unit/bootloader/template/zipl_test.py
+++ b/test/unit/bootloader/template/zipl_test.py
@@ -1,0 +1,28 @@
+from kiwi.bootloader.template.zipl import BootLoaderTemplateZipl
+
+
+class TestBootLoaderTemplateZipl:
+    def setup(self):
+        self.zipl = BootLoaderTemplateZipl()
+
+    def setup_method(self, cls):
+        self.setup()
+
+    def test_get_loader_template(self):
+        assert self.zipl.get_loader_template().substitute(
+            boot_timeout='10',
+            bootpath='/boot',
+            targetbase='',
+            targettype='SCSI',
+            targetblocksize='512',
+            targetoffset='2048',
+            targetgeometry=''
+        )
+
+    def test_get_entry_template(self):
+        assert self.zipl.get_entry_template().substitute(
+            title='title',
+            boot_options='',
+            kernel_file='linux',
+            initrd_file='initrd'
+        )

--- a/test/unit/storage/clone_device_test.py
+++ b/test/unit/storage/clone_device_test.py
@@ -24,6 +24,9 @@ class TestCloneDevice:
             self.storage_device, 'root_dir'
         )
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('kiwi.storage.clone_device.Command.run')
     @patch('kiwi.storage.clone_device.BlockID')
     @patch('kiwi.storage.clone_device.FileSystem.new')


### PR DESCRIPTION
Add support for

```xml
<bootloader name="zipl" .../>
```

to support BLS based zipl configuration.
This Fixes #2481

