### PR TITLE
Ensure we use a compatible docopt-ng version

### DIFF
--- a/package/python-kiwi-pkgbuild-template
+++ b/package/python-kiwi-pkgbuild-template
@@ -21,7 +21,7 @@ build() {
   cd kiwi-${pkgver}
   # Temporarily switch things back to docopt
   # FIXME: Drop this hack as soon as we can...
-  sed -e "s/docopt-ng/docopt/" -i pyproject.toml
+  sed -e 's/docopt-ng.*/docopt = ">=0.6.2"/' -i pyproject.toml
   make -C doc man
   python3 -m build --no-isolation --wheel
 }

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -623,7 +623,7 @@ Provides manual pages to describe the kiwi commands
 # Temporarily switch things back to docopt for everything but Fedora 41+
 # FIXME: Drop this hack as soon as we can...
 %if ! (0%{?fedora} >= 41 || 0%{?rhel} >= 10)
-sed -e "s/docopt-ng/docopt/" -i pyproject.toml
+sed -e 's/docopt-ng.*/docopt = ">=0.6.2"/' -i pyproject.toml
 %endif
 
 # Drop shebang for kiwi/xml_parse.py, as we don't intend to use it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-docopt-ng = ">=0.6.2"
+docopt-ng = ">=0.9.0"
 lxml = ">=4.6.0"
 requests = ">=2.25.0"
 PyYAML = ">=5.4.0"


### PR DESCRIPTION
To ensure our trick to switch between docopt and docopt-ng works, we need to have a higher minimum version for docopt-ng where compatibility with the original docopt was restored.
