### PR TITLE
Fixup use of /boot/zipl

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -894,7 +894,8 @@ class DiskBuilder:
             exclude_list.append(
                 '{0}/.*'.format(self.spare_part_mountpoint.lstrip(os.sep))
             )
-        if 'boot' in device_map and 's390' in self.arch:
+        if 'boot' in device_map \
+           and 's390' in self.arch and self.bootloader == 'grub2_s390x_emu':
             exclude_list.append('boot/zipl/*')
             exclude_list.append('boot/zipl/.*')
         elif 'boot' in device_map:
@@ -1016,7 +1017,7 @@ class DiskBuilder:
             if not boot_filesystem:
                 boot_filesystem = self.requested_filesystem
             boot_directory = self.root_dir + '/boot/'
-            if 's390' in self.arch:
+            if 's390' in self.arch and self.bootloader == 'grub2_s390x_emu':
                 boot_directory = self.root_dir + '/boot/zipl/'
             log.info(
                 'Creating boot(%s) filesystem on %s',
@@ -1315,7 +1316,7 @@ class DiskBuilder:
             custom_root_mount_args, fs_check_interval
         )
         if device_map.get('boot'):
-            if 's390' in self.arch:
+            if 's390' in self.arch and self.bootloader == 'grub2_s390x_emu':
                 boot_mount_point = '/boot/zipl'
             else:
                 boot_mount_point = '/boot'


### PR DESCRIPTION
Only for the grub2_s390x_emu bootloader setup an optional boot partition setup must be put to /boot/zipl rather than to /boot

