### PR TITLE
Drop rpm-dir from allowed repository type

### DIFF
--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -134,7 +134,7 @@ OPTIONS
 
   - **type**
 
-    repository type, could be one of `rpm-md`, `rpm-dir` or `yast2`.
+    repository type, could be one of `rpm-md`, or `apt-deb`.
 
   - **alias**
 

--- a/doc/source/commands/system_prepare.rst
+++ b/doc/source/commands/system_prepare.rst
@@ -135,7 +135,7 @@ OPTIONS
 
   - **type**
 
-    repository type, could be one of `rpm-md`, `rpm-dir` or `yast2`.
+    repository type, could be one of `rpm-md`, or `apt-deb`.
 
   - **alias**
 

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -65,7 +65,7 @@ div {
         attribute xsi:schemaLocation { xsd:anyURI }
     k.image.schemaversion.attribute =
         ## The allowed Schema version (fixed value)
-        attribute schemaversion { "8.0" }
+        attribute schemaversion { "8.1" }
     k.image.id =
         ## An identification number which is represented in a file
         ## named /etc/ImageID
@@ -1054,7 +1054,7 @@ div {
     k.repository.type.attribute =
         ## Type of repository
         attribute type {
-            "apt-deb" | "apt-rpm" | "deb-dir" | "mirrors" | "rpm-dir" | "rpm-md"
+            "apt-deb" | "apt-rpm" | "deb-dir" | "mirrors" | "rpm-md"
         }
     k.repository.alias.attribute =
         ## Alias name to be used for this repository. This is an

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -145,7 +145,7 @@ second the location of the XSD Schema
     <define name="k.image.schemaversion.attribute">
       <attribute name="schemaversion">
         <a:documentation>The allowed Schema version (fixed value)</a:documentation>
-        <value>8.0</value>
+        <value>8.1</value>
       </attribute>
     </define>
     <define name="k.image.id">
@@ -1597,7 +1597,6 @@ definition can be composed by other existing profiles.</a:documentation>
           <value>apt-rpm</value>
           <value>deb-dir</value>
           <value>mirrors</value>
-          <value>rpm-dir</value>
           <value>rpm-md</value>
         </choice>
       </attribute>

--- a/kiwi/xsl/convert80to81.xsl
+++ b/kiwi/xsl/convert80to81.xsl
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv80to81">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv80to81"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>8.0</literal> to <literal>8.1</literal>.
+</para>
+<xsl:template match="image" mode="conv80to81">
+    <xsl:choose>
+        <!-- nothing to do if already at 8.1 -->
+        <xsl:when test="@schemaversion > 8.0">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="8.1">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv80to81"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- delete type from repository if rpm-dir type spec is used -->
+<xsl:template match="repository" mode="conv80to81">
+    <xsl:choose>
+        <xsl:when test="@type='rpm-dir'">
+            <repository>
+                <xsl:copy-of select="@*[not(local-name(.) = 'type')]"/>
+                <xsl:apply-templates mode="conv80to81"/>
+            </repository>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:copy-of select="."/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/kiwi/xsl/master.xsl
+++ b/kiwi/xsl/master.xsl
@@ -9,6 +9,7 @@
 <xsl:import href="convert74to75.xsl"/>
 <xsl:import href="convert75to76.xsl"/>
 <xsl:import href="convert76to80.xsl"/>
+<xsl:import href="convert80to81.xsl"/>
 <xsl:import href="pretty.xsl"/>
 
 <xsl:output encoding="utf-8"/>
@@ -30,8 +31,12 @@
         <xsl:apply-templates select="exslt:node-set($v76)" mode="conv76to80"/>
     </xsl:variable>
 
+    <xsl:variable name="v81">
+        <xsl:apply-templates select="exslt:node-set($v80)" mode="conv80to81"/>
+    </xsl:variable>
+
     <xsl:apply-templates
-        select="exslt:node-set($v80)" mode="pretty"
+        select="exslt:node-set($v81)" mode="pretty"
     />
 </xsl:template>
 

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -45,7 +45,7 @@
 
 Name:           python-kiwi
 Version:        %%VERSION
-Provides:       kiwi-schema = 7.5
+Provides:       kiwi-schema = 8.1
 Release:        0
 Url:            https://github.com/OSInside/kiwi
 Summary:        KIWI - Appliance Builder Next Generation


### PR DESCRIPTION
Using an arbitrary list of rpm packages as repository is a zypper only feature, barely tested and from our pov not really needed as a simple createrepo call turns any custom list of packages into a clean rpm-md repo including metadata. This commit drops rpm-dir from the list of allowed repository types and auto converts those image descriptions which makes use of it. Please note this does not prevent users from using flat package directories with zypper, because the type argument in the repository section is an optional attribute. In case there is no type specification zypper auto-detects and handles the data as it handles it. This Fixes #1926


