### PR TITLE
Allow bundle format to be set on the commandline

### DIFF
--- a/doc/source/commands/result_bundle.rst
+++ b/doc/source/commands/result_bundle.rst
@@ -12,6 +12,7 @@ SYNOPSIS
 
    kiwi-ng result bundle -h | --help
    kiwi-ng result bundle --target-dir=<directory> --id=<bundle_id> --bundle-dir=<directory>
+       [--bundle-format=<format>]
        [--zsync_source=<download_location>]
        [--package-as-rpm]
    kiwi-ng result bundle help
@@ -35,6 +36,22 @@ OPTIONS
 
   Directory containing the bundle results, compressed versions of
   image results, and SHA checksum files.
+
+--bundle-format=<format>
+
+  Specify the bundle format to create the bundle. If provided,
+  this setting will overwrite an eventually provided `bundle_format`
+  attribute from the main image description. The format string
+  can contain placeholders for the following elements:
+
+  * %N : Image name
+  * %P : Concatenated profile name (_)
+  * %A : Architecture name
+  * %I : Bundle ID
+  * %T : Image build type name
+  * %M : Image Major version number
+  * %m : Image Minor version number
+  * %p : Image Patch version number
 
 --id=<bundle_id>
 

--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -18,6 +18,7 @@
 """
 usage: kiwi-ng result bundle -h | --help
        kiwi-ng result bundle --target-dir=<directory> --id=<bundle_id> --bundle-dir=<directory>
+           [--bundle-format=<format>]
            [--zsync-source=<download_location>]
            [--package-as-rpm]
        kiwi-ng result bundle help
@@ -48,6 +49,11 @@ options:
         are placed to the same download location
     --package-as-rpm
         Take all result files and create an rpm package out of it
+    --bundle-format=<format>
+        specify the bundle format to create the bundle.
+        If provided this setting will overwrite an eventually
+        provided bundle_format attribute from the main
+        image description
 """
 from collections import OrderedDict
 from textwrap import dedent
@@ -111,6 +117,10 @@ class ResultBundleTask(CliTask):
         result = Result.load(
             result_directory + '/kiwi.result'
         )
+
+        if self.command_args['--bundle-format']:
+            result.add_bundle_format(self.command_args['--bundle-format'])
+
         image_version = result.xml_state.get_image_version()
         image_name = result.xml_state.xml_data.get_name()
         image_description = result.xml_state.get_description_section()

--- a/test/unit/tasks/result_bundle_test.py
+++ b/test/unit/tasks/result_bundle_test.py
@@ -73,6 +73,7 @@ class TestResultBundleTask:
         self.task.command_args['--id'] = 'Build_42'
         self.task.command_args['--zsync-source'] = None
         self.task.command_args['--package-as-rpm'] = None
+        self.task.command_args['--bundle-format'] = None
 
     def test_process_invalid_bundle_directory(self):
         self._init_command_args()
@@ -239,6 +240,47 @@ class TestResultBundleTask:
         mock_exists.return_value = False
         mock_load.return_value = result
         self._init_command_args()
+
+        self.task.process()
+
+        mock_command.assert_called_once_with(
+            [
+                'cp',
+                '/tmp/mytest/Leap-15.2.x86_64-1.15.2.raw',
+                os.sep.join(
+                    [self.abs_bundle_dir, 'Leap-15.2-oem:1.raw']
+                )
+            ]
+        )
+
+    @patch('kiwi.tasks.result_bundle.Result.load')
+    @patch('kiwi.tasks.result_bundle.Command.run')
+    @patch('kiwi.tasks.result_bundle.Path.create')
+    @patch('os.path.exists')
+    def test_process_result_bundle_with_bundle_format_from_commandline(
+        self, mock_exists, mock_path_create, mock_command, mock_load
+    ):
+        self.xml_state.profiles = None
+        self.xml_state.host_architecture = 'x86_64'
+        self.xml_state.get_build_type_name = Mock(
+            return_value='oem'
+        )
+        self.xml_state.xml_data.get_name = Mock(
+            return_value='Leap-15.2'
+        )
+
+        result = Result(self.xml_state)
+        result.add(
+            key='disk_image',
+            filename='/tmp/mytest/Leap-15.2.x86_64-1.15.2.raw',
+            use_for_bundle=True, compress=False, shasum=False
+        )
+
+        mock_exists.return_value = False
+        mock_load.return_value = result
+        self._init_command_args()
+
+        self.task.command_args['--bundle-format'] = '%N-%T:%M'
 
         self.task.process()
 


### PR DESCRIPTION
The bundle format is usually specified as part of the image description in the bundle_format attribute. This commit also allows to specify/overwrite the bundle format in the kiwi result bundle command via the new --bundle-format option. This Fixes #2509

