### PR TITLE
Add support for %v in bundle format

### DIFF
--- a/doc/source/commands/result_bundle.rst
+++ b/doc/source/commands/result_bundle.rst
@@ -52,6 +52,7 @@ OPTIONS
   * %M : Image Major version number
   * %m : Image Minor version number
   * %p : Image Patch version number
+  * %v : Image Version string
 
 --id=<bundle_id>
 

--- a/doc/source/image_types_and_results.rst
+++ b/doc/source/image_types_and_results.rst
@@ -245,3 +245,6 @@ placeholders which gets replaced by their real value can be used:
 
 %p
   Turns into the patch number of the `<version>` section
+
+%v
+  Turns into the version text of the `<version>` section

--- a/kiwi/system/result.py
+++ b/kiwi/system/result.py
@@ -49,7 +49,8 @@ result_name_tags = NamedTuple(
         ('T', str),  # image type name
         ('M', int),  # Major version number
         ('m', int),  # Minor version number
-        ('p', int)   # Patch version number
+        ('p', int),  # Patch version number
+        ('v', str)   # Version string
     ]
 )
 
@@ -86,7 +87,8 @@ class Result:
             T=self.xml_state.get_build_type_name(),
             M=int(major),
             m=int(minor),
-            p=int(patch)
+            p=int(patch),
+            v=self.xml_state.get_image_version()
         )
         self.result_files['bundle_format'] = {
             'pattern': pattern,

--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -165,6 +165,10 @@ class ResultBundleTask(CliTask):
             bundle_file_format_name = bundle_file_format_name.replace(
                 '%p', format(tags.p)
             )
+            # Insert Version string
+            bundle_file_format_name = bundle_file_format_name.replace(
+                '%v', format(tags.v)
+            )
             # Insert Bundle ID
             bundle_file_format_name = bundle_file_format_name.replace(
                 '%I', self.command_args['--id']


### PR DESCRIPTION
Allow a placeholder for the entire version text as provided by the <version> section

