### PR TITLE
Allow ignore stanza in bootstrap

### DIFF
--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -254,6 +254,7 @@ class SystemPrepare:
         bootstrap_products = self.xml_state.get_bootstrap_products()
         bootstrap_archives = self.xml_state.get_bootstrap_archives()
         bootstrap_archives_target_dirs = self.xml_state.get_bootstrap_archives_target_dirs()
+        bootstrap_packages_ignored = self.xml_state.get_bootstrap_ignore_packages()
         # process package installations
         if collection_type == 'onlyRequired':
             manager.process_only_required()
@@ -263,7 +264,8 @@ class SystemPrepare:
             manager,
             bootstrap_packages,
             bootstrap_collections,
-            bootstrap_products
+            bootstrap_products,
+            bootstrap_packages_ignored
         )
         manager.setup_repository_modules(
             self.xml_state.get_collection_modules()

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -578,6 +578,25 @@ class XMLState:
                 result.append(archive.get_name().strip())
         return sorted(result)
 
+    def get_ignore_packages(self, section_type: str) -> List:
+        """
+        List of ignore package names from the packages sections matching
+        section_type and type=build_type
+
+        :return: package names
+
+        :rtype: list
+        """
+        result = []
+        image_packages_sections = self.get_packages_sections(
+            [section_type, self.get_build_type_name()]
+        )
+        for packages in image_packages_sections:
+            for package in packages.get_ignore():
+                if self.package_matches_host_architecture(package):
+                    result.append(package.get_name().strip())
+        return sorted(result)
+
     def get_system_ignore_packages(self) -> List:
         """
         List of ignore package names from the packages sections matching
@@ -587,15 +606,18 @@ class XMLState:
 
         :rtype: list
         """
-        result = []
-        image_packages_sections = self.get_packages_sections(
-            ['image', self.get_build_type_name()]
-        )
-        for packages in image_packages_sections:
-            for package in packages.get_ignore():
-                if self.package_matches_host_architecture(package):
-                    result.append(package.get_name().strip())
-        return sorted(result)
+        return self.get_ignore_packages('image')
+
+    def get_bootstrap_ignore_packages(self) -> List:
+        """
+        List of ignore package names from the packages sections matching
+        type="image" and type=build_type
+
+        :return: package names
+
+        :rtype: list
+        """
+        return self.get_ignore_packages('bootstrap')
 
     def get_bootstrap_package_name(self) -> str:
         """

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -238,6 +238,7 @@
         <namedCollection name="bootstrap-collection"/>
         <product name="kiwi"/>
         <archive name="bootstrap.tgz"/>
+        <ignore name="some"/>
     </packages>
     <packages type="delete">
         <package name="kernel-debug"/>

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -197,6 +197,11 @@ class TestXMLState:
             'baz'
         ]
 
+    def test_get_bootstrap_ignore_packages(self):
+        assert self.state.get_bootstrap_ignore_packages() == [
+            'some'
+        ]
+
     def test_get_system_collection_type(self):
         assert self.state.get_system_collection_type() == 'plusRecommended'
 


### PR DESCRIPTION
So far the ```<ignore>``` stanza was only effective when placed as part of the ```type="image"``` packages section. This commit allows to place it also to the ```type="bootstrap"``` packages. This Fixes #2499

