### PR TITLE
Fix zipl setup for use with custom btrfs root vol

### DIFF
--- a/kiwi/bootloader/config/zipl.py
+++ b/kiwi/bootloader/config/zipl.py
@@ -60,7 +60,8 @@ class BootLoaderZipl(BootLoaderSpecBase):
             boot_options.get('root_device'),
             boot_options.get('boot_device'),
             boot_options.get('efi_device'),
-            boot_options.get('system_volumes')
+            boot_options.get('system_volumes'),
+            boot_options.get('system_root_volume')
         )
         root_dir = self.root_mount.mountpoint
         kernel_info = BootImageBase(


### PR DESCRIPTION
In the setup case that btrfs is used for the system and the root partition is on a custom named volume (not /), this information was not passed to the zipl bootloader instance and this caused the mounting of the overall root system to fail. This commit fixes it


