### PR TITLE
setup: ensure a valid keymap is passed to systemd-firstboot

### DIFF
--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -322,7 +322,7 @@ class SystemSetup:
                 Path.wipe(self.root_dir + '/etc/vconsole.conf')
                 Command.run([
                     'chroot', self.root_dir, 'systemd-firstboot',
-                    '--keymap=' + self.preferences['keytable']
+                    '--keymap=' + self.preferences['keytable'].replace('.map.gz', '')
                 ])
             elif os.path.exists(self.root_dir + '/etc/sysconfig/keyboard'):
                 Shell.run_common_function(

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -453,6 +453,25 @@ class TestSystemSetup:
             ])
         ])
 
+    @patch('kiwi.system.setup.CommandCapabilities.has_option_in_help')
+    @patch('kiwi.system.setup.Shell.run_common_function')
+    @patch('kiwi.system.setup.Command.run')
+    @patch('os.path.exists')
+    def test_setup_keyboard_map_with_systemd_and_extension(
+        self, mock_path, mock_run, mock_shell, mock_caps
+    ):
+        mock_caps.return_value = True
+        mock_path.return_value = True
+        self.setup.preferences['keytable'] = 'keytable.map.gz'
+        self.setup.setup_keyboard_map()
+        mock_run.assert_has_calls([
+            call(['rm', '-r', '-f', 'root_dir/etc/vconsole.conf']),
+            call([
+                'chroot', 'root_dir', 'systemd-firstboot',
+                '--keymap=keytable'
+            ])
+        ])
+
     @patch('os.path.exists')
     @patch('kiwi.system.setup.CommandCapabilities.has_option_in_help')
     def test_setup_keyboard_skipped(self, mock_caps, mock_exists):


### PR DESCRIPTION
The keytable preference might specify the file extension (like us.map.gz), while systemd-firstboot actually expects only the keymap name [0].

Until recently [1], systemd-firstboot would not validate the supplied keymap, so /etc/vconsole.conf was always updated even if the keymap is wrong.

After the recent change, kiwi would fail with this error message when using the full file name as a keytable:

[   91s] [ INFO    ]: 11:04:56 | Setting up keytable: us.map.gz
[   91s] [ DEBUG   ]: 11:04:56 | EXEC: [chroot /usr/src/packages/KIWI-vmx/build/image-root systemd-firstboot --help]
[   91s] [ DEBUG   ]: 11:04:56 | EXEC: [chroot /usr/src/packages/KIWI-vmx/build/image-root systemd-firstboot --keymap=us.map.gz]
[   91s] [ DEBUG   ]: 11:04:56 | EXEC: Failed with stderr: Keymap us.map.gz is not installed.
[   91s] , stdout: (no output on stdout)
[   91s] [ ERROR   ]: 11:04:56 | KiwiCommandError: chroot: stderr: Keymap us.map.gz is not installed.
[   91s] , stdout: (no output on stdout)


[0] https://man7.org/linux/man-pages/man1/systemd-firstboot.1.html
[1] https://github.com/systemd/systemd/commit/321a8c595e3470a0fe9002014656eee6a50b9553

Fixes bsc#1221878.

As far as I know, there aren't any keymaps with a point in their name - so another approach could be to simply drop any extension from the keytable preference.