### PR TITLE
Fix efifatimagesize attribute type

### DIFF
--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1588,7 +1588,7 @@ div {
         attribute efifatimagesize { xsd:nonNegativeInteger }
         >> sch:pattern [ id = "efifatimagesize" is-a = "image_type"
             sch:param [ name = "attr" value = "efifatimagesize" ]
-            sch:param [ name = "types" value = "oem" ]
+            sch:param [ name = "types" value = "iso" ]
         ]
     k.type.dosparttable_extended_layout.attribute =
         ## Specify to make use of logical partitions inside of an

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1588,7 +1588,7 @@ div {
         attribute efifatimagesize { xsd:nonNegativeInteger }
         >> sch:pattern [ id = "efifatimagesize" is-a = "image_type"
             sch:param [ name = "attr" value = "efifatimagesize" ]
-            sch:param [ name = "types" value = "iso" ]
+            sch:param [ name = "types" value = "oem iso" ]
         ]
     k.type.dosparttable_extended_layout.attribute =
         ## Specify to make use of logical partitions inside of an

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2296,7 +2296,7 @@ in MB. If not set the min efifatimage size is set to 20 MB</a:documentation>
       </attribute>
       <sch:pattern id="efifatimagesize" is-a="image_type">
         <sch:param name="attr" value="efifatimagesize"/>
-        <sch:param name="types" value="iso"/>
+        <sch:param name="types" value="oem iso"/>
       </sch:pattern>
     </define>
     <define name="k.type.dosparttable_extended_layout.attribute">

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2296,7 +2296,7 @@ in MB. If not set the min efifatimage size is set to 20 MB</a:documentation>
       </attribute>
       <sch:pattern id="efifatimagesize" is-a="image_type">
         <sch:param name="attr" value="efifatimagesize"/>
-        <sch:param name="types" value="oem"/>
+        <sch:param name="types" value="iso"/>
       </sch:pattern>
     </define>
     <define name="k.type.dosparttable_extended_layout.attribute">


### PR DESCRIPTION
The efifatimagesize attribute type value is set to "oem" but the documentation says that it is intended to be used for creating ISO images. This causes a schema error when this attribute is set on a profile with type "iso" and blocks changing the EFI boot image size which is a problem if the image is bigger than 20M.

This patch changes the efifatimagesize attribute type to "iso" with the benefit of being able to change the EFI boot image size and avoid problems when the size is bigger than 20M.

Fixes # No issue for this problem.

Changes proposed in this pull request:
* Change the value for the type of the atrribute `efifatimagesize` to `iso`.
