### PR TITLE
Add schema upgrade opportunity for old schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ install:
 	# kiwi default configuration
 	install -d -m 755 ${buildroot}etc
 	install -m 644 kiwi.yml ${buildroot}etc/kiwi.yml
+	# kiwi old XSL stylesheets for upgrade
+	install -d -m 755 ${buildroot}usr/share/kiwi
+	cp -a helper/xsl_to_v74 ${buildroot}usr/share/kiwi/
 
 tox:
 	tox -- "-n 5"

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -5,7 +5,12 @@ Building Linux System Appliances
 
 .. note::
    This documentation covers {kiwi-product} |version|- the command line
-   utility to build Linux system appliances.
+   utility to build Linux system appliances. If you are using a {kiwi}
+   schema version older than v74, upgrade the kiwi file as follows:
+
+   .. code:: shell-session
+
+      $ xsltproc /usr/share/kiwi/xsl_to_v74/update.xsl config.xml|*.kiwi]
 
 .. toctree::
    :maxdepth: 1

--- a/helper/xsl_to_v74/convert14to20.xsl
+++ b/helper/xsl_to_v74/convert14to20.xsl
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+<xsl:strip-space elements="type"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv14to20">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv14to20"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemeversion</tag>
+    from <literal>1.4</literal> to <literal>2.0</literal>. 
+</para>
+<xsl:template match="image" mode="conv14to20">
+    <xsl:choose>
+        <!-- nothing to do if already at 2.0 -->
+        <xsl:when test="@schemeversion > 1.4 or @schemaversion > 1.4">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemeversion="2.0">
+                <xsl:copy-of select="@*[local-name() != 'schemeversion']"/>
+                <xsl:apply-templates mode="conv14to20"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- split section update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Copy all attributes, when contents is NOT 'split'.
+    If contents contains 'split' and attribute <tag class="attribute">
+    filesystem</tag> contains a comma, then split this attribute and
+    create two new attributes <tag class="attribute">fsreadwrite</tag>
+    and <tag class="attribute">fsreadonly</tag>.
+</para>
+<xsl:template match="type" mode="conv14to20" >
+    <xsl:variable name="fs" select="normalize-space(@filesystem)"/>
+    <xsl:variable name="contents" select="."/>
+    <type>
+    <xsl:choose>
+        <xsl:when test="$contents != 'split'">
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates mode="conv14to20"/>
+        </xsl:when>
+        <xsl:when test="$contents = 'split' and contains($fs, ',')">
+            <xsl:attribute name="fsreadwrite">
+            <xsl:value-of select="substring-before($fs, ',')"/>
+            </xsl:attribute>
+            <xsl:attribute name="fsreadonly">
+            <xsl:value-of select="substring-after($fs, ',')"/>
+            </xsl:attribute>
+            <xsl:copy-of select="@boot"/>
+            <xsl:copy-of select="@format"/>
+            <xsl:apply-templates mode="conv14to20"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates mode="conv14to20"/>
+        </xsl:otherwise>
+    </xsl:choose>
+    </type>
+</xsl:template>
+
+<!-- update boot / bootstrap -->
+<para xmlns="http://docbook.org/ns/docbook"> 
+    Change attribute value <tag class="attribute">boot</tag> to 
+    <tag class="attribute">bootstrap</tag>.
+</para>
+<xsl:template match="packages[@type='boot']" mode="conv14to20">
+    <packages type="bootstrap">
+        <xsl:apply-templates mode="conv14to20"/>
+    </packages>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert20to24.xsl
+++ b/helper/xsl_to_v74/convert20to24.xsl
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+<xsl:strip-space elements="type"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv20to24">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv20to24"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemeversion</tag>
+    from <literal>2.0</literal> to <literal>2.4</literal>. 
+</para>
+<xsl:template match="image" mode="conv20to24">
+    <xsl:choose>
+        <!-- nothing to do if already at 2.4 -->
+        <xsl:when test="@schemeversion > 2.0 or @schemaversion > 2.0">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemeversion="2.4">
+                <xsl:copy-of select="@*[local-name() != 'schemeversion']"/>
+                <xsl:apply-templates mode="conv20to24"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- remove attributes and add info -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Remove attributes memory,disk,HWversion,guestOS_32Bit and guestOS_64Bit
+    from the <literal>2.0</literal> packages type [vmware|xen] version.
+    This information needs to be provided by an additional
+    <tag class="element">vmwareconfig</tag> or
+    <tag class="element">xenconfig</tag> element
+</para>
+<xsl:template match="packages" mode="conv20to24">
+    <packages>
+    <xsl:if test="@memory or 
+        @disk or 
+        @HWversion or 
+        @guestOS_32Bit or 
+        @guestOS_64Bit">
+    <xsl:message>
+        <xsl:text>NOTE: You need to setup a vmwareconfig and/or&#10;</xsl:text>
+        <xsl:text>      xenconfig section in order to setup an&#10;</xsl:text>
+        <xsl:text>      appropriate guest configuration. For&#10;</xsl:text>
+        <xsl:text>      details see the 'KIWI image description'&#10;</xsl:text>
+        <xsl:text>      chapter of the kiwi cookbook</xsl:text>
+    </xsl:message>
+    </xsl:if>
+    <xsl:copy-of select="@*[not(local-name(.) = 'memory' or
+        local-name(.) = 'disk' or
+        local-name(.) = 'HWversion' or
+        local-name(.) = 'guestOS_32Bit' or
+        local-name(.) = 'guestOS_64Bit')]"/>
+    <xsl:apply-templates mode="conv20to24"/>
+    </packages>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert24to35.xsl
+++ b/helper/xsl_to_v74/convert24to35.xsl
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+<xsl:strip-space elements="type"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv24to35">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv24to35"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemeversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>2.4</literal> to <literal>3.5</literal>.
+</para>
+<xsl:template match="image" mode="conv24to35">
+    <xsl:choose>
+        <!-- nothing to do if already at 3.5 -->
+        <xsl:when test="@schemaversion > 2.4 or @schemeversion > 2.4">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="3.5">
+                <xsl:copy-of select="@*[local-name() != 'schemeversion']"/>
+                <xsl:apply-templates mode="conv24to35"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- remove compressed element -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Remove compressed element as it was moved into the type
+</para>
+<xsl:template match="node()|@*">
+    <xsl:copy>
+        <xsl:apply-templates select="node()|@*" mode="conv24to35"/>
+    </xsl:copy>
+</xsl:template>
+<xsl:template match="compressed" mode="conv24to35"/>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert35to37.xsl
+++ b/helper/xsl_to_v74/convert35to37.xsl
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY lowercase "'abcdefghijklmnopqrstuvwxyz'">
+    <!ENTITY uppercase "'ABCDEFGHIJKLMNOPQRSTUVWXYZ'">
+]>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+<xsl:strip-space elements="type"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv35to37">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv35to37"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>3.5</literal> to <literal>3.7</literal>.
+</para>
+<xsl:template match="image" mode="conv35to37">
+    <xsl:choose>
+        <!-- nothing to do if already at 3.7 -->
+        <xsl:when test="@schemaversion > 3.5">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="3.7">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates mode="conv35to37"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- update bool types -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Change possible mixed cases into lowercase and
+    normalize any whitespaces
+</para>
+<xsl:template name="oem-change-content" mode="conv35to37">
+    <xsl:variable name="content"
+        select="translate(normalize-space(.), &uppercase;, &lowercase;)"
+    />
+    <xsl:copy>
+        <xsl:copy-of select="@*"/><!-- Copy attributes -->
+        <xsl:choose>
+            <xsl:when test="$content = 'false'">false</xsl:when>
+            <xsl:when test="$content = 'true'">true</xsl:when>
+            <xsl:when test="$content = 'yes'">true</xsl:when>
+            <xsl:when test="$content = 'no'">false</xsl:when>
+            <xsl:otherwise>
+            <!-- Should not happen -->
+            <xsl:message>Wrong value!</xsl:message>
+        </xsl:otherwise>
+        </xsl:choose>
+    </xsl:copy>
+</xsl:template>
+
+<xsl:template match="oem-swap" mode="conv35to37">
+    <xsl:call-template name="oem-change-content"/>
+</xsl:template>
+
+<xsl:template match="oem-home" mode="conv35to37">
+    <xsl:call-template name="oem-change-content"/>
+</xsl:template>
+
+<xsl:template match="rpm-check-signatures" mode="conv35to37">
+        <xsl:call-template name="oem-change-content"/>
+</xsl:template>
+
+<xsl:template match="rpm-excludedocs" mode="conv35to37">
+        <xsl:call-template name="oem-change-content"/>
+</xsl:template>
+
+<xsl:template match="rpm-force" mode="conv35to37">
+        <xsl:call-template name="oem-change-content"/>
+</xsl:template>
+
+<xsl:template match="oem-recovery" mode="conv35to37">
+        <xsl:call-template name="oem-change-content"/>
+</xsl:template>
+
+<xsl:template match="oem-kiwi-initrd" mode="conv35to37">
+        <xsl:call-template name="oem-change-content"/>
+</xsl:template>
+
+<xsl:template match="oem-sap-install" mode="conv35to37">
+        <xsl:call-template name="oem-change-content"/>
+</xsl:template>
+
+<xsl:template match="oem-reboot" mode="conv35to37">
+        <xsl:call-template name="oem-change-content"/>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert37to38.xsl
+++ b/helper/xsl_to_v74/convert37to38.xsl
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+<xsl:strip-space elements="type"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv37to38">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv37to38"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>3.7</literal> to <literal>3.8</literal>.
+</para>
+<xsl:template match="image" mode="conv37to38">
+    <xsl:choose>
+        <!-- nothing to do if already at 3.8 -->
+        <xsl:when test="@schemaversion > 3.7">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="3.8">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates mode="conv37to38"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- update deploy / pxedeploy -->
+<para xmlns="http://docbook.org/ns/docbook"> 
+    Change attribute value <tag class="attribute">deploy</tag> to 
+    <tag class="attribute">pxedeploy</tag>.
+</para>
+<xsl:template match="deploy" mode="conv37to38">
+    <pxedeploy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv37to38"/>
+    </pxedeploy>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert38to39.xsl
+++ b/helper/xsl_to_v74/convert38to39.xsl
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+<xsl:strip-space elements="type"/>
+<xsl:strip-space elements="preferences"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv38to39">
+        <xsl:copy>
+                <xsl:copy-of select="@*"/>
+                     <xsl:apply-templates mode="conv38to39"/>
+        </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>3.8</literal> to <literal>3.9</literal>.
+</para>
+<xsl:template match="image" mode="conv38to39">
+    <xsl:choose>
+        <!-- nothing to do if already at 3.9 -->
+        <xsl:when test="@schemaversion > 3.8">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="3.9">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates mode="conv38to39"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- create new element oemconfig -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Create new <tag class="element">oemconfig</tag> element to collect
+    all <tag class="element">oem-*</tag> elements in one place and remove 
+    them from the <tag class="element">preferences</tag> element.
+</para>
+<xsl:template match="image" mode="conv38to39">
+    <xsl:variable name="boottitle" select="/image/preferences/oem-boot-title"/>
+    <xsl:variable name="home" select="/image/preferences/oem-home"/>
+    <xsl:variable name="initrd" select="/image/preferences/oem-kiwi-initrd"/>
+    <xsl:variable name="reboot" select="/image/preferences/oem-reboot"/>
+    <xsl:variable name="inplace" select="/image/preferences/oem-inplace-recovery"/>
+    <xsl:variable name="align" select="/image/preferences/oem-align-partition"/>
+    <xsl:variable name="recovery" select="/image/preferences/oem-recovery"/>
+    <xsl:variable name="dumphalt" select="/image/preferences/oem-dumphalt"/>
+    <xsl:variable name="recoveryid" select="/image/preferences/oem-recoveryID"/>
+    <xsl:variable name="sapinstall" select="/image/preferences/oem-sap-install"/>
+    <xsl:variable name="swap" select="/image/preferences/oem-swap"/>
+    <xsl:variable name="swapsize" select="/image/preferences/oem-swapsize"/>
+    <xsl:variable name="systemsize" select="/image/preferences/oem-systemsize"/>
+    <image>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv38to39"/>
+
+        <xsl:if test="$boottitle or $home or $initrd or $reboot or $recovery or $recoveryid or $sapinstall or $swap or $swapsize or $systemsize">
+            <oemconfig>
+                <xsl:copy-of select="$boottitle"/>
+                <xsl:copy-of select="$home"/>
+                <xsl:copy-of select="$initrd"/>
+                <xsl:copy-of select="$reboot"/>
+                <xsl:copy-of select="$align"/>
+                <xsl:copy-of select="$inplace"/>
+                <xsl:copy-of select="$recovery"/>
+                <xsl:copy-of select="$recoveryid"/>
+                <xsl:copy-of select="$sapinstall"/>
+                <xsl:copy-of select="$swap"/>
+                <xsl:copy-of select="$swapsize"/>
+                <xsl:copy-of select="$systemsize"/>
+                <xsl:copy-of select="$dumphalt"/>
+            </oemconfig>
+        </xsl:if>
+    </image>
+</xsl:template>
+
+<!-- swallow the output for the OEM settings in their current position -->
+<xsl:template match="preferences/oem-boot-title" mode="conv38to39"/>
+<xsl:template match="preferences/oem-home" mode="conv38to39"/>
+<xsl:template match="preferences/oem-kiwi-initrd" mode="conv38to39"/>
+<xsl:template match="preferences/oem-reboot" mode="conv38to39"/>
+<xsl:template match="preferences/oem-inplace-recovery" mode="conv38to39"/>
+<xsl:template match="preferences/oem-align-partition" mode="conv38to39"/>
+<xsl:template match="preferences/oem-recovery" mode="conv38to39"/>
+<xsl:template match="preferences/oem-recoveryID" mode="conv38to39"/>
+<xsl:template match="preferences/oem-sap-install" mode="conv38to39"/>
+<xsl:template match="preferences/oem-swap" mode="conv38to39"/>
+<xsl:template match="preferences/oem-swapsize" mode="conv38to39"/>
+<xsl:template match="preferences/oem-systemsize" mode="conv38to39"/>
+<xsl:template match="preferences/oem-dumphalt" mode="conv38to39"/>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert39to41.xsl
+++ b/helper/xsl_to_v74/convert39to41.xsl
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv39to41">
+        <xsl:copy>
+                <xsl:copy-of select="@*"/>
+                     <xsl:apply-templates mode="conv39to41"/>
+        </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+        Changed attribute <tag class="attribute">schemaversion</tag>
+        to <tag class="attribute">schemaversion</tag> from
+        <literal>3.9</literal> to <literal>4.1</literal>. Adding
+        <tag class="attribute">image</tag> attribute to
+        <tag class="element">type</tag> element and collecting the
+        appropriate <tag class="element">*config</tag> elements as
+        children of the <tag class="element">type</tag> element.
+</para>
+<xsl:template match="image" mode="conv39to41">
+    <xsl:choose>
+        <!-- nothing to do if already at 4.1 -->
+        <xsl:when test="@schemaversion > 3.9">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="4.1">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv39to41"/>  
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template match="preferences" mode="conv39to41">
+    <preferences>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates mode="conv39to41"/>
+    </preferences>
+</xsl:template>
+
+<!-- modify the type element -->
+<xsl:template match="type" mode="conv39to41">
+        <xsl:choose>
+                <xsl:when test="text()='ec2'">
+                        <type>
+                                <xsl:call-template name="insertcomprops"/>
+                        </type>
+                </xsl:when>
+                <xsl:when test="text()='iso'">
+                        <type>
+                                <xsl:call-template name="insertcomprops"/>
+                <xsl:call-template name="insertvmconfig"/>
+                <xsl:call-template name="insertxenconfig"/>
+                        </type>
+                </xsl:when>
+                <xsl:when test="text()='oem'">
+                        <type>
+                                <xsl:call-template name="insertcomprops"/>
+                                <xsl:call-template name="insertlvm"/>
+                                <xsl:call-template name="insertoemconfig"/>
+                                <xsl:call-template name="insertvmconfig"/>
+                                <xsl:call-template name="insertxenconfig"/>
+                        </type>
+                </xsl:when>
+                <xsl:when test="text()='split'">
+                        <type>
+                                <xsl:call-template name="insertcomprops"/>
+                                <xsl:call-template name="insertoemconfig"/>
+                                <xsl:call-template name="insertsplit"/>
+                                <xsl:call-template name="insertvmconfig"/>
+                                <xsl:call-template name="insertxenconfig"/>
+                        </type>
+                </xsl:when>
+                <xsl:when test="text()='usb'">
+                        <type>
+                                <xsl:call-template name="insertcomprops"/>
+                                <xsl:call-template name="insertlvm"/>
+                        </type>
+                </xsl:when>
+                <xsl:when test="text()='vmx'">
+                        <type>
+                                <xsl:call-template name="insertcomprops"/>
+                                <xsl:call-template name="insertlvm"/>
+                                <xsl:call-template name="insertvmconfig"/>
+                                <xsl:call-template name="insertxenconfig"/>
+                        </type>
+                </xsl:when>
+                <xsl:when test="text()='xen'">
+                        <type>
+                                <xsl:call-template name="insertcomprops"/>
+                                <xsl:call-template name="insertxenconfig"/>
+                        </type>
+                </xsl:when>
+                <xsl:when test="text()='pxe'">
+                        <type>
+                                <xsl:call-template name="insertcomprops"/>
+                                <xsl:call-template name="insertpxe"/>
+                        </type>
+                </xsl:when>
+                <xsl:otherwise>
+                        <type>
+                                <xsl:call-template name="insertcomprops" />
+                                <xsl:apply-templates select="*"/>
+                        </type>
+                </xsl:otherwise>
+        </xsl:choose>
+</xsl:template>
+
+<!-- generic insertion of block children -->
+<xsl:template name="insertblockchldnodes" mode="conv39to41">
+        <xsl:param name="blockname"/>
+        <xsl:for-each select="$blockname/*">
+                <xsl:copy-of select="current()"/>
+        </xsl:for-each>
+</xsl:template>
+
+<!-- add properties common to all type elements -->
+<xsl:template name="insertcomprops" mode="conv39to41">
+        <xsl:attribute name="image">
+                <xsl:value-of select="current()"/>
+        </xsl:attribute>
+        <xsl:copy-of select="@*"/>
+        <xsl:if test="/image/preferences/size">
+                <xsl:copy-of select="/image/preferences/size"/>
+        </xsl:if>
+</xsl:template>
+
+<!-- insert the lvmvolumes block -->
+<xsl:template name="insertlvm" mode="conv39to41">
+        <xsl:if test="/image/lvmvolumes">
+                <lvmvolumes>
+                <xsl:call-template name="insertblockchldnodes">
+                        <xsl:with-param name="blockname" select="/image/lvmvolumes"/>
+                </xsl:call-template>
+                </lvmvolumes>
+        </xsl:if>
+</xsl:template>
+
+<!-- insert the oemconfig block -->
+<xsl:template name="insertoemconfig" mode="conv39to41">
+        <xsl:if test="/image/oemconfig">
+                <oemconfig>
+                <xsl:call-template name="insertblockchldnodes">
+                    <xsl:with-param name="blockname" select="/image/oemconfig"/>
+                </xsl:call-template>
+                </oemconfig>
+        </xsl:if>
+</xsl:template>
+
+<!-- insert the pxedeploy block -->
+<xsl:template name="insertpxe" mode="conv39to41">
+        <xsl:if test="/image/pxedeploy">
+                <pxedeploy>
+                <xsl:copy-of select="/image/pxedeploy/@*"/>
+                <xsl:call-template name="insertblockchldnodes">
+                        <xsl:with-param name="blockname" select="/image/pxedeploy"/>
+                </xsl:call-template>  
+                </pxedeploy>
+        </xsl:if>
+</xsl:template>
+
+<!-- insert the split block -->
+<xsl:template name="insertsplit" mode="conv39to41">
+        <xsl:if test="/image/split">
+                <split>
+                <xsl:call-template name="insertblockchldnodes">
+                        <xsl:with-param name="blockname" select="/image/split"/>
+                </xsl:call-template>
+                </split>
+        </xsl:if>
+</xsl:template>
+
+<!-- Insert the vmwareconfig block -->
+<xsl:template name="insertvmconfig" mode="conv39to41">
+        <xsl:if test="/image/vmwareconfig">
+                <vmwareconfig>
+                <xsl:copy-of select="/image/vmwareconfig/@*"/>
+                <xsl:call-template name="insertblockchldnodes">
+                        <xsl:with-param name="blockname" select="/image/vmwareconfig"/>
+                </xsl:call-template>
+                </vmwareconfig>
+        </xsl:if>
+</xsl:template>
+
+<!-- Insert the xenconfig block -->
+<xsl:template name="insertxenconfig" mode="conv39to41">
+        <xsl:if test="/image/xenconfig">
+                <xenconfig>
+                <xsl:copy-of select="/image/xenconfig/@*"/>
+                <xsl:call-template name="insertblockchldnodes">
+                        <xsl:with-param name="blockname" select="/image/xenconfig"/>
+                </xsl:call-template>
+                </xenconfig>
+        </xsl:if>
+</xsl:template>
+
+<!-- Do not emmit blocks that have moved -->
+<xsl:template match="lvmvolumes" mode="conv39to41"/>
+<xsl:template match="oemconfig" mode="conv39to41"/>
+<xsl:template match="pxedeploy" mode="conv39to41"/>
+<xsl:template match="size" mode="conv39to41"/>
+<xsl:template match="split" mode="conv39to41"/>
+<xsl:template match="vmwareconfig" mode="conv39to41"/>
+<xsl:template match="xenconfig" mode="conv39to41"/>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert41to42.xsl
+++ b/helper/xsl_to_v74/convert41to42.xsl
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv41to42">
+        <xsl:copy>
+                <xsl:copy-of select="@*"/>
+                     <xsl:apply-templates mode="conv41to42"/>
+        </xsl:copy>  
+</xsl:template>
+
+<!-- ec2 varaibles -->
+<xsl:variable name="ec2privatekey" select="/image/preferences/type/@ec2privatekeyfile"/>
+<xsl:variable name="ec2cert" select="/image/preferences/type/@ec2certfile"/>
+<xsl:variable name="ec2acct" select="/image/preferences/type/@ec2accountnr"/>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+        Changed attribute <tag class="attribute">schemaversion</tag>
+        to <tag class="attribute">schemaversion</tag> from
+        <literal>4.1</literal> to <literal>4.2</literal>. Created new
+        <tag class="element">ec2config</tag> element to collect 
+        <tag class="attribute">ec2*</tag> attributes. The 
+        <tag class="element">ec2config</tag> element is a child of the
+        <tag class="element">type</tag> element.
+</para>
+<xsl:template match="image" mode="conv41to42">
+    <xsl:choose>
+        <!-- nothing to do if already at 4.2 -->
+        <xsl:when test="@schemaversion > 4.1">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="4.2">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates mode="conv41to42"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template match="preferences" mode="conv41to42">
+        <preferences>
+                <xsl:copy-of select="@*"/>
+                <xsl:apply-templates mode="conv41to42"/>
+        </preferences>
+</xsl:template>
+
+<xsl:template match="type" mode="conv41to42">
+        <xsl:choose>
+                <xsl:when test="@image='ec2'">
+                        <type>
+                        <xsl:for-each select="@*">
+                                <xsl:choose>
+                                        <xsl:when test="name()='ec2privatekeyfile'"/>
+                                        <xsl:when test="name()='ec2certfile'"/>
+                                        <xsl:when test="name()='ec2accountnr'"/>
+                                        <xsl:otherwise>
+                                            <xsl:attribute name="{local-name()}">
+                                                <xsl:value-of select="."/>
+                                            </xsl:attribute>
+                                        </xsl:otherwise>
+                                </xsl:choose>
+                        </xsl:for-each>
+                        <xsl:if test="$ec2privatekey or $ec2cert or $ec2acct">
+                                <ec2config>
+                                <xsl:if test="$ec2privatekey">
+                                        <ec2privatekeyfile>
+                                        <xsl:value-of select="$ec2privatekey"/>
+                                        </ec2privatekeyfile>
+                                </xsl:if>
+
+                                <xsl:if test="$ec2cert">
+                                        <ec2certfile>
+                                        <xsl:value-of select="$ec2cert"/>
+                                        </ec2certfile>
+                                </xsl:if>
+
+                                <xsl:if test="$ec2acct">
+                                        <ec2accountnr>
+                                        <xsl:value-of select="$ec2acct"/>
+                                        </ec2accountnr>
+                                </xsl:if>
+                                </ec2config>
+                        </xsl:if>
+                        <xsl:copy-of select="current()/*"/>
+                </type>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:copy-of select="."/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert42to43.xsl
+++ b/helper/xsl_to_v74/convert42to43.xsl
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv42to43">
+        <xsl:copy>
+                <xsl:copy-of select="@*"/>
+                     <xsl:apply-templates mode="conv42to43"/>
+        </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+        Changed attribute <tag class="attribute">schemaversion</tag>
+        to <tag class="attribute">schemaversion</tag> from
+        <literal>4.2</literal> to <literal>4.3</literal>. Moved the
+        <tag class="attribute">lvmgroup</tag> attribute from the 
+        <tag class="element">type</tag> to the 
+        <tag class="element">lvmvolumes</tag> element.
+</para>
+<xsl:template match="image" mode="conv42to43">
+    <xsl:choose>
+        <!-- nothing to do if already at 4.3 -->
+        <xsl:when test="@schemaversion > 4.2">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="4.3">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates mode="conv42to43"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template match="preferences" mode="conv42to43">
+        <preferences>
+                <xsl:copy-of select="@*"/>
+                <xsl:apply-templates mode="conv42to43"/>
+        </preferences>
+</xsl:template>
+
+<xsl:template match="type" mode="conv42to43">
+        <xsl:choose>
+            <xsl:when test="@lvmgroup">
+                    <type>
+                        <xsl:copy-of select="@*[local-name() != 'lvmgroup']"/>
+                        <xsl:for-each select="*">
+                            <xsl:choose>
+                                    <xsl:when test="name() = 'lvmvolumes'">
+                                            <lvmvolumes>
+                                                <xsl:attribute name="lvmgroup">
+                                                        <xsl:value-of select="../@lvmgroup"/>
+                                                </xsl:attribute>
+                                                <xsl:apply-templates mode="conv42to43"/>
+                                            </lvmvolumes>
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:copy-of select="."/>
+                                    </xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:for-each>
+                    </type>
+            </xsl:when>
+                <xsl:otherwise>
+                        <xsl:copy-of select="."/>
+                </xsl:otherwise>
+        </xsl:choose>
+</xsl:template>
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert43to44.xsl
+++ b/helper/xsl_to_v74/convert43to44.xsl
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+<xsl:strip-space elements="type"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv43to44">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv43to44"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>4.3</literal> to <literal>4.4</literal>.
+</para>
+<xsl:template match="image" mode="conv43to44">
+    <xsl:choose>
+        <!-- nothing to do if already at 4.4 -->
+        <xsl:when test="@schemaversion > 4.3">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="4.4">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates mode="conv43to44"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- remove commandline element -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Remove compressed element as it was moved into the type
+    represented as attribute kernelcmdline
+</para>
+<xsl:template match="node()|@*">
+    <xsl:copy>
+        <xsl:apply-templates select="node()|@*" mode="conv43to44"/>
+    </xsl:copy>
+</xsl:template>
+<xsl:template match="commandline" mode="conv43to44"/>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert44to45.xsl
+++ b/helper/xsl_to_v74/convert44to45.xsl
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+<xsl:strip-space elements="type"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv44to45">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv44to45"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>4.4</literal> to <literal>4.5</literal>.
+</para>
+<xsl:template match="image" mode="conv44to45">
+    <xsl:choose>
+        <!-- nothing to do if already at 4.5 -->
+        <xsl:when test="@schemaversion > 4.4">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="4.5">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates mode="conv44to45"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- remove patternPackageType attribute -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Remove patternPackageType attribute, it's no longer used
+</para>
+<xsl:template match="packages" mode="conv44to45">
+    <packages>
+    <xsl:copy-of select="@*[not(local-name(.) = 'patternPackageType')]"/>
+    <xsl:apply-templates mode="conv44to45"/>
+    </packages>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert45to46.xsl
+++ b/helper/xsl_to_v74/convert45to46.xsl
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+<xsl:strip-space elements="type"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv45to46">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv45to46"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>4.5</literal> to <literal>4.6</literal>.
+</para>
+<xsl:template match="image" mode="conv45to46">
+    <xsl:choose>
+        <!-- nothing to do if already at 4.6 -->
+        <xsl:when test="@schemaversion > 4.5">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="4.6">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates mode="conv45to46"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- update vmware / vmx -->
+<para xmlns="http://docbook.org/ns/docbook"> 
+    Change attribute value <tag class="attribute">vmware</tag> to 
+    <tag class="attribute">vmx</tag>.
+</para>
+<xsl:template match="packages[@type='vmware']" mode="conv45to46">
+    <packages type="vmx">
+                <xsl:copy-of select="@*[not(local-name(.) = 'type')]"/>
+        <xsl:apply-templates mode="conv45to46"/>
+    </packages>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert46to47.xsl
+++ b/helper/xsl_to_v74/convert46to47.xsl
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+<xsl:strip-space elements="type"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv46to47">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv46to47"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>4.6</literal> to <literal>4.7</literal>.
+</para>
+<xsl:template match="image" mode="conv46to47">
+    <xsl:choose>
+        <!-- nothing to do if already at 4.7 -->
+        <xsl:when test="@schemaversion > 4.6">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="4.7">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates mode="conv46to47"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- turn vmwareconfig into machine, ignore usb attribute -->
+<xsl:template match="vmwareconfig" mode="conv46to47">
+    <machine>
+        <xsl:copy-of select="@*[not(local-name(.) = 'usb')]"/>
+        <xsl:apply-templates mode="conv46to47"/>
+    </machine>
+</xsl:template>
+
+<!-- turn xenconfig into machine -->
+<xsl:template match="xenconfig" mode="conv46to47">
+    <machine>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv46to47"/>
+    </machine>
+</xsl:template>
+
+<!-- turn vmwaredisk into vmdisk -->
+<xsl:template match="vmwareconfig/vmwaredisk" mode="conv46to47">
+    <vmdisk>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv46to47"/>
+    </vmdisk>
+</xsl:template>
+
+<!-- turn vmwarenic into vmnic -->
+<xsl:template match="vmwareconfig/vmwarenic" mode="conv46to47">
+    <vmnic>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv46to47"/>
+    </vmnic>
+</xsl:template>
+
+<!-- turn vmwarecdrom into vmdvd -->
+<xsl:template match="vmwareconfig/vmwarecdrom" mode="conv46to47">
+    <vmdvd>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv46to47"/>
+    </vmdvd>
+</xsl:template>
+
+<!-- turn xenbridge into vmnic -->
+<xsl:template match="xenconfig/xenbridge" mode="conv46to47">
+    <xsl:variable name="iface" select="@name"/>
+    <vmnic>
+        <xsl:attribute name="interface">
+            <xsl:value-of select="$iface"/>
+        </xsl:attribute>
+        <xsl:copy-of select="@mac"/>
+        <xsl:apply-templates mode="conv46to47"/>
+    </vmnic>
+</xsl:template>
+
+<!-- turn xendisk into vmdisk -->
+<xsl:template match="xenconfig/xendisk" mode="conv46to47">
+    <vmdisk>
+        <xsl:attribute name="controller">
+            <xsl:text>ide</xsl:text>
+        </xsl:attribute>
+        <xsl:attribute name="id">
+            <xsl:text>0</xsl:text>
+        </xsl:attribute>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv46to47"/>
+    </vmdisk>
+</xsl:template>
+
+<!-- turn format="iso" into installiso and format="usb" into installstick -->
+<xsl:template match="type" mode="conv46to47">
+    <type>
+        <xsl:copy-of select="@*[not(local-name(.) = 'format')]"/>
+        <xsl:choose>
+            <xsl:when test="@format='iso'">
+                <xsl:attribute name="installiso">
+                    <xsl:text>true</xsl:text>
+                </xsl:attribute>
+            </xsl:when>
+            <xsl:when test="@format='usb'">
+                <xsl:attribute name="installstick">
+                    <xsl:text>true</xsl:text>
+                </xsl:attribute>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy-of select="@format"/>
+            </xsl:otherwise>
+        </xsl:choose>
+        <xsl:apply-templates mode="conv46to47"/>
+    </type>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert47to48.xsl
+++ b/helper/xsl_to_v74/convert47to48.xsl
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY lowercase "'abcdefghijklmnopqrstuvwxyz'">
+    <!ENTITY uppercase "'ABCDEFGHIJKLMNOPQRSTUVWXYZ'">
+]>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+<xsl:strip-space elements="type"/>
+
+<!-- create systemdisk element with optional home volume if oem-home is set -->
+<xsl:template name="add-systemdisk" mode="conv47to48">
+    <xsl:param name="content"/>
+    <xsl:param name="lvm"/>
+    <xsl:choose>
+        <xsl:when test="$content = 'true'">
+            <systemdisk name="kiwiVG">
+                <volume name="/home" freespace="200M"/>
+            </systemdisk>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:choose>
+                <xsl:when test="$lvm = 'true'">
+                    <systemdisk name="kiwiVG"/>
+                </xsl:when>
+            </xsl:choose>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- default rule conv47to48 -->
+<xsl:template match="*" mode="conv47to48">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv47to48"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>4.7</literal> to <literal>4.8</literal>.
+</para>
+<xsl:template match="image" mode="conv47to48">
+    <xsl:choose>
+        <!-- nothing to do if already at 4.8 -->
+        <xsl:when test="@schemaversion > 4.7">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="4.8">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates mode="conv47to48"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- remove lvm attribute, call add-systemdisk if no lvmvolumes exists and
+     either lvm is enabled or oem-home exists and set to true in oemconfig 
+     if lvmvolumes exists and there is oem-home enabled too, add a home
+         volume in the existing lvmvolumes section -->
+<xsl:template match="type" mode="conv47to48">
+    <type>
+        <xsl:copy-of select="@*[not(local-name(.) = 'lvm')]"/>
+        <xsl:choose>
+            <xsl:when test="lvmvolumes">
+                <xsl:variable name="content"
+                    select="translate(normalize-space(oemconfig/oem-home), 
+                            &uppercase;, &lowercase;)"
+                />
+                <xsl:choose>
+                    <xsl:when test="$content = 'true'">
+                        <xsl:apply-templates
+                            select="*[not(self::lvmvolumes)]" mode="conv47to48"
+                        />
+                        <xsl:apply-templates select="lvmvolumes"
+                            mode="mode-volumes"
+                        />
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:apply-templates mode="conv47to48"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="add-systemdisk">
+                    <xsl:with-param name="lvm" select="@lvm"/>
+                    <xsl:with-param name="content" select="oemconfig/oem-home"/>
+                </xsl:call-template>
+                <xsl:apply-templates mode="conv47to48"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </type>
+</xsl:template>
+
+<!-- add home volume in mode-volumes, see type template -->
+<xsl:template match="lvmvolumes" mode="mode-volumes">
+    <systemdisk>
+        <xsl:copy-of select="@*"/>
+        <volume name="/home" freespace="200M"/>
+        <xsl:apply-templates mode="conv47to48"/>
+    </systemdisk>
+</xsl:template>
+
+<!-- turn existing lvmvolumes into systemdisk -->
+<xsl:template match="lvmvolumes" mode="conv47to48">
+    <systemdisk>
+        <xsl:copy-of select="@*[not(local-name(.) = 'lvmgroup')]"/>
+        <xsl:variable name="groupname" select="@lvmgroup"/>
+        <xsl:choose>
+            <xsl:when test="@lvmgroup!=''">
+                <xsl:attribute name="name">
+                    <xsl:value-of select="$groupname"/>
+                </xsl:attribute>
+            </xsl:when>
+        </xsl:choose>
+        <xsl:apply-templates mode="conv47to48"/>
+    </systemdisk>
+</xsl:template>
+
+<!-- remove oem-home -->
+<xsl:template match="oemconfig/oem-home" mode="conv47to48">
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert48to49.xsl
+++ b/helper/xsl_to_v74/convert48to49.xsl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY lowercase "'abcdefghijklmnopqrstuvwxyz'">
+    <!ENTITY uppercase "'ABCDEFGHIJKLMNOPQRSTUVWXYZ'">
+]>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+<xsl:strip-space elements="type"/>
+
+<!-- default rule conv48to49 -->
+<xsl:template match="*" mode="conv48to49">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv48to49"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>4.8</literal> to <literal>4.9</literal>.
+</para>
+<xsl:template match="image" mode="conv48to49">
+    <xsl:choose>
+        <!-- nothing to do if already at 4.9 -->
+        <xsl:when test="@schemaversion > 4.8">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="4.9">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates mode="conv48to49"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- transform oem-dumphalt to oem-bootwait -->
+<xsl:template match="oemconfig/oem-dumphalt" mode="conv48to49">
+        <oem-bootwait><xsl:value-of select="text()"/></oem-bootwait>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert49to50.xsl
+++ b/helper/xsl_to_v74/convert49to50.xsl
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv49to50">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv49to50"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>4.9</literal> to <literal>5.0</literal>.
+</para>
+<xsl:template match="image" mode="conv49to50">
+    <xsl:choose>
+        <!-- nothing to do if already at 5.0 -->
+        <xsl:when test="@schemaversion > 4.9">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="5.0">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv49to50"/>  
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- convert xen image type to vmx -->
+<xsl:template match="type" mode="conv49to50">
+    <type>
+        <xsl:choose>
+            <xsl:when test="@image='xen'">
+                <xsl:copy-of select="@*[not(local-name(.) = 'image')]"/>
+                <xsl:attribute name="image">
+                    <xsl:text>vmx</xsl:text>
+                </xsl:attribute>
+                <xsl:attribute name="bootkernel">
+                    <xsl:text>xenk</xsl:text>
+                </xsl:attribute>
+                <xsl:attribute name="bootprofile">
+                    <xsl:text>xen</xsl:text>
+                </xsl:attribute>
+                <xsl:choose>
+                    <xsl:when test="starts-with(@boot,'xenboot')">
+                        <xsl:variable name="bootpath" select="concat('vmxboot',substring(@boot,8))"/>
+                        <xsl:attribute name="boot">
+                            <xsl:value-of select="$bootpath"/>
+                        </xsl:attribute>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:copy-of select="@boot"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+                <xsl:apply-templates mode="conv49to50"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy-of select="@*"/>
+                <xsl:apply-templates mode="conv49to50"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </type>
+</xsl:template>
+
+<!-- add domain="domU" to machine section if parent is in xen mode -->
+<xsl:template match="type/machine" mode="conv49to50">
+        <machine>
+            <xsl:choose>
+                <xsl:when test="../@image='xen'">
+                    <xsl:attribute name="domain">
+                        <xsl:text>domU</xsl:text>
+                    </xsl:attribute>
+                    <xsl:copy-of select="@*"/>
+                    <xsl:apply-templates mode="conv49to50"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:copy-of select="@*"/>
+                    <xsl:apply-templates mode="conv49to50"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </machine>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert50to51.xsl
+++ b/helper/xsl_to_v74/convert50to51.xsl
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv50to51">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv50to51"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>5.0</literal> to <literal>5.1</literal>.
+</para>
+<xsl:template match="image" mode="conv50to51">
+    <xsl:choose>
+        <!-- nothing to do if already at 5.1 -->
+        <xsl:when test="@schemaversion > 5.0">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="5.1">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv50to51"/>  
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- remove baseroot attribute from type -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Remove obsolete baseroot attribute from types
+</para>
+<xsl:template match="type" mode="conv50to51">
+    <type>
+        <xsl:copy-of select="@*[not(local-name(.) = 'baseroot')]"/>
+        <xsl:apply-templates mode="conv50to51"/>
+    </type>
+</xsl:template>
+
+<!-- remove defaultbaseroot element from preferences -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Remove defaultbaseroot element from preferences
+</para>
+<xsl:template match="defaultbaseroot" mode="conv50to51"/>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert51to52.xsl
+++ b/helper/xsl_to_v74/convert51to52.xsl
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv51to52">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv51to52"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<!-- remove inherit attribute from image -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>5.1</literal> to <literal>5.2</literal>.
+</para>
+<xsl:template match="image" mode="conv51to52">
+    <xsl:choose>
+        <!-- nothing to do if already at 5.2 -->
+        <xsl:when test="@schemaversion > 5.1">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="5.2">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion' and local-name() != 'inherit']"/>
+                <xsl:apply-templates  mode="conv51to52"/>  
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- remove obsolete usb image type -->
+<xsl:template match="type" mode="conv51to52">
+    <xsl:choose>
+        <xsl:when test="@image!='usb'">
+            <type>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates mode="conv51to52"/>
+            </type>
+        </xsl:when>
+    </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert52to53.xsl
+++ b/helper/xsl_to_v74/convert52to53.xsl
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv52to53">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv52to53"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>5.2</literal> to <literal>5.3</literal>.
+</para>
+<xsl:template match="image" mode="conv52to53">
+    <xsl:choose>
+        <!-- nothing to do if already at 5.3-->
+        <xsl:when test="@schemaversion > 5.2">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="5.3">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv52to53"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- convert ec2region names -->
+<xsl:template match="ec2region" mode="conv52to53">
+    <xsl:variable name="regionval" select="text()"/>
+    <xsl:choose>
+        <xsl:when test="$regionval='AP-Japan'">
+            <ec2region>AP-Northeast</ec2region>
+        </xsl:when>
+        <xsl:when test="$regionval='AP-Singapore'">
+            <ec2region>AP-Southeast</ec2region>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:copy-of select="."/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert53to54.xsl
+++ b/helper/xsl_to_v74/convert53to54.xsl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv53to54">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv53to54"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>5.3</literal> to <literal>5.4</literal>.
+</para>
+<xsl:template match="image" mode="conv53to54">
+    <xsl:choose>
+        <!-- nothing to do if already at 5.4 -->
+        <xsl:when test="@schemaversion > 5.3">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="5.4">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv53to54"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- remove type attribute from drivers -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Remove obsolete type attribute from drivers
+</para>
+<xsl:template match="drivers" mode="conv53to54">
+    <drivers>
+        <xsl:copy-of select="@*[not(local-name(.) = 'type')]"/>
+        <xsl:apply-templates mode="conv53to54"/>
+    </drivers>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert54to55.xsl
+++ b/helper/xsl_to_v74/convert54to55.xsl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv54to55">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv54to55"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>5.4</literal> to <literal>5.5</literal>.
+</para>
+<xsl:template match="image" mode="conv54to55">
+    <xsl:choose>
+        <!-- nothing to do if already at 5.5 -->
+        <xsl:when test="@schemaversion > 5.4">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="5.5">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv54to55"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- transform boot-theme to bootloader-theme and bootsplash-theme -->
+<xsl:template match="preferences/boot-theme" mode="conv54to55">
+    <bootsplash-theme><xsl:value-of select="text()"/></bootsplash-theme>
+    <bootloader-theme><xsl:value-of select="text()"/></bootloader-theme>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert55to56.xsl
+++ b/helper/xsl_to_v74/convert55to56.xsl
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv55to56">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv55to56"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>5.5</literal> to <literal>5.6</literal>.
+</para>
+<xsl:template match="image" mode="conv55to56">
+    <xsl:choose>
+        <!-- nothing to do if already at 5.6 -->
+        <xsl:when test="@schemaversion > 5.5">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="5.6">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv55to56"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- transform the pwd attribute of the instrepo element to password -->
+<xsl:template match="instsource/instrepo" mode="conv55to56">
+    <instrepo>
+        <xsl:choose>
+            <xsl:when test="@pwd">
+                <xsl:attribute name="password">
+                    <xsl:value-of select="@pwd"/>
+                </xsl:attribute>
+            </xsl:when>
+        </xsl:choose>
+        <xsl:copy-of select="@*[not(local-name(.) = 'pwd')]"/>
+        <xsl:apply-templates mode="conv55to56"/>
+    </instrepo>
+</xsl:template>
+
+<!-- transform the pwd attribute of the users element to password -->
+<xsl:template match="users/user" mode="conv55to56">
+    <user>
+        <xsl:choose>
+            <xsl:when test="@pwd">
+                <xsl:attribute name="password">
+                    <xsl:value-of select="@pwd"/>
+                </xsl:attribute>
+            </xsl:when>
+        </xsl:choose>
+        <xsl:copy-of select="@*[not(local-name(.) = 'pwd')]"/>
+        <xsl:apply-templates mode="conv55to56"/>
+    </user>
+</xsl:template>
+
+<!-- transform the pwd attribute of the repository element to password -->
+<xsl:template match="repository" mode="conv55to56">
+    <repository>
+        <xsl:choose>
+            <xsl:when test="@pwd">
+                <xsl:attribute name="password">
+                    <xsl:value-of select="@pwd"/>
+                </xsl:attribute>
+            </xsl:when>
+        </xsl:choose>
+        <xsl:copy-of select="@*[not(local-name(.) = 'pwd')]"/>
+        <xsl:apply-templates mode="conv55to56"/>
+    </repository>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert56to57.xsl
+++ b/helper/xsl_to_v74/convert56to57.xsl
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv56to57">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv56to57"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>5.6</literal> to <literal>5.7</literal>.
+</para>
+<xsl:template match="image" mode="conv56to57">
+    <xsl:choose>
+        <!-- nothing to do if already at 5.7 -->
+        <xsl:when test="@schemaversion > 5.6">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="5.7">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv56to57"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- transform the opensusePattern element into a namedCollection -->
+<xsl:template match="packages/opensusePattern" mode="conv56to57">
+    <namedCollection>
+        <xsl:copy-of select="@*"/>
+    </namedCollection>
+</xsl:template>
+
+<!-- transform the rhelGroup element into a namedCollection -->
+<xsl:template match="packages/rhelGroup" mode="conv56to57">
+    <namedCollection>
+        <xsl:copy-of select="@*"/>
+    </namedCollection>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert57to58.xsl
+++ b/helper/xsl_to_v74/convert57to58.xsl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv57to58">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv57to58"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>5.7</literal> to <literal>5.8</literal>.
+</para>
+<xsl:template match="image" mode="conv57to58">
+    <xsl:choose>
+        <!-- nothing to do if already at 5.8 -->
+        <xsl:when test="@schemaversion > 5.7">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="5.8">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv57to58"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- remove syncMBR attribute from type -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Remove obsolete syncMBR attribute from type
+</para>
+<xsl:template match="type" mode="conv57to58">
+    <type>
+        <xsl:copy-of select="@*[not(local-name(.) = 'syncMBR')]"/>
+        <xsl:apply-templates mode="conv57to58"/>
+    </type>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert58to59.xsl
+++ b/helper/xsl_to_v74/convert58to59.xsl
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv58to59">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv58to59"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>5.8</literal> to <literal>5.9</literal>.
+</para>
+<xsl:template match="image" mode="conv58to59">
+    <xsl:choose>
+        <!-- nothing to do if already at 5.9 -->
+        <xsl:when test="@schemaversion > 5.8">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="5.9">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv58to59"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- rename controller="scsi" to controller="lsilogic" in vmdisk -->
+<para xmlns="http://docbook.org/ns/docbook">
+    rename controller="scsi" to controller="lsilogic" in vmdisk
+</para>
+<xsl:template match="vmdisk" mode="conv58to59">
+    <vmdisk>
+        <xsl:copy-of select="@*[not(local-name(.) = 'controller')]"/>
+        <xsl:choose>
+            <xsl:when test="@controller='scsi'">
+                <xsl:variable name="controllername" select='"lsilogic"'/>
+                <xsl:attribute name="controller">
+                    <xsl:value-of select="$controllername"/>
+                </xsl:attribute>
+            </xsl:when>
+            <xsl:when test="@controller!='scsi'">
+                <xsl:variable name="controllername" select="@controller"/>
+                <xsl:attribute name="controller">
+                    <xsl:value-of select="$controllername"/>
+                </xsl:attribute>
+            </xsl:when>
+                </xsl:choose>
+        <xsl:apply-templates mode="conv58to59"/>
+    </vmdisk>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert59to60.xsl
+++ b/helper/xsl_to_v74/convert59to60.xsl
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv59to60">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv59to60"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>5.9</literal> to <literal>6.0</literal>.
+</para>
+<xsl:template match="image" mode="conv59to60">
+    <xsl:choose>
+        <!-- nothing to do if already at 6.0 -->
+        <xsl:when test="@schemaversion > 5.9">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="6.0">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates mode="conv59to60"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- remove oem-align-partition -->
+<xsl:template match="oemconfig/oem-align-partition" mode="conv59to60">
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert60to61.xsl
+++ b/helper/xsl_to_v74/convert60to61.xsl
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv60to61">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv60to61"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>6.0</literal> to <literal>6.1</literal>.
+</para>
+<xsl:template match="image" mode="conv60to61">
+    <xsl:choose>
+        <!-- nothing to do if already at 6.1 -->
+        <xsl:when test="@schemaversion > 6.0">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="6.1">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates mode="conv60to61"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- rename opensuseProduct -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Change section opensuseProduct to product
+</para>
+<xsl:template match="opensuseProduct" mode="conv60to61">
+    <product>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv60to61"/>
+    </product>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert61to62.xsl
+++ b/helper/xsl_to_v74/convert61to62.xsl
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv61to62">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv61to62"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>6.1</literal> to <literal>6.2</literal>.
+</para>
+<xsl:template match="image" mode="conv61to62">
+    <xsl:choose>
+        <!-- nothing to do if already at 6.2 -->
+        <xsl:when test="@schemaversion > 6.1">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="6.2">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates mode="conv61to62"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- add default bootloader if not specified -->
+<xsl:template match="type[not(@bootloader)]" mode="conv61to62">
+    <xsl:choose>
+        <xsl:when test="@image='oem' or @image='vmx'">
+            <type bootloader="grub2">
+                <xsl:copy-of select="@*[local-name() != 'bootloader']"/>
+                <xsl:apply-templates mode="conv61to62"/>
+            </type>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:copy-of select="."/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert62to63.xsl
+++ b/helper/xsl_to_v74/convert62to63.xsl
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv62to63">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv62to63"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>6.2</literal> to <literal>6.3</literal>.
+</para>
+<xsl:template match="image" mode="conv62to63">
+    <xsl:choose>
+        <!-- nothing to do if already at 6.3 -->
+        <xsl:when test="@schemaversion > 6.2">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="6.3">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv62to63"/>  
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<para xmlns="http://docbook.org/ns/docbook">
+    Remove obsolete fsreadonly, fsreadwrite and zfsoptions attributes from types
+</para>
+<xsl:template match="type" mode="conv62to63">
+    <type>
+        <xsl:copy-of select="@*[not(local-name(.) = 'fsreadonly') and not(local-name(.) = 'fsreadwrite') and not(local-name(.) = 'zfsoptions')]"/>
+        <xsl:apply-templates mode="conv62to63"/>
+    </type>
+</xsl:template>
+
+<para xmlns="http://docbook.org/ns/docbook">
+    Remove obsolete split section
+</para>
+<xsl:template match="split" mode="conv62to63">
+    <xsl:apply-templates mode="conv62to63"/>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert63to64.xsl
+++ b/helper/xsl_to_v74/convert63to64.xsl
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv63to64">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv63to64"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>6.3</literal> to <literal>6.4</literal>.
+</para>
+<xsl:template match="image" mode="conv63to64">
+    <xsl:choose>
+        <!-- nothing to do if already at 6.4 -->
+        <xsl:when test="@schemaversion > 6.3">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="6.4">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv63to64"/>  
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<para xmlns="http://docbook.org/ns/docbook">
+    Remove obsolete group and id attribute from users
+</para>
+<xsl:template match="users" mode="conv63to64">
+    <users>
+        <xsl:copy-of select="@*[not(local-name(.) = 'group') and not(local-name(.) = 'id')]"/>
+        <xsl:apply-templates mode="conv63to64"/>
+    </users>
+</xsl:template>
+
+<para xmlns="http://docbook.org/ns/docbook">
+    Move global group attribute as groups to user section(s)
+</para>
+<xsl:template match="user" mode="conv63to64">
+    <user>
+        <xsl:variable name="group_name" select="../@group"/>
+        <xsl:copy-of select="@*"/>
+        <xsl:if test="$group_name">
+            <xsl:attribute name="groups">
+                <xsl:value-of select="$group_name"/>
+            </xsl:attribute>
+        </xsl:if>
+        <xsl:apply-templates mode="conv63to64"/>
+    </user>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert64to65.xsl
+++ b/helper/xsl_to_v74/convert64to65.xsl
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv64to65">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv64to65"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>6.4</literal> to <literal>6.5</literal>.
+</para>
+<xsl:template match="image" mode="conv64to65">
+    <xsl:choose>
+        <!-- nothing to do if already at 6.5 -->
+        <xsl:when test="@schemaversion > 6.4">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="6.5">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv64to65"/>  
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<para xmlns="http://docbook.org/ns/docbook">
+    Move container attribute from type to containerconfig
+</para>
+<xsl:template match="type" mode="conv64to65">
+    <type>
+        <xsl:copy-of select="@*[not(local-name(.) = 'container')]"/>
+        <xsl:variable name="container_name" select="@container"/>
+        <xsl:if test="$container_name">
+            <containerconfig>
+                <xsl:attribute name="name">
+                    <xsl:value-of select="$container_name"/>
+                </xsl:attribute>
+            </containerconfig>
+        </xsl:if>
+        <xsl:apply-templates mode="conv64to65"/>
+    </type>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert65to66.xsl
+++ b/helper/xsl_to_v74/convert65to66.xsl
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv65to66">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv65to66"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>6.5</literal> to <literal>6.6</literal>.
+</para>
+<xsl:template match="image" mode="conv65to66">
+    <xsl:choose>
+        <!-- nothing to do if already at 6.6 -->
+        <xsl:when test="@schemaversion > 6.5">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="6.6">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv65to66"/>  
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<para xmlns="http://docbook.org/ns/docbook">
+    Add xen_server attribute to type for dom0 configurations
+</para>
+<xsl:template match="type[machine[@domain='dom0']]" mode="conv65to66">
+     <type>
+         <xsl:copy-of select="@*"/>
+         <xsl:attribute name="xen_server">
+             <xsl:value-of select="'true'"/>
+         </xsl:attribute>
+         <xsl:apply-templates  mode="conv65to66"/>
+     </type>
+</xsl:template>
+
+<para xmlns="http://docbook.org/ns/docbook">
+    Delete domain attribute from machine sections
+</para>
+<xsl:template match="machine" mode="conv65to66">
+    <machine>
+        <xsl:copy-of select="@*[not(local-name(.) = 'domain')]"/>
+        <xsl:variable name="domain_name" select="@domain"/>
+        <xsl:apply-templates mode="conv65to66"/>
+    </machine>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert66to67.xsl
+++ b/helper/xsl_to_v74/convert66to67.xsl
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv66to67">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv66to67"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<!-- remove kiwirevision attribute from image -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>6.6</literal> to <literal>6.7</literal>.
+</para>
+<xsl:template match="image" mode="conv66to67">
+    <xsl:choose>
+        <!-- nothing to do if already at 6.7 -->
+        <xsl:when test="@schemaversion > 6.6">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="6.7">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion' and local-name() != 'kiwirevision']"/>
+                <xsl:apply-templates  mode="conv66to67"/>  
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- delete checkprebuilt and fsnocheck attributes from type -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Delete checkprebuilt and fsnocheck attributes from type
+</para>
+<xsl:template match="type" mode="conv66to67">
+    <type>
+        <xsl:copy-of select="@*[not(local-name(.) = 'checkprebuilt') and not(local-name(.) = 'fsnocheck')]"/>
+        <xsl:apply-templates mode="conv66to67"/>
+    </type>
+</xsl:template>
+
+<!-- delete status and prefer-license attributes from repository -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Delete status and prefer-license attributes from repository
+</para>
+<xsl:template match="repository" mode="conv66to67">
+    <repository>
+        <xsl:copy-of select="@*[not(local-name(.) = 'status') and not(local-name(.) = 'prefer-license')]"/>
+        <xsl:apply-templates mode="conv66to67"/>
+    </repository>
+</xsl:template>
+
+<!-- delete replaces attribute from package -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Delete replaces attribute from package
+</para>
+<xsl:template match="package" mode="conv66to67">
+    <package>
+        <xsl:copy-of select="@*[not(local-name(.) = 'replaces')]"/>
+        <xsl:apply-templates mode="conv66to67"/>
+    </package>
+</xsl:template>
+
+<!-- Delete defaultprebuilt section -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Delete defaultprebuilt section
+</para>
+<xsl:template match="defaultprebuilt" mode="conv66to67">
+    <xsl:apply-templates select="*" mode="conv66to67"/>
+</xsl:template>
+
+<!-- Delete defaultdestination section -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Delete defaultdestination section
+</para>
+<xsl:template match="defaultdestination" mode="conv66to67">
+    <xsl:apply-templates select="*" mode="conv66to67"/>
+</xsl:template>
+
+<!-- Delete defaultroot section -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Delete defaultroot section
+</para>
+<xsl:template match="defaultroot" mode="conv66to67">
+    <xsl:apply-templates select="*" mode="conv66to67"/>
+</xsl:template>
+
+<!-- Delete partitioner section -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Delete partitioner section
+</para>
+<xsl:template match="partitioner" mode="conv66to67">
+    <xsl:apply-templates select="*" mode="conv66to67"/>
+</xsl:template>
+
+<!-- Delete rpm-force section -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Delete rpm-force section
+</para>
+<xsl:template match="rpm-force" mode="conv66to67">
+    <xsl:apply-templates select="*" mode="conv66to67"/>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert67to68.xsl
+++ b/helper/xsl_to_v74/convert67to68.xsl
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv67to68">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv67to68"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>6.7</literal> to <literal>6.8</literal>.
+</para>
+<xsl:template match="image" mode="conv67to68">
+    <xsl:choose>
+        <!-- nothing to do if already at 6.8 -->
+        <xsl:when test="@schemaversion > 6.7">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="6.8">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv67to68"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- Delete hwclock section -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Delete hwclock section
+</para>
+<xsl:template match="hwclock" mode="conv67to68">
+    <xsl:apply-templates select="*" mode="conv67to68"/>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert68to69.xsl
+++ b/helper/xsl_to_v74/convert68to69.xsl
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv68to69">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv68to69"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>6.8</literal> to <literal>6.9</literal>.
+</para>
+<xsl:template match="image" mode="conv68to69">
+    <xsl:choose>
+        <!-- nothing to do if already at 6.9 -->
+        <xsl:when test="@schemaversion > 6.8">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="6.9">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv68to69"/>  
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- delete hybrid attribute from type -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Delete hybrid attribute from type
+</para>
+<xsl:template match="type" mode="conv68to69">
+    <type>
+        <xsl:copy-of select="@*[not(local-name(.) = 'hybrid')]"/>
+        <xsl:apply-templates mode="conv68to69"/>
+    </type>
+</xsl:template>
+
+<!-- delete oem-ataraid-scan element from oemconfig -->
+<xsl:template match="oemconfig/oem-ataraid-scan" mode="conv68to69">
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert69to70.xsl
+++ b/helper/xsl_to_v74/convert69to70.xsl
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv69to70">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv69to70"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>6.9</literal> to <literal>7.0</literal>.
+</para>
+<xsl:template match="image" mode="conv69to70">
+    <xsl:choose>
+        <!-- nothing to do if already at 7.0 -->
+        <xsl:when test="@schemaversion > 6.9">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="7.0">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv69to70"/>  
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- delete pxedeploy element from type -->
+<xsl:template match="type/pxedeploy" mode="conv69to70">
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert70to71.xsl
+++ b/helper/xsl_to_v74/convert70to71.xsl
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv70to71">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv70to71"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>7.0</literal> to <literal>7.1</literal>.
+</para>
+<xsl:template match="image" mode="conv70to71">
+    <xsl:choose>
+        <!-- nothing to do if already at 7.1 -->
+        <xsl:when test="@schemaversion > 7.0">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="7.1">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv70to71"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- delete type from repository if obsolete type spec is used -->
+<xsl:template match="repository" mode="conv70to71">
+    <xsl:choose>
+        <xsl:when test="@type='red-carpet' or @type='slack-site' or @type='up2date-mirrors' or @type='urpmi' or @type='yast2'">
+            <repository>
+                <xsl:copy-of select="@*[not(local-name(.) = 'type')]"/>
+                <xsl:apply-templates mode="conv70to71"/>
+            </repository>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:copy-of select="."/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert71to72.xsl
+++ b/helper/xsl_to_v74/convert71to72.xsl
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv71to72">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv71to72"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>7.1</literal> to <literal>7.2</literal>.
+</para>
+<xsl:template match="image" mode="conv71to72">
+    <xsl:choose>
+        <!-- nothing to do if already at 7.2 -->
+        <xsl:when test="@schemaversion > 7.1">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="7.2">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv71to72"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<para xmlns="http://docbook.org/ns/docbook">
+    Move bootloader, bootloader_console, boottimeout
+    and zipl_targettype attributes from types into a new
+    bootloader subsection
+</para>
+<xsl:template match="type" mode="conv71to72">
+    <type>
+        <xsl:copy-of select="@*[not(local-name(.) = 'bootloader') and not(local-name(.) = 'bootloader_console') and not(local-name(.) = 'boottimeout') and not(local-name(.) = 'zipl_targettype')]"/>
+        <xsl:variable name="loadername" select="@bootloader"/>
+        <xsl:variable name="loaderconsole" select="@bootloader_console"/>
+        <xsl:variable name="loadertime" select="@boottimeout"/>
+        <xsl:variable name="loadertarget" select="@zipl_targettype"/>
+        <xsl:choose>
+            <xsl:when test="@bootloader!=''">
+                <bootloader>
+                    <xsl:attribute name="name">
+                        <xsl:value-of select="$loadername"/>
+                    </xsl:attribute>
+                    <xsl:choose>
+                        <xsl:when test="@bootloader_console!=''">
+                            <xsl:attribute name="console">
+                                <xsl:value-of select="$loaderconsole"/>
+                            </xsl:attribute>
+                        </xsl:when>
+                    </xsl:choose>
+                    <xsl:choose>
+                        <xsl:when test="@boottimeout!=''">
+                            <xsl:attribute name="timeout">
+                                <xsl:value-of select="$loadertime"/>
+                            </xsl:attribute>
+                        </xsl:when>
+                    </xsl:choose>
+                    <xsl:choose>
+                        <xsl:when test="@zipl_targettype!=''">
+                            <xsl:attribute name="targettype">
+                                <xsl:value-of select="$loadertarget"/>
+                            </xsl:attribute>
+                        </xsl:when>
+                    </xsl:choose>
+                </bootloader>
+            </xsl:when>
+        </xsl:choose>
+        <xsl:apply-templates mode="conv71to72"/>
+    </type>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert72to73.xsl
+++ b/helper/xsl_to_v74/convert72to73.xsl
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv72to73">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv72to73"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>7.2</literal> to <literal>7.3</literal>.
+</para>
+<xsl:template match="image" mode="conv72to73">
+    <xsl:choose>
+        <!-- nothing to do if already at 7.3 -->
+        <xsl:when test="@schemaversion > 7.2">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="7.3">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv72to73"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- change vmx type to oem type with oem-resize set to false-->
+<xsl:template match="type[@image='vmx']" mode="conv72to73">
+    <type image="oem">
+        <xsl:copy-of select="@*[local-name() != 'image']"/>
+        <oemconfig>
+            <xsl:apply-templates select="oemconfig/*[not(self::oem-resize)]" mode="conv72to73"/>
+            <oem-resize>false</oem-resize>
+        </oemconfig>
+        <xsl:apply-templates select="*[not(self::oemconfig)]" mode="conv72to73"/>
+    </type>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/convert73to74.xsl
+++ b/helper/xsl_to_v74/convert73to74.xsl
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv73to74">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv73to74"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- version update -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>7.3</literal> to <literal>7.4</literal>.
+</para>
+<xsl:template match="image" mode="conv73to74">
+    <xsl:choose>
+        <!-- nothing to do if already at 7.4 -->
+        <xsl:when test="@schemaversion > 7.3">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="7.4">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion']"/>
+                <xsl:apply-templates  mode="conv73to74"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- change packagemanager to apt if set to apt-get -->
+<!-- change packagemanager to dnf if set to yum -->
+<xsl:template match="packagemanager" mode="conv73to74">
+    <xsl:choose>
+        <xsl:when test="text()='apt-get'">
+            <packagemanager>apt</packagemanager>
+        </xsl:when>
+        <xsl:when test="text()='yum'">
+            <packagemanager>dnf</packagemanager>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:copy-of select="."/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/include.xsl
+++ b/helper/xsl_to_v74/include.xsl
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    indent="yes"
+    omit-xml-declaration="no"
+    encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="include">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="include"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- incorporate optional include file(s) -->
+<xsl:template match="image/include" mode="include">
+    <xsl:param name="include_file_name" select="@from"/>
+    <xsl:choose>
+        <xsl:when test="document($include_file_name)">
+            <xsl:copy-of select="document($include_file_name)/image/*"/>
+            <xsl:apply-templates  mode="include"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:copy-of select="."/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/pretty.xsl
+++ b/helper/xsl_to_v74/pretty.xsl
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+    omit-xml-declaration="no" 
+    encoding="utf-8"/>
+<xsl:strip-space elements="*"/>
+
+<xsl:param name="indent-increment" select="'&#32;&#32;&#32;&#32;'"/>
+
+<xsl:template name="newline">
+    <xsl:text>&#10;</xsl:text>
+</xsl:template>
+
+<xsl:template match="comment()" mode="pretty">
+    <xsl:param name="indent" select="''"/>
+    <xsl:call-template name="newline"/>
+    <xsl:apply-templates mode="pretty"/>
+    <xsl:comment><xsl:value-of select="."/></xsl:comment>
+</xsl:template>
+ 
+<xsl:template match="processing-instruction()" mode="pretty">
+    <xsl:param name="indent" select="''"/>
+    <xsl:call-template name="newline"/>
+    <xsl:apply-templates mode="pretty"/>
+    <xsl:processing-instruction><xsl:value-of
+    select="."/></xsl:processing-instruction>
+</xsl:template>
+    
+<xsl:template match="text()" mode="pretty">
+    <xsl:param name="indent" select="''"/>
+    <xsl:call-template name="newline"/>    
+    <xsl:value-of select="$indent"/>
+    <xsl:value-of select="normalize-space(.)"/>
+</xsl:template>
+
+<xsl:template match="*" mode="pretty">
+    <xsl:param name="indent" select="''"/>
+    <xsl:call-template name="newline"/>
+    <xsl:value-of select="$indent"/>
+    <xsl:choose>
+        <xsl:when test="count(child::*) > 0">
+            <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates select="*|node()" mode="pretty">
+            <xsl:with-param name="indent"
+            select="concat ($indent, $indent-increment)"/>
+            </xsl:apply-templates>
+            <xsl:call-template name="newline"/>
+            <xsl:value-of select="$indent"/>
+            </xsl:copy>
+        </xsl:when>       
+        <xsl:otherwise>
+            <xsl:copy-of select="."/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/helper/xsl_to_v74/update.xsl
+++ b/helper/xsl_to_v74/update.xsl
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns:exslt="http://exslt.org/common"
+        exclude-result-prefixes="exslt"
+>
+
+<xsl:import href="include.xsl"/>
+<xsl:import href="convert14to20.xsl"/>
+<xsl:import href="convert20to24.xsl"/>
+<xsl:import href="convert24to35.xsl"/>
+<xsl:import href="convert35to37.xsl"/>
+<xsl:import href="convert37to38.xsl"/>
+<xsl:import href="convert38to39.xsl"/>
+<xsl:import href="convert39to41.xsl"/>
+<xsl:import href="convert41to42.xsl"/>
+<xsl:import href="convert42to43.xsl"/>
+<xsl:import href="convert43to44.xsl"/>
+<xsl:import href="convert44to45.xsl"/>
+<xsl:import href="convert45to46.xsl"/>
+<xsl:import href="convert46to47.xsl"/>
+<xsl:import href="convert47to48.xsl"/>
+<xsl:import href="convert48to49.xsl"/>
+<xsl:import href="convert49to50.xsl"/>
+<xsl:import href="convert50to51.xsl"/>
+<xsl:import href="convert51to52.xsl"/>
+<xsl:import href="convert52to53.xsl"/>
+<xsl:import href="convert53to54.xsl"/>
+<xsl:import href="convert54to55.xsl"/>
+<xsl:import href="convert55to56.xsl"/>
+<xsl:import href="convert56to57.xsl"/>
+<xsl:import href="convert57to58.xsl"/>
+<xsl:import href="convert58to59.xsl"/>
+<xsl:import href="convert59to60.xsl"/>
+<xsl:import href="convert60to61.xsl"/>
+<xsl:import href="convert61to62.xsl"/>
+<xsl:import href="convert62to63.xsl"/>
+<xsl:import href="convert63to64.xsl"/>
+<xsl:import href="convert64to65.xsl"/>
+<xsl:import href="convert65to66.xsl"/>
+<xsl:import href="convert66to67.xsl"/>
+<xsl:import href="convert67to68.xsl"/>
+<xsl:import href="convert68to69.xsl"/>
+<xsl:import href="convert69to70.xsl"/>
+<xsl:import href="convert70to71.xsl"/>
+<xsl:import href="convert71to72.xsl"/>
+<xsl:import href="convert72to73.xsl"/>
+<xsl:import href="convert73to74.xsl"/>
+<xsl:import href="pretty.xsl"/>
+
+<xsl:output encoding="utf-8"/>
+
+<xsl:template match="/">
+    <xsl:variable name="preprocess">
+        <xsl:apply-templates select="/" mode="include"/>
+    </xsl:variable>
+
+    <xsl:variable name="v14">
+        <xsl:apply-templates select="exslt:node-set($preprocess)" mode="conv14to20"/>
+    </xsl:variable>
+
+    <xsl:variable name="v20">
+        <xsl:apply-templates select="exslt:node-set($v14)" mode="conv20to24"/>
+    </xsl:variable>
+
+    <xsl:variable name="v35">
+        <xsl:apply-templates select="exslt:node-set($v20)" mode="conv24to35"/>
+    </xsl:variable>
+
+    <xsl:variable name="v37">
+        <xsl:apply-templates select="exslt:node-set($v35)" mode="conv35to37"/>
+    </xsl:variable>
+
+    <xsl:variable name="v38">
+        <xsl:apply-templates select="exslt:node-set($v37)" mode="conv37to38"/>
+    </xsl:variable>
+
+    <xsl:variable name="v39">
+        <xsl:apply-templates select="exslt:node-set($v38)" mode="conv38to39"/>
+    </xsl:variable>
+
+    <xsl:variable name="v41">
+        <xsl:apply-templates select="exslt:node-set($v39)" mode="conv39to41"/>
+    </xsl:variable>
+
+    <xsl:variable name="v42">
+        <xsl:apply-templates select="exslt:node-set($v41)" mode="conv41to42"/>
+    </xsl:variable>
+
+    <xsl:variable name="v43">
+        <xsl:apply-templates select="exslt:node-set($v42)" mode="conv42to43"/>
+    </xsl:variable>
+
+    <xsl:variable name="v44">
+        <xsl:apply-templates select="exslt:node-set($v43)" mode="conv43to44"/>
+    </xsl:variable>
+
+    <xsl:variable name="v45">
+        <xsl:apply-templates select="exslt:node-set($v44)" mode="conv44to45"/>
+    </xsl:variable>
+
+    <xsl:variable name="v46">
+        <xsl:apply-templates select="exslt:node-set($v45)" mode="conv45to46"/>
+    </xsl:variable>
+
+    <xsl:variable name="v47">
+        <xsl:apply-templates select="exslt:node-set($v46)" mode="conv46to47"/>
+    </xsl:variable>
+
+    <xsl:variable name="v48">
+        <xsl:apply-templates select="exslt:node-set($v47)" mode="conv47to48"/>
+    </xsl:variable>
+
+    <xsl:variable name="v49">
+        <xsl:apply-templates select="exslt:node-set($v48)" mode="conv48to49"/>
+    </xsl:variable>
+
+    <xsl:variable name="v50">
+        <xsl:apply-templates select="exslt:node-set($v49)" mode="conv49to50"/>
+    </xsl:variable>
+
+    <xsl:variable name="v51">
+        <xsl:apply-templates select="exslt:node-set($v50)" mode="conv50to51"/>
+    </xsl:variable>
+
+    <xsl:variable name="v52">
+        <xsl:apply-templates select="exslt:node-set($v51)" mode="conv51to52"/>
+    </xsl:variable>
+
+    <xsl:variable name="v53">
+        <xsl:apply-templates select="exslt:node-set($v52)" mode="conv52to53"/>
+    </xsl:variable>
+
+    <xsl:variable name="v54">
+        <xsl:apply-templates select="exslt:node-set($v53)" mode="conv53to54"/>
+    </xsl:variable>
+
+    <xsl:variable name="v55">
+        <xsl:apply-templates select="exslt:node-set($v54)" mode="conv54to55"/>
+    </xsl:variable>
+
+    <xsl:variable name="v56">
+        <xsl:apply-templates select="exslt:node-set($v55)" mode="conv55to56"/>
+    </xsl:variable>
+
+    <xsl:variable name="v57">
+        <xsl:apply-templates select="exslt:node-set($v56)" mode="conv56to57"/>
+    </xsl:variable>
+
+    <xsl:variable name="v58">
+        <xsl:apply-templates select="exslt:node-set($v57)" mode="conv57to58"/>
+    </xsl:variable>
+
+    <xsl:variable name="v59">
+        <xsl:apply-templates select="exslt:node-set($v58)" mode="conv58to59"/>
+    </xsl:variable>
+
+    <xsl:variable name="v60">
+        <xsl:apply-templates select="exslt:node-set($v59)" mode="conv59to60"/>
+    </xsl:variable>
+
+    <xsl:variable name="v61">
+        <xsl:apply-templates select="exslt:node-set($v60)" mode="conv60to61"/>
+    </xsl:variable>
+
+    <xsl:variable name="v62">
+        <xsl:apply-templates select="exslt:node-set($v61)" mode="conv61to62"/>
+    </xsl:variable>
+
+    <xsl:variable name="v63">
+        <xsl:apply-templates select="exslt:node-set($v62)" mode="conv62to63"/>
+    </xsl:variable>
+
+    <xsl:variable name="v64">
+        <xsl:apply-templates select="exslt:node-set($v63)" mode="conv63to64"/>
+    </xsl:variable>
+
+    <xsl:variable name="v65">
+        <xsl:apply-templates select="exslt:node-set($v64)" mode="conv64to65"/>
+    </xsl:variable>
+
+    <xsl:variable name="v66">
+        <xsl:apply-templates select="exslt:node-set($v65)" mode="conv65to66"/>
+    </xsl:variable>
+
+    <xsl:variable name="v67">
+        <xsl:apply-templates select="exslt:node-set($v66)" mode="conv66to67"/>
+    </xsl:variable>
+
+    <xsl:variable name="v68">
+        <xsl:apply-templates select="exslt:node-set($v67)" mode="conv67to68"/>
+    </xsl:variable>
+
+    <xsl:variable name="v69">
+        <xsl:apply-templates select="exslt:node-set($v68)" mode="conv68to69"/>
+    </xsl:variable>
+
+    <xsl:variable name="v70">
+        <xsl:apply-templates select="exslt:node-set($v69)" mode="conv69to70"/>
+    </xsl:variable>
+
+    <xsl:variable name="v71">
+        <xsl:apply-templates select="exslt:node-set($v70)" mode="conv70to71"/>
+    </xsl:variable>
+
+    <xsl:variable name="v72">
+        <xsl:apply-templates select="exslt:node-set($v71)" mode="conv71to72"/>
+    </xsl:variable>
+
+    <xsl:variable name="v73">
+        <xsl:apply-templates select="exslt:node-set($v72)" mode="conv72to73"/>
+    </xsl:variable>
+
+    <xsl:variable name="v74">
+        <xsl:apply-templates select="exslt:node-set($v73)" mode="conv73to74"/>
+    </xsl:variable>
+
+    <xsl:apply-templates
+        select="exslt:node-set($v74)" mode="pretty"
+    />
+</xsl:template>
+
+</xsl:stylesheet>

--- a/kiwi/xsl/convert74to75.xsl
+++ b/kiwi/xsl/convert74to75.xsl
@@ -19,6 +19,11 @@
 </para>
 <xsl:template match="image" mode="conv74to75">
     <xsl:choose>
+        <!-- fail if smaller than 7.4 -->
+        <xsl:when test="not(@schemaversion >= 7.4)">
+            <xsl:message terminate="yes">Error: Schema version must be >= 7.4 For details how to update older schemas refer to: https://osinside.github.io/kiwi
+            </xsl:message>
+        </xsl:when>
         <!-- nothing to do if already at 7.5 -->
         <xsl:when test="@schemaversion > 7.4">
             <xsl:copy-of select="/"/>

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -724,11 +724,13 @@ fi
 
 %files -n python%{python3_pkgversion}-kiwi
 %dir %{_defaultdocdir}/python-kiwi
+%dir %{_usr}/share/kiwi
 %{_bindir}/kiwi
 %{_bindir}/kiwi-ng
 %{_bindir}/kiwi-ng-3*
 %{python3_sitelib}/kiwi*
 %{_usr}/share/bash-completion/completions/kiwi-ng
+%{_usr}/share/kiwi/xsl_to_v74/
 %{_defaultdocdir}/python-kiwi/LICENSE
 %{_defaultdocdir}/python-kiwi/README
 

--- a/test/unit/xml_description_test.py
+++ b/test/unit/xml_description_test.py
@@ -29,7 +29,7 @@ class TestSchema:
     def setup(self):
         test_xml = bytes(
             b"""<?xml version="1.0" encoding="utf-8"?>
-            <image schemaversion="1.4" name="bob">
+            <image schemaversion="7.4" name="bob">
                 <description type="system">
                     <author>John Doe</author>
                     <contact>john@example.com</contact>
@@ -49,7 +49,7 @@ class TestSchema:
         )
         test_xml_extension = bytes(
             b"""<?xml version="1.0" encoding="utf-8"?>
-            <image schemaversion="1.4" name="bob">
+            <image schemaversion="7.4" name="bob">
                 <description type="system">
                     <author>John Doe</author>
                     <contact>john@example.com</contact>
@@ -74,7 +74,7 @@ class TestSchema:
         )
         test_xml_extension_not_unique = bytes(
             b"""<?xml version="1.0" encoding="utf-8"?>
-            <image schemaversion="1.4" name="bob">
+            <image schemaversion="7.4" name="bob">
                 <description type="system">
                     <author>John Doe</author>
                     <contact>john@example.com</contact>
@@ -98,7 +98,7 @@ class TestSchema:
         )
         test_xml_extension_invalid = bytes(
             b"""<?xml version="1.0" encoding="utf-8"?>
-            <image schemaversion="1.4" name="bob">
+            <image schemaversion="7.4" name="bob">
                 <description type="system">
                     <author>John Doe</author>
                     <contact>john@example.com</contact>


### PR DESCRIPTION
kiwi files using a schema version < 7.4 are no longer supported by kiwi >= v10.x.x. Thus this commit provides the required XSL stylesheets to upgrade older schemas to v74 such that they can be consumed by the latest kiwi version. The needed xsltproc instruction is placed on the main page of the documentation


