### PR TITLE
Fixed runtime checks for dracut module packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,11 @@ install:
 	# kiwi default configuration
 	install -d -m 755 ${buildroot}etc
 	install -m 644 kiwi.yml ${buildroot}etc/kiwi.yml
-	# kiwi old XSL stylesheets for upgrade
+	# kiwi runtime checker metadata
 	install -d -m 755 ${buildroot}usr/share/kiwi
+	install -m 644 kiwi/runtime_checker_metadata.yml \
+		${buildroot}usr/share/kiwi/runtime_checker_metadata.yml
+	# kiwi old XSL stylesheets for upgrade
 	cp -a helper/xsl_to_v74 ${buildroot}usr/share/kiwi/
 
 tox:

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -82,6 +82,7 @@ EDIT_BOOT_INSTALL_SCRIPT = 'edit_boot_install.sh'
 IMAGE_METADATA_DIR = 'image'
 ROOT_VOLUME_NAME = 'LVRoot'
 SHARED_CACHE_DIR = '/var/cache/kiwi'
+RUNTIME_CHECKER_METADATA = '/usr/share/kiwi/runtime_checker_metadata.yml'
 TEMP_DIR = '/var/tmp'
 CUSTOM_RUNTIME_CONFIG_FILE = None
 PLATFORM_MACHINE = platform.machine()
@@ -265,6 +266,16 @@ class Defaults:
         return '/var/tmp/kiwi/satsolver'
 
     @staticmethod
+    def set_runtime_checker_metadata(filename):
+        """
+        Sets the runtime checker metadata filename
+
+        :param str filename: a file path name
+        """
+        global RUNTIME_CHECKER_METADATA
+        RUNTIME_CHECKER_METADATA = filename
+
+    @staticmethod
     def set_shared_cache_location(location):
         """
         Sets the shared cache location once
@@ -388,6 +399,11 @@ class Defaults:
             Defaults.get_shared_cache_location()
         ]
         return exclude_list
+
+    @staticmethod
+    def get_runtime_checker_metadata() -> Dict:
+        with open(RUNTIME_CHECKER_METADATA) as meta:
+            return yaml.safe_load(meta)
 
     @staticmethod
     def get_exclude_list_from_custom_exclude_files(root_dir: str) -> List:

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -713,14 +713,15 @@ class RuntimeChecker:
         message = dedent('''\n
             Required dracut module package missing in package list
 
-            The package '{0}' is required to build an installation
-            image for the selected oem image type. Please add the
-            following in your <packages type="image"> section to
-            your system XML description:
+            One of the packages '{0}' is required
+            to build an installation image for the selected oem image type.
+            Depending on your distribution, add the following in the
+            <packages type="image"> section:
 
-            <package name="{0}"/>
+            <package name="ONE_FROM_ABOVE"/>
         ''')
-        required_dracut_package = 'dracut-kiwi-oem-dump'
+        meta = Defaults.get_runtime_checker_metadata()
+        required_dracut_packages = meta['package_names']['dracut_oem_dump']
         initrd_system = self.xml_state.get_initrd_system()
         build_type = self.xml_state.get_build_type_name()
         if build_type == 'oem' and initrd_system == 'dracut':
@@ -731,9 +732,11 @@ class RuntimeChecker:
                 package_names = \
                     self.xml_state.get_bootstrap_packages() + \
                     self.xml_state.get_system_packages()
-                if required_dracut_package not in package_names:
+                if not RuntimeChecker._package_in_list(
+                    package_names, required_dracut_packages
+                ):
                     raise KiwiRuntimeError(
-                        message.format(required_dracut_package)
+                        message.format(required_dracut_packages)
                     )
 
     def check_dracut_module_for_disk_oem_in_package_list(self) -> None:
@@ -747,14 +750,14 @@ class RuntimeChecker:
         message = dedent('''\n
             Required dracut module package missing in package list
 
-            The package '{0}' is required for the selected
-            oem image type. Please add the following in your
-            <packages type="image"> section to your system XML
-            description:
+            One of the packages '{0}' is required
+            for the selected oem image type. Depending on your distribution,
+            add the following in the <packages type="image"> section:
 
-            <package name="{0}"/>
+            <package name="ONE_FROM_ABOVE"/>
         ''')
-        required_dracut_package = 'dracut-kiwi-oem-repart'
+        meta = Defaults.get_runtime_checker_metadata()
+        required_dracut_packages = meta['package_names']['dracut_oem_repart']
         initrd_system = self.xml_state.get_initrd_system()
         disk_resize_requested = self.xml_state.get_oemconfig_oem_resize()
         build_type = self.xml_state.get_build_type_name()
@@ -763,9 +766,11 @@ class RuntimeChecker:
             package_names = \
                 self.xml_state.get_bootstrap_packages() + \
                 self.xml_state.get_system_packages()
-            if required_dracut_package not in package_names:
+            if not RuntimeChecker._package_in_list(
+                package_names, required_dracut_packages
+            ):
                 raise KiwiRuntimeError(
-                    message.format(required_dracut_package)
+                    message.format(required_dracut_packages)
                 )
 
     def check_dracut_module_for_live_iso_in_package_list(self) -> None:
@@ -779,23 +784,25 @@ class RuntimeChecker:
         message = dedent('''\n
             Required dracut module package missing in package list
 
-            The package '{0}' is required for the selected
-            live iso image type. Please add the following in your
-            <packages type="image"> section to your system XML
-            description:
+            One of the packages '{0}' is required
+            for the selected live iso image type. Depending on your distribution,
+            add the following in your <packages type="image"> section:
 
-            <package name="{0}"/>
+            <package name="ONE_FROM_ABOVE"/>
         ''')
-        required_dracut_package = 'dracut-kiwi-live'
+        meta = Defaults.get_runtime_checker_metadata()
+        required_dracut_packages = meta['package_names']['dracut_live']
         type_name = self.xml_state.get_build_type_name()
         type_flag = self.xml_state.build_type.get_flags()
         if type_name == 'iso' and type_flag != 'dmsquash':
             package_names = \
                 self.xml_state.get_bootstrap_packages() + \
                 self.xml_state.get_system_packages()
-            if required_dracut_package not in package_names:
+            if not RuntimeChecker._package_in_list(
+                package_names, required_dracut_packages
+            ):
                 raise KiwiRuntimeError(
-                    message.format(required_dracut_package)
+                    message.format(required_dracut_packages)
                 )
 
     def check_dracut_module_for_disk_overlay_in_package_list(self) -> None:
@@ -809,23 +816,26 @@ class RuntimeChecker:
         message = dedent('''\n
             Required dracut module package missing in package list
 
-            The package '{0}' is required for the selected
-            overlayroot activated image type. Please add the
-            following in your <packages type="image"> section to
-            your system XML description:
+            The package '{0}' is required
+            for the selected overlayroot activated image type.
+            Depending on your distribution, add the following in your
+            <packages type="image"> section:
 
-            <package name="{0}"/>
+            <package name="ONE_FROM_ABOVE"/>
         ''')
         initrd_system = self.xml_state.get_initrd_system()
-        required_dracut_package = 'dracut-kiwi-overlay'
+        meta = Defaults.get_runtime_checker_metadata()
+        required_dracut_packages = meta['package_names']['dracut_overlay']
         if initrd_system == 'dracut' and \
            self.xml_state.build_type.get_overlayroot():
             package_names = \
                 self.xml_state.get_bootstrap_packages() + \
                 self.xml_state.get_system_packages()
-            if required_dracut_package not in package_names:
+            if not RuntimeChecker._package_in_list(
+                package_names, required_dracut_packages
+            ):
                 raise KiwiRuntimeError(
-                    message.format(required_dracut_package)
+                    message.format(required_dracut_packages)
                 )
 
     def check_efi_mode_for_disk_overlay_correctly_setup(self) -> None:
@@ -991,6 +1001,17 @@ class RuntimeChecker:
             raise KiwiRuntimeError(
                 message.format(fat_image_mbsize)
             )
+
+    @staticmethod
+    def _package_in_list(
+        package_list: List[str], search_list: List[str]
+    ) -> str:
+        result = ''
+        for search in search_list:
+            if search in package_list:
+                result = search
+                break
+        return result
 
     @staticmethod
     def _get_dracut_module_version_from_pdb(

--- a/kiwi/runtime_checker_metadata.yml
+++ b/kiwi/runtime_checker_metadata.yml
@@ -1,0 +1,13 @@
+package_names:
+  dracut_oem_dump:
+    - dracut-kiwi-oem-dump
+    - kiwi-dracut-oem-dump
+  dracut_oem_repart:
+    - dracut-kiwi-oem-repart
+    - kiwi-dracut-oem-repart
+  dracut_live:
+    - dracut-kiwi-live
+    - kiwi-dracut-live
+  dracut_overlay:
+    - dracut-kiwi-overlay
+    - kiwi-dracut-overlay

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -731,6 +731,7 @@ fi
 %{python3_sitelib}/kiwi*
 %{_usr}/share/bash-completion/completions/kiwi-ng
 %{_usr}/share/kiwi/xsl_to_v74/
+%{_usr}/share/kiwi/runtime_checker_metadata.yml
 %{_defaultdocdir}/python-kiwi/LICENSE
 %{_defaultdocdir}/python-kiwi/README
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ include = [
    { path = "package", format = "sdist" },
    { path = "test", format = "sdist" },
    { path = "tox.ini", format = "sdist" },
+   { path = "kiwi/runtime_checker_metadata.yml", format = "sdist" },
 ]
 
 classifiers = [

--- a/test/data/runtime_checker_metadata.yml
+++ b/test/data/runtime_checker_metadata.yml
@@ -1,0 +1,13 @@
+package_names:
+  dracut_oem_dump:
+    - dracut-kiwi-oem-dump
+    - kiwi-dracut-oem-dump
+  dracut_oem_repart:
+    - dracut-kiwi-oem-repart
+    - kiwi-dracut-oem-repart
+  dracut_live:
+    - dracut-kiwi-live
+    - kiwi-dracut-live
+  dracut_overlay:
+    - dracut-kiwi-overlay
+    - kiwi-dracut-overlay

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -24,6 +24,9 @@ class TestRuntimeChecker:
         self._caplog = caplog
 
     def setup(self):
+        Defaults.set_runtime_checker_metadata(
+            '../data/runtime_checker_metadata.yml'
+        )
         self.description = XMLDescription(
             '../data/example_runtime_checker_config.xml'
         )
@@ -427,6 +430,10 @@ class TestRuntimeChecker:
         runtime_checker = RuntimeChecker(xml_state)
         with raises(KiwiRuntimeError):
             runtime_checker.check_include_references_unresolvable()
+
+    def test_check_package_in_list(self):
+        assert RuntimeChecker._package_in_list(['a', 'b'], ['b']) == 'b'
+        assert RuntimeChecker._package_in_list(['a', 'b'], ['c']) == ''
 
     def teardown(self):
         sys.argv = argv_kiwi_tests


### PR DESCRIPTION
Unfortunately the packaging of kiwi on Debian follows different naming conventions for dracut module packages which causes the runtime check to fail. This commit allows to check for multiple package names and adds the variants used on Debian. This Fixes #2524

