### PR TITLE
Added another search path for signed EFI binaries

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -817,6 +817,7 @@ class Defaults:
         shim_file_patterns = [
             shim_pattern_type('/usr/lib/shim/shim*.efi.signed.latest', 'shimx64.efi'),
             shim_pattern_type('/usr/lib/shim/shim*.efi.signed', 'shimx64.efi'),
+            shim_pattern_type('/usr/lib/grub/*-efi-signed', 'shimx64.efi'),
             shim_pattern_type('/usr/share/efi/*/shim.efi', None),
             shim_pattern_type('/usr/lib64/efi/shim.efi', None),
             shim_pattern_type('/boot/efi/EFI/*/shim[a-z]*.efi', None),


### PR DESCRIPTION
Add /usr/lib/grub/*-efi-signed to search for shim signed EFI binaries too. This Fixes #2525

