### PR TITLE
Confidential compute s390

### DIFF
--- a/build-tests/s390/tumbleweed/test-image-MicroOS/appliance.kiwi
+++ b/build-tests/s390/tumbleweed/test-image-MicroOS/appliance.kiwi
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- OBS-Profiles: @BUILD_FLAVOR@ -->
+<image schemaversion="7.5" name="kiwi-test-image-MicroOS">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>marcus.schaefer@suse.com</contact>
+        <specification>MicroOS disk test build for IBM Secure Execution</specification>
+    </description>
+    <profiles>
+        <profile name="SUSE-Infra" description="MicroOS IBM SEL image LinuxONE_III@SUSE"/>
+        <profile name="IBM-Cloud-Secure-Execution" description="MicroOS IBM SEL image LinuxONE@IBM-Cloud-VPC-Region-eu-de(z16)/Region-eu-gb(z15)"/>
+        <profile name="IBM-Cloud-Standard" description="MicroOS IBM Cloud image"/>
+    </profiles>
+    <preferences>
+        <version>16.0.0</version>
+        <packagemanager>zypper</packagemanager>
+        <bootloader-theme>openSUSE</bootloader-theme>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <locale>en_US</locale>
+    </preferences>
+    <preferences profiles="IBM-Cloud-Standard">
+        <type
+            image="oem"
+            luks="random"
+            luks_pbkdf="pbkdf2"
+            luks_version="luks2"
+            filesystem="btrfs"
+            kernelcmdline="systemd.show_status=yes console=ttyS0,115200 console=tty0 net.ifnames=0 \$ignition_firstboot ignition.platform.id=qemu rd.debug"
+            devicepersistency="by-uuid"
+            btrfs_root_is_snapshot="true"
+            btrfs_root_is_readonly_snapshot="false"
+            btrfs_root_is_subvolume="true"
+            btrfs_quota_groups="true"
+            bootpartition="true"
+            bootfilesystem="ext3"
+            format="qcow2"
+        >
+            <luksformat>
+                <option name="--cipher" value="aes-xts-plain64"/>
+                <option name="--key-size" value="256"/>
+            </luksformat>
+            <oemconfig>
+                <oem-unattended>true</oem-unattended>
+                <oem-resize>true</oem-resize>
+            </oemconfig>
+            <bootloader name="zipl" timeout="10"/>
+            <systemdisk>
+                <volume name="home"/>
+                <volume name="root"/>
+                <volume name="opt"/>
+                <volume name="srv"/>
+                <volume name="boot/writable"/>
+                <volume name="usr/local"/>
+                <volume name="var" copy_on_write="false"/>
+            </systemdisk>
+            <size unit="G">2</size>
+        </type>
+    </preferences>
+    <preferences profiles="IBM-Cloud-Secure-Execution">
+        <type
+            image="oem"
+            luks="random"
+            luks_pbkdf="pbkdf2"
+            luks_version="luks2"
+            filesystem="btrfs"
+            kernelcmdline="systemd.show_status=yes console=ttyS0,115200 console=tty0 net.ifnames=0 \$ignition_firstboot ignition.platform.id=qemu swiotlb=262144 rd.debug"
+            devicepersistency="by-uuid"
+            btrfs_root_is_snapshot="true"
+            btrfs_root_is_readonly_snapshot="false"
+            btrfs_root_is_subvolume="true"
+            btrfs_quota_groups="true"
+            bootpartition="true"
+            bootfilesystem="ext3"
+            format="qcow2"
+        >
+            <luksformat>
+                <option name="--cipher" value="aes-xts-plain64"/>
+                <option name="--key-size" value="256"/>
+            </luksformat>
+            <oemconfig>
+                <oem-unattended>true</oem-unattended>
+                <oem-resize>true</oem-resize>
+            </oemconfig>
+            <bootloader name="zipl" timeout="10">
+                <!-- LinuxONE@IBM-Cloud-VPC-Region-eu-de(z16) -->
+                <securelinux hkd_sign_cert="/var/lib/se-certs/ibm-z-host-key-signing-gen2.crt" hkd_ca_cert="/var/lib/se-certs/DigiCertCA.crt">
+                    <hkd_cert name="/var/lib/se-certs/HKD-3932-02967D8.crt"/>
+                    <hkd_cert name="/var/lib/se-certs/HKD-3932-02967F8.crt"/>
+                    <hkd_cert name="/var/lib/se-certs/HKD-3932-0296878.crt"/>
+                    <hkd_revocation_list name="/var/lib/se-certs/ibm-z-host-key-gen2.crl"/>
+                    <hkd_revocation_list name="/var/lib/se-certs/DigiCertTrustedG4CodeSigningRSA4096SHA3842021CA1.crl"/>
+                    <hkd_revocation_list name="/var/lib/se-certs/DigiCertTrustedRootG4.crl"/>
+                </securelinux>
+                <!-- LinuxONE@IBM-Cloud-VPC-Region-eu-gb(z15) -->
+                <securelinux hkd_sign_cert="/var/lib/se-certs/ibm-z-host-key-signing.crt" hkd_ca_cert="/var/lib/se-certs/DigiCertCA.crt">
+                    <hkd_cert name="/var/lib/se-certs/HKD-8562-024B858.crt"/>
+                    <hkd_cert name="/var/lib/se-certs/HKD-8562-024B868.crt"/>
+                    <hkd_cert name="/var/lib/se-certs/HKD-8562-024B878.crt"/>
+                    <hkd_revocation_list name="/var/lib/se-certs/ibm-z-host-key.crl"/>
+                    <hkd_revocation_list name="/var/lib/se-certs/DigiCertTrustedG4CodeSigningRSA4096SHA3842021CA1.crl"/>
+                    <hkd_revocation_list name="/var/lib/se-certs/DigiCertTrustedRootG4.crl"/>
+                </securelinux>
+            </bootloader>
+            <systemdisk>
+                <volume name="home"/>
+                <volume name="root"/>
+                <volume name="opt"/>
+                <volume name="srv"/>
+                <volume name="boot/writable"/>
+                <volume name="usr/local"/>
+                <volume name="var" copy_on_write="false"/>
+            </systemdisk>
+            <size unit="G">2</size>
+        </type>
+    </preferences>
+    <preferences profiles="SUSE-Infra">
+        <type
+            image="oem"
+            luks="random"
+            luks_pbkdf="pbkdf2"
+            luks_version="luks2"
+            filesystem="btrfs"
+            kernelcmdline="systemd.show_status=yes console=ttyS0,115200 console=tty0 net.ifnames=0 \$ignition_firstboot ignition.platform.id=qemu swiotlb=262144 rd.debug"
+            devicepersistency="by-uuid"
+            btrfs_root_is_snapshot="true"
+            btrfs_root_is_readonly_snapshot="false"
+            btrfs_root_is_subvolume="true"
+            btrfs_quota_groups="true"
+            bootpartition="true"
+            bootfilesystem="ext3"
+            format="qcow2"
+        >
+            <luksformat>
+                <option name="--cipher" value="aes-xts-plain64"/>
+                <option name="--key-size" value="256"/>
+            </luksformat>
+            <oemconfig>
+                <oem-unattended>true</oem-unattended>
+                <oem-resize>true</oem-resize>
+            </oemconfig>
+            <bootloader name="zipl" timeout="10">
+                <securelinux hkd_sign_cert="/var/lib/se-certs/ibm-z-host-key-signing.crt" hkd_ca_cert="/var/lib/se-certs/DigiCertCA.crt">
+                    <!-- LinuxONE_III@SUSE -->
+                    <hkd_cert name="/var/lib/se-certs/HKD-8561-02688E8.crt.20241112"/>
+                    <hkd_revocation_list name="/var/lib/se-certs/ibm-z-host-key.crl"/>
+                    <hkd_revocation_list name="/var/lib/se-certs/DigiCertTrustedG4CodeSigningRSA4096SHA3842021CA1.crl"/>
+                    <hkd_revocation_list name="/var/lib/se-certs/DigiCertTrustedRootG4.crl"/>
+                </securelinux>
+            </bootloader>
+            <systemdisk>
+                <volume name="home"/>
+                <volume name="root"/>
+                <volume name="opt"/>
+                <volume name="srv"/>
+                <volume name="boot/writable"/>
+                <volume name="usr/local"/>
+                <volume name="var" copy_on_write="false"/>
+            </systemdisk>
+            <size unit="G">2</size>
+        </type>
+    </preferences>
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
+    </users>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
+    </repository>
+    <packages type="image" profiles="IBM-Cloud-Secure-Execution">
+        <package name="ibm-se-certificates"/>
+        <package name="ibm-se-revocation-lists"/>
+        <package name="cloud-se-host-certificates"/>
+        <package name="cloud-init"/>
+        <package name="cloud-init-config-suse"/>
+        <package name="systemd-network"/>
+    </packages>
+    <packages type="image" profiles="IBM-Cloud-Standard">
+        <package name="cloud-init"/>
+        <package name="cloud-init-config-suse"/>
+        <package name="systemd-network"/>
+    </packages>
+    <packages type="image" profiles="SUSE-Infra">
+        <package name="ibm-se-certificates"/>
+        <package name="ibm-se-revocation-lists"/>
+        <package name="suse-se-host-certificates"/>
+        <package name="systemd-network"/>
+    </packages>
+    <packages type="image">
+        <package name="patterns-base-bootloader"/>
+        <package name="kernel-default"/>
+        <package name="ignition-dracut"/>
+        <package name="combustion"/>
+        <package name="btrfsmaintenance"/>
+        <package name="btrfsprogs"/>
+        <package name="microos-tools"/>
+        <package name="sudo"/>
+        <package name="s390-tools"/>
+        <package name="dracut-kiwi-oem-repart"/>
+        <package name="shadow"/>
+        <package name="snapper"/>
+        <package name="snapper-zypp-plugin"/>
+        <package name="firewalld"/>
+        <package name="microos-tools"/>
+        <package name="health-checker-plugins-MicroOS"/>
+        <package name="squashfs"/>
+        <package name="openSUSE-repos-Tumbleweed"/>
+        <package name="openssh-server"/>
+        <package name="openssh"/>
+        <package name="iproute2"/>
+        <package name="less"/>
+        <package name="curl"/>
+        <package name="cryptsetup"/>
+        <package name="procps"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="gawk"/>
+        <package name="grep"/> 
+        <package name="gzip"/>
+        <package name="udev"/>
+        <package name="xz"/>
+        <package name="shadow"/>
+        <package name="filesystem"/>
+        <package name="coreutils"/>
+        <package name="openssl"/>
+        <package name="glibc-locale-base"/>
+        <package name="ca-certificates"/>
+        <package name="ca-certificates-mozilla"/>
+        <package name="MicroOS-release-dvd"/>
+        <package name="systemd-presets-branding-MicroOS"/>
+        <package name="diffutils"/>
+    </packages>
+</image>

--- a/build-tests/s390/tumbleweed/test-image-MicroOS/config.sh
+++ b/build-tests/s390/tumbleweed/test-image-MicroOS/config.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# shellcheck disable=SC1091
+test -f /.kconfig && . /.kconfig
+set -euxo pipefail
+
+declare kiwi_iname=${kiwi_iname}
+declare kiwi_profiles=${kiwi_profiles}
+
+echo "Configure image: [${kiwi_iname}]-[${kiwi_profiles}]..."
+
+#======================================
+# Setup Core Services
+#--------------------------------------
+systemctl enable sshd.service
+
+#======================================
+# Setup Cloud Services
+#--------------------------------------
+for profile in ${kiwi_profiles//,/ }; do
+    if [ "${profile}" = "IBM-Cloud-Standard" ] || [ "${profile}" = "IBM-Cloud-Secure-Execution" ]; then
+        for service in \
+            cloud-init-local.service \
+            cloud-init.service \
+            cloud-config.service \
+            cloud-final.service \
+            systemd-networkd \
+            systemd-resolved
+        do
+            systemctl enable "${service}"
+        done
+    fi
+    if [ "${profile}" = "SUSE-Infra" ]; then
+        for service in \
+            systemd-networkd \
+            systemd-resolved
+        do
+            systemctl enable "${service}"
+        done
+    fi
+done
+
+#=====================================
+# Configure snapper
+#-------------------------------------
+if [ "${kiwi_btrfs_root_is_snapshot-false}" = 'true' ]; then
+    echo "creating initial snapper config ..."
+    cp /usr/share/snapper/config-templates/default /etc/snapper/configs/root
+    baseUpdateSysConfig /etc/sysconfig/snapper SNAPPER_CONFIGS root
+    # Adjust parameters
+    sed -i'' 's/^TIMELINE_CREATE=.*$/TIMELINE_CREATE="no"/g' \
+        /etc/snapper/configs/root
+    sed -i'' 's/^NUMBER_LIMIT=.*$/NUMBER_LIMIT="2-10"/g' \
+        /etc/snapper/configs/root
+    sed -i'' 's/^NUMBER_LIMIT_IMPORTANT=.*$/NUMBER_LIMIT_IMPORTANT="4-10"/g' \
+        /etc/snapper/configs/root
+fi
+
+for profile in ${kiwi_profiles//,/ }; do
+    if [ "${profile}" = "IBM-Cloud-Standard" ]; then
+        # For image tests with an extra boot partition the
+        # kernel must not be a symlink to another area of
+        # the filesystem. Latest changes on SUSE changed the
+        # layout of the kernel which breaks every image with
+        # an extra boot partition
+        #
+        # All of the following is more than a hack and I
+        # don't like it all
+        #
+        # Complains and discussions about this please with
+        # the SUSE kernel team as we in kiwi can just live
+        # with the consequences of this change
+        #
+        pushd /
+
+        for file in /boot/* /boot/.*; do
+            if [ -L "${file}" ];then
+                link_target=$(readlink "${file}")
+                if [[ "${link_target}" =~ usr/lib/modules ]];then
+                    mv "${link_target}" "${file}"
+                fi
+            fi
+        done
+    fi
+done

--- a/build-tests/s390/tumbleweed/test-image-MicroOS/root/etc/dracut.conf.d/oem_resize.conf
+++ b/build-tests/s390/tumbleweed/test-image-MicroOS/root/etc/dracut.conf.d/oem_resize.conf
@@ -1,0 +1,1 @@
+add_dracutmodules+=" kiwi-repart "

--- a/build-tests/s390/tumbleweed/test-image-MicroOS/root/etc/fstab.script
+++ b/build-tests/s390/tumbleweed/test-image-MicroOS/root/etc/fstab.script
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eux
+
+/usr/sbin/setup-fstab-for-overlayfs
+# If /var is on a different partition than /...
+if [ "$(findmnt -snT / -o SOURCE)" != "$(findmnt -snT /var -o SOURCE)" ]; then
+    # ... set options for autoexpanding /var
+    gawk -i inplace '$2 == "/var" { $4 = $4",x-growpart.grow,x-systemd.growfs" } { print $0 }' /etc/fstab
+fi

--- a/build-tests/s390/tumbleweed/test-image-MicroOS/root/etc/systemd/network/20-local.network
+++ b/build-tests/s390/tumbleweed/test-image-MicroOS/root/etc/systemd/network/20-local.network
@@ -1,0 +1,8 @@
+[Match]
+Name=eth0
+
+[Network]
+DHCP=yes
+
+[DHCP]
+ClientIdentifier=mac

--- a/build-tests/s390/tumbleweed/test-image-MicroOS/run
+++ b/build-tests/s390/tumbleweed/test-image-MicroOS/run
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+qemu-system-s390x \
+    -cpu host \
+    -machine accel=kvm,usb=off \
+    -netdev user,id=user0 \
+    -device virtio-net-ccw,netdev=user0 \
+    -object s390-pv-guest,id=pv0 \
+    -machine confidential-guest-support=pv0 \
+    -enable-kvm \
+    -nodefaults \
+    -name suse-cc \
+    -nographic \
+    -drive id=disk0,file="$1",format=qcow2,if=none,cache=writeback \
+    -device virtio-blk,id=data0,drive=disk0,physical_block_size=512,logical_block_size=512 \
+    -device virtio-serial-ccw \
+    -device sclpconsole,chardev=console \
+    -chardev stdio,id=console \
+    -smp 4 \
+    -m 4096 \
+    -mem-prealloc

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -566,15 +566,34 @@ root_clone="number"
 boot_clone="number"
   Same as `root_clone` but applied to the boot partition if present
 
-luks="passphrase|file:///path/to/keyfile":
+luks="passphrase|file:///path/to/keyfile|random":
   Supplying a value will trigger the encryption of the partition
   serving the root filesystem using the LUKS extension. The supplied
   value represents either the passphrase string or the location of
-  a key file if specified as `file://...` resource. When using
-  a key file it is in the responsibility of the user how
-  this key file is actually being used. By default any
-  distribution will just open an interactive dialog asking
-  for the credentials at boot time !
+  a key file if specified as `file://...` resource or the reserved
+  name `random`. When using a passphrase the system will interactively
+  ask for that passphrase on first boot unless it is set empty.
+  In case of an empty passphrase the system cannot be considered secure.
+  When using a key file the information from the file is read and
+  used as a passphrase. The given key file is **not automatically**
+  placed into the system or added to the `etc/crypttab` which means
+  the passphrase in the key file is by default requested from an
+  interactive dialog at boot time. When using the reserved word
+  `random`, kiwi will create a key file with a random passphrase
+  and place this information into `etc/crypttab`. This allows
+  the system to boot without user interaction but also requires
+  the initrd to be protected in some way because it will contain
+  the keyfile. The use of `random` is therefore only secure if
+  the image adds additional security that encrypts the initrd
+  like it is e.g. done in the IBM secure execution process.
+  If the encryption of the system is combined with the attribute
+  `bootpartition="false"` it's important to understand that this
+  will place `/boot` into the encrypted area of the system and
+  leaves reading boot data from it as a responsibility to the
+  bootloader. Not every bootloader can cope with that and those
+  that can e.g. grub will then open an interactive dialog at
+  the bootloader level asking for the credentials to decrypt the
+  root filesystem.
 
 luks_version="luks|luks1|luks2":
   Specify which `LUKS` version should be used. If not set and by

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -1026,7 +1026,7 @@ the `editbootinstall` and `editbootconfig` custom scripts.
    selected bootloader the image build process will fail with
    an exception message.
 
-name="grub2|systemd_boot|grub2_s390x_emu":
+name="grub2|systemd_boot|grub2_s390x_emu|zipl":
   Specifies the bootloader to use for this image.
 
   .. note:: systemd_boot ESP size
@@ -1158,6 +1158,71 @@ targettype="CDL|LDL|FBA|SCSI":
   emulated DASD devices, use `FBA`. The attribute is available for the
   zipl loader only.
 
+<preferences><type><bootloader><securelinux>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Used to specify data required to setup secure linux execution. Secure
+linux execution reads the kernel, initrd and boot parameters from an
+encrypted data blob and couples the image to the machine it gets
+executed on. Typically the private key is protected in hardware on
+the machine itself. {kiwi} supports secure execution for the IBM secure
+linux target on the s390 platform along with the bootloaders
+`zipl` and `grub2-s390x-emu`
+
+.. code:: xml
+
+   <securelinux>
+       <hkd_cert name="some1-host.crt"/>
+       <hkd_cert name="some2-host.crt"/>
+       <hkd_ca_cert name="some-ca.crt"/>
+       <hkd_sign_cert name="some1-signing.crt"/>
+       <hkd_sign_cert name="some2-signing.crt"/>
+       <hkd_revocation_list name="some1-revocation.crl"/>
+       <hkd_revocation_list name="some2-revocation.crl"/>
+   </securelinux>
+
+Except for the `hkd_ca_cert` all other certificates can be specified
+multiple times.
+
+hkd_cert:
+  The file specified in hkd_cert defines the `Host Key Document`
+  and tightly couples the image to the host matching the document
+
+hkd_ca_cert:
+  Required in combination with `hkd_cert`, providing the `Common Authority`
+  certificate (signed by the root CA) that is used to establish a chain
+  of trust for the verification of the `Host Key Document`.
+
+hkd_sign_cert:
+  Required in combination with `hkd_cert`, providing the `Signing`
+  certificate that is used to establish a chain of trust for the
+  verification of the `Host Key Document`.
+
+hkd_revocation_list:
+  Optional in combination with `hkd_cert`, providing the the
+  revocation list to check on use of expired certificates in
+  the chain of trust.
+
+<preferences><type><bootloader><bootloadersettings>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Used to specify custom arguments for the tools called to setup
+secure boot e.g `shiminstall`, installation of the bootloader
+e.g `grub-install` or configuration of the bootloader e.g `grub-mkconfig`.
+
+.. code:: xml
+
+   <bootloadersettings>
+       <shimoption name="--suse-enable-tpm"/>
+       <shimoption name="--bootloader-id" value="some-id"/>
+       <installoption name="--suse-enable-tpm"/>
+       <configoption name="--debug"/>
+   </bootloadersettings>
+
+.. note::
+
+   {kiwi-ng} does not judge on the given parameters and if the provided
+   data is effectively used depends on the individual bootloader
+   implementation.
+
 <preferences><type><containerconfig>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Used to describe the container configuration metadata in docker or wsl
@@ -1184,27 +1249,6 @@ For details see: :ref:`custom_volumes`
    complete disk setup, so there cannot be any overlapping volumes
    or mount points. As a result, whatever is written in `<partitions>`
    cannot be expressed in the same way in `<volumes>`.
-
-<preferences><type><bootloader><bootloadersettings>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Used to specify custom arguments for the tools called to setup
-secure boot e.g `shiminstall`, installation of the bootloader
-e.g `grub-install` or configuration of the bootloader e.g `grub-mkconfig`.
-
-.. code:: xml
-
-   <bootloadersettings>
-       <shimoption name="--suse-enable-tpm"/>
-       <shimoption name="--bootloader-id" value="some-id"/>
-       <installoption name="--suse-enable-tpm"/>
-       <configoption name="--debug"/>
-   </bootloadersettings>
-
-.. note::
-
-   {kiwi-ng} does not judge on the given parameters and if the provided
-   data is effectively used depends on the individual bootloader
-   implementation.
 
 <preferences><type><partitions>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/kiwi/bootloader/template/zipl.py
+++ b/kiwi/bootloader/template/zipl.py
@@ -40,7 +40,13 @@ class BootLoaderTemplateZipl:
             secure=auto
         ''').strip() + self.cr
 
-        self.entry = dedent('''
+        self.entry_secure = dedent('''
+            title ${title}
+            options ${boot_options}
+            linux ${secure_image_file}
+        ''').strip() + self.cr
+
+        self.entry_standard = dedent('''
             title ${title}
             options ${boot_options}
             linux ${kernel_file}
@@ -58,7 +64,7 @@ class BootLoaderTemplateZipl:
         template_data = self.main_conf
         return Template(template_data)
 
-    def get_entry_template(self) -> Template:
+    def get_entry_template(self, secure: bool = False) -> Template:
         """
         Bootloader entry configuration template
 
@@ -66,5 +72,8 @@ class BootLoaderTemplateZipl:
 
         :rtype: Template
         """
-        template_data = self.entry
+        if secure:
+            template_data = self.entry_secure
+        else:
+            template_data = self.entry_standard
         return Template(template_data)

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -667,7 +667,7 @@ class DiskBuilder:
         #    LUKS pool without asking
         #
         luks_need_keyfile = \
-            True if self.boot_is_crypto or self.luks == '' else False
+            True if self.boot_is_crypto or self.luks == '' or self.luks == 'random' else False
         luks_root.create_crypto_luks(
             passphrase=self.luks or '',
             osname=self.luks_os,

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2958,7 +2958,8 @@ div {
         ## and to provide configuration parameters for it
         element bootloader {
             k.bootloader.attlist &
-            k.bootloadersettings?
+            k.bootloadersettings? &
+            k.securelinux*
         }
 }
 
@@ -3236,6 +3237,74 @@ div {
             k.shimoption* &
             k.installoption* &
             k.configoption*
+        }
+}
+
+#==========================================
+# main block: <securelinux>
+#
+div {
+    sch:pattern [
+        abstract = "true"
+        id = "securelinux_loader_requirement"
+        sch:rule [
+            context = "securelinux"
+            sch:assert [
+                test = "../@name='zipl' or ../@name='grub2-s390x-emu'"
+                "<securelinux> section only available for the "
+                "bootloader types: zipl and grub2-s390x-emu"
+            ]
+        ]
+    ]
+    k.securelinux.hkd_ca_cert.attribute =
+        attribute hkd_ca_cert { text }
+    k.securelinux.hkd_sign_cert.attribute =
+        attribute hkd_sign_cert { text }
+    k.securelinux.attlist =
+        k.securelinux.hkd_ca_cert.attribute &
+        k.securelinux.hkd_sign_cert.attribute
+    k.securelinux =
+        ## securelinux contains all elements to describe
+        ## data required to setup a secure linux execution
+        ## process for the individual architecture in the scope
+        ## of the bootloader process
+        element securelinux {
+            k.securelinux.attlist &
+            k.hkd_cert+ &
+            k.hkd_revocation_list*
+        }
+        >> sch:pattern [
+            id = "bootloader_matches" is-a = "securelinux_loader_requirement"
+        ]
+}
+
+#==========================================
+# common element <hkd_cert>
+#
+div {
+    k.hkd_cert.name.attribute =
+        attribute name { text }
+    k.hkd_cert.attlist =
+        k.hkd_cert.name.attribute
+    k.hkd_cert =
+        element hkd_cert {
+            k.hkd_cert.attlist,
+            empty
+        }
+}
+
+#==========================================
+# common element <hkd_revocation_list>
+#
+div {
+    k.hkd_revocation_list.name.attribute =
+        attribute name { text }
+    k.hkd_revocation_list.attlist =
+        k.hkd_revocation_list.name.attribute
+    k.hkd_revocation_list =
+        element hkd_revocation_list {
+            k.hkd_revocation_list.attlist,
+            empty
         }
 }
 

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -4465,6 +4465,9 @@ and to provide configuration parameters for it</a:documentation>
           <optional>
             <ref name="k.bootloadersettings"/>
           </optional>
+          <zeroOrMore>
+            <ref name="k.securelinux"/>
+          </zeroOrMore>
         </interleave>
       </element>
     </define>
@@ -4856,6 +4859,86 @@ of the storage device</a:documentation>
             <ref name="k.configoption"/>
           </zeroOrMore>
         </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <securelinux>
+    
+  -->
+  <div>
+    <sch:pattern abstract="true" id="securelinux_loader_requirement">
+      <sch:rule context="securelinux">
+        <sch:assert test="../@name='zipl' or ../@name='grub2-s390x-emu'">&lt;securelinux&gt; section only available for the bootloader types: zipl and grub2-s390x-emu</sch:assert>
+      </sch:rule>
+    </sch:pattern>
+    <define name="k.securelinux.hkd_ca_cert.attribute">
+      <attribute name="hkd_ca_cert"/>
+    </define>
+    <define name="k.securelinux.hkd_sign_cert.attribute">
+      <attribute name="hkd_sign_cert"/>
+    </define>
+    <define name="k.securelinux.attlist">
+      <interleave>
+        <ref name="k.securelinux.hkd_ca_cert.attribute"/>
+        <ref name="k.securelinux.hkd_sign_cert.attribute"/>
+      </interleave>
+    </define>
+    <define name="k.securelinux">
+      <element name="securelinux">
+        <a:documentation>securelinux contains all elements to describe
+data required to setup a secure linux execution
+process for the individual architecture in the scope
+of the bootloader process</a:documentation>
+        <interleave>
+          <ref name="k.securelinux.attlist"/>
+          <oneOrMore>
+            <ref name="k.hkd_cert"/>
+          </oneOrMore>
+          <zeroOrMore>
+            <ref name="k.hkd_revocation_list"/>
+          </zeroOrMore>
+        </interleave>
+      </element>
+      <sch:pattern id="bootloader_matches" is-a="securelinux_loader_requirement"/>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <hkd_cert>
+    
+  -->
+  <div>
+    <define name="k.hkd_cert.name.attribute">
+      <attribute name="name"/>
+    </define>
+    <define name="k.hkd_cert.attlist">
+      <ref name="k.hkd_cert.name.attribute"/>
+    </define>
+    <define name="k.hkd_cert">
+      <element name="hkd_cert">
+        <ref name="k.hkd_cert.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    common element <hkd_revocation_list>
+    
+  -->
+  <div>
+    <define name="k.hkd_revocation_list.name.attribute">
+      <attribute name="name"/>
+    </define>
+    <define name="k.hkd_revocation_list.attlist">
+      <ref name="k.hkd_revocation_list.name.attribute"/>
+    </define>
+    <define name="k.hkd_revocation_list">
+      <element name="hkd_revocation_list">
+        <ref name="k.hkd_revocation_list.attlist"/>
+        <empty/>
       </element>
     </define>
   </div>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.29.24.
-# Python 3.11.9 (main, Apr 18 2024, 16:44:43) [GCC]
+# Python 3.11.10 (main, Sep 18 2024, 22:13:39) [GCC]
 #
 # Command line options:
 #   ('-f', '')
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/ms/Project/kiwi/.tox/unit_py3_11/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/ms/.cache/pypoetry/virtualenvs/kiwi-Btua-i95-py3.11/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -5967,7 +5967,7 @@ class bootloader(GeneratedsSuper):
     provide configuration parameters for it"""
     subclass = None
     superclass = None
-    def __init__(self, name=None, bls=None, console=None, serial_line=None, timeout=None, timeout_style=None, targettype=None, use_disk_password=None, grub_template=None, bootloadersettings=None):
+    def __init__(self, name=None, bls=None, console=None, serial_line=None, timeout=None, timeout_style=None, targettype=None, use_disk_password=None, grub_template=None, bootloadersettings=None, securelinux=None):
         self.original_tagname_ = None
         self.name = _cast(None, name)
         self.bls = _cast(bool, bls)
@@ -5978,7 +5978,14 @@ class bootloader(GeneratedsSuper):
         self.targettype = _cast(None, targettype)
         self.use_disk_password = _cast(bool, use_disk_password)
         self.grub_template = _cast(None, grub_template)
-        self.bootloadersettings = bootloadersettings
+        if bootloadersettings is None:
+            self.bootloadersettings = []
+        else:
+            self.bootloadersettings = bootloadersettings
+        if securelinux is None:
+            self.securelinux = []
+        else:
+            self.securelinux = securelinux
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -5992,6 +5999,14 @@ class bootloader(GeneratedsSuper):
     factory = staticmethod(factory)
     def get_bootloadersettings(self): return self.bootloadersettings
     def set_bootloadersettings(self, bootloadersettings): self.bootloadersettings = bootloadersettings
+    def add_bootloadersettings(self, value): self.bootloadersettings.append(value)
+    def insert_bootloadersettings_at(self, index, value): self.bootloadersettings.insert(index, value)
+    def replace_bootloadersettings_at(self, index, value): self.bootloadersettings[index] = value
+    def get_securelinux(self): return self.securelinux
+    def set_securelinux(self, securelinux): self.securelinux = securelinux
+    def add_securelinux(self, value): self.securelinux.append(value)
+    def insert_securelinux_at(self, index, value): self.securelinux.insert(index, value)
+    def replace_securelinux_at(self, index, value): self.securelinux[index] = value
     def get_name(self): return self.name
     def set_name(self, name): self.name = name
     def get_bls(self): return self.bls
@@ -6019,7 +6034,8 @@ class bootloader(GeneratedsSuper):
     validate_grub_console_patterns_ = [['^(none|console|gfxterm|serial|vga_text|mda_text|morse|spkmodem)( (none|console|serial|at_keyboard|usb_keyboard))*$']]
     def hasContent_(self):
         if (
-            self.bootloadersettings is not None
+            self.bootloadersettings or
+            self.securelinux
         ):
             return True
         else:
@@ -6078,8 +6094,10 @@ class bootloader(GeneratedsSuper):
             eol_ = '\n'
         else:
             eol_ = ''
-        if self.bootloadersettings is not None:
-            self.bootloadersettings.export(outfile, level, namespaceprefix_, name_='bootloadersettings', pretty_print=pretty_print)
+        for bootloadersettings_ in self.bootloadersettings:
+            bootloadersettings_.export(outfile, level, namespaceprefix_, name_='bootloadersettings', pretty_print=pretty_print)
+        for securelinux_ in self.securelinux:
+            securelinux_.export(outfile, level, namespaceprefix_, name_='securelinux', pretty_print=pretty_print)
     def build(self, node):
         already_processed = set()
         self.buildAttributes(node, node.attrib, already_processed)
@@ -6148,8 +6166,13 @@ class bootloader(GeneratedsSuper):
         if nodeName_ == 'bootloadersettings':
             obj_ = bootloadersettings.factory()
             obj_.build(child_)
-            self.bootloadersettings = obj_
+            self.bootloadersettings.append(obj_)
             obj_.original_tagname_ = 'bootloadersettings'
+        elif nodeName_ == 'securelinux':
+            obj_ = securelinux.factory()
+            obj_.build(child_)
+            self.securelinux.append(obj_)
+            obj_.original_tagname_ = 'securelinux'
 # end class bootloader
 
 
@@ -7218,6 +7241,262 @@ class bootloadersettings(GeneratedsSuper):
             self.configoption.append(obj_)
             obj_.original_tagname_ = 'configoption'
 # end class bootloadersettings
+
+
+class securelinux(GeneratedsSuper):
+    """securelinux contains all elements to describe data required to setup
+    a secure linux execution process for the individual architecture
+    in the scope of the bootloader process"""
+    subclass = None
+    superclass = None
+    def __init__(self, hkd_ca_cert=None, hkd_sign_cert=None, hkd_cert=None, hkd_revocation_list=None):
+        self.original_tagname_ = None
+        self.hkd_ca_cert = _cast(None, hkd_ca_cert)
+        self.hkd_sign_cert = _cast(None, hkd_sign_cert)
+        if hkd_cert is None:
+            self.hkd_cert = []
+        else:
+            self.hkd_cert = hkd_cert
+        if hkd_revocation_list is None:
+            self.hkd_revocation_list = []
+        else:
+            self.hkd_revocation_list = hkd_revocation_list
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, securelinux)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if securelinux.subclass:
+            return securelinux.subclass(*args_, **kwargs_)
+        else:
+            return securelinux(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_hkd_cert(self): return self.hkd_cert
+    def set_hkd_cert(self, hkd_cert): self.hkd_cert = hkd_cert
+    def add_hkd_cert(self, value): self.hkd_cert.append(value)
+    def insert_hkd_cert_at(self, index, value): self.hkd_cert.insert(index, value)
+    def replace_hkd_cert_at(self, index, value): self.hkd_cert[index] = value
+    def get_hkd_revocation_list(self): return self.hkd_revocation_list
+    def set_hkd_revocation_list(self, hkd_revocation_list): self.hkd_revocation_list = hkd_revocation_list
+    def add_hkd_revocation_list(self, value): self.hkd_revocation_list.append(value)
+    def insert_hkd_revocation_list_at(self, index, value): self.hkd_revocation_list.insert(index, value)
+    def replace_hkd_revocation_list_at(self, index, value): self.hkd_revocation_list[index] = value
+    def get_hkd_ca_cert(self): return self.hkd_ca_cert
+    def set_hkd_ca_cert(self, hkd_ca_cert): self.hkd_ca_cert = hkd_ca_cert
+    def get_hkd_sign_cert(self): return self.hkd_sign_cert
+    def set_hkd_sign_cert(self, hkd_sign_cert): self.hkd_sign_cert = hkd_sign_cert
+    def hasContent_(self):
+        if (
+            self.hkd_cert or
+            self.hkd_revocation_list
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', name_='securelinux', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('securelinux')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='securelinux')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='securelinux', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='securelinux'):
+        if self.hkd_ca_cert is not None and 'hkd_ca_cert' not in already_processed:
+            already_processed.add('hkd_ca_cert')
+            outfile.write(' hkd_ca_cert=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.hkd_ca_cert), input_name='hkd_ca_cert')), ))
+        if self.hkd_sign_cert is not None and 'hkd_sign_cert' not in already_processed:
+            already_processed.add('hkd_sign_cert')
+            outfile.write(' hkd_sign_cert=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.hkd_sign_cert), input_name='hkd_sign_cert')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='securelinux', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for hkd_cert_ in self.hkd_cert:
+            hkd_cert_.export(outfile, level, namespaceprefix_, name_='hkd_cert', pretty_print=pretty_print)
+        for hkd_revocation_list_ in self.hkd_revocation_list:
+            hkd_revocation_list_.export(outfile, level, namespaceprefix_, name_='hkd_revocation_list', pretty_print=pretty_print)
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('hkd_ca_cert', node)
+        if value is not None and 'hkd_ca_cert' not in already_processed:
+            already_processed.add('hkd_ca_cert')
+            self.hkd_ca_cert = value
+        value = find_attr_value_('hkd_sign_cert', node)
+        if value is not None and 'hkd_sign_cert' not in already_processed:
+            already_processed.add('hkd_sign_cert')
+            self.hkd_sign_cert = value
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        if nodeName_ == 'hkd_cert':
+            obj_ = hkd_cert.factory()
+            obj_.build(child_)
+            self.hkd_cert.append(obj_)
+            obj_.original_tagname_ = 'hkd_cert'
+        elif nodeName_ == 'hkd_revocation_list':
+            obj_ = hkd_revocation_list.factory()
+            obj_.build(child_)
+            self.hkd_revocation_list.append(obj_)
+            obj_.original_tagname_ = 'hkd_revocation_list'
+# end class securelinux
+
+
+class hkd_cert(GeneratedsSuper):
+    subclass = None
+    superclass = None
+    def __init__(self, name=None):
+        self.original_tagname_ = None
+        self.name = _cast(None, name)
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, hkd_cert)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if hkd_cert.subclass:
+            return hkd_cert.subclass(*args_, **kwargs_)
+        else:
+            return hkd_cert(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_name(self): return self.name
+    def set_name(self, name): self.name = name
+    def hasContent_(self):
+        if (
+
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', name_='hkd_cert', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('hkd_cert')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='hkd_cert')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='hkd_cert', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='hkd_cert'):
+        if self.name is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='hkd_cert', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('name', node)
+        if value is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            self.name = value
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        pass
+# end class hkd_cert
+
+
+class hkd_revocation_list(GeneratedsSuper):
+    subclass = None
+    superclass = None
+    def __init__(self, name=None):
+        self.original_tagname_ = None
+        self.name = _cast(None, name)
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, hkd_revocation_list)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if hkd_revocation_list.subclass:
+            return hkd_revocation_list.subclass(*args_, **kwargs_)
+        else:
+            return hkd_revocation_list(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_name(self): return self.name
+    def set_name(self, name): self.name = name
+    def hasContent_(self):
+        if (
+
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', name_='hkd_revocation_list', namespacedef_='', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('hkd_revocation_list')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='hkd_revocation_list')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_='', name_='hkd_revocation_list', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='hkd_revocation_list'):
+        if self.name is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', name_='hkd_revocation_list', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('name', node)
+        if value is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            self.name = value
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        pass
+# end class hkd_revocation_list
 
 
 class environment(GeneratedsSuper):
@@ -9880,6 +10159,8 @@ __all__ = [
     "extension",
     "file",
     "history",
+    "hkd_cert",
+    "hkd_revocation_list",
     "ignore",
     "image",
     "include",
@@ -9905,6 +10186,7 @@ __all__ = [
     "profiles",
     "repository",
     "requires",
+    "securelinux",
     "shimoption",
     "signing",
     "size",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,12 @@ pyenchant = "*"
 travis-sphinx = "*"
 ghp-import = "*"
 
+[tool.poetry.group.development]
+[tool.poetry.group.development.dependencies]
+python-dateutil = "*"
+generateDS = "==2.29.24"
+bumpversion = "*"
+
 [build-system]
 requires = ["poetry-core>=1.2.0"]
 build-backend = "poetry.core.masonry.api"

--- a/test/data/example_hkd_config.xml
+++ b/test/data/example_hkd_config.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="8.2" name="test-containers">
+    <description type="system">
+        <author>Some</author>
+        <contact>some@example.com</contact>
+        <specification>
+            Test containers section used in the buildservice
+        </specification>
+    </description>
+    <preferences>
+        <version>1.1.1</version>
+        <packagemanager>zypper</packagemanager>
+        <type image="oem" filesystem="xfs">
+            <bootloader name="zipl" timeout="10">
+                <securelinux hkd_sign_cert="some1-signing.crt" hkd_ca_cert="some-ca.crt">
+                    <hkd_cert name="some1-host.crt"/>
+                    <hkd_cert name="some2-host.crt"/>
+                    <hkd_revocation_list name="some1-revocation.crl"/>
+                </securelinux>
+                <securelinux hkd_sign_cert="some2-signing.crt" hkd_ca_cert="some-ca.crt">
+                    <hkd_cert name="some3-host.crt"/>
+                    <hkd_revocation_list name="some2-revocation.crl"/>
+                </securelinux>
+            </bootloader>
+        </type>
+    </preferences>
+    <repository>
+        <source path="obs://some/repo/oss"/>
+    </repository>
+    <packages type="bootstrap">
+        <package name="filesystem"/>
+    </packages>
+</image>

--- a/test/unit/bootloader/template/zipl_test.py
+++ b/test/unit/bootloader/template/zipl_test.py
@@ -19,10 +19,17 @@ class TestBootLoaderTemplateZipl:
             targetgeometry=''
         )
 
-    def test_get_entry_template(self):
+    def test_get_entry_template_standard(self):
         assert self.zipl.get_entry_template().substitute(
             title='title',
             boot_options='',
             kernel_file='linux',
             initrd_file='initrd'
+        )
+
+    def test_get_entry_template_secure(self):
+        assert self.zipl.get_entry_template(secure=True).substitute(
+            title='title',
+            boot_options='',
+            secure_image_file='linux'
         )

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1301,6 +1301,25 @@ class TestXMLState:
             '--joe', '-x'
         ]
 
+    def test_get_host_key_certificates(self):
+        description = XMLDescription('../data/example_hkd_config.xml')
+        xml_data = description.load()
+        state = XMLState(xml_data)
+        assert state.get_host_key_certificates() == [
+            {
+                'hkd_cert': ['some1-host.crt', 'some2-host.crt'],
+                'hkd_revocation_list': ['some1-revocation.crl'],
+                'hkd_ca_cert': 'some-ca.crt',
+                'hkd_sign_cert': 'some1-signing.crt'
+            },
+            {
+                'hkd_cert': ['some3-host.crt'],
+                'hkd_revocation_list': ['some2-revocation.crl'],
+                'hkd_ca_cert': 'some-ca.crt',
+                'hkd_sign_cert': 'some2-signing.crt'
+            }
+        ]
+
     def test_get_btrfs_root_is_subvolume(self):
         assert self.state.build_type.get_btrfs_root_is_subvolume() is \
             None


### PR DESCRIPTION
Added IBM Secure Execution support on s390
    
IBM SEL(Secure Execution for Linux) is supported for s390 KVM guests. SEL images used to start a confidential computing protected guest contain an encrypted boot image which encapsulates the kernel the initrd and the bootparams. The encrypted Image is provided by the KVM/hypervisor to the Embedded zFirmware of the system (the ultravisor device). The decryption keys are hardware based and each system has an individual keypool unique to that system. The root filesystem is LUKS encrypted with a random key produced by kiwi at build time and kept inside of the initrd which exists only inside of the encrypted boot image and the encrypted rootfs to allow kernel updates. The commit to support secure execution also comes with an integration test that provides profiled image builds to target SUSE's LinuxONE as well as IBM Cloud systems.
