### PR TITLE
Prevent extra volume mount/umount on btrfs

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1727,7 +1727,6 @@ class DiskBuilder:
             )
 
         if system and self.volume_manager_name:
-            system.umount_volumes()
             custom_install_arguments.update(
                 {
                     'system_volumes': system.get_volumes(),

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1780,9 +1780,7 @@ class DiskBuilder:
                 log.info(
                     'Setting root filesystem into read-only mode'
                 )
-                system.mount_volumes()
                 system.set_property_readonly_root()
-                system.umount_volumes()
 
     def _copy_first_boot_files_to_system_image(self) -> None:
         boot_names = self.boot_image.get_boot_names()

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -72,10 +72,6 @@ class VolumeManagerBase(DeviceProvider):
         #: the underlaying device provider
         self.device_provider_root = device_map['root']
 
-        #: An indicator for the mount of the filesystem and its volumes
-        #: when mounted for the first time
-        self.volumes_mounted_initially = False
-
         #: root directory path name
         self.root_dir = root_dir
         #: list of volumes from :class:`XMLState::get_volumes()`

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -355,13 +355,6 @@ class VolumeManagerBtrfs(VolumeManagerBase):
         )
 
         for volume_mount in self.subvol_mount_list:
-            if self.volumes_mounted_initially:
-                toplevel = self.root_volume_name
-                if self.custom_args['root_is_snapshot']:
-                    toplevel = f'{self.root_volume_name}/.snapshots/1/snapshot'
-                volume_mount.mountpoint = os.path.normpath(
-                    volume_mount.mountpoint.replace(toplevel, '', 1)
-                )
             if not os.path.exists(volume_mount.mountpoint):
                 Path.create(volume_mount.mountpoint)
             subvol_path = volume_mount.get_attributes().get('subvol_path')
@@ -373,8 +366,6 @@ class VolumeManagerBtrfs(VolumeManagerBase):
             volume_mount.mount(
                 options=[subvol_options]
             )
-
-        self.volumes_mounted_initially = True
 
     def umount_volumes(self) -> None:
         """

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -443,7 +443,7 @@ class VolumeManagerBtrfs(VolumeManagerBase):
         root_is_readonly_snapshot = \
             self.custom_args['root_is_readonly_snapshot']
         if root_is_snapshot and root_is_readonly_snapshot:
-            sync_target = self.mountpoint
+            sync_target = self.get_mountpoint()
             Command.run(
                 ['btrfs', 'property', 'set', sync_target, 'ro', 'true']
             )

--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -302,7 +302,6 @@ class VolumeManagerLVM(VolumeManagerBase):
             volume_mount.mount(
                 options=[self.mount_options]
             )
-        self.volumes_mounted_initially = True
 
     def umount_volumes(self):
         """

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -1458,8 +1458,6 @@ class TestDiskBuilder:
                 'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
             ]
         )
-        volume_manager.umount_volumes.call_args_list[0].assert_called_once_with(
-        )
         self.setup.create_fstab.assert_called_once_with(
             self.disk_builder.fstab
         )

--- a/test/unit/volume_manager/btrfs_test.py
+++ b/test/unit/volume_manager/btrfs_test.py
@@ -393,51 +393,6 @@ class TestVolumeManagerBtrfs:
             options=['subvol=@/var/tmp']
         )
 
-    @patch('os.chmod')
-    @patch('os.path.exists')
-    @patch('kiwi.volume_manager.btrfs.Command.run')
-    @patch('kiwi.volume_manager.btrfs.FileSystem.new')
-    @patch('kiwi.volume_manager.btrfs.MappedDevice')
-    @patch('kiwi.volume_manager.btrfs.MountManager')
-    @patch('kiwi.volume_manager.base.Temporary')
-    def test_remount_volumes(
-        self, mock_Temporary, mock_mount, mock_mapped_device, mock_fs,
-        mock_command, mock_os_exists, mock_os_chmod
-    ):
-        mock_Temporary.return_value.new_dir.return_value.name = \
-            '/var/tmp/kiwi_volumes.xx'
-        toplevel_mount = Mock()
-        toplevel_mount.is_mounted = Mock(
-            return_value=False
-        )
-        mock_mount.return_value = toplevel_mount
-        command_call = Mock()
-        command_call.output = \
-            'ID 258 gen 26 top level 257 path @/.snapshots/1/snapshot'
-        mock_mapped_device.return_value = 'mapped_device'
-        mock_os_exists.return_value = False
-        mock_command.return_value = command_call
-        self.volume_manager.custom_args['root_is_snapshot'] = True
-
-        self.volume_manager.setup()
-        mock_os_chmod.assert_called_once_with(
-            '/var/tmp/kiwi_volumes.xx/@/.snapshots', 0o700
-        )
-        mock_os_exists.return_value = True
-        volume_mount = Mock()
-        volume_mount.mountpoint = \
-            '/var/tmp/kiwi_volumes.xx/@/.snapshots/1/snapshot/var/tmp'
-        volume_mount.get_attributes.return_value = {
-            'subvol_path': '@/var/tmp'
-        }
-        self.volume_manager.subvol_mount_list = [volume_mount]
-
-        self.volume_manager.mount_volumes()
-        self.volume_manager.umount_volumes()
-        self.volume_manager.mount_volumes()
-
-        assert volume_mount.mountpoint == '/var/tmp/kiwi_volumes.xx/var/tmp'
-
     def test_umount_volumes(self):
         self.volume_manager.toplevel_mount = Mock()
         volume_mount = Mock()

--- a/test/unit/volume_manager/btrfs_test.py
+++ b/test/unit/volume_manager/btrfs_test.py
@@ -624,7 +624,8 @@ class TestVolumeManagerBtrfs:
         self.volume_manager.set_property_readonly_root()
         mock_command.assert_called_once_with(
             [
-                'btrfs', 'property', 'set', 'tmpdir', 'ro', 'true'
+                'btrfs', 'property',
+                'set', 'tmpdir/@/.snapshots/1/snapshot', 'ro', 'true'
             ]
         )
 


### PR DESCRIPTION
For setting up the read-only property an extra mount of the btrfs sub-volumes was issued. However, all volumes are mounted at that time. Thus it's not required to mount them again, resulting in a busy state because of the auto-snapshot mounts which does not get umounted and keeps a busy state until the lazy umount kicks in. This Fixes #2529

