### PR TITLE
Handle XSLT errors better

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-disk/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.5" name="kiwi-test-image-disk">
+<image schemaversion="7.2" name="kiwi-test-image-disk">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/markup/base.py
+++ b/kiwi/markup/base.py
@@ -89,6 +89,8 @@ class MarkupBase:
                 )
         except etree.XMLSyntaxError as issue:
             raise KiwiDescriptionInvalid(issue)
+        except etree.XSLTApplyError as issue:
+            raise KiwiDescriptionInvalid(issue)
 
         return self.description_xslt_processed.name
 

--- a/test/data/example_deprecated_schema.xml
+++ b/test/data/example_deprecated_schema.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="7.3" name="LimeJeOS">
+    <description type="system">
+        <author>Marcus</author>
+        <contact>ms@suse.com</contact>
+        <specification>
+            Testing too old schema version condition
+        </specification>
+    </description>
+    <preferences>
+        <version>1.13.2</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <type image="tbz"/>
+    </preferences>
+    <packages type="image" patternType="plusRecommended">
+        <namedCollection name="base"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="filesystem"/>
+    </packages>
+</image>

--- a/test/unit/markup/base_test.py
+++ b/test/unit/markup/base_test.py
@@ -48,6 +48,13 @@ class TestMarkupBase:
                 '../data/example_include_config.xml'
             )
 
+    def test_apply_xslt_stylesheets_deprecated(self):
+        markup = MarkupBase('../data/example_deprecated_schema.xml')
+        with raises(KiwiDescriptionInvalid):
+            markup.apply_xslt_stylesheets(
+                '../data/example_deprecated_schema.xml'
+            )
+
     def test_apply_xslt_stylesheets_missing_include_reference(self):
         markup = MarkupBase(
             '../data/example_include_config_missing_reference.xml'


### PR DESCRIPTION
Make sure etree.XSLTApplyError is a known error in the kiwi scope and raise an appropriate exception

