### PR TITLE
Don't compress vmdk images

### DIFF
--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -68,7 +68,7 @@ class DiskFormatVmdk(DiskFormatBase):
 
         :param object result: Instance of Result
         """
-        compression = self.runtime_config.get_bundle_compression(default=True)
+        compression = self.runtime_config.get_bundle_compression(default=False)
         if self.xml_state.get_luks_credentials() is not None:
             compression = False
         result.add(


### PR DESCRIPTION
Like with qcow2 it's not expected that the format type gets compressed in the bundle

