### PR TITLE
Keep runtime_checker_metadata.yml as module file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,8 @@ install:
 	# kiwi default configuration
 	install -d -m 755 ${buildroot}etc
 	install -m 644 kiwi.yml ${buildroot}etc/kiwi.yml
-	# kiwi runtime checker metadata
-	install -d -m 755 ${buildroot}usr/share/kiwi
-	install -m 644 kiwi/runtime_checker_metadata.yml \
-		${buildroot}usr/share/kiwi/runtime_checker_metadata.yml
 	# kiwi old XSL stylesheets for upgrade
+	install -d -m 755 ${buildroot}usr/share/kiwi
 	cp -a helper/xsl_to_v74 ${buildroot}usr/share/kiwi/
 
 tox:

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -18,6 +18,8 @@
 import logging
 import os
 import glob
+from importlib.util import find_spec
+from importlib.machinery import ModuleSpec
 from collections import namedtuple
 import platform
 import yaml
@@ -82,7 +84,11 @@ EDIT_BOOT_INSTALL_SCRIPT = 'edit_boot_install.sh'
 IMAGE_METADATA_DIR = 'image'
 ROOT_VOLUME_NAME = 'LVRoot'
 SHARED_CACHE_DIR = '/var/cache/kiwi'
-RUNTIME_CHECKER_METADATA = '/usr/share/kiwi/runtime_checker_metadata.yml'
+MODULE_SPEC: Optional[ModuleSpec] = find_spec('kiwi')
+RUNTIME_CHECKER_METADATA = '{}/runtime_checker_metadata.yml'.format(
+    os.path.dirname(MODULE_SPEC.origin or 'unknown')
+) if MODULE_SPEC else 'unknown'
+
 TEMP_DIR = '/var/tmp'
 CUSTOM_RUNTIME_CONFIG_FILE = None
 PLATFORM_MACHINE = platform.machine()

--- a/package/python-kiwi-pkgbuild-template
+++ b/package/python-kiwi-pkgbuild-template
@@ -33,7 +33,6 @@ package_python-kiwi(){
   python3 -m installer --destdir "${pkgdir}/" dist/*.whl
   ln -sr "${pkgdir}/usr/bin/kiwi-ng" "${pkgdir}/usr/bin/kiwi"
   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE" 
-  install -Dm644 kiwi/runtime_checker_metadata.yml "$pkgdir/usr/share/kiwi/runtime_checker_metadata.yml"
 }
 
 package_kiwi-man-pages(){

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -731,7 +731,6 @@ fi
 %{python3_sitelib}/kiwi*
 %{_usr}/share/bash-completion/completions/kiwi-ng
 %{_usr}/share/kiwi/xsl_to_v74/
-%{_usr}/share/kiwi/runtime_checker_metadata.yml
 %{_defaultdocdir}/python-kiwi/LICENSE
 %{_defaultdocdir}/python-kiwi/README
 


### PR DESCRIPTION
It was a bad idea to install a mandatory source file outside the module path. This prevents running kiwi from source

