### PR TITLE
Only enable BLSCFG if the new 'bls' attribute is set

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -133,6 +133,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         self.timeout_style = \
             self.xml_state.get_build_type_bootloader_timeout_style()
         self.displayname = self.xml_state.xml_data.get_displayname()
+        self.bls = self.xml_state.get_build_type_bootloader_bls()
         self.serial_line_setup = \
             self.xml_state.get_build_type_bootloader_serial_line_setup()
         self.continue_on_timeout = self.get_continue_on_timeout()
@@ -794,7 +795,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 self._get_grub2_mkconfig_tool()
             ], raise_on_error=False
         )
-        if enable_blscfg_implemented.returncode == 0:
+        if self.bls and enable_blscfg_implemented.returncode == 0:
             grub_default_entries['GRUB_ENABLE_BLSCFG'] = 'true'
 
         if grub_default_entries:

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2757,6 +2757,13 @@ div {
             sch:param [ name = "attr" value = "grub_template" ]
             sch:param [ name = "types" value = "oem iso" ]
         ]
+    k.bootloader.bls.attribute =
+        ## Specifies if the GRUB2 bootloader uses the boot loader specification
+        attribute bls { xsd:boolean }
+        >> sch:pattern [ id = "bls" is-a = "bootloader_name_type"
+            sch:param [ name = "attr" value = "bls" ]
+            sch:param [ name = "types" value = "grub2" ]
+        ]
     k.bootloader.console.attribute =
         ## Specifies the bootloader console.
         attribute console { grub_console }
@@ -2814,6 +2821,7 @@ div {
         attribute use_disk_password { xsd:boolean }
     k.bootloader.attlist =
         k.bootloader.name.attribute &
+        k.bootloader.bls.attribute? &
         k.bootloader.console.attribute? &
         k.bootloader.serial_line.attribute? &
         k.bootloader.timeout.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -4128,6 +4128,16 @@ setting only affects the oem and iso image types.</a:documentation>
         <sch:param name="types" value="oem iso"/>
       </sch:pattern>
     </define>
+    <define name="k.bootloader.bls.attribute">
+      <attribute name="bls">
+        <a:documentation>Specifies if the GRUB2 bootloader uses the boot loader specification</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="bls" is-a="bootloader_name_type">
+        <sch:param name="attr" value="bls"/>
+        <sch:param name="types" value="grub2"/>
+      </sch:pattern>
+    </define>
     <define name="k.bootloader.console.attribute">
       <attribute name="console">
         <a:documentation>Specifies the bootloader console.</a:documentation>
@@ -4207,6 +4217,9 @@ is useful for full disk encryption images</a:documentation>
     <define name="k.bootloader.attlist">
       <interleave>
         <ref name="k.bootloader.name.attribute"/>
+        <optional>
+          <ref name="k.bootloader.bls.attribute"/>
+        </optional>
         <optional>
           <ref name="k.bootloader.console.attribute"/>
         </optional>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.29.24.
-# Python 3.11.5 (main, Sep 06 2023, 11:21:05) [GCC]
+# Python 3.11.9 (main, Apr 08 2024, 06:18:15) [GCC]
 #
 # Command line options:
 #   ('-f', '')
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/ms/Project/kiwi/.tox/unit_py3_11/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/aplanas/mnt/Documents/Work/kiwi/venv/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -5560,9 +5560,10 @@ class bootloader(GeneratedsSuper):
     provide configuration parameters for it"""
     subclass = None
     superclass = None
-    def __init__(self, name=None, console=None, serial_line=None, timeout=None, timeout_style=None, targettype=None, use_disk_password=None, grub_template=None, bootloadersettings=None):
+    def __init__(self, name=None, bls=None, console=None, serial_line=None, timeout=None, timeout_style=None, targettype=None, use_disk_password=None, grub_template=None, bootloadersettings=None):
         self.original_tagname_ = None
         self.name = _cast(None, name)
+        self.bls = _cast(bool, bls)
         self.console = _cast(None, console)
         self.serial_line = _cast(None, serial_line)
         self.timeout = _cast(int, timeout)
@@ -5586,6 +5587,8 @@ class bootloader(GeneratedsSuper):
     def set_bootloadersettings(self, bootloadersettings): self.bootloadersettings = bootloadersettings
     def get_name(self): return self.name
     def set_name(self, name): self.name = name
+    def get_bls(self): return self.bls
+    def set_bls(self, bls): self.bls = bls
     def get_console(self): return self.console
     def set_console(self, console): self.console = console
     def get_serial_line(self): return self.serial_line
@@ -5639,6 +5642,9 @@ class bootloader(GeneratedsSuper):
         if self.name is not None and 'name' not in already_processed:
             already_processed.add('name')
             outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
+        if self.bls is not None and 'bls' not in already_processed:
+            already_processed.add('bls')
+            outfile.write(' bls="%s"' % self.gds_format_boolean(self.bls, input_name='bls'))
         if self.console is not None and 'console' not in already_processed:
             already_processed.add('console')
             outfile.write(' console=%s' % (quote_attrib(self.console), ))
@@ -5680,6 +5686,15 @@ class bootloader(GeneratedsSuper):
             already_processed.add('name')
             self.name = value
             self.name = ' '.join(self.name.split())
+        value = find_attr_value_('bls', node)
+        if value is not None and 'bls' not in already_processed:
+            already_processed.add('bls')
+            if value in ('true', '1'):
+                self.bls = True
+            elif value in ('false', '0'):
+                self.bls = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('console', node)
         if value is not None and 'console' not in already_processed:
             already_processed.add('console')

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -998,6 +998,19 @@ class XMLState:
         return bootloader.get_name() if bootloader else \
             Defaults.get_default_bootloader()
 
+    def get_build_type_bootloader_bls(self) -> bool:
+        """
+        Return bootloader bls setting for selected build type
+
+        :return: True or False
+
+        :rtype: bool
+        """
+        bootloader = self.get_build_type_bootloader_section()
+        if bootloader:
+            return bootloader.get_bls()
+        return False
+
     def get_build_type_bootloader_console(self) -> List[str]:
         """
         Return bootloader console setting for selected build type

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -58,6 +58,7 @@ class TestXMLState:
         self.bootloader.get_timeout.return_value = 'some-timeout'
         self.bootloader.get_timeout_style.return_value = 'some-style'
         self.bootloader.get_targettype.return_value = 'some-target'
+        self.bootloader.get_bls.return_value = False
         self.bootloader.get_console.return_value = 'some-console'
         self.bootloader.get_serial_line.return_value = 'some-serial'
         self.bootloader.get_use_disk_password.return_value = True
@@ -1036,6 +1037,11 @@ class TestXMLState:
         assert self.state.get_build_type_bootloader_use_disk_password() is False
         mock_bootloader.return_value = [self.bootloader]
         assert self.state.get_build_type_bootloader_use_disk_password() is True
+
+    @patch('kiwi.xml_parse.type_.get_bootloader')
+    def test_get_build_type_bootloader_bls(self, mock_bootloader):
+        mock_bootloader.return_value = [self.bootloader]
+        assert self.state.get_build_type_bootloader_bls() is False
 
     @patch('kiwi.xml_parse.type_.get_bootloader')
     def test_get_build_type_bootloader_console(self, mock_bootloader):


### PR DESCRIPTION
Partially fixes #2497 

It is not properly tested, as I did not generate images with grub2-bls (not sure how to do that outside OBS), but I added some tests to cover this feature.