### PR TITLE
Fix package removal with dnf5

### DIFF
--- a/kiwi/package_manager/dnf5.py
+++ b/kiwi/package_manager/dnf5.py
@@ -244,9 +244,10 @@ class PackageManagerDnf5(PackageManagerBase):
             dnf_command = [
                 'chroot', self.root_dir, 'dnf5'
             ] + chroot_dnf_args + [
-                f'--releasever={self.release_version}'
+                f'--releasever={self.release_version}',
+                '--setopt=clean_requirements_on_remove=true'
             ] + self.custom_args + [
-                'autoremove'
+                'remove'
             ] + self.package_requests
             self.cleanup_requests()
             return Command.call(

--- a/test/unit/package_manager/dnf5_test.py
+++ b/test/unit/package_manager/dnf5_test.py
@@ -141,7 +141,8 @@ class TestPackageManagerDnf5:
             [
                 'chroot', '/root-dir', 'dnf5',
                 '--config', '/dnf.conf', '-y',
-                '--releasever=0', 'autoremove', 'vim'
+                '--releasever=0', '--setopt=clean_requirements_on_remove=true',
+                'remove', 'vim'
             ],
             ['env']
         )


### PR DESCRIPTION
dnf5 does not implement `dnf autoremove <package>` as a synonym for `--setopt=clean_requirements_on_remove=true remove <package>` as dnf4 did. So, we should do it this way instead.