### PR TITLE
Fix luks_randomize setting

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -164,8 +164,8 @@ class DiskBuilder:
         self.root_filesystem_embed_integrity_metadata = \
             xml_state.build_type.get_embed_integrity_metadata()
         self.luks_format_options = xml_state.get_luks_format_options()
-        self.luks_randomize = \
-            xml_state.build_type.get_luks_randomize() or True
+        self.luks_randomize = xml_state.build_type.get_luks_randomize() \
+            if xml_state.build_type.get_luks_randomize() is not None else True
         self.luks_os = xml_state.build_type.get_luksOS()
         self.xen_server = xml_state.is_xen_server()
         self.requested_filesystem = xml_state.build_type.get_filesystem()

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2057,10 +2057,10 @@ div {
         ]
     k.type.luks_randomize.attribute =
         ## By default, all blocks of a LUKS volume will be filled
-	## with pseudo-random data. If you're shipping an image with
-	## a well-known key, which is going to be re-encrypted at
-	## deployment time, you can decrease the size of the image
-	## by setting this attribute to false.
+        ## with pseudo-random data. If you're shipping an image with
+        ## a well-known key, which is going to be re-encrypted at
+        ## deployment time, you can decrease the size of the image
+        ## by setting this attribute to false.
         attribute luks_randomize { xsd:boolean }
         >> sch:pattern [ id = "luks_randomize" is-a = "image_type"
             sch:param [ name = "attr" value = "luksversion" ]


### PR DESCRIPTION
Make sure the value passed for luks_randomize in the description becomes effective. It was not possible to switch off luks_randomize because any "not" value was turned into a true value. The actual default should therefore only apply in case luks_randomize is not specified at all which means only a None value will turn into a true value for this setting.

