### PR TITLE
Stop leaking plugins/{priorities,versionlock}.conf file with dnf4/5.

### DIFF
--- a/kiwi/repository/dnf5.py
+++ b/kiwi/repository/dnf5.py
@@ -100,14 +100,13 @@ class RepositoryDnf5(RepositoryBase):
         ).unmanaged_file()
 
         self.dnf_args = [
-            '--config', self.runtime_dnf_config_file.name, '-y'
+            '--config', self.runtime_dnf_config_file.name, '-y', '--disable-plugin=priorities,versionlock'
         ] + self.custom_args
 
         self.command_env = self._create_dnf_runtime_environment()
 
         # config file parameters for dnf tool
         self._create_runtime_config_parser()
-        self._create_runtime_plugin_config_parsers()
         self._write_runtime_config()
 
     def setup_package_database_configuration(self) -> None:
@@ -173,7 +172,6 @@ class RepositoryDnf5(RepositoryBase):
         self.shared_dnf_dir['vars-dir'] = \
             self.root_dir + '/etc/dnf/vars'
         self._create_runtime_config_parser()
-        self._create_runtime_plugin_config_parsers()
         self._write_runtime_config()
 
     def runtime_config(self) -> Dict:
@@ -341,21 +339,9 @@ class RepositoryDnf5(RepositoryBase):
                 "ignorearch": "1",
             })
 
-    def _create_runtime_plugin_config_parsers(self) -> None:
-        self.runtime_dnf_plugin_configs = {
-            plugin: ConfigParser(interpolation=None) for plugin in ("priorities", "versionlock")
-        }
-        self.runtime_dnf_plugin_configs["priorities"]["main"] = {"enabled": "0"}
-        self.runtime_dnf_plugin_configs["versionlock"]["main"] = {"enabled": "0"}
-
     def _write_runtime_config(self) -> None:
         with open(self.runtime_dnf_config_file.name, 'w') as config:
             self.runtime_dnf_config.write(config)
-        if os.path.exists(self.shared_dnf_dir['pluginconf-dir']):
-            for plugin_name, plugin_config in self.runtime_dnf_plugin_configs.items():
-                path = f"{self.shared_dnf_dir['pluginconf-dir']}/{plugin_name}.conf"
-                with open(path, "w") as plugin_config_fobj:
-                    plugin_config.write(plugin_config_fobj)
 
     def cleanup(self) -> None:
         """

--- a/test/unit/repository/dnf4_test.py
+++ b/test/unit/repository/dnf4_test.py
@@ -45,9 +45,7 @@ class TestRepositoryDnf4:
                 'obsoletes': '1',
                 'plugins': '1',
                 'gpgcheck': '0'
-            }),
-            call('main', {'enabled': '1'}),
-            call('main', {'enabled': '0'})
+            })
         ]
 
     @patch('kiwi.repository.dnf4.Temporary.unmanaged_file')
@@ -74,9 +72,7 @@ class TestRepositoryDnf4:
         with patch('builtins.open', m_open, create=True):
             self.repo.post_init(['check_signatures'])
             assert m_open.call_args_list == [
-                call(mock_temp.return_value.name, 'w'),
-                call('/shared-dir/dnf/pluginconf/priorities.conf', 'w'),
-                call('/shared-dir/dnf/pluginconf/versionlock.conf', 'w'),
+                call(mock_temp.return_value.name, 'w')
             ]
         assert self.repo.custom_args == []
         assert self.repo.gpg_check == '1'
@@ -101,9 +97,7 @@ class TestRepositoryDnf4:
                 'obsoletes': '1',
                 'plugins': '1',
                 'gpgcheck': '0'
-            }),
-            call('main', {'enabled': '1'}),
-            call('main', {'enabled': '0'})
+            })
         ]
 
     def test_runtime_config(self):

--- a/test/unit/repository/dnf5_test.py
+++ b/test/unit/repository/dnf5_test.py
@@ -45,9 +45,7 @@ class TestRepositoryDnf5:
                 'obsoletes': '1',
                 'plugins': '0',
                 'gpgcheck': '0'
-            }),
-            call('main', {'enabled': '0'}),
-            call('main', {'enabled': '0'})
+            })
         ]
 
     @patch('kiwi.repository.dnf5.Temporary.unmanaged_file')
@@ -74,9 +72,7 @@ class TestRepositoryDnf5:
         with patch('builtins.open', m_open, create=True):
             self.repo.post_init(['check_signatures'])
             assert m_open.call_args_list == [
-                call(mock_temp.return_value.name, 'w'),
-                call('/shared-dir/dnf/pluginconf/priorities.conf', 'w'),
-                call('/shared-dir/dnf/pluginconf/versionlock.conf', 'w'),
+                call(mock_temp.return_value.name, 'w')
             ]
         assert self.repo.custom_args == []
         assert self.repo.gpg_check == '1'
@@ -101,9 +97,7 @@ class TestRepositoryDnf5:
                 'obsoletes': '1',
                 'plugins': '0',
                 'gpgcheck': '0'
-            }),
-            call('main', {'enabled': '0'}),
-            call('main', {'enabled': '0'})
+            })
         ]
 
     def test_runtime_config(self):


### PR DESCRIPTION
This fixes the fedora issue
https://bugzilla.redhat.com/show_bug.cgi?id=2270364

Description of the issue:
With Fedora 40 it seems the Fedora base image moved to being created with Kiwi while apparently Fedora <= 39 used something else. Starting with fedora 40, we can see that all OCI fedora images have one new file `/etc/dnf/plugins/versionlock.conf` which explicitly disables the versionlock plugin. If later, with this generated OCI fedora image you try to install the versionlock plugin via dnf (ie package `python3-dnf-plugin-versionlock` then since the config file `/etc/dnf/plugins/versionlock.conf` exists already, the one from the package is ignored. The end result is that when users of fedora try to install `python3-dnf-plugin-versionlock` in the end the versionlock plugin is still disabled, which is not expected.

In order to fix this, I can see two possible ways. Either adding some explicit code in the `cleanup` method to correctly remove the plugin configuration files. However I really don't know your codebase and I am quite unsure when exactly is cleanup called, and to be honest it would strange to me to explicitly remove files here. Indeed if one day in the fedora base image the package `python3-dnf-plugin-versionlock` is pre-installed then... you end up removing an actual packaged file.

The other way to fix this, and the solution I propose here is to stop creating any plugin configuration file, since the only thing kiwi seems to care about is enabling/disabling plugins, and instead achieve the same activation/deactivation via command line arguments.

I discovered kiwi today, I am just trying to fix an issue I have with fedora OCI images, so excuse my lack of internal knowledge in your project ;)

Note: I tested only the dnf4 code (re-building locally the fedora images to fix my initial versionlock issue), the dnf5 code change was made blindly, reading the doc as it seems the `--disable-plugin` flag name has been renamed compared to dnf4.