### PR TITLE
Make sure lsblk output is sorted by dev name

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -30,7 +30,7 @@ function get_disk_list {
     local list_items
     local max_disk
     local kiwi_oem_maxdisk
-    local blk_opts="-p -n -r -o NAME,SIZE,TYPE"
+    local blk_opts="-p -n -r --sort NAME -o NAME,SIZE,TYPE"
     local message
     local blk_opts_plus_label="${blk_opts},LABEL"
     local kiwi_install_disk_part


### PR DESCRIPTION
lsblk without the sorting option can provide the list of devices in different order. This patch makes sure lsblk sorts the output by the device name.
This Fixes bsc#1223374

