### PR TITLE
Overwrite compression setting only if randomized

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -399,7 +399,7 @@ class DiskBuilder:
 
         # store image file name in result
         compression = self.runtime_config.get_bundle_compression(default=True)
-        if self.luks is not None:
+        if self.luks is not None and self.luks_randomize:
             compression = False
         self.result.add(
             key='disk_image',


### PR DESCRIPTION
When building an encrypted image, the bundler never compressed the result. This overwrite from the runtime configuration and the default compression setting actually only makes sense when the image is randomized because only then a compression is for sure useless. This Fixes #2540

