### PR TITLE
Add support for stopsignal in containerconfig

### DIFF
--- a/doc/source/building_images/build_container_image.rst
+++ b/doc/source/building_images/build_container_image.rst
@@ -50,6 +50,11 @@ specified.
 * ``volumes``: Creates mountpoints with the given name and marks them to hold
   external volumes from the host or from other containers. Equivalent to
   one or more `VOLUME` directives in a :file:`Dockerfile`.
+* ``stopsignal``: The stopsignal element sets the system call signal that
+  will be sent to the container to exit. This signal can be a signal name
+  in the format SIG[NAME], for instance SIGKILL, or an unsigned number that
+  matches a position in the kernel's syscall table, for instance 9.
+  The default is SIGTERM if not defined
 
 Other :file:`Dockerfile` directives such as ``RUN``, ``COPY`` or ``ADD``,
 can be mapped to {kiwi} using the

--- a/kiwi/oci_tools/buildah.py
+++ b/kiwi/oci_tools/buildah.py
@@ -285,6 +285,11 @@ class OCIBuildah(OCIBase):
             for vol in oci_config['volumes']:
                 arguments.append('--volume={0}'.format(vol))
 
+        if 'stopsignal' in oci_config:
+            arguments.append(
+                '--stop-signal={0}'.format(oci_config['stopsignal'])
+            )
+
         if 'expose_ports' in oci_config:
             for port in oci_config['expose_ports']:
                 arguments.append('--port={0}'.format(port))

--- a/kiwi/oci_tools/umoci.py
+++ b/kiwi/oci_tools/umoci.py
@@ -238,6 +238,11 @@ class OCIUmoci(OCIBase):
             for vol in oci_config['volumes']:
                 arguments.append('--config.volume={0}'.format(vol))
 
+        if 'stopsignal' in oci_config:
+            arguments.append(
+                '--config.stopsignal={0}'.format(oci_config['stopsignal'])
+            )
+
         if 'expose_ports' in oci_config:
             for port in oci_config['expose_ports']:
                 arguments.append('--config.exposedports={0}'.format(port))

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2925,6 +2925,7 @@ div {
             k.subcommand? &
             k.expose? &
             k.volumes? &
+            k.stopsignal? &
             k.environment? &
             k.labels? &
             k.history?
@@ -3042,6 +3043,24 @@ div {
         element volumes {
             k.volumes.attlist &
             k.volume+
+        }
+}
+
+#==========================================
+# main block: <stopsignal>
+#
+div {
+    k.stopsignal.attlist = empty
+    k.stopsignal =
+        ## The stopsignal element sets the system call signal that
+        ## will be sent to the container to exit. This signal can be a
+        ## signal name in the format SIG<NAME>, for instance SIGKILL,
+        ## or an unsigned number that matches a position in the kernel's
+        ## syscall table, for instance 9. The default is SIGTERM if not
+        ## defined.
+        element stopsignal {
+            k.stopsignal.attlist &
+            text
         }
 }
 

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -4371,6 +4371,9 @@ section provides globally useful container information.</a:documentation>
             <ref name="k.volumes"/>
           </optional>
           <optional>
+            <ref name="k.stopsignal"/>
+          </optional>
+          <optional>
             <ref name="k.environment"/>
           </optional>
           <optional>
@@ -4540,6 +4543,30 @@ At least one volume must be configured</a:documentation>
           <oneOrMore>
             <ref name="k.volume"/>
           </oneOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <stopsignal>
+    
+  -->
+  <div>
+    <define name="k.stopsignal.attlist">
+      <empty/>
+    </define>
+    <define name="k.stopsignal">
+      <element name="stopsignal">
+        <a:documentation>The stopsignal element sets the system call signal that
+will be sent to the container to exit. This signal can be a
+signal name in the format SIG&lt;NAME&gt;, for instance SIGKILL,
+or an unsigned number that matches a position in the kernel's
+syscall table, for instance 9. The default is SIGTERM if not
+defined.</a:documentation>
+        <interleave>
+          <ref name="k.stopsignal.attlist"/>
+          <text/>
         </interleave>
       </element>
     </define>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.29.24.
-# Python 3.11.9 (main, Apr 08 2024, 06:18:15) [GCC]
+# Python 3.11.5 (main, Sep 06 2023, 11:21:05) [GCC]
 #
 # Command line options:
 #   ('-f', '')
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/aplanas/mnt/Documents/Work/kiwi/venv/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/ms/Project/kiwi/.tox/unit_py3_11/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -5754,7 +5754,7 @@ class containerconfig(GeneratedsSuper):
     useful container information."""
     subclass = None
     superclass = None
-    def __init__(self, name=None, tag=None, additionalnames=None, maintainer=None, user=None, workingdir=None, entrypoint=None, subcommand=None, expose=None, volumes=None, environment=None, labels=None, history=None):
+    def __init__(self, name=None, tag=None, additionalnames=None, maintainer=None, user=None, workingdir=None, entrypoint=None, subcommand=None, expose=None, volumes=None, stopsignal=None, environment=None, labels=None, history=None):
         self.original_tagname_ = None
         self.name = _cast(None, name)
         self.tag = _cast(None, tag)
@@ -5778,6 +5778,10 @@ class containerconfig(GeneratedsSuper):
             self.volumes = []
         else:
             self.volumes = volumes
+        if stopsignal is None:
+            self.stopsignal = []
+        else:
+            self.stopsignal = stopsignal
         if environment is None:
             self.environment = []
         else:
@@ -5821,6 +5825,11 @@ class containerconfig(GeneratedsSuper):
     def add_volumes(self, value): self.volumes.append(value)
     def insert_volumes_at(self, index, value): self.volumes.insert(index, value)
     def replace_volumes_at(self, index, value): self.volumes[index] = value
+    def get_stopsignal(self): return self.stopsignal
+    def set_stopsignal(self, stopsignal): self.stopsignal = stopsignal
+    def add_stopsignal(self, value): self.stopsignal.append(value)
+    def insert_stopsignal_at(self, index, value): self.stopsignal.insert(index, value)
+    def replace_stopsignal_at(self, index, value): self.stopsignal[index] = value
     def get_environment(self): return self.environment
     def set_environment(self, environment): self.environment = environment
     def add_environment(self, value): self.environment.append(value)
@@ -5854,6 +5863,7 @@ class containerconfig(GeneratedsSuper):
             self.subcommand or
             self.expose or
             self.volumes or
+            self.stopsignal or
             self.environment or
             self.labels or
             self.history
@@ -5914,6 +5924,9 @@ class containerconfig(GeneratedsSuper):
             expose_.export(outfile, level, namespaceprefix_, name_='expose', pretty_print=pretty_print)
         for volumes_ in self.volumes:
             volumes_.export(outfile, level, namespaceprefix_, name_='volumes', pretty_print=pretty_print)
+        for stopsignal_ in self.stopsignal:
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<stopsignal>%s</stopsignal>%s' % (self.gds_encode(self.gds_format_string(quote_xml(stopsignal_), input_name='stopsignal')), eol_))
         for environment_ in self.environment:
             environment_.export(outfile, level, namespaceprefix_, name_='environment', pretty_print=pretty_print)
         for labels_ in self.labels:
@@ -5973,6 +5986,10 @@ class containerconfig(GeneratedsSuper):
             obj_.build(child_)
             self.volumes.append(obj_)
             obj_.original_tagname_ = 'volumes'
+        elif nodeName_ == 'stopsignal':
+            stopsignal_ = child_.text
+            stopsignal_ = self.gds_validate_string(stopsignal_, node, 'stopsignal')
+            self.stopsignal.append(stopsignal_)
         elif nodeName_ == 'environment':
             obj_ = environment.factory()
             obj_.build(child_)

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1482,6 +1482,9 @@ class XMLState:
             self._match_docker_volumes()
         )
         container_config.update(
+            self._match_docker_stopsignal()
+        )
+        container_config.update(
             self._match_docker_environment()
         )
         container_config.update(
@@ -2720,6 +2723,15 @@ class XMLState:
                 for volume in volumes[0].get_volume():
                     container_volumes['volumes'].append(volume.get_name())
         return container_volumes
+
+    def _match_docker_stopsignal(self) -> dict:
+        container_config_section = self.get_build_type_containerconfig_section()
+        container_stopsignal = {}
+        if container_config_section:
+            stopsignal_section = container_config_section.get_stopsignal()
+            if stopsignal_section:
+                container_stopsignal['stopsignal'] = stopsignal_section[0]
+        return container_stopsignal
 
     def _match_docker_environment(self):
         container_config_section = self.get_build_type_containerconfig_section()

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -156,6 +156,7 @@
                     <volume name="/tmp"/>
                     <volume name="/var/log"/>
                 </volumes>
+                <stopsignal>SIGINT</stopsignal>
                 <environment>
                     <env name="PATH" value="/bin:/usr/bin:/home/user/bin"/>
                     <env name="SOMEVAR" value="somevalue"/>

--- a/test/unit/oci_tools/buildah_test.py
+++ b/test/unit/oci_tools/buildah_test.py
@@ -111,6 +111,7 @@ class TestOCIBuildah:
             'workingdir': '/root',
             'expose_ports': ['80', '42'],
             'volumes': ['/var/log', '/tmp'],
+            'stopsignal': 'SIGINT',
             'environment': {'FOO': 'bar', 'PATH': '/bin'},
             'labels': {'a': 'value', 'b': 'value'},
             'history': {
@@ -127,7 +128,9 @@ class TestOCIBuildah:
                 'buildah', 'config', '--author=tux', '--user=root',
                 '--workingdir=/root', '--entrypoint=["/bin/bash","-x"]',
                 '--cmd=ls -l',
-                '--volume=/var/log', '--volume=/tmp', '--port=80', '--port=42',
+                '--volume=/var/log', '--volume=/tmp',
+                '--stop-signal=SIGINT',
+                '--port=80', '--port=42',
                 '--env=FOO=bar', '--env=PATH=/bin', '--label=a=value',
                 '--label=b=value', '--history-comment=This is a comment',
                 '--created-by=created by text', 'kiwi-working'

--- a/test/unit/oci_tools/umoci_test.py
+++ b/test/unit/oci_tools/umoci_test.py
@@ -119,6 +119,7 @@ class TestOCIUmoci:
             'workingdir': '/root',
             'expose_ports': ['80', '42'],
             'volumes': ['/var/log', '/tmp'],
+            'stopsignal': 'SIGINT',
             'environment': {'FOO': 'bar', 'PATH': '/bin'},
             'labels': {'a': 'value', 'b': 'value'},
         }
@@ -129,6 +130,7 @@ class TestOCIUmoci:
                 '--config.workingdir=/root', '--config.entrypoint=/bin/bash',
                 '--config.entrypoint=-x', '--config.cmd=ls', '--config.cmd=-l',
                 '--config.volume=/var/log', '--config.volume=/tmp',
+                '--config.stopsignal=SIGINT',
                 '--config.exposedports=80', '--config.exposedports=42',
                 '--config.env=FOO=bar', '--config.env=PATH=/bin',
                 '--config.label=a=value', '--config.label=b=value',

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -912,6 +912,7 @@ class TestXMLState:
             'volumes': ['/tmp', '/var/log'],
             'entry_command': ['/bin/bash', '-x'],
             'expose_ports': ['80', '8080'],
+            'stopsignal': 'SIGINT',
             'history': {
                 'author': 'history author',
                 'comment': 'This is a comment',


### PR DESCRIPTION
Allow to specify the stopsignal via the containerconfig element as the following example shows

```xml
<type image="docker">
    <containerconfig ...>
        <stopsignal>SIGINT</stopsignal>
    </containerconfig>
</type>
```

This Fixes #2543

