### PR TITLE
Fix set_disk_password() to really add the password to grub.cfg.

### DIFF
--- a/kiwi/bootloader/install/grub2.py
+++ b/kiwi/bootloader/install/grub2.py
@@ -31,7 +31,8 @@ from kiwi.path import Path
 from kiwi.exceptions import (
     KiwiBootLoaderGrubInstallError,
     KiwiBootLoaderGrubPlatformError,
-    KiwiBootLoaderGrubDataError
+    KiwiBootLoaderGrubDataError,
+    KiwiBootLoaderDiskPasswordError
 )
 
 log = logging.getLogger('kiwi')
@@ -287,22 +288,26 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
                         self._enable_grub2_install(self.root_mount.mountpoint)
 
     def set_disk_password(self, password: str):
-        if self.root_mount and password is not None:
-            log.debug('Include cryptomount credentials...')
-            config_file = '{0}/boot/efi/EFI/BOOT/grub.cfg'.format(
-                self.root_mount.mountpoint
-            )
-            if os.path.isfile(config_file):
-                with open(config_file) as config:
-                    grub_config = config.read()
-                    grub_config = re.sub(
-                        r'cryptomount',
-                        f'cryptomount -p "{password}"',
-                        grub_config
+        with ExitStack() as stack:
+            self._mount_device_and_volumes(stack)
+            if self.root_mount and password is not None:
+                log.debug('Include cryptomount credentials...')
+                config_file = f'{self.root_mount.mountpoint}/boot/efi/EFI/BOOT/grub.cfg'
+                try:
+                    with open(config_file) as config:
+                        grub_config = config.read()
+                        grub_config = re.sub(
+                            r'cryptomount',
+                            f'cryptomount -p "{password}"',
+                            grub_config
+                        )
+                    with open(config_file, 'w') as grub_config_file:
+                        grub_config_file.write(grub_config)
+                        log.debug(f'<<< {grub_config} >>>')
+                except IOError as issue:
+                    raise KiwiBootLoaderDiskPasswordError(
+                        f'Failed to open {config_file}: {issue}'
                     )
-                with open(config_file, 'w') as grub_config_file:
-                    grub_config_file.write(grub_config)
-                    log.debug(f'<<< {grub_config} >>>')
 
     def _mount_device_and_volumes(self, stack: ExitStack):
         self.root_mount = MountManager(

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -847,3 +847,9 @@ class KiwiOffsetError(KiwiError):
     Exception raised if the offset for a seek operation does not
     match the expected data to write
     """
+
+
+class KiwiBootLoaderDiskPasswordError(KiwiError):
+    """
+    Exception raised if the disk password could not be set
+    """


### PR DESCRIPTION
Since commit 8aa517eb7 it is necessary to call _mount_device_and_volumes() in methods that want to modify the grub setup to ensure the current boot files are mounted.

Also, raise an error if the config file could not be modified.

