### PR TITLE
RepositoryDnf5: correct defaults, set system_cachedir

### DIFF
--- a/kiwi/repository/dnf5.py
+++ b/kiwi/repository/dnf5.py
@@ -166,9 +166,9 @@ class RepositoryDnf5(RepositoryBase):
         self.shared_dnf_dir['reposd-dir'] = \
             self.root_dir + '/etc/yum.repos.d'
         self.shared_dnf_dir['cache-dir'] = \
-            self.root_dir + '/var/cache/dnf'
+            self.root_dir + '/var/cache/libdnf5'
         self.shared_dnf_dir['pluginconf-dir'] = \
-            self.root_dir + '/etc/dnf/plugins'
+            self.root_dir + '/etc/dnf/libdnf5-plugins'
         self.shared_dnf_dir['vars-dir'] = \
             self.root_dir + '/etc/dnf/vars'
         self._create_runtime_config_parser()
@@ -320,7 +320,7 @@ class RepositoryDnf5(RepositoryBase):
     def _create_runtime_config_parser(self) -> None:
         self.runtime_dnf_config = ConfigParser(interpolation=None)
         self.runtime_dnf_config["main"] = {
-            "cachedir": self.shared_dnf_dir['cache-dir'],
+            "system_cachedir": self.shared_dnf_dir['cache-dir'],
             "reposdir": self.shared_dnf_dir['reposd-dir'],
             "varsdir": self.shared_dnf_dir['vars-dir'],
             "pluginconfpath": self.shared_dnf_dir['pluginconf-dir'],

--- a/test/unit/repository/dnf5_test.py
+++ b/test/unit/repository/dnf5_test.py
@@ -35,7 +35,7 @@ class TestRepositoryDnf5:
 
         assert runtime_dnf_config.__setitem__.call_args_list == [
             call('main', {
-                'cachedir': '/shared-dir/dnf/cache',
+                'system_cachedir': '/shared-dir/dnf/cache',
                 'reposdir': '/shared-dir/dnf/repos',
                 'varsdir': '/shared-dir/dnf/vars',
                 'pluginconfpath': '/shared-dir/dnf/pluginconf',
@@ -87,10 +87,10 @@ class TestRepositoryDnf5:
 
         assert runtime_dnf_config.__setitem__.call_args_list == [
             call('main', {
-                'cachedir': '../data/var/cache/dnf',
+                'system_cachedir': '../data/var/cache/libdnf5',
                 'reposdir': '../data/etc/yum.repos.d',
                 'varsdir': '../data/etc/dnf/vars',
-                'pluginconfpath': '../data/etc/dnf/plugins',
+                'pluginconfpath': '../data/etc/dnf/libdnf5-plugins',
                 'keepcache': '1',
                 'debuglevel': '2',
                 'best': '1',


### PR DESCRIPTION
The "defaults" in `use_default_location` here are the dnf4 defaults, not the dnf5 defaults, so let's update them. Also, for dnf5, we need to set `system_cachedir` instead of `cachedir` - see https://dnf5.readthedocs.io/en/latest/misc/caching.7.html , `system_cachedir` is the cache location used when running as root, `cachedir` is the cache location used when running as a regular user.