### PR TITLE
Drop use of obsolete pkg_resources

### DIFF
--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -119,7 +119,7 @@ global options for services: image, system
 import logging
 import sys
 import os
-import pkg_resources
+from importlib.metadata import entry_points
 from docopt import docopt
 
 # project
@@ -252,10 +252,16 @@ class Cli:
 
         :rtype: object
         """
-        discovered_tasks = {
-            entry_point.name: entry_point.load()
-            for entry_point in pkg_resources.iter_entry_points('kiwi.tasks')
-        }
+        discovered_tasks = {}
+        if sys.version_info >= (3, 12):
+            for entry in list(entry_points()):  # pragma: no cover
+                if entry.group == 'kiwi.tasks':
+                    discovered_tasks[entry.name] = entry.load()
+        else:  # pragma: no cover
+            module_entries = dict.get(entry_points(), 'kiwi.tasks')
+            for entry in module_entries:
+                discovered_tasks[entry.name] = entry.load()
+
         service = self.get_servicename()
         command = self.get_command()
 

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -18,12 +18,13 @@
 import logging
 import os
 import glob
+import importlib
+from importlib.resources import as_file
 from importlib.util import find_spec
 from importlib.machinery import ModuleSpec
 from collections import namedtuple
 import platform
 import yaml
-from pkg_resources import resource_filename
 from typing import (
     List, NamedTuple, Optional, Dict
 )
@@ -1682,11 +1683,22 @@ class Defaults:
         return Defaults.project_file('xsl/master.xsl')
 
     @staticmethod
+    def get_schematron_module_name():
+        """
+        Provides module name for XML SchemaTron validations
+
+        :return: python module name
+
+        :rtype: str
+        """
+        return 'lxml.isoschematron'
+
+    @staticmethod
     def project_file(filename):
         """
         Provides the python module base directory search path
 
-        The method uses the resource_filename method to identify
+        The method uses the importlib.resources.path method to identify
         files and directories from the application
 
         :param string filename: relative project file
@@ -1695,7 +1707,8 @@ class Defaults:
 
         :rtype: str
         """
-        return resource_filename('kiwi', filename)
+        with as_file(importlib.resources.files('kiwi')) as path:
+            return f'{path}/{filename}'
 
     @staticmethod
     def get_imported_root_image(root_dir):

--- a/kiwi/xml_description.py
+++ b/kiwi/xml_description.py
@@ -83,7 +83,9 @@ class XMLDescription:
         isoschematron = None
         schematron = None
         try:
-            isoschematron = importlib.import_module('lxml.isoschematron')
+            isoschematron = importlib.import_module(
+                Defaults.get_schematron_module_name()
+            )
         except Exception as error:
             log.warning(f"schematron validation skipped: {error}")
         try:

--- a/test/unit/xml_description_test.py
+++ b/test/unit/xml_description_test.py
@@ -172,11 +172,11 @@ class TestSchema:
         with raises(KiwiSchemaImportError):
             self.description_from_file.load()
 
-    @patch('importlib.import_module')
+    @patch('kiwi.xml_description.Defaults.get_schematron_module_name')
     def test_load_schema_from_xml_content_skipping_isoschematron(
-        self, mock_import_module
+        self, mock_get_schematron_module_name
     ):
-        mock_import_module.side_effect = Exception
+        mock_get_schematron_module_name.return_value = 'bogus'
         with self._caplog.at_level(logging.WARNING):
             self.description_from_data.load()
             assert 'schematron validation skipped:' in self._caplog.text


### PR DESCRIPTION
As documented in https://setuptools.pypa.io/en/latest/pkg_resources.html the use of pkg_resources is obsolete and will cause issues. So happened on Debian unstable. This Fixes #2548

