### PR TITLE
Fix sdist upstream tarball contents

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ include = [
    { path = ".bumpversion.cfg", format = "sdist" },
    { path = ".coverage*", format = "sdist" },
    { path = ".virtualenv.requirements*.txt", format = "sdist" },
+   { path = ".virtualenv.dev-requirements.txt", format = "sdist" },
+   { path = "setup.cfg", format = "sdist" },
    { path = "doc/source", format = "sdist" },
    { path = "doc/Makefile", format = "sdist" },
    { path = "dracut", format = "sdist" },


### PR DESCRIPTION
The .virtualenv.dev-requirements.txt file is referenced by tox.ini but not put into the sdist tarball and therefore missing in the pypi upstream data.


