### PR TITLE
Fix method ineffective

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-simple/appliance.kiwi
@@ -58,7 +58,12 @@
         <package name="timezone"/>
     </packages>
     <packages type="bootstrap">
+        <package name="gawk"/>
+        <package name="grep"/>
+        <package name="gzip"/>
         <package name="udev"/>
+        <package name="xz"/>
+        <package name="shadow"/>
         <package name="filesystem"/>
         <package name="glibc-locale"/>
         <package name="cracklib-dict-full"/>

--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -50,6 +50,7 @@ class BootLoaderConfigBase(ABC):
         self.bootloader = xml_state.get_build_type_bootloader_name()
         self.arch = Defaults.get_platform_name()
 
+        self.system_is_mounted = False
         self.volumes_mount = []
         self.root_mount = None
         self.boot_mount = None
@@ -578,6 +579,27 @@ class BootLoaderConfigBase(ABC):
         self.device_mount.bind_mount()
         self.proc_mount.bind_mount()
         self.sys_mount.bind_mount()
+        self.system_is_mounted = True
+
+    def _umount_system(self):
+        if self.system_is_mounted:
+            for volume_mount in reversed(self.volumes_mount):
+                volume_mount.umount()
+            if self.device_mount:
+                self.device_mount.umount()
+            if self.proc_mount:
+                self.proc_mount.umount()
+            if self.sys_mount:
+                self.sys_mount.umount()
+            if self.efi_mount:
+                self.efi_mount.umount()
+            if self.tmp_mount:
+                self.tmp_mount.umount()
+            if self.boot_mount:
+                self.boot_mount.umount()
+            if self.root_mount:
+                self.root_mount.umount()
+            self.system_is_mounted = False
 
     def _get_root_cmdline_parameter(self, boot_device):
         """
@@ -662,19 +684,4 @@ class BootLoaderConfigBase(ABC):
         }
 
     def __exit__(self, exc_type, exc_value, traceback):
-        for volume_mount in reversed(self.volumes_mount):
-            volume_mount.umount()
-        if self.device_mount:
-            self.device_mount.umount()
-        if self.proc_mount:
-            self.proc_mount.umount()
-        if self.sys_mount:
-            self.sys_mount.umount()
-        if self.efi_mount:
-            self.efi_mount.umount()
-        if self.tmp_mount:
-            self.tmp_mount.umount()
-        if self.boot_mount:
-            self.boot_mount.umount()
-        if self.root_mount:
-            self.root_mount.umount()
+        self._umount_system()

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -322,6 +322,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             self._copy_grub_config_to_efi_path(
                 self.efi_mount.mountpoint, self.early_boot_script_efi
             )
+        self._umount_system()
 
     def setup_install_image_config(
         self, mbrid, hypervisor='xen.gz', kernel='linux', initrd='initrd'


### PR DESCRIPTION
**Make sure BootLoaderConfig fixes are effective**
    
The BootLoaderConfigGrub2 class has methods to fix the grub-mkconfig generated files. It does that by mounting the system and changing the respective files after the mkconfig call. However, after the change  the class instance stays open in combination with BootLoaderInstallGrub2  instance which itself under certain circumstances also mounts the system to call grub-install. At the time grub-install is called it cannot be guaranteed that all changes has been written unless an explicit umount in the BootLoaderConfigGrub2 class instance happened. This commit address the potential race condition.