### PR TITLE
Initrd dialog adaptions

### DIFF
--- a/doc/source/concept_and_workflow/customize_the_boot_process.rst
+++ b/doc/source/concept_and_workflow/customize_the_boot_process.rst
@@ -268,6 +268,12 @@ the available kernel boot parameters for this modules:
   Tells a live ISO image the name of the squashfs
   image file which holds the OS root. Defaults to `squashfs.img`.
 
+``rd.kiwi.allow_plymouth``
+  By default kiwi stops plymouth if present and active in the
+  initrd. Setting rd.kiwi.allow_plymouth will keep plymouth
+  active in the initrd including all effects that might have
+  to the available consoles.
+
 Boot Debugging
 ''''''''''''''
 

--- a/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
@@ -58,8 +58,10 @@ function get_dialog_result {
 }
 
 function stop_plymouth {
-    if command -v plymouth &>/dev/null;then
-        plymouth --quit --wait
+    if ! getargbool 0 rd.kiwi.allow_plymouth; then
+        if command -v plymouth &>/dev/null;then
+            plymouth --quit --wait
+        fi
     fi
 }
 

--- a/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
@@ -116,12 +116,7 @@ function _fbiterm_ok {
         # no framebuffer terminal program found
         return 1
     fi
-    if command -v isconsole &>/dev/null;then
-        if ! isconsole;then
-            # inappropriate ioctl (not a linux console)
-            return 1
-        fi
-    elif ! fbiterm echo &>/dev/null;then
+    if ! fbiterm echo &>/dev/null;then
         # fbiterm can't be called with echo test cmd
         return 1
     fi


### PR DESCRIPTION
This patch is two fold

**Add initrd boot option rd.kiwi.allow_plymouth**
    
By default kiwi stops plymouth if present and active in the initrd. Setting rd.kiwi.allow_plymouth will keep plymouth active in the initrd including all effects that might have  to the available consoles.


**Drop use of obsolete tool isconsole**
    
isconsole was provided with the dropped kiwi-tools package. It was a simple C application that checked the capabilities  of the current console. In the context of fbiterm it was just used to provide proper error messages which fbiterm on its own did not show. As also fbiterm is on its way to become obsolete and isconsole is already no longer present, it's ok to just drop that extra check and therefore keep the fbiterm mode functional if one manages to include fbiterm and its fonts into the initrd