### PR TITLE
Fixed profile variable settings for preferences

### DIFF
--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -244,7 +244,7 @@ class Profile:
         # kiwi_language
         # kiwi_splash_theme
         # kiwi_loader_theme
-        for preferences in self.xml_state.get_preferences_sections():
+        for preferences in reversed(self.xml_state.get_preferences_sections()):
             if 'kiwi_iversion' not in self.dot_profile:
                 self.dot_profile['kiwi_iversion'] = \
                     self._text(preferences.get_version())


### PR DESCRIPTION
It's allowed to have multiple preferences sections. If those sections provides the same value multiple times, e.g keytable, the last one in the row will win. The setup of the variables in .profile environment file for the preferences elements is not following this rule and used the first section not the last. This commit fixes the profile variables to match the actual setup and Fixes #2560

