### PR TITLE
Better error handling on grub vendor dir lookup

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -396,6 +396,8 @@ Conflicts:      kiwi-man-pages < %{version}
 Requires:       screen
 Requires:       file
 Requires:       sed
+Requires:       bash
+Recommends:     bash-completion
 Requires:       python%{python3_pkgversion} >= 3.9
 %if 0%{?ubuntu} || 0%{?debian}
 Requires:       python%{python3_pkgversion}-yaml


### PR DESCRIPTION
The strings command is used to lookup the in-efi binary encoded vendor path. However, if the strings or bash command is not availabe on the build host, the command silently failed and moved into the standard (non vendored) EFI boot path. This can lead to a broken boot for those distros and image targets which requires a vendor directory and should lead to an error message instead of a successful image build. This Fixes #2565

