### PR TITLE
Allow to customize the path of the isoscan cowfile

### DIFF
--- a/doc/source/concept_and_workflow/customize_the_boot_process.rst
+++ b/doc/source/concept_and_workflow/customize_the_boot_process.rst
@@ -253,6 +253,13 @@ the available kernel boot parameters for these modules:
   a COW file (live_system.cow) of a partition is created alongside the live ISO
   image file. The default size of the COW file is 500MB.
 
+``rd.live.cowfile.path``
+  Effectively used in isoscan loop mounted live systems. For details on this
+  type of live system refer to :ref:`iso_as_file_to_usb_stick`.
+  Specifies the path of the COW file below the `/run/initramfs/isoscan` loop
+  mount point. If not specified the cowfile is placed at
+  `/run/initramfs/isoscan/live_system.cow`.
+
 ``rd.live.dir``
   Specifies a directory that contains the live OS root directory. Default is
   `LiveOS`.

--- a/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
@@ -108,6 +108,9 @@ function initGlobalOptions {
 
     cow_file_mbsize=$(getarg rd.live.cowfile.mbsize)
     [ -z "${cow_file_mbsize}" ] && cow_file_mbsize="500"
+
+    cow_file_path=$(getarg rd.live.cowfile.path)
+    [ -z "${cow_file_path}" ] && cow_file_path="live_system.cow"
 }
 
 function mountIso {
@@ -193,7 +196,7 @@ function preparePersistentOverlayLoopBoot {
     # or the default size of 500MB
     local overlay_mount_point=$1
     local isoscan_loop_mount=/run/initramfs/isoscan
-    local cow_file_name="${isoscan_loop_mount}/live_system.cow"
+    local cow_file_name="${isoscan_loop_mount}/${cow_file_path}"
     mkdir -m 0755 -p "${overlay_mount_point}"
     if ! mount -o "remount,rw" "${isoscan_loop_mount}"; then
         return 1


### PR DESCRIPTION
Added rd.live.cowfile.path option to specify the cowfile at any path below the isoscan-loop-mount. This Fixes #2554

