### PR TITLE
Fix displaying the image verification failure dialog

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -315,11 +315,11 @@ function check_image_integrity {
     then
         # verify with dialog based progress information
         setup_progress_fifo ${progress}
-        run_progress_dialog "${verify_text}" "${title_text}" &
         (
             pv --size $((blocks * blocksize)) --stop-at-size \
             -n "${image_target}" | md5sum - > ${verify_result}
-        ) 2>${progress}
+        ) 2>${progress} &
+        run_progress_dialog "${verify_text}" "${title_text}"
     else
         # verify with silently blocked console
         head --bytes=$((blocks * blocksize)) "${image_target}" |\


### PR DESCRIPTION
Kiwi must wait for the previous dialog to finish before showing another one as it's the same systemd service behind it.

Without this, the failure dialog fails (how ironic):

```
-------------+---------------------------------------------------------------+|
Verifying /dev/disk/by-path/ccw-0.0.0160                      ||
                                               ||  +----------------------------
-----------------------------+  ||  |                            0%
              |  ||  +---------------------------------------------------------+
  |+---------------------------------------------------------------+
                9                      1                 2           3     4857%
  67%        76%             86%                   95%                        10
0%                            [ [0;32m  OK   [0m] Finished  [0;1;39mDracut Run I
nteractive [0m.
[   52.852546] dracut-pre-mount[1120]: cat: /tmp/dialog_code: No such file or di
rectory
[   52.852789] dracut-pre-mount[716]: /lib/kiwi-dialog-lib.sh: line 21: return:
: numeric argument required
```

(Ignore the screwed up display, running in an x3270)