### PR TITLE
test-image-live: add shadow package

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
@@ -68,6 +68,7 @@
         <package name="vim"/>
         <package name="lvm2"/>
         <package name="plymouth"/>
+        <package name="shadow"/>
         <package name="fontconfig"/>
         <package name="fonts-config"/>
         <package name="tar"/>


### PR DESCRIPTION
Fixes:
KiwiCommandError: chroot: stderr: /usr/bin/chroot: failed to run command ‘usermod’: No such file or directory

