### PR TITLE
Fixed selinux labels for boot files

### DIFF
--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -27,6 +27,7 @@ from kiwi.storage.setup import DiskSetup
 from kiwi.path import Path
 from kiwi.defaults import Defaults
 from kiwi.utils.block import BlockID
+from kiwi.system.setup import SystemSetup
 
 from kiwi.exceptions import (
     KiwiBootLoaderTargetError
@@ -583,6 +584,10 @@ class BootLoaderConfigBase(ABC):
 
     def _umount_system(self):
         if self.system_is_mounted:
+            # Rebuild security context
+            setup = SystemSetup(self.xml_state, self.root_mount.mountpoint)
+            setup.setup_selinux_file_contexts()
+            # Umount system
             for volume_mount in reversed(self.volumes_mount):
                 volume_mount.umount()
             if self.device_mount:

--- a/kiwi/bootloader/install/__init__.py
+++ b/kiwi/bootloader/install/__init__.py
@@ -17,6 +17,7 @@
 #
 import importlib
 from typing import Dict
+from kiwi.xml_state import XMLState
 from abc import (
     ABCMeta,
     abstractmethod
@@ -42,7 +43,7 @@ class BootLoaderInstall(metaclass=ABCMeta):
 
     @staticmethod
     def new(
-        name: str, root_dir: str, device_provider: object,
+        name: str, xml_state: XMLState, root_dir: str, device_provider: object,
         custom_args: Dict = None
     ):
         name_map = {
@@ -58,7 +59,7 @@ class BootLoaderInstall(metaclass=ABCMeta):
                 'kiwi.bootloader.install.{}'.format(bootloader_namespace)
             )
             return bootloader_install.__dict__[bootloader_name](
-                root_dir, device_provider, custom_args
+                xml_state, root_dir, device_provider, custom_args
             )
         except Exception:
             raise KiwiBootLoaderInstallSetupError(

--- a/kiwi/bootloader/install/base.py
+++ b/kiwi/bootloader/install/base.py
@@ -25,7 +25,10 @@ class BootLoaderInstallBase:
     :param object device_provider: instance of :class:`DeviceProvider`
     :param dict custom_args: custom arguments dictionary
     """
-    def __init__(self, root_dir, device_provider, custom_args=None):
+    def __init__(
+        self, xml_state, root_dir, device_provider, custom_args=None
+    ):
+        self.xml_state = xml_state
         self.root_dir = root_dir
         self.device_provider = device_provider
 

--- a/kiwi/bootloader/install/grub2.py
+++ b/kiwi/bootloader/install/grub2.py
@@ -26,6 +26,7 @@ from kiwi.bootloader.install.base import BootLoaderInstallBase
 from kiwi.command import Command
 from kiwi.defaults import Defaults
 from kiwi.mount_manager import MountManager
+from kiwi.system.setup import SystemSetup
 from kiwi.path import Path
 
 from kiwi.exceptions import (
@@ -251,6 +252,10 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
                 Command.run(
                     ['mv', zipl_config_file, zipl_config_file + '.kiwi']
                 )
+
+            # Rebuild security context
+            setup = SystemSetup(self.xml_state, self.root_mount.mountpoint)
+            setup.setup_selinux_file_contexts()
 
     def secure_boot_install(self):
         if self.firmware and self.firmware.efi_mode() == 'uefi' and (

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1753,8 +1753,8 @@ class DiskBuilder:
                 custom_install_arguments
             )
             bootloader = BootLoaderInstall.new(
-                self.bootloader, self.root_dir, disk.storage_provider,
-                custom_install_arguments
+                self.bootloader, self.xml_state, self.root_dir,
+                disk.storage_provider, custom_install_arguments
             )
             if bootloader.install_required():
                 bootloader.install()

--- a/test/unit/bootloader/config/base_test.py
+++ b/test/unit/bootloader/config/base_test.py
@@ -353,7 +353,10 @@ class TestBootLoaderConfigBase:
         ]
 
     @patch('kiwi.bootloader.config.base.MountManager')
-    def test_mount_system(self, mock_MountManager):
+    @patch('kiwi.bootloader.config.base.SystemSetup')
+    def test_mount_system(self, mock_SystemSetup, mock_MountManager):
+        setup = Mock()
+        mock_SystemSetup.return_value = setup
         tmp_mount = MagicMock()
         proc_mount = MagicMock()
         sys_mount = MagicMock()
@@ -408,6 +411,8 @@ class TestBootLoaderConfigBase:
             proc_mount.bind_mount.assert_called_once_with()
             sys_mount.bind_mount.assert_called_once_with()
             dev_mount.bind_mount.assert_called_once_with()
+
+        setup.setup_selinux_file_contexts.assert_called_once_with()
 
         volume_mount.umount.assert_called_once_with()
         tmp_mount.umount.assert_called_once_with()

--- a/test/unit/bootloader/install/base_test.py
+++ b/test/unit/bootloader/install/base_test.py
@@ -7,7 +7,7 @@ from kiwi.bootloader.install.base import BootLoaderInstallBase
 class TestBootLoaderInstallBase:
     def setup(self):
         self.bootloader = BootLoaderInstallBase(
-            'root_dir', Mock()
+            Mock(), 'root_dir', Mock()
         )
 
     def setup_method(self, cls):

--- a/test/unit/bootloader/install/grub2_test.py
+++ b/test/unit/bootloader/install/grub2_test.py
@@ -1,6 +1,6 @@
 import io
 from unittest.mock import (
-    patch, call, MagicMock
+    patch, call, MagicMock, Mock
 )
 from pytest import raises
 import unittest.mock as mock
@@ -86,7 +86,7 @@ class TestBootLoaderInstallGrub2:
         )
 
         self.bootloader = BootLoaderInstallGrub2(
-            'root_dir', device_provider, self.custom_args
+            Mock(), 'root_dir', device_provider, self.custom_args
         )
 
     def setup_method(self, cls):
@@ -155,10 +155,13 @@ class TestBootLoaderInstallGrub2:
     @patch('kiwi.bootloader.install.grub2.MountManager')
     @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
     @patch('kiwi.bootloader.install.grub2.glob.glob')
+    @patch('kiwi.bootloader.install.grub2.SystemSetup')
     def test_install_with_extra_boot_partition(
-        self, mock_glob, mock_grub_path, mock_mount_manager,
-        mock_command, mock_which, mock_wipe
+        self, mock_SystemSetup, mock_glob, mock_grub_path,
+        mock_mount_manager, mock_command, mock_which, mock_wipe
     ):
+        setup = Mock()
+        mock_SystemSetup.return_value = setup
         mock_glob.return_value = ['tmp_root/boot/grub2/grubenv']
         mock_grub_path.return_value = \
             self.root_mount.mountpoint + '/usr/lib/grub2/i386-pc'
@@ -194,6 +197,7 @@ class TestBootLoaderInstallGrub2:
                 '/dev/some-device'
             ]
         )
+        setup.setup_selinux_file_contexts.assert_called_once_with()
 
     @patch('kiwi.bootloader.install.grub2.Path.wipe')
     @patch('kiwi.bootloader.install.grub2.Path.which')
@@ -249,10 +253,13 @@ class TestBootLoaderInstallGrub2:
     @patch('kiwi.bootloader.install.grub2.MountManager')
     @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
     @patch('kiwi.bootloader.install.grub2.glob.glob')
+    @patch('kiwi.bootloader.install.grub2.SystemSetup')
     def test_install_ppc_ieee1275(
-        self, mock_glob, mock_grub_path, mock_mount_manager,
+        self, mock_SystemSetup, mock_glob, mock_grub_path, mock_mount_manager,
         mock_command, mock_which, mock_wipe
     ):
+        setup = Mock()
+        mock_SystemSetup.return_value = setup
         mock_glob.return_value = ['tmp_root/boot/grub2/grubenv']
         mock_grub_path.return_value = \
             self.root_mount.mountpoint + '/usr/lib/grub2/powerpc-ieee1275'
@@ -283,6 +290,7 @@ class TestBootLoaderInstallGrub2:
                 self.custom_args['prep_device']
             ]
         )
+        setup.setup_selinux_file_contexts.assert_called_once_with()
 
     @patch('kiwi.bootloader.install.grub2.Path.wipe')
     @patch('kiwi.bootloader.install.grub2.Path.which')
@@ -290,10 +298,13 @@ class TestBootLoaderInstallGrub2:
     @patch('kiwi.bootloader.install.grub2.MountManager')
     @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
     @patch('kiwi.bootloader.install.grub2.glob.glob')
+    @patch('kiwi.bootloader.install.grub2.SystemSetup')
     def test_install_s390_emu(
-        self, mock_glob, mock_grub_path, mock_mount_manager,
+        self, mock_SystemSetup, mock_glob, mock_grub_path, mock_mount_manager,
         mock_command, mock_which, mock_wipe
     ):
+        setup = Mock()
+        mock_SystemSetup.return_value = setup
         mock_glob.return_value = ['tmp_root/boot/grub2/grubenv']
         mock_grub_path.return_value = \
             self.root_mount.mountpoint + '/usr/lib/grub2/s390x-emu'
@@ -324,6 +335,7 @@ class TestBootLoaderInstallGrub2:
                 '/dev/some-device'
             ]
         )
+        setup.setup_selinux_file_contexts.assert_called_once_with()
 
     @patch('kiwi.bootloader.install.grub2.Path.wipe')
     @patch('kiwi.bootloader.install.grub2.Path.which')
@@ -331,10 +343,13 @@ class TestBootLoaderInstallGrub2:
     @patch('kiwi.bootloader.install.grub2.MountManager')
     @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
     @patch('kiwi.bootloader.install.grub2.glob.glob')
+    @patch('kiwi.bootloader.install.grub2.SystemSetup')
     def test_install(
-        self, mock_glob, mock_grub_path, mock_mount_manager,
+        self, mock_SystemSetup, mock_glob, mock_grub_path, mock_mount_manager,
         mock_command, mock_which, mock_wipe
     ):
+        setup = Mock()
+        mock_SystemSetup.return_value = setup
         mock_which.return_value = None
         mock_glob.return_value = ['tmp_root/boot/grub2/grubenv']
         mock_grub_path.return_value = \
@@ -368,7 +383,9 @@ class TestBootLoaderInstallGrub2:
                     Defaults.get_grub_bios_modules(multiboot=True)
                 ),
                 '/dev/some-device'
-            ])
+            ]
+        )
+        setup.setup_selinux_file_contexts.assert_called_once_with()
 
     @patch('kiwi.bootloader.install.grub2.Command.run')
     @patch('kiwi.bootloader.install.grub2.MountManager')

--- a/test/unit/bootloader/install/init_test.py
+++ b/test/unit/bootloader/install/init_test.py
@@ -10,10 +10,13 @@ from kiwi.bootloader.install import BootLoaderInstall
 class TestBootLoaderInstall:
     def test_bootloader_install_not_implemented(self):
         with raises(KiwiBootLoaderInstallSetupError):
-            BootLoaderInstall.new('foo', 'root_dir', Mock())
+            BootLoaderInstall.new('foo', Mock(), 'root_dir', Mock())
 
     @patch('kiwi.bootloader.install.grub2.BootLoaderInstallGrub2')
     def test_bootloader_install_grub2(self, mock_grub2):
         device_provider = Mock()
-        BootLoaderInstall.new('grub2', 'root_dir', device_provider)
-        mock_grub2.assert_called_once_with('root_dir', device_provider, None)
+        xml_state = Mock()
+        BootLoaderInstall.new('grub2', xml_state, 'root_dir', device_provider)
+        mock_grub2.assert_called_once_with(
+            xml_state, 'root_dir', device_provider, None
+        )

--- a/test/unit/bootloader/install/systemd_boot_test.py
+++ b/test/unit/bootloader/install/systemd_boot_test.py
@@ -7,7 +7,7 @@ from kiwi.bootloader.install.systemd_boot import BootLoaderInstallSystemdBoot
 class TestBootLoaderInstallSystemdBoot:
     def setup(self):
         self.bootloader = BootLoaderInstallSystemdBoot(
-            'root_dir', Mock()
+            Mock(), 'root_dir', Mock()
         )
 
     def setup_method(self, cls):

--- a/test/unit/bootloader/install/zipl_test.py
+++ b/test/unit/bootloader/install/zipl_test.py
@@ -7,7 +7,7 @@ from kiwi.bootloader.install.zipl import BootLoaderInstallZipl
 class TestBootLoaderInstallZipl:
     def setup(self):
         self.bootloader = BootLoaderInstallZipl(
-            'root_dir', Mock()
+            Mock(), 'root_dir', Mock()
         )
 
     def setup_method(self, cls):


### PR DESCRIPTION
When kiwi calls the bootloader config and installation modules several files gets created as unlabeled_t because the labeling happened earlier. This commit ensures that setfiles gets called after BootLoaderConfig and/or BootLoaderInstall has done its job. This Fixes #2568

