### PR TITLE
Fixed repository include to image with dnf

### DIFF
--- a/kiwi/repository/dnf4.py
+++ b/kiwi/repository/dnf4.py
@@ -246,6 +246,8 @@ class RepositoryDnf4(RepositoryBase):
             repo_config.set(
                 name, 'module_hotfixes', '1'
             )
+        if not os.path.isdir(self.shared_dnf_dir['reposd-dir']):
+            Path.create(self.shared_dnf_dir['reposd-dir'])
         with open(repo_file, 'w') as repo:
             repo_config.write(repo)
         if customization_script:

--- a/kiwi/repository/dnf5.py
+++ b/kiwi/repository/dnf5.py
@@ -246,6 +246,8 @@ class RepositoryDnf5(RepositoryBase):
             repo_config.set(
                 name, 'module_hotfixes', '1'
             )
+        if not os.path.isdir(self.shared_dnf_dir['reposd-dir']):
+            Path.create(self.shared_dnf_dir['reposd-dir'])
         with open(repo_file, 'w') as repo:
             repo_config.write(repo)
         if customization_script:

--- a/test/unit/repository/dnf4_test.py
+++ b/test/unit/repository/dnf4_test.py
@@ -110,9 +110,13 @@ class TestRepositoryDnf4:
     @patch('kiwi.repository.dnf4.Defaults.is_buildservice_worker')
     @patch('os.path.exists')
     @patch('kiwi.command.Command.run')
+    @patch('os.path.isdir')
+    @patch('kiwi.repository.dnf4.Path')
     def test_add_repo(
-        self, mock_Command_run, mock_exists, mock_buildservice, mock_config
+        self, mock_Path, mock_os_path_isdir, mock_Command_run, mock_exists,
+        mock_buildservice, mock_config
     ):
+        mock_os_path_isdir.return_value = False
         repo_config = mock.Mock()
         mock_buildservice.return_value = False
         mock_config.return_value = repo_config
@@ -141,6 +145,7 @@ class TestRepositoryDnf4:
                     '/shared-dir/dnf/repos/foo.repo'
                 ]
             )
+            mock_Path.create.assert_called_once_with('/shared-dir/dnf/repos')
 
         repo_config.add_section.reset_mock()
         repo_config.set.reset_mock()

--- a/test/unit/repository/dnf5_test.py
+++ b/test/unit/repository/dnf5_test.py
@@ -110,9 +110,13 @@ class TestRepositoryDnf5:
     @patch('kiwi.repository.dnf5.Defaults.is_buildservice_worker')
     @patch('os.path.exists')
     @patch('kiwi.command.Command.run')
+    @patch('os.path.isdir')
+    @patch('kiwi.repository.dnf5.Path')
     def test_add_repo(
-        self, mock_Command_run, mock_exists, mock_buildservice, mock_config
+        self, mock_Path, mock_os_path_isdir, mock_Command_run, mock_exists,
+        mock_buildservice, mock_config
     ):
+        mock_os_path_isdir.return_value = False
         repo_config = mock.Mock()
         mock_buildservice.return_value = False
         mock_config.return_value = repo_config
@@ -141,6 +145,7 @@ class TestRepositoryDnf5:
                     '/shared-dir/dnf/repos/foo.repo'
                 ]
             )
+            mock_Path.create.assert_called_once_with('/shared-dir/dnf/repos')
 
         repo_config.add_section.reset_mock()
         repo_config.set.reset_mock()


### PR DESCRIPTION
When specifying a repository element with ```imageinclude="true"```, kiwi permanently adds the repo file inside of the image. The distribution standard path is used to store the repo file in this case. With dnf a package manager exists that is primarily used on Fedora and RHEL systems. Thus the standard path for the repo files is set to ```/etc/yum.repos.d```. However, dnf can also be used for other rpm based distributions e.g SUSE. On such a system the default path does not exist or is different because another package manager is the default. This commit makes sure that the expected path is created prior adding any repo files.

