### PR TITLE
Added rd.kiwi.oem.skip_resize_check boot option

### DIFF
--- a/doc/source/concept_and_workflow/customize_the_boot_process.rst
+++ b/doc/source/concept_and_workflow/customize_the_boot_process.rst
@@ -217,6 +217,20 @@ the available kernel boot parameters for these modules:
   with a 480G RAID1 configured for OS deployment. With
   `rd.kiwi.oem.maxdisk=500G`, the deployment is performed on the RAID disk.
 
+``rd.kiwi.oem.force_resize``
+  Forces the disk resize process on an OEM disk image. If set, no sanity
+  check for unpartitioned/free space is performed and also an eventually
+  configured `<oem-resize-once>` configuration from the image description
+  will not be taken into account. The disk resize will be started which
+  includes re-partition as well as all steps to resize the block layers
+  up to the filesystem holding the data. As `rd.kiwi.oem.force_resize`
+  bypasses all sanity checks to detect if such a resize process is
+  needed or not, it can happen that all program calls of the resize
+  process ends without any effect if the disk is already properly
+  resized. It's also important to understand that the partition UUIDs
+  will change on every resize which might be an unwanted side effect
+  of a forced resize.
+
 ``rd.kiwi.oem.installdevice``
   Configures the disk device to use in an OEM installation. This overwrites or
   resets any other OEM device-specific settings, such as `oem-device-filter`,

--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -404,6 +404,11 @@ function resize_wanted {
     local root_device=$1
     local disk_device=$2
     kiwi_oemresizeonce=$(bool "${kiwi_oemresizeonce}")
+    if getargbool 0 rd.kiwi.oem.force_resize; then
+        info "System resize forced via rd.kiwi.oem.force_resize"
+        info "Activating resize operation"
+        return 0
+    fi
     if [ "${kiwi_oemresizeonce}" = "true" ];then
         current_rootpart_uuid=$(get_partition_uuid "${root_device}")
         if [ "${current_rootpart_uuid}" == "${kiwi_rootpartuuid}" ];then


### PR DESCRIPTION
Specifies to skip the check for unallocated space on a GPT partitioned disk. GPT disks holds a backup table at the end of the disk. Dumping an image to a disk that is larger than the image itself will therefore leave a gab between the backup table and the real end of the disk. kiwi uses this situation to detect if there is free space available for a subsequent resize operation. However, smart firmware implementations can also detect this and sometimes moves the backup table but without any proper resize operation. In such a case rd.kiwi.oem.skip_resize_check will force the resize. This Fixes bsc#1224389

