### PR TITLE
package: Add fully qualified provides for python3-kiwi in spec

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -32,6 +32,14 @@
 %global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 %endif
 
+%if %{undefined python3_version}
+%global python3_version %(%{__python3} -Esc "import sys; sys.stdout.write('{0.major}.{0.minor}'.format(sys.version_info))")
+%endif
+
+%if %{undefined python3_version_nodots}
+%global python3_version_nodots %(%{__python3} -Esc "import sys; sys.stdout.write('{0.major}{0.minor}'.format(sys.version_info))")
+%endif
+
 %if 0%{?debian} || 0%{?ubuntu}
 %global is_deb 1
 %global pygroup python
@@ -390,6 +398,13 @@ leverage all functionality in KIWI.
 %package -n python%{python3_pkgversion}-kiwi
 Summary:        KIWI - Appliance Builder Next Generation
 Group:          %{pygroup}
+%if "%{python3_pkgversion}" == "3"
+%if 0%{?suse_version}
+Provides:       python%{python3_version_nodots}-kiwi = %{version}-%{release}
+%else
+Provides:       python%{python3_version}-kiwi = %{version}-%{release}
+%endif
+%endif
 Obsoletes:      python2-kiwi
 Conflicts:      python2-kiwi
 Conflicts:      kiwi-man-pages < %{version}


### PR DESCRIPTION
On SUSE distributions, currently the expectation is that packages built against the Python interpreter should have fully qualified names in the form of `pythonXY-<modulename>`. Additionally, all other Linux distributions prefer something similar in the form of `pythonX.Y-<modulename>`.

This ensures we have those names so that distribution dependency generation works as expected.
