### PR TITLE
Split out bash completion into a sub-package

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -412,7 +412,6 @@ Requires:       screen
 Requires:       file
 Requires:       sed
 Requires:       bash
-Recommends:     bash-completion
 Requires:       python%{python3_pkgversion} >= 3.9
 %if 0%{?ubuntu} || 0%{?debian}
 Requires:       python%{python3_pkgversion}-yaml
@@ -655,6 +654,17 @@ Group:          %{sysgroup}
 %description -n kiwi-man-pages
 Provides manual pages to describe the kiwi commands
 
+%package -n kiwi-bash-completion
+Summary:        Bash Completion for kiwi-ng
+Requires:       bash-completion
+Requires:       python%{python3_pkgversion}-kiwi = %{version}
+Supplements:    (%{name} and bash-completion)
+BuildArch:      noarch
+
+%description -n kiwi-bash-completion
+Bash command line completion support for python-kiwi - completion
+of subcommands, parameters and keywords for the kiwi-ng command.
+
 %prep
 %setup -q -n kiwi-%{version}
 
@@ -764,10 +774,12 @@ fi
 %{_bindir}/kiwi-ng
 %{_bindir}/kiwi-ng-3*
 %{python3_sitelib}/kiwi*
-%{_usr}/share/bash-completion/completions/kiwi-ng
 %{_usr}/share/kiwi/xsl_to_v74/
 %{_defaultdocdir}/python-kiwi/LICENSE
 %{_defaultdocdir}/python-kiwi/README
+
+%files -n kiwi-bash-completion
+%{_usr}/share/bash-completion/completions/kiwi-ng
 
 %files -n kiwi-man-pages
 %config %_sysconfdir/kiwi.yml


### PR DESCRIPTION
Per review of the SUSE packaging team we should split out the bash completion into its own sub-package to give users better control over the completion feature.

