### PR TITLE
Update requires for kiwi-systemdeps-disk-images

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -334,6 +334,10 @@ Provides:       kiwi-image:vmx
 Requires:       kiwi-systemdeps-filesystems = %{version}-%{release}
 Requires:       kiwi-systemdeps-bootloaders = %{version}-%{release}
 Requires:       kiwi-systemdeps-iso-media = %{version}-%{release}
+%if 0%{?suse_version} >= 1650
+Requires:       binutils
+Requires:       glibc-gconv-modules-extra
+%endif
 %if 0%{?suse_version}
 Requires:       gptfdisk
 %else


### PR DESCRIPTION
On Tumbleweed several changes caused tools like strings or the codepage for mtools to be missing in a standard installation. For building disk images especially EFI capable ones with vendor information kiwi needs the above tool. This commit adds the packages providing them on Tumbleweed to the meta systemdeps for disk images. This Fixes #2585

