### PR TITLE
Add new eficsm type attribute

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-simple/appliance.kiwi
@@ -16,7 +16,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>breeze</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext3" kernelcmdline="console=ttyS0" firmware="uefi" format="vmdk">
+        <type image="oem" filesystem="ext3" kernelcmdline="console=ttyS0" firmware="uefi" eficsm="false" format="vmdk">
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>

--- a/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
@@ -37,7 +37,7 @@
         </type>
     </preferences>
     <preferences profiles="Secure">
-        <type image="iso" flags="overlay" firmware="uefi" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="true">
+        <type image="iso" flags="overlay" firmware="uefi" eficsm="false" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="true">
             <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -384,6 +384,11 @@ bootpartsize="nonNegativeInteger":
   specifies the size in MB. If not set the boot partition
   size is set to 200 MB
 
+eficsm="true|false":
+  For images with an EFI layout, specify if the legacy
+  CSM (BIOS) mode should be supported or not. By default
+  CSM mode is enabled.
+
 efipartsize="nonNegativeInteger":
   For images with an EFI fat partition this attribute
   specifies the size in MB. If not set the EFI partition
@@ -483,13 +488,31 @@ editbootinstall="file_path":
 filesystem="btrfs|ext2|ext3|ext4|squashfs|xfs":
   The root filesystem
 
-firmware="efi|uefi":
-  Specifies the boot firmware of the appliance, supported
-  options are: `bios`, `ec2`, `efi`, `uefi`, `ofw` and `opal`.
-  This attribute is used to differentiate the image according to the
-  firmware which boots up the system. It mostly impacts the disk
-  layout and the partition table type. By default `bios` is used on x86,
+firmware="efi|uefi|bios|ec2|ofw|opal":
+  Specifies the boot firmware of the appliance. This attribute is
+  used to differentiate the image according to the firmware which
+  boots up the system. It mostly impacts the disk layout and the
+  partition table type. By default `bios` is used on x86,
   `ofw` on PowerPC and `efi` on ARM.
+
+  * `efi`
+    Standard EFI layout
+
+  * `uefi`
+    Standard EFI layout for secure boot
+
+  * `bios`
+    Standard BIOS layout for x86
+
+  * `ec2`
+    Standard BIOS layout for x86 using Xen grub modules for old
+    style Xen boot in Amazon EC2
+
+  * `ofw`
+    Standard PPC layout
+
+  * `opal`
+    Standard openPOWER PPC64 layout. kexec based boot process
 
 force_mbr="true|false":
   Boolean parameter to force the usage of a MBR partition

--- a/kiwi/bootloader/install/grub2.py
+++ b/kiwi/bootloader/install/grub2.py
@@ -131,6 +131,13 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
                 'No grub boot code installation on %s', self.arch
             )
             return False
+        elif self.firmware.efi_mode() and not self.firmware.legacy_bios_mode():
+            # In EFI mode without CSM, no install
+            # of grub2 boot code makes sense
+            log.info(
+                'No grub boot code installation in EFI only mode'
+            )
+            return False
         return True
 
     def install(self):

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -160,7 +160,8 @@ class InstallImageBuilder:
                 'volume_id': self.iso_volume_id,
                 'mbr_id': self.mbrid.get_id(),
                 'efi_mode': self.firmware.efi_mode(),
-                'ofw_mode': self.firmware.ofw_mode()
+                'ofw_mode': self.firmware.ofw_mode(),
+                'legacy_bios_mode': self.firmware.legacy_bios_mode()
             }
         }
 

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -140,7 +140,8 @@ class LiveImageBuilder:
                 'preparer': Defaults.get_preparer(),
                 'volume_id': self.volume_id,
                 'mbr_id': self.mbrid.get_id(),
-                'efi_mode': self.firmware.efi_mode()
+                'efi_mode': self.firmware.efi_mode(),
+                'legacy_bios_mode': self.firmware.legacy_bios_mode()
             }
         }
 

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1261,7 +1261,7 @@ class Defaults:
         :rtype: dict
         """
         return {
-            'x86_64': ['efi', 'uefi', 'bios', 'ec2hvm', 'ec2'],
+            'x86_64': ['efi', 'uefi', 'bios', 'ec2'],
             'i586': ['bios'],
             'i686': ['bios'],
             'ix86': ['bios'],

--- a/kiwi/firmware.py
+++ b/kiwi/firmware.py
@@ -42,6 +42,8 @@ class FirmWare:
         self.firmware = xml_state.build_type.get_firmware()
         self.efipart_mbytes = xml_state.build_type.get_efipartsize()
         self.efi_partition_table = xml_state.build_type.get_efiparttable()
+        self.efi_csm = True if xml_state.build_type.get_eficsm() is None \
+            else xml_state.build_type.get_eficsm()
 
         if not self.firmware:
             self.firmware = Defaults.get_default_firmware(self.arch)
@@ -75,7 +77,7 @@ class FirmWare:
         else:
             return 'msdos'
 
-    def legacy_bios_mode(self):
+    def legacy_bios_mode(self) -> bool:
         """
         Check if the legacy boot from BIOS systems should be activated
 
@@ -84,14 +86,16 @@ class FirmWare:
         :rtype: bool
         """
         if self.get_partition_table_type() == 'gpt':
-            if self.arch == 'x86_64' or re.match('i.86', self.arch):
+            if (self.arch == 'x86_64' or re.match('i.86', self.arch)) and \
+               (self.firmware == 'efi' or self.firmware == 'uefi') and \
+               self.efi_csm:
                 return True
             else:
                 return False
         else:
             return False
 
-    def efi_mode(self):
+    def efi_mode(self) -> str:
         """
         Check if EFI mode is requested
 
@@ -101,6 +105,7 @@ class FirmWare:
         """
         if self.firmware in Defaults.get_efi_capable_firmware_names():
             return self.firmware
+        return ''
 
     def ec2_mode(self):
         """

--- a/kiwi/iso_tools/base.py
+++ b/kiwi/iso_tools/base.py
@@ -19,7 +19,7 @@ import os
 import shutil
 import logging
 from typing import (
-    Dict, List
+    Dict, List, Union
 )
 
 # project
@@ -61,7 +61,7 @@ class IsoToolsBase:
         raise NotImplementedError
 
     def init_iso_creation_parameters(
-        self, custom_args: Dict[str, str] = None
+        self, custom_args: Dict[str, Union[str, bool]] = None
     ) -> None:
         """
         Create a set of standard parameters for the main loader

--- a/kiwi/iso_tools/xorriso.py
+++ b/kiwi/iso_tools/xorriso.py
@@ -18,7 +18,7 @@
 import os
 import logging
 from typing import (
-    Dict, List, Optional
+    Dict, List, Optional, Union
 )
 
 # project
@@ -66,36 +66,39 @@ class IsoToolsXorrIso(IsoToolsBase):
         raise KiwiIsoToolError('xorriso tool not found')
 
     def init_iso_creation_parameters(
-        self, custom_args: Optional[Dict[str, str]] = None
+        self, custom_args: Optional[Dict[str, Union[str, bool]]] = None
     ) -> None:
         """
         Create a set of standard parameters
 
         :param list custom_args: custom ISO meta data
         """
+        legacy_bios_mode = True
         if custom_args:
             if 'mbr_id' in custom_args:
                 self.iso_parameters += [
-                    '-application_id', custom_args['mbr_id']
+                    '-application_id', format(custom_args['mbr_id'])
                 ]
             if 'publisher' in custom_args:
                 self.iso_parameters += [
-                    '-publisher', custom_args['publisher']
+                    '-publisher', format(custom_args['publisher'])
                 ]
             if 'preparer' in custom_args:
                 self.iso_parameters += [
-                    '-preparer_id', custom_args['preparer']
+                    '-preparer_id', format(custom_args['preparer'])
                 ]
             if 'volume_id' in custom_args:
                 self.iso_parameters += [
-                    '-volid', custom_args['volume_id']
+                    '-volid', format(custom_args['volume_id'])
                 ]
+            if 'legacy_bios_mode' in custom_args:
+                legacy_bios_mode = bool(custom_args['legacy_bios_mode'])
         catalog_file = self.boot_path + '/boot.catalog'
         self.iso_parameters += [
             '-joliet', 'on', '-padding', '0'
         ]
 
-        if Defaults.is_x86_arch(self.arch):
+        if Defaults.is_x86_arch(self.arch) and legacy_bios_mode:
             mbr_file = os.sep.join(
                 [
                     self.source_dir, self.boot_path, 'loader',

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1583,6 +1583,15 @@ div {
             sch:param [ name = "attr" value = "efipartsize" ]
             sch:param [ name = "types" value = "oem" ]
         ]
+    k.type.eficsm.attribute =
+        ## For images with an EFI layout, specify if the legacy
+        ## CSM (BIOS) mode should be supported or not. By default
+        ## CSM mode is enabled
+        attribute eficsm { xsd:boolean }
+        >> sch:pattern [ id = "eficsm" is-a = "image_type"
+            sch:param [ name = "attr" value = "eficsm" ]
+            sch:param [ name = "types" value = "oem iso" ]
+        ]
     k.type.efifatimagesize.attribute =
         ## For ISO images (live and install) the EFI boot requires
         ## an embedded FAT image. This attribute specifies the size
@@ -2235,6 +2244,7 @@ div {
         k.type.bootpartsize.attribute? &
         k.type.efipartsize.attribute? &
         k.type.efifatimagesize.attribute? &
+        k.type.eficsm.attribute? &
         k.type.efiparttable.attribute? &
         k.type.dosparttable_extended_layout.attribute? &
         k.type.bootprofile.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2293,6 +2293,18 @@ size is set to 20 MB</a:documentation>
         <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
+    <define name="k.type.eficsm.attribute">
+      <attribute name="eficsm">
+        <a:documentation>For images with an EFI layout, specify if the legacy
+CSM (BIOS) mode should be supported or not. By default
+CSM mode is enabled</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="eficsm" is-a="image_type">
+        <sch:param name="attr" value="eficsm"/>
+        <sch:param name="types" value="oem iso"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.efifatimagesize.attribute">
       <attribute name="efifatimagesize">
         <a:documentation>For ISO images (live and install) the EFI boot requires
@@ -3191,6 +3203,9 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.efifatimagesize.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.eficsm.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.efiparttable.attribute"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.29.24.
-# Python 3.11.9 (main, Apr 18 2024, 16:44:43) [GCC]
+# Python 3.11.8 (main, Feb 29 2024, 12:19:47) [GCC]
 #
 # Command line options:
 #   ('-f', '')
@@ -3067,7 +3067,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_subvolume=None, btrfs_set_default_volume=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, eficsm=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_subvolume=None, btrfs_set_default_volume=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -3077,6 +3077,7 @@ class type_(GeneratedsSuper):
         self.bootpartsize = _cast(int, bootpartsize)
         self.efipartsize = _cast(int, efipartsize)
         self.efifatimagesize = _cast(int, efifatimagesize)
+        self.eficsm = _cast(bool, eficsm)
         self.efiparttable = _cast(None, efiparttable)
         self.dosparttable_extended_layout = _cast(bool, dosparttable_extended_layout)
         self.bootprofile = _cast(None, bootprofile)
@@ -3269,6 +3270,8 @@ class type_(GeneratedsSuper):
     def set_efipartsize(self, efipartsize): self.efipartsize = efipartsize
     def get_efifatimagesize(self): return self.efifatimagesize
     def set_efifatimagesize(self, efifatimagesize): self.efifatimagesize = efifatimagesize
+    def get_eficsm(self): return self.eficsm
+    def set_eficsm(self, eficsm): self.eficsm = eficsm
     def get_efiparttable(self): return self.efiparttable
     def set_efiparttable(self, efiparttable): self.efiparttable = efiparttable
     def get_dosparttable_extended_layout(self): return self.dosparttable_extended_layout
@@ -3523,6 +3526,9 @@ class type_(GeneratedsSuper):
         if self.efifatimagesize is not None and 'efifatimagesize' not in already_processed:
             already_processed.add('efifatimagesize')
             outfile.write(' efifatimagesize="%s"' % self.gds_format_integer(self.efifatimagesize, input_name='efifatimagesize'))
+        if self.eficsm is not None and 'eficsm' not in already_processed:
+            already_processed.add('eficsm')
+            outfile.write(' eficsm="%s"' % self.gds_format_boolean(self.eficsm, input_name='eficsm'))
         if self.efiparttable is not None and 'efiparttable' not in already_processed:
             already_processed.add('efiparttable')
             outfile.write(' efiparttable=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.efiparttable), input_name='efiparttable')), ))
@@ -3835,6 +3841,15 @@ class type_(GeneratedsSuper):
                 raise_parse_error(node, 'Bad integer attribute: %s' % exp)
             if self.efifatimagesize < 0:
                 raise_parse_error(node, 'Invalid NonNegativeInteger')
+        value = find_attr_value_('eficsm', node)
+        if value is not None and 'eficsm' not in already_processed:
+            already_processed.add('eficsm')
+            if value in ('true', '1'):
+                self.eficsm = True
+            elif value in ('false', '0'):
+                self.eficsm = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('efiparttable', node)
         if value is not None and 'efiparttable' not in already_processed:
             already_processed.add('efiparttable')

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -79,7 +79,7 @@ class TestBootLoaderConfigGrub2:
             return_value=None
         )
         self.firmware.efi_mode = Mock(
-            return_value=None
+            return_value=''
         )
         mock_firmware.return_value = self.firmware
 
@@ -1381,7 +1381,7 @@ class TestBootLoaderConfigGrub2:
         Defaults.set_platform_name('x86_64')
         mock_get_boot_path.return_value = '/boot'
         self.firmware.efi_mode = Mock(
-            return_value=None
+            return_value=''
         )
         self.bootloader.xen_guest = True
         self.os_exists['root_dir/boot/grub2/fonts/unicode.pf2'] = False
@@ -1417,7 +1417,7 @@ class TestBootLoaderConfigGrub2:
         mock_get_boot_path.return_value = '/boot'
         self.bootloader.arch = 'ppc64le'
         self.firmware.efi_mode = Mock(
-            return_value=None
+            return_value=''
         )
         self.bootloader.xen_guest = False
         self.os_exists['root_dir/boot/grub2/fonts/unicode.pf2'] = False
@@ -1448,7 +1448,7 @@ class TestBootLoaderConfigGrub2:
         mock_get_boot_path.return_value = '/boot'
         self.bootloader.arch = 's390x'
         self.firmware.efi_mode = Mock(
-            return_value=None
+            return_value=''
         )
         self.bootloader.xen_guest = False
         self.os_exists['root_dir/boot/grub2/fonts/unicode.pf2'] = False

--- a/test/unit/bootloader/install/grub2_test.py
+++ b/test/unit/bootloader/install/grub2_test.py
@@ -141,6 +141,17 @@ class TestBootLoaderInstallGrub2:
         )
         assert self.bootloader.install_required() is False
 
+    def test_install_required_efi_no_csm(self):
+        self.bootloader.arch = 'x86_64'
+        self.bootloader.firmware = mock.Mock()
+        self.bootloader.firmware.efi_mode = mock.Mock(
+            return_value='efi'
+        )
+        self.bootloader.firmware.legacy_bios_mode = mock.Mock(
+            return_value=False
+        )
+        assert self.bootloader.install_required() is False
+
     def test_install_required_arm64(self):
         self.bootloader.arch = 'arm64'
         assert self.bootloader.install_required() is False

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -18,6 +18,9 @@ class TestLiveImageBuilder:
         Defaults.set_platform_name('x86_64')
 
         self.firmware = Mock()
+        self.firmware.legacy_bios_mode = Mock(
+            return_value=True
+        )
         self.firmware.efi_mode = Mock(
             return_value='uefi'
         )
@@ -355,7 +358,8 @@ class TestLiveImageBuilder:
                     'volume_id': 'volid',
                     'efi_mode': 'uefi',
                     'efi_loader': 'kiwi-tmpfile',
-                    'udf': True
+                    'udf': True,
+                    'legacy_bios_mode': True
                 }
             },
             device_provider=mock_DeviceProvider.return_value,

--- a/test/unit/firmware_test.py
+++ b/test/unit/firmware_test.py
@@ -87,7 +87,7 @@ class TestFirmWare:
         assert self.firmware_bios.ec2_mode() is None
 
     def test_efi_mode(self):
-        assert self.firmware_bios.efi_mode() is None
+        assert self.firmware_bios.efi_mode() == ''
         assert self.firmware_efi.efi_mode() == 'efi'
 
     def test_bios_mode(self):

--- a/test/unit/iso_tools/xorriso_test.py
+++ b/test/unit/iso_tools/xorriso_test.py
@@ -45,7 +45,8 @@ class TestIsoToolsXorrIso:
                     'publisher': 'org',
                     'preparer': 'preparer',
                     'volume_id': 'vol_id',
-                    'efi_mode': 'uefi'
+                    'efi_mode': 'uefi',
+                    'legacy_bios_mode': True
                 }
             )
             assert 'No hybrid MBR file found' in self._caplog.text
@@ -59,7 +60,8 @@ class TestIsoToolsXorrIso:
                 'publisher': 'org',
                 'preparer': 'preparer',
                 'volume_id': 'vol_id',
-                'efi_mode': 'uefi'
+                'efi_mode': 'uefi',
+                'legacy_bios_mode': True
             }
         )
         assert self.iso_tool.iso_parameters == [


### PR DESCRIPTION
Allow to produce EFI/UEFI images without hybrid CSM capabilities. This Fixes #2407

