### PR TITLE
Add --set-type-attr and --set-release-version

### DIFF
--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -28,6 +28,8 @@ SYNOPSIS
        [--set-container-derived-from=<uri>]
        [--set-container-tag=<name>]
        [--add-container-label=<label>...]
+       [--set-type-attr=<attribute=value>...]
+       [--set-release-version=<version>]
        [--signing-key=<key-file>...]
    kiwi-ng system build help
 
@@ -194,6 +196,16 @@ OPTIONS
   Overwrite the container tag in the container configuration.
   The setting is only effective if the container configuration
   provides the initial tag value.
+
+--set-type-attr=<attribute=value>
+
+  Overwrite/set the attribute with the provided value in the selected
+  build type section. Example: `--set-type-attr volid=some`
+
+--set-release-version=<version>
+
+  Overwrite/set the release-version element in the selected
+  build type preferences section
 
 --signing-key=<key-file>
 

--- a/doc/source/commands/system_prepare.rst
+++ b/doc/source/commands/system_prepare.rst
@@ -26,6 +26,8 @@ SYNOPSIS
        [--set-container-derived-from=<uri>]
        [--set-container-tag=<name>]
        [--add-container-label=<label>...]
+       [--set-type-attr=<attribute=value>...]
+       [--set-release-version=<version>]
        [--signing-key=<key-file>...]
    kiwi-ng system prepare help
 
@@ -195,6 +197,16 @@ OPTIONS
   Overwrite the container tag in the container configuration.
   The setting applies only if the container configuration
   provides an initial tag value.
+
+--set-type-attr=<attribute=value>
+
+  Overwrite/set the attribute with the provided value in the selected
+  build type section. Example: `--set-type-attr volid=some`
+
+--set-release-version=<version>
+
+  Overwrite/set the release-version element in the selected
+  build type preferences section
 
 --signing-key=<key-file>
 

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -236,6 +236,21 @@ class CliTask:
         """
         return self._ntuple_token(option, 10)
 
+    def attr_token(
+        self, option: str
+    ) -> List[Union[bool, str, List[str], None]]:
+        """
+        Helper method for commandline options of the
+        form --option attribute=value
+
+        :param str option: attribute=value string
+
+        :return: common option value representation
+
+        :rtype: list
+        """
+        return self._ntuple_token(option, 2, '=')
+
     def run_checks(self, checks: Dict[str, List[str]]) -> None:
         """
         This method runs the given runtime checks excluding the ones disabled
@@ -264,7 +279,7 @@ class CliTask:
             return token
 
     def _ntuple_token(
-        self, option: str, tuple_count: int
+        self, option: str, tuple_count: int, separator: str = ','
     ) -> List[Union[bool, str, List[str], None]]:
         """
         Helper method for commandline options of the form --option a,b,c,d,e,f
@@ -279,7 +294,7 @@ class CliTask:
 
         :rtype: list
         """
-        tokens = option.split(',', tuple_count - 1) if option else []
+        tokens = option.split(separator, tuple_count - 1) if option else []
         return [
             self._pop_token(tokens) if len(tokens) else None for _ in range(
                 0, tuple_count

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -32,6 +32,8 @@ usage: kiwi-ng system build -h | --help
            [--set-container-derived-from=<uri>]
            [--set-container-tag=<name>]
            [--add-container-label=<label>...]
+           [--set-type-attr=<attribute=value>...]
+           [--set-release-version=<version>]
            [--signing-key=<key-file>...]
        kiwi-ng system build help
 
@@ -104,6 +106,12 @@ options:
         password connected to the set-repo specification. If the provided
         value describes a filename in the filesystem, the first line of that
         file is read and used as credentials information.
+    --set-type-attr=<attribute=value>
+        overwrite/set the attribute with the provided value in the selected
+        build type section
+    --set-release-version=<version>
+        overwrite/set the release-version element in the selected
+        build type preferences section
     --signing-key=<key-file>
         includes the key-file as a trusted key for package manager validations
     --target-dir=<directory>
@@ -172,6 +180,32 @@ class SystemBuildTask(CliTask):
             }
         )
         self.run_checks(build_checks)
+
+        if self.command_args['--set-type-attr']:
+            for set_type_attr in self.command_args['--set-type-attr']:
+                (attribute, value) = self.attr_token(set_type_attr)
+                log.info(f'--> Set <type ... {attribute}="{value}" .../>')
+                try:
+                    eval(
+                        f'self.xml_state.build_type.set_{attribute}("{value}")'
+                    )
+                except AttributeError as issue:
+                    log.error(f'Failed to set type attribute: {issue}')
+                    return
+
+        if self.command_args['--set-release-version']:
+            release_version = self.command_args['--set-release-version']
+            log.info(f'--> Set <release-version> = {release_version}')
+            section_overwrite = False
+            for preferences in self.xml_state.get_preferences_sections():
+                section = preferences.get_release_version()
+                if section:
+                    section[0] = release_version
+                    section_overwrite = True
+                    break
+            if not section_overwrite:
+                preferences = self.xml_state.get_preferences_sections()[0]
+                preferences.add_release_version(release_version)
 
         if self.command_args['--ignore-repos']:
             self.xml_state.delete_repository_sections()

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -48,6 +48,8 @@ class TestCli:
         self.command_args = {
             '--add-repo': [],
             '--add-repo-credentials': [],
+            '--set-type-attr': [],
+            '--set-release-version': None,
             '--allow-existing-root': False,
             '--description': 'description',
             '--help': False,

--- a/test/unit/tasks/base_test.py
+++ b/test/unit/tasks/base_test.py
@@ -142,6 +142,9 @@ class TestCliTask:
             None, None, None
         ]
 
+    def test_attr_token(self):
+        assert self.task.attr_token('a=b') == ['a', 'b']
+
     @patch('kiwi.tasks.base.RuntimeChecker')
     def test_load_xml_description(self, mock_runtime_checker):
         self.task.load_xml_description('../data/description')


### PR DESCRIPTION
Allow to set/overwrite type section attributes via the cmdline. Allow to set/add the release-version element via the cmdline.
This Fixes #2478 and Fixes #2588

