### PR TITLE
Allow to set custom ISO Application ID

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -943,6 +943,11 @@ volid="string":
   For the ISO type only, specifies the volume ID (volume name or label)
   to be written into the master block. There is space for 32 characters.
 
+application_id="string":
+  For the ISO/(oem install ISO) type only, specifies the Application
+  ID to be written into the master block. There is space for
+  128 characters.
+
 vhdfixedtag="GUID_string":
   For the VHD disk format, specifies the GUID
 

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -159,6 +159,7 @@ class InstallImageBuilder:
             'meta_data': {
                 'volume_id': self.iso_volume_id,
                 'mbr_id': self.mbrid.get_id(),
+                'application_id': self.xml_state.build_type.get_application_id(),
                 'efi_mode': self.firmware.efi_mode(),
                 'ofw_mode': self.firmware.ofw_mode(),
                 'legacy_bios_mode': self.firmware.legacy_bios_mode()

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -140,6 +140,7 @@ class LiveImageBuilder:
                 'preparer': Defaults.get_preparer(),
                 'volume_id': self.volume_id,
                 'mbr_id': self.mbrid.get_id(),
+                'application_id': self.xml_state.build_type.get_application_id(),
                 'efi_mode': self.firmware.efi_mode(),
                 'legacy_bios_mode': self.firmware.legacy_bios_mode()
             }

--- a/kiwi/iso_tools/xorriso.py
+++ b/kiwi/iso_tools/xorriso.py
@@ -75,9 +75,11 @@ class IsoToolsXorrIso(IsoToolsBase):
         """
         legacy_bios_mode = True
         if custom_args:
-            if 'mbr_id' in custom_args:
+            application_id = \
+                custom_args.get('application_id') or custom_args.get('mbr_id')
+            if application_id:
                 self.iso_parameters += [
-                    '-application_id', format(custom_args['mbr_id'])
+                    '-application_id', format(application_id)
                 ]
             if 'publisher' in custom_args:
                 self.iso_parameters += [

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -26,6 +26,7 @@ namespace nul = ""
 
 safe-posix-name = xsd:token {pattern = "[a-zA-Z0-9_\-\.]+"}
 safe-posix-short-name = xsd:token {pattern = "[a-zA-Z0-9_\-\.]{1,32}"}
+safe-posix-long-name = xsd:token {pattern = "[a-zA-Z0-9_\-\.]{1,128}"}
 locale-name = xsd:token {pattern = "(POSIX|[a-z]{2,3}_[A-Z]{2})(,[a-z]{2,3}_[A-Z]{2})*"}
 mac-address-type = xsd:token {pattern = "([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}"}
 size-type = xsd:token {pattern = "(\d*|image)"}
@@ -2148,6 +2149,15 @@ div {
             sch:param [ name = "attr" value = "volid" ]
             sch:param [ name = "types" value = "iso oem" ]
         ]
+    k.type.application_id.attribute =
+        ## for the iso/(oem install iso) type only:
+        ## Specifies the Application ID to be written
+        ## into the master block. There is space for 128 characters.
+        attribute application_id { safe-posix-long-name }
+        >> sch:pattern [ id = "application_id" is-a = "image_type"
+            sch:param [ name = "attr" value = "application_id" ]
+            sch:param [ name = "types" value = "iso oem" ]
+        ]
     k.type.wwid_wait_timeout.attribute =
         ## Specifies the wait period in seconds after launching
         ## the multipath daemon to wait until all presented devices
@@ -2310,6 +2320,7 @@ div {
         k.type.vga.attribute? &
         k.type.vhdfixedtag.attribute? &
         k.type.volid.attribute? &
+        k.type.application_id.attribute? &
         k.type.wwid_wait_timeout.attribute? &
         k.type.derived_from.attribute? &
         k.type.delta_root.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -31,6 +31,11 @@
       <param name="pattern">[a-zA-Z0-9_\-\.]{1,32}</param>
     </data>
   </define>
+  <define name="safe-posix-long-name">
+    <data type="token">
+      <param name="pattern">[a-zA-Z0-9_\-\.]{1,128}</param>
+    </data>
+  </define>
   <define name="locale-name">
     <data type="token">
       <param name="pattern">(POSIX|[a-z]{2,3}_[A-Z]{2})(,[a-z]{2,3}_[A-Z]{2})*</param>
@@ -3064,6 +3069,18 @@ into the master block. There is space for 32 characters.</a:documentation>
         <sch:param name="types" value="iso oem"/>
       </sch:pattern>
     </define>
+    <define name="k.type.application_id.attribute">
+      <attribute name="application_id">
+        <a:documentation>for the iso/(oem install iso) type only:
+Specifies the Application ID to be written
+into the master block. There is space for 128 characters.</a:documentation>
+        <ref name="safe-posix-long-name"/>
+      </attribute>
+      <sch:pattern id="application_id" is-a="image_type">
+        <sch:param name="attr" value="application_id"/>
+        <sch:param name="types" value="iso oem"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.wwid_wait_timeout.attribute">
       <attribute name="wwid_wait_timeout">
         <a:documentation>Specifies the wait period in seconds after launching
@@ -3399,6 +3416,9 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.volid.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.application_id.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.wwid_wait_timeout.attribute"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.29.24.
-# Python 3.11.8 (main, Feb 29 2024, 12:19:47) [GCC]
+# Python 3.11.9 (main, Apr 18 2024, 16:44:43) [GCC]
 #
 # Command line options:
 #   ('-f', '')
@@ -3067,7 +3067,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, eficsm=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_subvolume=None, btrfs_set_default_volume=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, eficsm=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_subvolume=None, btrfs_set_default_volume=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, application_id=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -3143,6 +3143,7 @@ class type_(GeneratedsSuper):
         self.vga = _cast(None, vga)
         self.vhdfixedtag = _cast(None, vhdfixedtag)
         self.volid = _cast(None, volid)
+        self.application_id = _cast(None, application_id)
         self.wwid_wait_timeout = _cast(int, wwid_wait_timeout)
         self.derived_from = _cast(None, derived_from)
         self.delta_root = _cast(bool, delta_root)
@@ -3402,6 +3403,8 @@ class type_(GeneratedsSuper):
     def set_vhdfixedtag(self, vhdfixedtag): self.vhdfixedtag = vhdfixedtag
     def get_volid(self): return self.volid
     def set_volid(self, volid): self.volid = volid
+    def get_application_id(self): return self.application_id
+    def set_application_id(self, application_id): self.application_id = application_id
     def get_wwid_wait_timeout(self): return self.wwid_wait_timeout
     def set_wwid_wait_timeout(self, wwid_wait_timeout): self.wwid_wait_timeout = wwid_wait_timeout
     def get_derived_from(self): return self.derived_from
@@ -3457,6 +3460,13 @@ class type_(GeneratedsSuper):
                     self.validate_safe_posix_short_name_patterns_, value):
                 warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_safe_posix_short_name_patterns_, ))
     validate_safe_posix_short_name_patterns_ = [['^[a-zA-Z0-9_\\-\\.]{1,32}$']]
+    def validate_safe_posix_long_name(self, value):
+        # Validate type safe-posix-long-name, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_safe_posix_long_name_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_safe_posix_long_name_patterns_, ))
+    validate_safe_posix_long_name_patterns_ = [['^[a-zA-Z0-9_\\-\\.]{1,128}$']]
     def validate_number_type(self, value):
         # Validate type number-type, a restriction on xs:token.
         if value is not None and Validate_simpletypes_:
@@ -3724,6 +3734,9 @@ class type_(GeneratedsSuper):
         if self.volid is not None and 'volid' not in already_processed:
             already_processed.add('volid')
             outfile.write(' volid=%s' % (quote_attrib(self.volid), ))
+        if self.application_id is not None and 'application_id' not in already_processed:
+            already_processed.add('application_id')
+            outfile.write(' application_id=%s' % (quote_attrib(self.application_id), ))
         if self.wwid_wait_timeout is not None and 'wwid_wait_timeout' not in already_processed:
             already_processed.add('wwid_wait_timeout')
             outfile.write(' wwid_wait_timeout="%s"' % self.gds_format_integer(self.wwid_wait_timeout, input_name='wwid_wait_timeout'))
@@ -4281,6 +4294,12 @@ class type_(GeneratedsSuper):
             self.volid = value
             self.volid = ' '.join(self.volid.split())
             self.validate_safe_posix_short_name(self.volid)    # validate type safe-posix-short-name
+        value = find_attr_value_('application_id', node)
+        if value is not None and 'application_id' not in already_processed:
+            already_processed.add('application_id')
+            self.application_id = value
+            self.application_id = ' '.join(self.application_id.split())
+            self.validate_safe_posix_long_name(self.application_id)    # validate type safe-posix-long-name
         value = find_attr_value_('wwid_wait_timeout', node)
         if value is not None and 'wwid_wait_timeout' not in already_processed:
             already_processed.add('wwid_wait_timeout')

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -80,6 +80,9 @@ class TestLiveImageBuilder:
         self.xml_state.get_fs_create_option_list = Mock(
             return_value=['-O', 'option']
         )
+        self.xml_state.build_type.get_application_id = Mock(
+            return_value='0xffffffff'
+        )
         self.xml_state.build_type.get_flags = Mock(
             return_value=None
         )
@@ -353,6 +356,7 @@ class TestLiveImageBuilder:
             custom_args={
                 'meta_data': {
                     'mbr_id': '0xffffffff',
+                    'application_id': '0xffffffff',
                     'preparer': 'KIWI - https://github.com/OSInside/kiwi',
                     'publisher': 'Custom publisher',
                     'volume_id': 'volid',

--- a/test/unit/iso_tools/xorriso_test.py
+++ b/test/unit/iso_tools/xorriso_test.py
@@ -87,6 +87,31 @@ class TestIsoToolsXorrIso:
             '-boot_image', 'any', 'load_size=2048'
         ]
 
+    @patch('os.path.exists')
+    def test_init_iso_creation_parameters_efi_custom_app_id(
+        self, mock_os_path_exists
+    ):
+        mock_os_path_exists.return_value = True
+        self.iso_tool.init_iso_creation_parameters(
+            {
+                'mbr_id': 'app_id',
+                'application_id': 'some_other_app_id',
+                'publisher': 'org',
+                'preparer': 'preparer',
+                'volume_id': 'vol_id',
+                'efi_mode': 'uefi',
+                'legacy_bios_mode': True
+            }
+        )
+        assert self.iso_tool.iso_parameters == [
+            '-application_id', 'some_other_app_id',
+            '-publisher', 'org',
+            '-preparer_id', 'preparer',
+            '-volid', 'vol_id',
+            '-joliet', 'on',
+            '-padding', '0'
+        ]
+
     def test_add_efi_loader_parameters(self):
         self.iso_tool.add_efi_loader_parameters('target_dir/efi-loader')
         assert self.iso_tool.iso_loaders == [


### PR DESCRIPTION
Add new <type ... application_id="..."/> attribute to be set in the ISO header main block. The application ID was used as identifier in the legacy initrd code from former kiwi versions. Because of this there is still the compat layer which sets an App ID as MBR identifier string unless the new application_id overwrites it. This Fixes #1810

