### PR TITLE
Fixed logging behavior of Compress::get_format

### DIFF
--- a/kiwi/utils/compress.py
+++ b/kiwi/utils/compress.py
@@ -129,17 +129,9 @@ class Compress:
         :rtype: Optional[str]
         """
         for zipper in self.supported_zipper:
-            cmd = [zipper, '-l', self.source_filename]
-            try:
-                Command.run(cmd)
+            result = Command.run(
+                [zipper, '-l', self.source_filename], raise_on_error=False
+            )
+            if result.returncode == 0:
                 return zipper
-            except Exception as exc:
-                log.debug(
-                    'Error running "{cmd:s}", got a {exc_t:s}: {exc:s}'
-                    .format(
-                        cmd=' '.join(cmd),
-                        exc_t=type(exc).__name__,
-                        exc=str(exc)
-                    )
-                )
         return None

--- a/test/unit/tasks/result_bundle_test.py
+++ b/test/unit/tasks/result_bundle_test.py
@@ -191,14 +191,23 @@ class TestResultBundleTask:
     @patch('os.path.islink')
     @patch('os.symlink')
     @patch('os.readlink')
+    @patch('os.path.realpath')
+    @patch('os.path.abspath')
     def test_process_result_bundle_as_rpm(
-        self, mock_os_readlink, mock_os_symlink, mock_os_path_islink,
-        mock_iglob, mock_unlink, mock_chdir, mock_exists, mock_checksum,
-        mock_compress, mock_path_wipe, mock_path_which, mock_path_create,
-        mock_command, mock_load, mock_Privileges_check_for_root_permissions
+        self, mock_os_path_abspath, mock_os_path_realpath, mock_os_readlink,
+        mock_os_symlink, mock_os_path_islink, mock_iglob, mock_unlink,
+        mock_chdir, mock_exists, mock_checksum, mock_compress,
+        mock_path_wipe, mock_path_which, mock_path_create, mock_command,
+        mock_load, mock_Privileges_check_for_root_permissions
     ):
+        abs_path = ['bundle-dir', 'target-dir']
+
+        def side_effect(path):
+            return abs_path.pop()
+
         checksum = Mock()
         compress = Mock()
+        mock_os_path_abspath.side_effect = side_effect
         mock_path_which.return_value = 'zsyncmake'
         compress.xz.return_value = 'compressed_filename'
         mock_compress.return_value = compress
@@ -216,14 +225,14 @@ class TestResultBundleTask:
         with patch('builtins.open', m_open, create=True):
             self.task.process()
 
-        mock_path_wipe.assert_called_once_with(self.abs_bundle_dir)
+        mock_path_wipe.assert_called_once_with('bundle-dir')
         mock_Privileges_check_for_root_permissions.assert_called_once_with()
         assert mock_command.call_args_list == [
             call(
                 [
                     'cp', 'test-image-1.2.3',
                     os.sep.join(
-                        [self.abs_bundle_dir, 'test-image-1.2.3-Build_42']
+                        ['bundle-dir', 'test-image-1.2.3-Build_42']
                     )
                 ]
             ),
@@ -231,23 +240,21 @@ class TestResultBundleTask:
                 [
                     'file',
                     os.sep.join(
-                        [self.abs_bundle_dir, 'test-image-1.2.3-Build_42']
+                        ['bundle-dir', 'test-image-1.2.3-Build_42']
                     )
                 ]
             ),
             call(
                 [
                     'rpmbuild', '--nodeps', '--nocheck', '--rmspec', '-bb',
-                    os.sep.join([self.abs_bundle_dir, 'test-image.spec'])
+                    os.sep.join(['bundle-dir', 'test-image.spec'])
                 ]
             ),
             call(
                 ['bash', '-c', 'mv noarch/*.rpm . && rmdir noarch']
             )
         ]
-        mock_chdir.assert_called_once_with(
-            self.abs_bundle_dir
-        )
+        mock_chdir.assert_called_once_with('bundle-dir')
         assert mock_unlink.called
 
     @patch('kiwi.tasks.result_bundle.Result.load')

--- a/test/unit/utils/compress_test.py
+++ b/test/unit/utils/compress_test.py
@@ -105,14 +105,14 @@ class TestCompress:
 
     @patch('kiwi.command.Command.run')
     def test_get_format_invalid_format(self, mock_run):
-        mock_run.side_effect = ValueError("nothing")
+        result = Mock()
+        result.returncode = 1
+        mock_run.return_value = result
         invalid = Compress("../data/gz_data.gz")
         invalid.supported_zipper = ["mock_zip"]
 
         with self._caplog.at_level(logging.DEBUG):
             assert invalid.get_format() is None
             mock_run.assert_called_once_with(
-                ['mock_zip', '-l', '../data/gz_data.gz']
+                ['mock_zip', '-l', '../data/gz_data.gz'], raise_on_error=False
             )
-            assert 'Error running "mock_zip -l ../data/gz_data.gz", got a'
-            ' ValueError: nothing' in self._caplog.text


### PR DESCRIPTION
The get_format() method allows to check which compression format a given input stream has. This is done by calling the supported compression tools in a row and let them check if they can deal with the provided data or not. As a result error messages are logged for streams that some tool doesn't understand. However, those error messages are no errors and only the result of the checking. This information in the kiwi log file is confusing and several users already complained when they see information like:

```
EXEC: Failed with stderr: /usr/bin/xz: ...: File format not recognized
```

This commit changes how the compression tooling is called in a way that no exception is raised (which leads to the above error message) but the result returncode is used to decide on the success or error of the respective compression tooling.

