### PR TITLE
Support file includes

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-disk-simple/a_custom_file
+++ b/build-tests/x86/tumbleweed/test-image-disk-simple/a_custom_file
@@ -1,0 +1,1 @@
+This is a custom file

--- a/build-tests/x86/tumbleweed/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-simple/appliance.kiwi
@@ -25,6 +25,7 @@
     </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/bob" name="bob" groups="users"/>
     </users>
     <repository type="rpm-md">
         <source path="obsrepositories:/"/>
@@ -56,6 +57,7 @@
         <package name="kernel-default"/>
         <package name="shim"/>
         <package name="timezone"/>
+        <file name="a_custom_file" target="/home/bob/some_file" owner="bob:users" permissions="444"/>
     </packages>
     <packages type="bootstrap">
         <package name="gawk"/>

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -1536,6 +1536,37 @@ elements:
 * The `enable` attribute is mandatory because it should be an explicit
   setting if a module is effectively used or not.
 
+<packages><file>
+~~~~~~~~~~~~~~~~~~~
+.. code:: xml
+
+   <packages type="image"/>
+     <file name="name"/>
+   </packages>
+
+The file element takes the `name` attribute and looks up the
+given name as file on the system. If specified relative {kiwi}
+looks up the name in the image description directory. The file
+is installed using the `rsync` program. The file element has the
+following optional attributes:
+
+owner="user:group"
+  The `owner` attribute can be specified to make the file
+  belonging to the specified owner and group. The ownership of
+  the original file is meaningless in this case. The provided
+  value is passed along to the `chown` program.
+
+permissions="perms"
+  The `permissions` attribute can be specified to store the file
+  with the provided permission. The permission bits of the original
+  file are meaningless in this case. The provided value is passed
+  along to the `chmod` program.
+
+target="some/path"
+  The `target` attribute can be used to specify a target path to
+  install the file to the specified directory and name. Eventually
+  missing parent directories will be created.
+
 <packages><archive>
 ~~~~~~~~~~~~~~~~~~~
 .. code:: xml

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -273,8 +273,20 @@ div {
 div {
     k.file.name.attribute = k.name.attribute
     k.file.arch.attribute = k.arch.attribute
+    k.file.target.attribute =
+        # include file as target to the root(/) of the image.
+        attribute target { text }
+    k.file.owner.attribute =
+        # set ownership to the file. The value is passed to chown
+        attribute owner { text }
+    k.file.permissions.attribute =
+        # set file permissions. The value is passed to chmod
+        attribute permissions { text }
     k.file.attlist =
         k.file.name.attribute &
+        k.file.target.attribute? &
+        k.file.owner.attribute? &
+        k.file.permissions.attribute? &
         k.file.arch.attribute?
     k.file =
         ## A Pointer to a File
@@ -3560,6 +3572,7 @@ div {
         element packages {
             k.packages.attlist &
             k.archive* &
+            k.file* &
             k.ignore* &
             k.namedCollection* &
             k.collectionModule* &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -505,9 +505,30 @@ file was fetched</a:documentation>
     <define name="k.file.arch.attribute">
       <ref name="k.arch.attribute"/>
     </define>
+    <define name="k.file.target.attribute">
+      <!-- include file as target to the root(/) of the image. -->
+      <attribute name="target"/>
+    </define>
+    <define name="k.file.owner.attribute">
+      <!-- set ownership to the file. The value is passed to chown -->
+      <attribute name="owner"/>
+    </define>
+    <define name="k.file.permissions.attribute">
+      <!-- set file permissions. The value is passed to chmod -->
+      <attribute name="permissions"/>
+    </define>
     <define name="k.file.attlist">
       <interleave>
         <ref name="k.file.name.attribute"/>
+        <optional>
+          <ref name="k.file.target.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.file.owner.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.file.permissions.attribute"/>
+        </optional>
         <optional>
           <ref name="k.file.arch.attribute"/>
         </optional>
@@ -5366,6 +5387,9 @@ alternative bootstrap method for debootstrap</a:documentation>
           <ref name="k.packages.attlist"/>
           <zeroOrMore>
             <ref name="k.archive"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="k.file"/>
           </zeroOrMore>
           <zeroOrMore>
             <ref name="k.ignore"/>

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -576,9 +576,10 @@ class SystemPrepare:
                 )
             target_dir = self.root_bind.root_dir
             if archive_target_dir_dict.get(archive):
-                target_dir = os.path.join(
-                    target_dir,
-                    archive_target_dir_dict.get(archive)
+                target_dir = os.path.normpath(
+                    os.sep.join(
+                        [target_dir, archive_target_dir_dict.get(archive)]
+                    )
                 )
             log.info('--> target dir: %s', target_dir)
             tar = ArchiveTar(archive_file)

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -306,6 +306,7 @@ class SystemBuildTask(CliTask):
                 setup.setup_plymouth_splash()
                 setup.setup_timezone()
                 setup.setup_permissions()
+                setup.import_files()
 
                 # setup permanent image repositories after cleanup
                 setup.import_repositories_marked_as_imageinclude()

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -315,6 +315,7 @@ class SystemPrepareTask(CliTask):
                 setup.setup_plymouth_splash()
                 setup.setup_timezone()
                 setup.setup_permissions()
+                setup.import_files()
 
                 # setup permanent image repositories after cleanup
                 setup.import_repositories_marked_as_imageinclude()

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -1287,9 +1287,12 @@ class file(GeneratedsSuper):
     """A Pointer to a File"""
     subclass = None
     superclass = None
-    def __init__(self, name=None, arch=None):
+    def __init__(self, name=None, target=None, owner=None, permissions=None, arch=None):
         self.original_tagname_ = None
         self.name = _cast(None, name)
+        self.target = _cast(None, target)
+        self.owner = _cast(None, owner)
+        self.permissions = _cast(None, permissions)
         self.arch = _cast(None, arch)
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
@@ -1304,6 +1307,12 @@ class file(GeneratedsSuper):
     factory = staticmethod(factory)
     def get_name(self): return self.name
     def set_name(self, name): self.name = name
+    def get_target(self): return self.target
+    def set_target(self, target): self.target = target
+    def get_owner(self): return self.owner
+    def set_owner(self, owner): self.owner = owner
+    def get_permissions(self): return self.permissions
+    def set_permissions(self, permissions): self.permissions = permissions
     def get_arch(self): return self.arch
     def set_arch(self, arch): self.arch = arch
     def validate_arch_name(self, value):
@@ -1344,6 +1353,15 @@ class file(GeneratedsSuper):
         if self.name is not None and 'name' not in already_processed:
             already_processed.add('name')
             outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
+        if self.target is not None and 'target' not in already_processed:
+            already_processed.add('target')
+            outfile.write(' target=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.target), input_name='target')), ))
+        if self.owner is not None and 'owner' not in already_processed:
+            already_processed.add('owner')
+            outfile.write(' owner=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.owner), input_name='owner')), ))
+        if self.permissions is not None and 'permissions' not in already_processed:
+            already_processed.add('permissions')
+            outfile.write(' permissions=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.permissions), input_name='permissions')), ))
         if self.arch is not None and 'arch' not in already_processed:
             already_processed.add('arch')
             outfile.write(' arch=%s' % (quote_attrib(self.arch), ))
@@ -1361,6 +1379,18 @@ class file(GeneratedsSuper):
         if value is not None and 'name' not in already_processed:
             already_processed.add('name')
             self.name = value
+        value = find_attr_value_('target', node)
+        if value is not None and 'target' not in already_processed:
+            already_processed.add('target')
+            self.target = value
+        value = find_attr_value_('owner', node)
+        if value is not None and 'owner' not in already_processed:
+            already_processed.add('owner')
+            self.owner = value
+        value = find_attr_value_('permissions', node)
+        if value is not None and 'permissions' not in already_processed:
+            already_processed.add('permissions')
+            self.permissions = value
         value = find_attr_value_('arch', node)
         if value is not None and 'arch' not in already_processed:
             already_processed.add('arch')
@@ -8668,7 +8698,7 @@ class packages(GeneratedsSuper):
     """Specifies Packages/Patterns Used in Different Stages"""
     subclass = None
     superclass = None
-    def __init__(self, type_=None, profiles=None, patternType=None, bootstrap_package=None, archive=None, ignore=None, namedCollection=None, collectionModule=None, product=None, package=None):
+    def __init__(self, type_=None, profiles=None, patternType=None, bootstrap_package=None, archive=None, file=None, ignore=None, namedCollection=None, collectionModule=None, product=None, package=None):
         self.original_tagname_ = None
         self.type_ = _cast(None, type_)
         self.profiles = _cast(None, profiles)
@@ -8678,6 +8708,10 @@ class packages(GeneratedsSuper):
             self.archive = []
         else:
             self.archive = archive
+        if file is None:
+            self.file = []
+        else:
+            self.file = file
         if ignore is None:
             self.ignore = []
         else:
@@ -8714,6 +8748,11 @@ class packages(GeneratedsSuper):
     def add_archive(self, value): self.archive.append(value)
     def insert_archive_at(self, index, value): self.archive.insert(index, value)
     def replace_archive_at(self, index, value): self.archive[index] = value
+    def get_file(self): return self.file
+    def set_file(self, file): self.file = file
+    def add_file(self, value): self.file.append(value)
+    def insert_file_at(self, index, value): self.file.insert(index, value)
+    def replace_file_at(self, index, value): self.file[index] = value
     def get_ignore(self): return self.ignore
     def set_ignore(self, ignore): self.ignore = ignore
     def add_ignore(self, value): self.ignore.append(value)
@@ -8750,6 +8789,7 @@ class packages(GeneratedsSuper):
     def hasContent_(self):
         if (
             self.archive or
+            self.file or
             self.ignore or
             self.namedCollection or
             self.collectionModule or
@@ -8800,6 +8840,8 @@ class packages(GeneratedsSuper):
             eol_ = ''
         for archive_ in self.archive:
             archive_.export(outfile, level, namespaceprefix_, name_='archive', pretty_print=pretty_print)
+        for file_ in self.file:
+            file_.export(outfile, level, namespaceprefix_, name_='file', pretty_print=pretty_print)
         for ignore_ in self.ignore:
             ignore_.export(outfile, level, namespaceprefix_, name_='ignore', pretty_print=pretty_print)
         for namedCollection_ in self.namedCollection:
@@ -8842,6 +8884,11 @@ class packages(GeneratedsSuper):
             obj_.build(child_)
             self.archive.append(obj_)
             obj_.original_tagname_ = 'archive'
+        elif nodeName_ == 'file':
+            obj_ = file.factory()
+            obj_.build(child_)
+            self.file.append(obj_)
+            obj_.original_tagname_ = 'file'
         elif nodeName_ == 'ignore':
             obj_ = ignore.factory()
             obj_.build(child_)

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -79,6 +79,12 @@ volume_type = NamedTuple(
 )
 
 
+class FileT(NamedTuple):
+    target: str
+    owner: str
+    permissions: str
+
+
 class XMLState:
     """
     **Implements methods to get stateful information from the XML data**
@@ -573,6 +579,49 @@ class XMLState:
             for package in package_list:
                 result.append(package.package_section.get_name().strip())
         return sorted(list(set(result)))
+
+    def get_bootstrap_files(self) -> Dict[str, FileT]:
+        """
+        List of file names from the type="bootstrap" packages section(s)
+
+        :return: file names
+
+        :rtype: dict
+        """
+        result = {}
+        bootstrap_packages_sections = self.get_bootstrap_packages_sections()
+        if bootstrap_packages_sections:
+            for bootstrap_packages_section in bootstrap_packages_sections:
+                file_list = bootstrap_packages_section.get_file() or []
+                for file in file_list:
+                    result[file.get_name()] = FileT(
+                        target=file.get_target() or '',
+                        owner=file.get_owner() or '',
+                        permissions=file.get_permissions() or ''
+                    )
+        return result
+
+    def get_system_files(self) -> Dict[str, FileT]:
+        """
+        List of file names from the packages sections matching
+        type="image" and type=build_type
+
+        :return: file names
+
+        :rtype: dict
+        """
+        result = {}
+        image_packages_sections = self.get_packages_sections(
+            ['image', self.get_build_type_name()]
+        )
+        for packages in image_packages_sections:
+            for file in packages.get_file():
+                result[file.get_name()] = FileT(
+                    target=file.get_target() or '',
+                    owner=file.get_owner() or '',
+                    permissions=file.get_permissions() or ''
+                )
+        return result
 
     def get_bootstrap_archives(self) -> List:
         """

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -208,6 +208,8 @@
         <package name="openssh"/>
         <archive name="/absolute/path/to/image.tgz" bootinclude="true"/>
         <package name="foo" arch="s390,aarch64"/>
+        <file name="some"/>
+        <file name="/absolute/path/to/some" owner="bob:users" permissions="u+x"/>
     </packages>
     <packages type="iso">
         <package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
@@ -239,6 +241,7 @@
         <namedCollection name="bootstrap-collection"/>
         <product name="kiwi"/>
         <archive name="bootstrap.tgz"/>
+        <file name="some" target="/some/target"/>
         <ignore name="some"/>
     </packages>
     <packages type="delete">

--- a/test/unit/bootloader/config/base_test.py
+++ b/test/unit/bootloader/config/base_test.py
@@ -126,7 +126,6 @@ class TestBootLoaderConfigBase:
             assert self.bootloader.get_boot_cmdline(
                 '/dev/myroot'
             ) == 'rd.root.overlay.write=/dev/myrw root=overlay:PARTUUID=mock'
-            print(self._caplog.text)
             assert 'Overlay write device explicitly set via kernelcmdline' \
                 in self._caplog.text
 

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -191,7 +191,9 @@ class TestSystemPrepare:
 
     @patch('kiwi.system.prepare.CommandProcess.poll_show_progress')
     @patch('kiwi.system.prepare.ArchiveTar')
-    def test_install_bootstrap_archives_raises(self, mock_tar, mock_poll):
+    def test_install_bootstrap_archives_raises(
+        self, mock_tar, mock_poll
+    ):
         mock_tar.side_effect = Exception
         with raises(KiwiBootStrapPhaseFailed):
             self.system.install_bootstrap(self.manager)
@@ -216,7 +218,9 @@ class TestSystemPrepare:
 
     @patch('kiwi.system.prepare.CommandProcess.poll_show_progress')
     @patch('kiwi.system.prepare.ArchiveTar')
-    def test_install_system_archives_raises(self, mock_tar, mock_poll):
+    def test_install_system_archives_raises(
+        self, mock_tar, mock_poll
+    ):
         mock_tar.side_effect = KiwiInstallPhaseFailed
         with raises(KiwiInstallPhaseFailed):
             self.system.install_system(self.manager)
@@ -409,7 +413,8 @@ class TestSystemPrepare:
     @patch('kiwi.system.prepare.ArchiveTar')
     @patch('os.path.exists')
     def test_install_bootstrap_archive_from_derived_description(
-        self, mock_exists, mock_tar, mock_poll, mock_collection_type
+        self, mock_exists, mock_tar, mock_poll,
+        mock_collection_type
     ):
         mock_exists.return_value = False
         self.system.install_bootstrap(self.manager)

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -185,6 +185,7 @@ class TestSystemBuildTask:
         self.setup.setup_plymouth_splash.assert_called_once_with()
         self.setup.setup_timezone.assert_called_once_with()
         self.setup.setup_permissions.assert_called_once_with()
+        self.setup.import_files.assert_called_once_with()
         self.setup.setup_selinux_file_contexts.assert_called_once_with()
         system_prepare.pinch_system.assert_has_calls(
             [call(force=False), call(force=True)]

--- a/test/unit/tasks/system_prepare_test.py
+++ b/test/unit/tasks/system_prepare_test.py
@@ -173,6 +173,7 @@ class TestSystemPrepareTask:
         self.setup.setup_plymouth_splash.assert_called_once_with()
         self.setup.setup_timezone.assert_called_once_with()
         self.setup.setup_permissions.assert_called_once_with()
+        self.setup.import_files.assert_called_once_with()
         self.setup.setup_selinux_file_contexts.assert_called_once_with()
 
         system_prepare.pinch_system.assert_has_calls(

--- a/test/unit/utils/checksum_test.py
+++ b/test/unit/utils/checksum_test.py
@@ -17,7 +17,6 @@ class TestChecksum:
         read_results = [bytes(b''), bytes(b'data'), bytes(b''), bytes(b'data')]
 
         def side_effect(arg):
-            print(read_results[0])
             return read_results.pop()
 
         self.m_open = mock_open()

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -193,6 +193,16 @@ class TestXMLState:
             'openSUSE'
         ]
 
+    def test_get_system_files(self):
+        assert self.state.\
+            get_system_files()['some'].target == ''
+        assert self.state.\
+            get_system_files()['/absolute/path/to/some'].target == ''
+
+    def test_get_bootstrap_files(self):
+        assert self.state.\
+            get_bootstrap_files()['some'].target == '/some/target'
+
     def test_get_system_archives(self):
         assert self.state.get_system_archives() == [
             '/absolute/path/to/image.tgz'


### PR DESCRIPTION
Add ```<file>``` directive to incorporate custom files
    
Usually custom files are managed by placing them as overlay files or archives. However, overlay files must be structured inside of a root/ subdirectory and archive files are binary data. It is therefore not straight forward to just reference one or more files as source files to the image description  to be placed into the image. This commit adds a new ```<file>```  element which allows to do this.

This Fixes #1953
