### PR TITLE
Fix dracut-interactive with systemd 256

### DIFF
--- a/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
@@ -280,7 +280,8 @@ function runMediaCheck {
 # Methods considered private
 #-----------------------------------------
 function _setup_interactive_service {
-    local service=/usr/lib/systemd/system/dracut-run-interactive.service
+    local service=/run/systemd/system/dracut-run-interactive.service
+    mkdir -p /run/systemd/system
     [ -e ${service} ] && return
     {
         echo "[Unit]"
@@ -294,7 +295,7 @@ function _setup_interactive_service {
         echo "Environment=DRACUT_SYSTEMD=1"
         echo "Environment=NEWROOT=/sysroot"
         echo "WorkingDirectory=/"
-        echo "ExecStart=/bin/bash /bin/dracut-interactive"
+        echo "ExecStart=/bin/bash /run/dracut-interactive"
         echo "Type=oneshot"
         echo "StandardInput=tty-force"
         echo "StandardOutput=inherit"
@@ -312,7 +313,7 @@ function _run_interactive {
 }
 
 function _run_dialog {
-    echo "dialog $*" >/bin/dracut-interactive
+    echo "dialog $*" >/run/dracut-interactive
     _run_interactive
 }
 

--- a/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
@@ -16,7 +16,7 @@ function run_dialog {
     {
         echo "dialog $* 2>$dialog_result"
         echo "echo -n \$? >$dialog_exit_code"
-    } >/bin/dracut-interactive
+    } >/run/dracut-interactive
     _run_interactive
     return "$(cat $dialog_exit_code)"
 }
@@ -48,7 +48,7 @@ function run_progress_dialog {
         echo -n "cat ${fifo} | dialog --backtitle \"${backtitle}\" "
         echo -n "--gauge \"${title}\"" 7 65 0
         echo
-    } >/bin/dracut-interactive
+    } >/run/dracut-interactive
     _run_interactive
 }
 
@@ -69,8 +69,9 @@ function stop_plymouth {
 # Methods considered private
 #-----------------------------------------
 function _setup_interactive_service {
-    local service=/usr/lib/systemd/system/dracut-run-interactive.service
-    local script=/bin/dracut-interactive
+    local service=/run/systemd/system/dracut-run-interactive.service
+    local script=/run/dracut-interactive
+    mkdir -p /run/systemd/system
     [ -e ${service} ] && return
     {
         echo "[Unit]"


### PR DESCRIPTION
With systemd 256, /usr (and thus also /bin/) is read-only in the initrd. Move dracut-interactive into /run instead.

~Draft because not tested yet.~