### PR TITLE
Do not exclude the .profile env file by default

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -397,7 +397,7 @@ class Defaults:
         :rtype: list
         """
         exclude_list = [
-            'image', '.profile', '.kconfig'
+            'image', '.kconfig'
         ]
         if no_tmpdirs:
             exclude_list += ['run/*', 'tmp/*']

--- a/test/unit/builder/archive_test.py
+++ b/test/unit/builder/archive_test.py
@@ -66,7 +66,7 @@ class TestArchiveBuilder:
         )
         archive.create_xz_compressed.assert_called_once_with(
             'root_dir', exclude=[
-                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                'image', '.kconfig', 'run/*', 'tmp/*',
                 '.buildenv', 'var/cache/kiwi'
             ], xz_options=None
         )
@@ -89,7 +89,7 @@ class TestArchiveBuilder:
         )
         archive.create.assert_called_once_with(
             'root_dir', exclude=[
-                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                'image', '.kconfig', 'run/*', 'tmp/*',
                 '.buildenv', 'var/cache/kiwi'
             ]
         )

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -390,7 +390,7 @@ class TestDiskBuilder:
         call = filesystem.sync_data.call_args_list[0]
         assert filesystem.sync_data.call_args_list[0] == \
             call([
-                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                'image', '.kconfig', 'run/*', 'tmp/*',
                 '.buildenv', 'var/cache/kiwi', 'boot/*', 'boot/.*',
                 'boot/efi/*', 'boot/efi/.*'
             ])
@@ -803,7 +803,7 @@ class TestDiskBuilder:
 
         assert filesystem.__enter__.return_value \
             .sync_data.call_args_list[2] == call([
-                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                'image', '.kconfig', 'run/*', 'tmp/*',
                 '.buildenv', 'var/cache/kiwi', 'boot/*', 'boot/.*',
                 'boot/efi/*', 'boot/efi/.*'
             ])
@@ -963,7 +963,7 @@ class TestDiskBuilder:
         assert squashfs.create_on_file.call_args_list == [
             call(exclude=['var/cache/kiwi'], filename='kiwi-tempname'),
             call(exclude=[
-                '.profile', '.kconfig', 'run/*', 'tmp/*',
+                '.kconfig', 'run/*', 'tmp/*',
                 '.buildenv', 'var/cache/kiwi',
                 'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*', 'image/*'
             ], filename='kiwi-tempname')
@@ -1453,7 +1453,7 @@ class TestDiskBuilder:
         ]
         volume_manager.sync_data.assert_called_once_with(
             [
-                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                'image', '.kconfig', 'run/*', 'tmp/*',
                 '.buildenv', 'var/cache/kiwi',
                 'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
             ]
@@ -1609,7 +1609,7 @@ class TestDiskBuilder:
         )
         assert filesystem.sync_data.call_args_list.pop() == call(
             [
-                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                'image', '.kconfig', 'run/*', 'tmp/*',
                 '.buildenv', 'var/cache/kiwi', 'var/*', 'var/.*',
                 'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
             ]

--- a/test/unit/builder/filesystem_test.py
+++ b/test/unit/builder/filesystem_test.py
@@ -117,7 +117,7 @@ class TestFileSystemBuilder:
         )
         self.filesystem.create_on_device.assert_called_once_with(None)
         self.filesystem.sync_data.assert_called_once_with([
-            'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+            'image', '.kconfig', 'run/*', 'tmp/*',
             '.buildenv', 'var/cache/kiwi'
         ])
         self.setup.export_package_verification.assert_called_once_with(
@@ -153,7 +153,7 @@ class TestFileSystemBuilder:
         self.filesystem.create_on_file.assert_called_once_with(
             'target_dir/myimage.x86_64-1.2.3.squashfs', None,
             [
-                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                'image', '.kconfig', 'run/*', 'tmp/*',
                 '.buildenv', 'var/cache/kiwi'
             ]
         )

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -283,7 +283,7 @@ class TestLiveImageBuilder:
 
             filesystem.create_on_device.assert_called_once_with()
             filesystem.sync_data.assert_called_once_with([
-                'image', '.profile', '.kconfig',
+                'image', '.kconfig',
                 'run/*', 'tmp/*', '.buildenv', 'var/cache/kiwi'
             ])
 

--- a/test/unit/container/oci_test.py
+++ b/test/unit/container/oci_test.py
@@ -150,7 +150,7 @@ class TestContainerImageOCI:
         mock_oci.unpack.assert_called_once_with()
         mock_oci.sync_rootfs.assert_called_once_with(
             'root_dir', [
-                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                'image', '.kconfig', 'run/*', 'tmp/*',
                 '.buildenv', 'var/cache/kiwi', 'dev/*', 'sys/*', 'proc/*'
             ]
         )
@@ -199,7 +199,7 @@ class TestContainerImageOCI:
         mock_oci.unpack.assert_called_once_with()
         mock_oci.sync_rootfs.assert_called_once_with(
             'root_dir', [
-                'image', '.profile', '.kconfig', 'run/*', 'tmp/*',
+                'image', '.kconfig', 'run/*', 'tmp/*',
                 '.buildenv', 'var/cache/kiwi', 'dev/*', 'sys/*', 'proc/*'
             ]
         )

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -124,12 +124,12 @@ class TestDefaults:
 
     def test_get_exclude_list_for_root_data_sync(self):
         assert Defaults.get_exclude_list_for_root_data_sync() == [
-            'image', '.profile', '.kconfig',
+            'image', '.kconfig',
             'run/*', 'tmp/*',
             '.buildenv', 'var/cache/kiwi'
         ]
         assert Defaults.get_exclude_list_for_root_data_sync(no_tmpdirs=False) == [
-            'image', '.profile', '.kconfig',
+            'image', '.kconfig',
             '.buildenv', 'var/cache/kiwi'
         ]
 


### PR DESCRIPTION
kiwi's initrd modules read a .profile file which gets included into the initrd produced at build time. To allow rebuild of a host-only initrd from the booted system this information should be present such that it is possible to re-use kiwi initrd code.

