### PR TITLE
CI: Add testing against Python 3.13

### DIFF
--- a/.github/workflows/ci-code-style.yml
+++ b/.github/workflows/ci-code-style.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   unit_tests:
     name: Linter checks for KIWI python and Shell code
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-units-types.yml
+++ b/.github/workflows/ci-units-types.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ skip_missing_interpreters = True
 skipsdist = True
 envlist =
     check,
+    unit_py3_13,
     unit_py3_12,
     unit_py3_11,
     unit_py3_10,
@@ -26,7 +27,7 @@ envlist =
 
 [testenv]
 description =
-    {unit_py3_9,unit_py3_10,unit_py3_11,unit_py3_12}: Unit Test run with basepython set to {basepython}
+    {unit_py3_9,unit_py3_10,unit_py3_11,unit_py3_12,unit_py3_13}: Unit Test run with basepython set to {basepython}
     devel: Test KIWI
 allowlist_externals =
     bash
@@ -41,6 +42,7 @@ allowlist_externals =
     python
     pytest
 basepython =
+    unit_py3_13: python3.13
     unit_py3_12: python3.12
     unit_py3_11: python3.11
     unit_py3_10: python3.10
@@ -89,6 +91,15 @@ commands =
 
 # Test run with basepython set to 3.12
 [testenv:unit_py3_12]
+setenv =
+    PYTHONPATH={toxinidir}/test
+changedir=test/unit
+commands =
+    {[testenv:mypy]commands}
+    {[testenv:unit]commands}
+
+# Test run with basepython set to 3.13
+[testenv:unit_py3_13]
 setenv =
     PYTHONPATH={toxinidir}/test
 changedir=test/unit


### PR DESCRIPTION
Python 3.13 is shipping in Fedora Linux for Fedora Linux 41, so we should ensure kiwi is tested against it.