### PR TITLE
Remove Path.remove, Path.rename and refactor Path.which & Path.create

### DIFF
--- a/kiwi/path.py
+++ b/kiwi/path.py
@@ -122,29 +122,6 @@ class Path:
             )
 
     @staticmethod
-    def remove(path: str) -> None:
-        """
-        Delete empty path, causes an error if target is not empty
-
-        :param string path: path name
-        """
-        Command.run(
-            ['rmdir', path]
-        )
-
-    @staticmethod
-    def rename(cur: str, new: str) -> None:
-        """
-        Move path from cur name to new name
-
-        :param string cur: current path name
-        :param string new: new path name
-        """
-        Command.run(
-            ['mv', cur, new]
-        )
-
-    @staticmethod
     def remove_hierarchy(root: str, path: str) -> None:
         """
         Recursively remove an empty path and its sub directories

--- a/kiwi/path.py
+++ b/kiwi/path.py
@@ -18,6 +18,7 @@
 import os
 import logging
 import collections
+import pathlib
 from typing import Dict, List, MutableMapping, Optional
 
 # project
@@ -105,10 +106,8 @@ class Path:
 
         :param string path: path name
         """
-        if not os.path.exists(path):
-            Command.run(
-                ['mkdir', '-p', path]
-            )
+        log.debug("Creating directory %s", path)
+        pathlib.Path(path).mkdir(parents=True, exist_ok=True)
 
     @staticmethod
     def wipe(path: str) -> None:

--- a/kiwi/path.py
+++ b/kiwi/path.py
@@ -19,6 +19,7 @@ import os
 import logging
 import collections
 import pathlib
+import shutil
 from typing import Dict, List, MutableMapping, Optional
 
 # project
@@ -199,9 +200,9 @@ class Path:
 
     @staticmethod
     def which(
-        filename: str, alternative_lookup_paths: Optional[List[str]] = None,
+        filename: str,
         custom_env: Optional[MutableMapping[str, str]] = None,
-        access_mode: Optional[int] = None,
+        access_mode: int = os.F_OK | os.X_OK,
         root_dir: Optional[str] = None
     ) -> Optional[str]:
         """
@@ -209,7 +210,7 @@ class Path:
 
         :param string filename: file base name
         :param list alternative_lookup_paths: list of additional lookup paths
-        :param list custom_env: a custom os.environ
+        :param list custom_env: a custom os.environ used to obtain ``$PATH``
         :param int access_mode: one of the os access modes or a combination of
          them (os.R_OK, os.W_OK and os.X_OK). If the provided access mode
          does not match the file is considered not existing
@@ -219,31 +220,10 @@ class Path:
 
         :rtype: str
         """
-        lookup_paths = []
-        multipart_message = [
-            '"%s": ' % filename, 'exists: unknown', 'mode match: not checked'
-        ]
-        system_path = os.environ.get('PATH')
-        if custom_env:
-            system_path = custom_env.get('PATH')
-        if system_path:
-            lookup_paths = system_path.split(os.pathsep)
-        if alternative_lookup_paths:
-            lookup_paths += alternative_lookup_paths
+        system_path = (custom_env.get("PATH") if custom_env else os.environ.get("PATH")) or os.defpath
+
+        lookup_paths = system_path.split(os.pathsep)
         if root_dir:
             lookup_paths = Path.rebase_to_root(root_dir, lookup_paths)
-        multipart_message[0] += 'in paths "%s"' % ':'.join(lookup_paths)
-        for path in lookup_paths:
-            location = os.path.join(path, filename)
-            file_exists = os.path.exists(location)
-            multipart_message[1] = 'exists: "%s"' % file_exists
-            if access_mode and file_exists:
-                mode_match = os.access(location, access_mode)
-                multipart_message[2] = 'mode match: "%s"' % mode_match
-                if mode_match:
-                    return location
-            elif file_exists:
-                return location
-
-        log.debug(' '.join(multipart_message))
-        return None
+        log.debug(f"Looking for {filename} in {os.pathsep.join(lookup_paths)}")
+        return shutil.which(filename, access_mode, path=os.pathsep.join(lookup_paths))

--- a/kiwi/system/root_import/base.py
+++ b/kiwi/system/root_import/base.py
@@ -17,6 +17,7 @@
 #
 import os
 import logging
+import pathlib
 
 # project
 from kiwi.xml_state import XMLState
@@ -109,7 +110,8 @@ class RootImportBase:
             # Umount and rename upper to be the new root
             self.overlay.umount()
             Path.wipe(self.root_dir)
-            Path.rename(self.overlay.upper, self.root_dir)
+            log.debug("renaming %s -> %s", self.overlay.upper, self.root_dir)
+            pathlib.Path(self.overlay.upper).replace(self.root_dir)
 
             # Create removed files metadata
             if not os.path.isdir(pinch_reference):

--- a/kiwi/system/root_import/oci.py
+++ b/kiwi/system/root_import/oci.py
@@ -17,6 +17,7 @@
 #
 import os
 import logging
+import pathlib
 
 # project
 from kiwi.system.root_import.base import RootImportBase
@@ -74,7 +75,8 @@ class RootImportOCI(RootImportBase):
             oci.import_container_image(image_uri)
             oci.unpack()
             oci.import_rootfs(self.root_dir)
-            Path.rename(self.root_dir, root_dir_ro)
+            log.debug("renaming %s -> %s", self.root_dir, root_dir_ro)
+            pathlib.Path(self.root_dir).replace(root_dir_ro)
             Path.create(self.root_dir)
 
             self.overlay = MountManager(device='', mountpoint=self.root_dir)

--- a/test/unit/command_test.py
+++ b/test/unit/command_test.py
@@ -38,7 +38,7 @@ class TestCommand:
 
     def test_run_invalid_environment(self):
         with raises(KiwiCommandNotFound):
-            Command.run(['command', 'args'], {'HOME': '/root'})
+            Command.run(['command', 'args'], custom_env={'PATH': '/root'})
 
     @patch('kiwi.path.Path.which')
     @patch('subprocess.Popen')

--- a/test/unit/path_test.py
+++ b/test/unit/path_test.py
@@ -7,6 +7,8 @@ from pytest import (
 
 import os
 
+import pytest
+
 from kiwi.path import Path
 from kiwi.exceptions import KiwiFileAccessError
 
@@ -85,23 +87,23 @@ class TestPath:
         assert Path.which('some-file') == '/usr/local/bin/some-file'
         mock_exists.return_value = False
         assert Path.which('some-file') is None
-        mock_env.return_value = None
-        mock_exists.return_value = True
-        assert Path.which('some-file', alternative_lookup_paths=['alternative']) == \
-            'alternative/some-file'
         mock_access.return_value = False
         mock_env.return_value = '/usr/local/bin:/usr/bin:/bin'
         assert Path.which('some-file', access_mode=os.X_OK) is None
-        mock_access.return_value = True
-        assert Path.which('some-file', access_mode=os.X_OK) == \
-            '/usr/local/bin/some-file'
-        assert Path.which('some-file', custom_env={'PATH': 'custom_path'}) == \
-            'custom_path/some-file'
+
+    def test_which_with_real_data(self, pytestconfig: pytest.Config):
         assert Path.which(
-            'some-file',
-            custom_env={'PATH': 'custom_path'},
-            root_dir='/root_dir'
-        ) == '/root_dir/custom_path/some-file'
+            'tox.ini',
+            custom_env={'PATH': str(pytestconfig.rootpath)},
+            access_mode=os.F_OK
+        ) == str(pytestconfig.rootpath / "tox.ini")
+
+        assert Path.which(
+            '__init__.py',
+            custom_env={'PATH': "/kiwi/"},
+            access_mode=os.F_OK,
+            root_dir=str(pytestconfig.rootpath)
+        ) == str(pytestconfig.rootpath / "kiwi" / "__init__.py")
 
     @patch('os.access')
     @patch('os.environ.get')
@@ -109,30 +111,12 @@ class TestPath:
     def test_which_not_found_log(
         self, mock_exists, mock_env, mock_access
     ):
-        mock_env.return_value = '/usr/local/bin:/usr/bin:/bin'
+        PATH = '/usr/local/bin:/usr/bin:/bin'
+        mock_env.return_value = PATH
         mock_exists.return_value = False
         with self._caplog.at_level(logging.DEBUG):
             assert Path.which('file') is None
-            assert (
-                '"file": in paths "{0}" exists: "False" mode match: '
-                'not checked'
-            ).format(mock_env.return_value) in self._caplog.text
-
-    @patch('os.access')
-    @patch('os.environ.get')
-    @patch('os.path.exists')
-    def test_which_not_found_for_mode_log(
-        self, mock_exists, mock_env, mock_access
-    ):
-        mock_env.return_value = '/usr/local/bin:/usr/bin:/bin'
-        mock_exists.return_value = True
-        mock_access.return_value = False
-        with self._caplog.at_level(logging.DEBUG):
-            assert Path.which('file', access_mode=os.X_OK) is None
-            assert (
-                '"file": in paths "{0}" exists: "True" mode match: '
-                '"False"'
-            ).format(mock_env.return_value) in self._caplog.text
+            assert ('Looking for file in ' + PATH) in self._caplog.text
 
     def test_access_invalid_mode(self):
         with raises(ValueError) as issue:

--- a/test/unit/path_test.py
+++ b/test/unit/path_test.py
@@ -41,20 +41,6 @@ class TestPath:
         assert not mock_command.called
 
     @patch('kiwi.command.Command.run')
-    def test_rename(self, mock_command):
-        Path.rename('cur', 'new')
-        mock_command.assert_called_once_with(
-            ['mv', 'cur', 'new']
-        )
-
-    @patch('kiwi.command.Command.run')
-    def test_remove(self, mock_command):
-        Path.remove('foo')
-        mock_command.assert_called_once_with(
-            ['rmdir', 'foo']
-        )
-
-    @patch('kiwi.command.Command.run')
     def test_remove_hierarchy(self, mock_command):
         Path.remove_hierarchy('/my_root', '/tmp/foo/bar')
         with self._caplog.at_level(logging.WARNING):

--- a/test/unit/path_test.py
+++ b/test/unit/path_test.py
@@ -1,4 +1,5 @@
 import logging
+import pathlib
 from unittest.mock import patch, call
 from pytest import (
     raises, fixture
@@ -21,18 +22,10 @@ class TestPath:
         )
         assert ordered == ['usr', 'etc', 'usr/bin', 'usr/lib']
 
-    @patch('kiwi.command.os.path.exists')
-    @patch('kiwi.command.Command.run')
-    def test_create(self, mock_command, mock_exists):
-        mock_exists.return_value = False
-        Path.create('foo')
-        mock_command.assert_called_once_with(
-            ['mkdir', '-p', 'foo']
-        )
-        mock_exists.return_value = True
-        mock_command.reset_mock()
-        Path.create('foo')
-        assert not mock_command.called
+    def test_create(self, tmp_path: pathlib.Path):
+        dest = tmp_path / "foo" / "bar" / "baz"
+        Path.create(str(dest))
+        assert pathlib.Path(dest).exists()
 
     @patch('kiwi.command.os.path.exists')
     @patch('kiwi.command.Command.run')

--- a/test/unit/repository/dnf4_test.py
+++ b/test/unit/repository/dnf4_test.py
@@ -169,8 +169,9 @@ class TestRepositoryDnf4:
     @patch('kiwi.repository.dnf4.ConfigParser')
     @patch('kiwi.repository.dnf4.Defaults.is_buildservice_worker')
     @patch('os.path.exists')
+    @patch('kiwi.repository.dnf4.Path')
     def test_add_repo_inside_buildservice(
-        self, mock_exists, mock_buildservice, mock_config
+        self, mock_path, mock_exists, mock_buildservice, mock_config
     ):
         repo_config = mock.Mock()
         mock_buildservice.return_value = True
@@ -252,8 +253,9 @@ class TestRepositoryDnf4:
     @patch('kiwi.repository.dnf4.ConfigParser')
     @patch('kiwi.repository.dnf4.Defaults.is_buildservice_worker')
     @patch('os.path.exists')
+    @patch('kiwi.repository.dnf4.Path')
     def test_add_repo_with_gpgchecks(
-        self, mock_exists, mock_buildservice, mock_config
+        self, mock_path, mock_exists, mock_buildservice, mock_config
     ):
         repo_config = mock.Mock()
         mock_buildservice.return_value = False

--- a/test/unit/repository/dnf5_test.py
+++ b/test/unit/repository/dnf5_test.py
@@ -169,8 +169,9 @@ class TestRepositoryDnf5:
     @patch('kiwi.repository.dnf5.ConfigParser')
     @patch('kiwi.repository.dnf5.Defaults.is_buildservice_worker')
     @patch('os.path.exists')
+    @patch('kiwi.repository.dnf5.Path')
     def test_add_repo_inside_buildservice(
-        self, mock_exists, mock_buildservice, mock_config
+        self, mock_path, mock_exists, mock_buildservice, mock_config
     ):
         repo_config = mock.Mock()
         mock_buildservice.return_value = True
@@ -252,8 +253,9 @@ class TestRepositoryDnf5:
     @patch('kiwi.repository.dnf5.ConfigParser')
     @patch('kiwi.repository.dnf5.Defaults.is_buildservice_worker')
     @patch('os.path.exists')
+    @patch('kiwi.repository.dnf5.Path')
     def test_add_repo_with_gpgchecks(
-        self, mock_exists, mock_buildservice, mock_config
+        self, mock_path, mock_exists, mock_buildservice, mock_config
     ):
         repo_config = mock.Mock()
         mock_buildservice.return_value = False

--- a/test/unit/system/root_import/oci_test.py
+++ b/test/unit/system/root_import/oci_test.py
@@ -66,15 +66,18 @@ class TestRootImportOCI:
 
     @patch('kiwi.system.root_import.oci.Compress')
     @patch('kiwi.system.root_import.oci.Path.create')
-    @patch('kiwi.system.root_import.oci.Path.rename')
+    @patch('kiwi.system.root_import.oci.pathlib.Path')
     @patch('kiwi.system.root_import.oci.MountManager')
     @patch('kiwi.system.root_import.oci.OCI')
     def test_overlay_data(
-        self, mock_OCI, mock_MountManager, mock_path_rename,
+        self, mock_OCI, mock_MountManager, mock_Path,
         mock_path_create, mock_compress
     ):
         oci = Mock()
         mock_OCI.new.return_value.__enter__.return_value = oci
+
+        mock_pth = Mock()
+        mock_Path.return_value = mock_pth
 
         self.oci_import.overlay_data()
 
@@ -87,9 +90,8 @@ class TestRootImportOCI:
         oci.import_rootfs.assert_called_once_with(
             'root_dir'
         )
-        mock_path_rename.assert_called_once_with(
-            'root_dir', 'root_dir_ro'
-        )
+        mock_Path.assert_called_once_with('root_dir')
+        mock_pth.replace.assert_called_once_with('root_dir_ro')
         mock_path_create.assert_called_once_with('root_dir')
         mock_MountManager.return_value.overlay_mount.assert_called_once_with(
             'root_dir_ro'

--- a/test/unit/utils/rpm_database_test.py
+++ b/test/unit/utils/rpm_database_test.py
@@ -56,7 +56,6 @@ class TestRpmDataBase:
         mock_exists.return_value = False
         self.rpmdb.link_database_to_host_path()
         assert mock_Command_run.call_args_list == [
-            call(['mkdir', '-p', 'root_dir/usr/lib/sysimage']),
             call(
                 [
                     'ln', '-s', '../../../var/lib/rpm',

--- a/test/unit/volume_manager/btrfs_test.py
+++ b/test/unit/volume_manager/btrfs_test.py
@@ -162,7 +162,6 @@ class TestVolumeManagerBtrfs:
             call(['btrfs', 'quota', 'enable', 'tmpdir']),
             call(['btrfs', 'subvolume', 'create', 'tmpdir/@']),
             call(['btrfs', 'subvolume', 'create', 'tmpdir/@/.snapshots']),
-            call(['mkdir', '-p', 'tmpdir/@/.snapshots/1']),
             call(['btrfs', 'subvolume', 'create', 'tmpdir/@/.snapshots/1/snapshot']),
             call(['btrfs', 'subvolume', 'list', 'tmpdir']),
             call(['btrfs', 'subvolume', 'set-default', '258', 'tmpdir'])


### PR DESCRIPTION
Changes proposed in this pull request:
* Drop `Path.remove` & `Path.rename`: each method is only used in one place each and they were subprocessing into shell commands. Let's use the pathlib builtins instead (more pythonic & efficient)
* Refactor `Path.create` to not subprocess into `mkdir`
* Refactor `Path.which` to use the shutil builtin `which`
