### PR TITLE
Increase default volume size

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-raid/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-raid/appliance.kiwi
@@ -16,7 +16,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>breeze</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext4" kernelcmdline="splash" firmware="efi" mdraid="mirroring" installiso="true" installboot="install">
+        <type image="oem" filesystem="btrfs" kernelcmdline="splash" firmware="efi" mdraid="mirroring" installiso="true" installboot="install">
             <oemconfig>
                 <oem-device-filter>/dev/ram</oem-device-filter>
                 <oem-multipath-scan>false</oem-multipath-scan>
@@ -77,6 +77,7 @@
         <package name="gzip"/>
         <package name="udev"/>
         <package name="xz"/>
+        <package name="shadow"/>
         <package name="filesystem"/>
         <package name="glibc-locale"/>
         <package name="cracklib-dict-full"/>

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1156,7 +1156,7 @@ class Defaults:
 
         :rtype: int
         """
-        return 30
+        return 120
 
     @staticmethod
     def get_lvm_overhead_mbytes():

--- a/test/unit/storage/setup_test.py
+++ b/test/unit/storage/setup_test.py
@@ -212,7 +212,7 @@ class TestDiskSetup:
     @patch('os.path.exists')
     def test_get_disksize_mbytes_volumes(self, mock_exists):
         mock_exists.side_effect = lambda path: path != 'root_dir/newfolder'
-        assert self.setup_volumes.get_disksize_mbytes() == 2144
+        assert self.setup_volumes.get_disksize_mbytes() == 2774
 
     @patch('os.path.exists')
     def test_get_disksize_mbytes_partitions(self, mock_exists):

--- a/test/unit/system/profile_test.py
+++ b/test/unit/system/profile_test.py
@@ -81,9 +81,9 @@ class TestProfile:
         os.remove(self.profile_file)
         assert self.profile.dot_profile == {
             'kiwi_Volume_1': 'usr_lib|size:1024|usr/lib',
-            'kiwi_Volume_2': 'etc_volume|freespace:30|etc',
+            'kiwi_Volume_2': 'etc_volume|freespace:120|etc',
             'kiwi_Volume_3': 'bin_volume|size:all|/usr/bin',
-            'kiwi_Volume_4': 'usr_bin|freespace:30|usr/bin',
+            'kiwi_Volume_4': 'usr_bin|freespace:120|usr/bin',
             'kiwi_Volume_5': 'LVSwap|size:128|',
             'kiwi_Volume_Root': 'LVRoot|freespace:500|',
             'kiwi_bootkernel': None,

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -124,7 +124,7 @@ class TestVolumeManagerBase:
         assert self.volume_manager.get_volume_mbsize(
             self.volume_manager.volumes[0], self.volume_manager.volumes,
             'ext3'
-        ) == 272
+        ) == 362
 
     @patch('kiwi.volume_manager.base.SystemSize')
     @patch('os.path.exists')
@@ -140,7 +140,7 @@ class TestVolumeManagerBase:
         assert self.volume_manager.get_volume_mbsize(
             self.volume_manager.volumes[0], self.volume_manager.volumes,
             'ext3', True
-        ) == 72
+        ) == 162
 
     @patch('kiwi.volume_manager.base.SystemSize')
     @patch('os.path.exists')
@@ -168,7 +168,7 @@ class TestVolumeManagerBase:
         assert self.volume_manager.get_volume_mbsize(
             self.volume_manager.volumes[0], self.volume_manager.volumes,
             'ext3'
-        ) == 272
+        ) == 362
         size.accumulate_mbyte_file_sizes.assert_called_once_with(
             ['root_dir/usr/lib']
         )
@@ -204,7 +204,7 @@ class TestVolumeManagerBase:
         assert self.volume_manager.get_volume_mbsize(
             self.volume_manager.volumes[2], self.volume_manager.volumes,
             'ext3', True
-        ) == 72
+        ) == 162
         size.accumulate_mbyte_file_sizes.assert_called_once_with(
             ['root_dir/usr', 'root_dir/usr/lib']
         )

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -434,7 +434,7 @@ class TestXMLState:
             volume_type(
                 name='usr_lib',
                 parent='',
-                size='freespace:30',
+                size='freespace:120',
                 realpath='usr/lib',
                 mountpoint='usr/lib',
                 fullsize=False,
@@ -493,7 +493,7 @@ class TestXMLState:
                 is_root_volume=True
             ),
             volume_type(
-                name='etc_volume', parent='', size='freespace:30',
+                name='etc_volume', parent='', size='freespace:120',
                 realpath='etc',
                 mountpoint='etc', fullsize=False,
                 label=None,
@@ -557,7 +557,7 @@ class TestXMLState:
                 is_root_volume=False
             ),
             volume_type(
-                name='LVRoot', parent='', size='freespace:30', realpath='/',
+                name='LVRoot', parent='', size='freespace:120', realpath='/',
                 mountpoint=None, fullsize=False,
                 label=None,
                 attributes=[],


### PR DESCRIPTION
**Increase default volume size**
    
So far 30MB was set as default volume size which is by far too small for a number of filesystems, e.g btrfs and also XFS. This commit increases the default volume size such that all modern filesystems builds if the default volume size is used

**Update test-image-raid**
    
Apart from testing raid this integration test also tests a certain LVM volume setup. The test has been updated to use the btrfs filesystem because it has the most strict size requirements.

