### PR TITLE
Setup default minimum volume size per filesystem

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1148,15 +1148,21 @@ class Defaults:
         return 10
 
     @staticmethod
-    def get_min_volume_mbytes():
+    def get_min_volume_mbytes(filesystem: str):
         """
         Provides default minimum LVM volume size in mbytes
+        per filesystem
 
         :return: mbsize value
 
         :rtype: int
         """
-        return 120
+        if filesystem == 'btrfs':
+            return 120
+        elif filesystem == 'xfs':
+            return 300
+        else:
+            return 30
 
     @staticmethod
     def get_lvm_overhead_mbytes():

--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -361,7 +361,9 @@ class DiskSetup:
         # on first boot of the disk image in oemboot/repart
         if self.disk_resize_requested:
             for volume in self.volumes:
-                disk_volume_mbytes += Defaults.get_min_volume_mbytes()
+                disk_volume_mbytes += Defaults.get_min_volume_mbytes(
+                    self.filesystem
+                )
             return disk_volume_mbytes
 
         # For static disk(no resize requested) we need to add the
@@ -378,7 +380,7 @@ class DiskSetup:
                         data_volume_mbytes.volume[volume.realpath]
                 if disk_add_mbytes > 0:
                     disk_volume_mbytes += disk_add_mbytes + \
-                        Defaults.get_min_volume_mbytes()
+                        Defaults.get_min_volume_mbytes(self.filesystem)
                 else:
                     message = dedent('''\n
                         Requested volume size {0}MB for {1!r} is too small
@@ -402,7 +404,7 @@ class DiskSetup:
 
             if disk_add_mbytes > 0:
                 disk_volume_mbytes += disk_add_mbytes + \
-                    Defaults.get_min_volume_mbytes()
+                    Defaults.get_min_volume_mbytes(self.filesystem)
             else:
                 log.warning(
                     'root volume size of %s MB is too small, skipped',

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -317,7 +317,7 @@ class VolumeManagerBase(DeviceProvider):
             # Therefore the requested size is set to null and we add
             # the required minimum size for just storing the data
             size_type = 'freespace'
-            mbsize = Defaults.get_min_volume_mbytes()
+            mbsize = Defaults.get_min_volume_mbytes(filesystem_name)
 
         if size_type == 'freespace' and os.path.exists(lookup_abspath):
             exclude_paths = []
@@ -337,8 +337,8 @@ class VolumeManagerBase(DeviceProvider):
                     )
 
             volume_size = SystemSize(lookup_abspath)
-            if mbsize != Defaults.get_min_volume_mbytes():
-                mbsize += Defaults.get_min_volume_mbytes()
+            if mbsize != Defaults.get_min_volume_mbytes(filesystem_name):
+                mbsize += Defaults.get_min_volume_mbytes(filesystem_name)
             mbsize += volume_size.customize(
                 volume_size.accumulate_mbyte_file_sizes(exclude_paths),
                 filesystem_name

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1731,6 +1731,7 @@ class XMLState:
         """
         volume_type_list: List[volume_type] = []
         systemdisk_section = self.get_build_type_system_disk_section()
+        selected_filesystem = self.build_type.get_filesystem()
         swap_mbytes = self.get_oemconfig_swap_mbytes()
         swap_name = self.get_oemconfig_swap_name()
         if not systemdisk_section:
@@ -1802,7 +1803,7 @@ class XMLState:
                     )
                 else:
                     size = 'freespace:' + format(
-                        Defaults.get_min_volume_mbytes()
+                        Defaults.get_min_volume_mbytes(selected_filesystem)
                     )
 
                 if ':all' in size:
@@ -1832,7 +1833,7 @@ class XMLState:
                 defaults.ROOT_VOLUME_NAME if volume_management == 'lvm' else ''
             if have_full_size_volume:
                 size = 'freespace:' + format(
-                    Defaults.get_min_volume_mbytes()
+                    Defaults.get_min_volume_mbytes(selected_filesystem)
                 )
                 fullsize = False
             else:

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -217,3 +217,8 @@ class TestDefaults:
         mock_os_path_exists.return_value = True
         assert Defaults.get_snapper_config_template_file('root') == \
             'root/etc/snapper/config-templates/default'
+
+    def test_get_min_volume_mbytes(self):
+        assert Defaults.get_min_volume_mbytes('btrfs') == 120
+        assert Defaults.get_min_volume_mbytes('xfs') == 300
+        assert Defaults.get_min_volume_mbytes('some') == 30

--- a/test/unit/storage/setup_test.py
+++ b/test/unit/storage/setup_test.py
@@ -212,7 +212,7 @@ class TestDiskSetup:
     @patch('os.path.exists')
     def test_get_disksize_mbytes_volumes(self, mock_exists):
         mock_exists.side_effect = lambda path: path != 'root_dir/newfolder'
-        assert self.setup_volumes.get_disksize_mbytes() == 2774
+        assert self.setup_volumes.get_disksize_mbytes() == 2144
 
     @patch('os.path.exists')
     def test_get_disksize_mbytes_partitions(self, mock_exists):
@@ -244,7 +244,7 @@ class TestDiskSetup:
             Defaults.get_default_efi_boot_mbytes() + \
             Defaults.get_default_boot_mbytes() + \
             root_size + \
-            5 * Defaults.get_min_volume_mbytes()
+            5 * Defaults.get_min_volume_mbytes('ext3')
 
     @patch('os.path.exists')
     def test_get_disksize_mbytes_root_volume(self, mock_exists):

--- a/test/unit/system/profile_test.py
+++ b/test/unit/system/profile_test.py
@@ -81,9 +81,9 @@ class TestProfile:
         os.remove(self.profile_file)
         assert self.profile.dot_profile == {
             'kiwi_Volume_1': 'usr_lib|size:1024|usr/lib',
-            'kiwi_Volume_2': 'etc_volume|freespace:120|etc',
+            'kiwi_Volume_2': 'etc_volume|freespace:30|etc',
             'kiwi_Volume_3': 'bin_volume|size:all|/usr/bin',
-            'kiwi_Volume_4': 'usr_bin|freespace:120|usr/bin',
+            'kiwi_Volume_4': 'usr_bin|freespace:30|usr/bin',
             'kiwi_Volume_5': 'LVSwap|size:128|',
             'kiwi_Volume_Root': 'LVRoot|freespace:500|',
             'kiwi_bootkernel': None,

--- a/test/unit/volume_manager/base_test.py
+++ b/test/unit/volume_manager/base_test.py
@@ -124,7 +124,7 @@ class TestVolumeManagerBase:
         assert self.volume_manager.get_volume_mbsize(
             self.volume_manager.volumes[0], self.volume_manager.volumes,
             'ext3'
-        ) == 362
+        ) == 272
 
     @patch('kiwi.volume_manager.base.SystemSize')
     @patch('os.path.exists')
@@ -140,7 +140,7 @@ class TestVolumeManagerBase:
         assert self.volume_manager.get_volume_mbsize(
             self.volume_manager.volumes[0], self.volume_manager.volumes,
             'ext3', True
-        ) == 162
+        ) == 72
 
     @patch('kiwi.volume_manager.base.SystemSize')
     @patch('os.path.exists')
@@ -168,7 +168,7 @@ class TestVolumeManagerBase:
         assert self.volume_manager.get_volume_mbsize(
             self.volume_manager.volumes[0], self.volume_manager.volumes,
             'ext3'
-        ) == 362
+        ) == 272
         size.accumulate_mbyte_file_sizes.assert_called_once_with(
             ['root_dir/usr/lib']
         )
@@ -204,7 +204,7 @@ class TestVolumeManagerBase:
         assert self.volume_manager.get_volume_mbsize(
             self.volume_manager.volumes[2], self.volume_manager.volumes,
             'ext3', True
-        ) == 162
+        ) == 72
         size.accumulate_mbyte_file_sizes.assert_called_once_with(
             ['root_dir/usr', 'root_dir/usr/lib']
         )

--- a/test/unit/volume_manager/lvm_test.py
+++ b/test/unit/volume_manager/lvm_test.py
@@ -175,8 +175,8 @@ class TestVolumeManagerLVM:
         self.volume_manager.volume_group = 'volume_group'
         self.volume_manager.create_volumes('ext3')
         myvol_size = 500
-        etc_size = 200 + 42 + Defaults.get_min_volume_mbytes()
-        root_size = 100 + 42 + Defaults.get_min_volume_mbytes()
+        etc_size = 200 + 42 + Defaults.get_min_volume_mbytes('ext3')
+        root_size = 100 + 42 + Defaults.get_min_volume_mbytes('ext3')
 
         assert mock_attrs.call_args_list == [
             call(

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -434,7 +434,7 @@ class TestXMLState:
             volume_type(
                 name='usr_lib',
                 parent='',
-                size='freespace:120',
+                size='freespace:30',
                 realpath='usr/lib',
                 mountpoint='usr/lib',
                 fullsize=False,
@@ -493,7 +493,7 @@ class TestXMLState:
                 is_root_volume=True
             ),
             volume_type(
-                name='etc_volume', parent='', size='freespace:120',
+                name='etc_volume', parent='', size='freespace:30',
                 realpath='etc',
                 mountpoint='etc', fullsize=False,
                 label=None,
@@ -557,7 +557,7 @@ class TestXMLState:
                 is_root_volume=False
             ),
             volume_type(
-                name='LVRoot', parent='', size='freespace:120', realpath='/',
+                name='LVRoot', parent='', size='freespace:30', realpath='/',
                 mountpoint=None, fullsize=False,
                 label=None,
                 attributes=[],


### PR DESCRIPTION
The former method provided a static value but there are huge differences for the minimum size requirement of a filesystem. For example extX is fine with 30MB whereas XFS requires 300MB. This commit adds a more dynamic default value based on the used filesystem.

