### PR TITLE
Improve remote install error handling

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-orthos/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-orthos/appliance.kiwi
@@ -18,7 +18,9 @@
             <oemconfig>
                 <oem-skip-verify>true</oem-skip-verify>
                 <oem-unattended>true</oem-unattended>
+                <oem-unattended-id>/dev/ram1</oem-unattended-id>
                 <oem-swap>false</oem-swap>
+                <oem-multipath-scan>false</oem-multipath-scan>
             </oemconfig>
             <size unit="G">5</size>
         </type>
@@ -47,11 +49,17 @@
         <package name="dracut-kiwi-oem-dump"/>
     </packages>
     <packages type="bootstrap">
-        <package name="openSUSE-release-ftp"/>
-        <package name="openSUSE-release"/>
+        <package name="gawk"/>
+        <package name="grep"/>
+        <package name="gzip"/>
+        <package name="udev"/>
+        <package name="xz"/>
+        <package name="shadow"/>
         <package name="filesystem"/>
         <package name="glibc-locale"/>
-        <package name="filesystem"/>
-        <package name="udev"/>
+        <package name="cracklib-dict-full"/>
+        <package name="ca-certificates"/>
+        <package name="ca-certificates-mozilla"/>
+        <package name="openSUSE-release"/>
     </packages>
 </image>

--- a/build-tests/x86/tumbleweed/test-image-orthos/config.sh
+++ b/build-tests/x86/tumbleweed/test-image-orthos/config.sh
@@ -43,6 +43,12 @@ suseInsertService sshd
 suseInsertService network
 
 #======================================
+# setup dracut for live system
+#--------------------------------------
+echo 'add_drivers+=" brd "' >> \
+    /etc/dracut.conf.d/10-liveroot-file.conf
+
+#======================================
 # Setup default target, multi-user
 #--------------------------------------
 baseSetRunlevel 3

--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -387,25 +387,25 @@ function get_remote_image_source_files {
             echo "--- ip a ---"; ip a
             echo "--- ip r ---"; ip r
         } >> /tmp/fetch.info 2>&1
-        report_and_quit \
-            "Failed to fetch ${image_md5_uri}, see /tmp/fetch.info"
+        show_log_and_quit \
+            "Failed to fetch ${image_md5_uri}" /tmp/fetch.info
     fi
 
     if ! fetch_file "${image_kernel_uri}" > "${metadata_dir}/linux";then
-        report_and_quit \
-            "Failed to fetch ${image_kernel_uri}, see /tmp/fetch.info"
+        show_log_and_quit \
+            "Failed to fetch ${image_kernel_uri}" /tmp/fetch.info
     fi
 
     if ! fetch_file "${image_initrd_uri}" > "${install_dir}/initrd.system_image"
     then
-        report_and_quit \
-            "Failed to fetch ${image_initrd_uri}, see /tmp/fetch.info"
+        show_log_and_quit \
+            "Failed to fetch ${image_initrd_uri}" /tmp/fetch.info
     fi
 
     if ! fetch_file "${image_config_uri}" > "/config.bootoptions"
     then
-        report_and_quit \
-            "Failed to fetch ${image_config_uri}, see /tmp/fetch.info"
+        show_log_and_quit \
+            "Failed to fetch ${image_config_uri}" /tmp/fetch.info
     fi
 
     echo "${image_uri}|${image_md5}"

--- a/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
@@ -126,6 +126,18 @@ function _fbiterm_ok {
     return 0
 }
 
+function show_log_and_quit {
+    local text_message="$1"
+    local log_file="$2"
+    run_dialog --timeout 60 --backtitle "\"${text_message}\"" \
+        --textbox "${log_file}" 15 80
+    if getargbool 0 rd.debug; then
+        die "${text_message}"
+    else
+        reboot -f
+    fi
+}
+
 function report_and_quit {
     local text_message="$1"
     run_dialog --timeout 60 --msgbox "\"${text_message}\"" 5 80


### PR DESCRIPTION
Improve error reporting for remote deployment
    
Add new method called show_log_and_quit which displays  the written error log file as a file box to the user
