### PR TITLE
Fix handling of zipl.conf in plain zipl bootloader

### DIFF
--- a/test/unit/bootloader/config/zipl_test.py
+++ b/test/unit/bootloader/config/zipl_test.py
@@ -56,15 +56,20 @@ class TestBootLoaderZipl:
     @patch('kiwi.bootloader.config.zipl.Path.create')
     @patch('kiwi.bootloader.config.zipl.Command.run')
     @patch('kiwi.bootloader.config.zipl.BootLoaderTemplateZipl')
+    @patch('kiwi.bootloader.config.zipl.Temporary.new_file')
     @patch.object(BootLoaderZipl, '_write_config_file')
     @patch.object(BootLoaderZipl, '_get_template_parameters')
     @patch.object(BootLoaderSpecBase, 'get_entry_name')
     def test_setup_loader(
         self, mock_get_entry_name, mock_get_template_parameters,
-        mock_write_config_file, mock_BootLoaderTemplateZipl, mock_Command_run,
+        mock_write_config_file, mock_Temporary_new_file,
+        mock_BootLoaderTemplateZipl, mock_Command_run,
         mock_Path_create, mock_Path_wipe, mock_BootImageBase_get_boot_names,
         mock_os_path_exists
     ):
+        temporary = Mock()
+        temporary.name = 'system_root_mount/kiwi_zipl.conf_'
+        mock_Temporary_new_file.return_value = temporary
         mock_get_entry_name.return_value = \
             'opensuse-leap-5.3.18-59.10-default.conf'
 
@@ -82,7 +87,7 @@ class TestBootLoaderZipl:
             call(
                 mock_BootLoaderTemplateZipl.
                 return_value.get_loader_template.return_value,
-                'system_root_mount/etc/zipl.conf',
+                'system_root_mount/kiwi_zipl.conf_',
                 mock_get_template_parameters.return_value
             ),
             call(
@@ -91,12 +96,6 @@ class TestBootLoaderZipl:
                 'system_root_mount/boot/loader/entries/'
                 'opensuse-leap-5.3.18-59.10-default.conf',
                 mock_get_template_parameters.return_value
-            ),
-            call(
-                mock_BootLoaderTemplateZipl.
-                return_value.get_loader_template.return_value,
-                'system_root_mount/etc/zipl.conf',
-                {'targetbase': ''}
             )
         ]
         assert self.bootloader._mount_system.called
@@ -104,7 +103,7 @@ class TestBootLoaderZipl:
             [
                 'chroot', 'system_root_mount', 'zipl',
                 '--noninteractive',
-                '--config', '/etc/zipl.conf',
+                '--config', '/kiwi_zipl.conf_',
                 '--blsdir', '/boot/loader/entries',
                 '--verbose'
             ]


### PR DESCRIPTION
When using the plain zipl bootloader kiwi created a /etc/zipl.conf file. However, this file was only useful during image build as it points to a loop target device and geometry but does not represent a proper config file to be used in the running system. In addition the different distributors provides their own version and layout of the zipl.conf to be used inside of the system and with their respective tools. Thus this commit changes the way how kiwi operates in a way that the zipl.conf used in the initial image only exists during the image build process. An eventual present /etc/zipl.conf will not be touched by kiwi. This Fixes #2597

