### PR TITLE
Fixed wrong log level on --logfile

### DIFF
--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -64,7 +64,7 @@ global options:
         up at ~/.config/kiwi/config.yml or /etc/kiwi.yml
     --logfile=<filename>
         create a log file containing all log information including
-        debug information even if this is was not requested by the
+        debug information even if this was not requested by the
         debug switch. The special call: '--logfile stdout' sends all
         information to standard out instead of writing to a file
     --logsocket=<socketfile>

--- a/kiwi/logger.py
+++ b/kiwi/logger.py
@@ -97,13 +97,27 @@ class Logger(logging.Logger):
         """
         return self.log_flags
 
-    def setLogLevel(self, level: int, except_for: List[str] = []) -> None:
+    def setLogLevel(
+        self, level: int, except_for: List[str] = [], only_for: List[str] = []
+    ) -> None:
         """
         Set custom log level for all console handlers
 
         :param int level: log level number
+        :param list except_for:
+            set log level to all handlers except for the given list
+        :param list only_for:
+            set log level to the given handlers only
+
+        if both except_for and only_for handlers are specified,
+        the except_for list will be ignored
         """
         self.log_level = level
+        if only_for:
+            for handler_type in self.log_handlers:
+                if handler_type in only_for:
+                    self.log_handlers[handler_type].setLevel(level)
+            return
         for handler_type in self.log_handlers:
             if handler_type not in except_for:
                 self.log_handlers[handler_type].setLevel(level)

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -124,10 +124,14 @@ class CliTask:
                 log.setLogLevel(logging.DEBUG)
             else:
                 log.setLogLevel(logging.INFO)
+
             if self.global_args['--logfile'] == 'stdout':
                 # deactivate standard console logger by setting
                 # the highest possible log entry level
                 log.setLogLevel(logging.CRITICAL, except_for=['file', 'socket'])
+            elif self.global_args['--logfile']:
+                # set debug level for the file and socket logger
+                log.setLogLevel(logging.DEBUG, only_for=['file', 'socket'])
 
             # set log flags
             if self.global_args['--debug-run-scripts-in-screen']:

--- a/test/unit/logger_test.py
+++ b/test/unit/logger_test.py
@@ -1,6 +1,6 @@
 import sys
 from unittest.mock import (
-    patch, call
+    patch, call, Mock
 )
 from pytest import raises
 
@@ -86,6 +86,35 @@ class TestLogger:
     def test_getLogLevel(self):
         self.log.setLogLevel(42)
         assert self.log.getLogLevel() == 42
+
+    def test_setLogLevel(self):
+        handler_one = Mock()
+        handler_two = Mock()
+        self.log.log_handlers = {
+            'handler_one': handler_one,
+            'handler_two': handler_two
+        }
+        self.log.setLogLevel(
+            10, except_for=['handler_one']
+        )
+        assert not handler_one.setLevel.called
+        handler_two.setLevel.assert_called_once_with(10)
+
+        handler_one.reset_mock()
+        handler_two.reset_mock()
+        self.log.setLogLevel(
+            10, only_for=['handler_one']
+        )
+        assert not handler_two.setLevel.called
+        handler_one.setLevel.assert_called_once_with(10)
+
+        handler_one.reset_mock()
+        handler_two.reset_mock()
+        self.log.setLogLevel(
+            10, except_for=['handler_one'], only_for=['handler_one']
+        )
+        assert not handler_two.setLevel.called
+        handler_one.setLevel.assert_called_once_with(10)
 
     def test_getLogFlags(self):
         assert self.log.getLogFlags().get('run-scripts-in-screen') is None

--- a/test/unit/tasks/base_test.py
+++ b/test/unit/tasks/base_test.py
@@ -61,12 +61,30 @@ class TestCliTask:
         mock_command_args.assert_called_once_with()
         mock_global_args.assert_called_once_with()
         assert mock_setLogLevel.call_args_list == [
-            call(logging.DEBUG), call(logging.CRITICAL, except_for=['file', 'socket'])
+            call(logging.DEBUG),
+            call(logging.CRITICAL, except_for=['file', 'socket'])
         ]
         mock_setLogFlag.assert_called_once_with('run-scripts-in-screen')
         mock_setlog.assert_called_once_with('stdout')
         mock_color.assert_called_once_with()
         mock_runtime_config.assert_called_once_with()
+
+        mock_setLogLevel.reset_mock()
+        mock_global_args.return_value = {
+            '--debug': True,
+            '--debug-run-scripts-in-screen': True,
+            '--logfile': 'some',
+            '--logsocket': 'log_socket',
+            '--loglevel': None,
+            '--color-output': True,
+            '--profile': ['vmxFlavour'],
+            '--type': None
+        }
+        self.task = CliTask()
+        assert mock_setLogLevel.call_args_list == [
+            call(logging.DEBUG),
+            call(logging.DEBUG, only_for=['file', 'socket'])
+        ]
 
     @patch('kiwi.logger.Logger.setLogLevel')
     @patch('kiwi.logger.Logger.setLogFlag')


### PR DESCRIPTION
When using --logfile, the log generated there matches the stdout log (which without --debug, does not include any debug info). This is in contrast to the automatically generated one in the output directory, which always does and also not following the way how it is documented. This Fixes #2503

