### PR TITLE
Add support for isomd5sum for tagging iso files

### DIFF
--- a/kiwi.yml
+++ b/kiwi.yml
@@ -60,6 +60,9 @@
 #  # Specify tool category which should be used to build iso images
 #  # Possible values are: xorriso
 #  - tool_category: xorriso
+#  # Specify media tag tool used to implant iso checksums
+#  # Possible values are checkmedia and isomd5sum
+#  - media_tag_tool: checkmedia
 
 
 # Setup process parameters for OCI toolchain

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1759,6 +1759,17 @@ class Defaults:
         return 'xorriso'
 
     @staticmethod
+    def get_iso_media_tag_tool():
+        """
+        Provides default iso media tag tool
+
+        :return: name
+
+        :rtype: str
+        """
+        return 'checkmedia'
+
+    @staticmethod
     def get_container_compression():
         """
         Provides default container compression

--- a/kiwi/iso_tools/iso.py
+++ b/kiwi/iso_tools/iso.py
@@ -18,6 +18,7 @@
 # project
 from kiwi.defaults import Defaults
 from kiwi.command import Command
+from kiwi.runtime_config import RuntimeConfig
 
 
 class Iso:
@@ -42,12 +43,22 @@ class Iso:
 
         :param str isofile: path to the ISO file
         """
-        Command.run(
-            [
-                'tagmedia',
-                '--digest', 'sha256',
-                '--check',
-                '--pad', '0',
-                isofile
-            ]
-        )
+        media_tagger = RuntimeConfig().get_iso_media_tag_tool()
+        if media_tagger == 'checkmedia':
+            Command.run(
+                [
+                    'tagmedia',
+                    '--digest', 'sha256',
+                    '--check',
+                    '--pad', '0',
+                    isofile
+                ]
+            )
+        elif media_tagger == 'isomd5sum':
+            Command.run(
+                [
+                    'implantisomd5',
+                    '--force',
+                    isofile
+                ]
+            )

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -919,6 +919,11 @@ class RuntimeChecker:
         ''')
         if self.xml_state.build_type.get_mediacheck() is True:
             tool = 'tagmedia'
+            media_tagger = RuntimeConfig().get_iso_media_tag_tool()
+            if media_tagger == 'checkmedia':
+                tool = 'tagmedia'
+            elif media_tagger == 'isomd5sum':
+                tool = 'implantisomd5'
             if not Path.which(filename=tool, access_mode=os.X_OK):
                 raise KiwiRuntimeError(
                     message_tool_not_found.format(name=tool)

--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -17,6 +17,7 @@
 #
 import os
 import logging
+from typing import Literal
 import yaml
 
 # project
@@ -308,6 +309,37 @@ class RuntimeConfig:
                 )
             )
             return Defaults.get_iso_tool_category()
+
+    def get_iso_media_tag_tool(self) -> Literal['checkmedia', 'isomd5sum']:
+        """
+        Return media tag tool used to checksum iso images
+
+        iso:
+          - media_tag_tool: checkmedia
+
+        if no or invalid configuration exists the default media tagger
+        from the Defaults class is returned
+
+        :return: A name
+
+        :rtype: str
+        """
+        iso_media_tag_tool = self._get_attribute(
+            element='iso', attribute='media_tag_tool'
+        )
+        if not iso_media_tag_tool:
+            return Defaults.get_iso_media_tag_tool()
+        elif 'checkmedia' in iso_media_tag_tool:
+            return iso_media_tag_tool
+        elif 'isomd5sum' in iso_media_tag_tool:
+            return iso_media_tag_tool
+        else:
+            log.warning(
+                'Skipping invalid iso media tag tool: {0}'.format(
+                    iso_media_tag_tool
+                )
+            )
+            return Defaults.get_iso_media_tag_tool()
 
     def get_oci_archive_tool(self):
         """

--- a/test/data/kiwi_config/invalid/.config/kiwi/config.yml
+++ b/test/data/kiwi_config/invalid/.config/kiwi/config.yml
@@ -1,5 +1,6 @@
 iso:
   - tool_category: foo
+  - media_tag_tool: foo
 
 container:
   - compress: foo

--- a/test/data/kiwi_config/ok/.config/kiwi/config.yml
+++ b/test/data/kiwi_config/ok/.config/kiwi/config.yml
@@ -13,6 +13,7 @@ obs:
 
 iso:
   - tool_category: xorriso
+  - media_tag_tool: isomd5sum
 
 oci:
   - archive_tool: umoci

--- a/test/data/kiwi_config/other/.config/kiwi/config.yml
+++ b/test/data/kiwi_config/other/.config/kiwi/config.yml
@@ -3,3 +3,6 @@ bundle:
 
 container:
   - compress: true
+
+iso:
+  - media_tag_tool: checkmedia

--- a/test/unit/iso_tools/iso_test.py
+++ b/test/unit/iso_tools/iso_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from kiwi.defaults import Defaults
 from kiwi.iso_tools.iso import Iso
@@ -13,8 +13,23 @@ class TestIso:
         self.setup()
 
     @patch('kiwi.iso_tools.iso.Command.run')
-    def test_set_media_tag(self, mock_command):
+    @patch('kiwi.iso_tools.iso.RuntimeConfig')
+    def test_set_media_tag_checkmedia(self, mock_RuntimeConfig, mock_command):
+        runtime_config = Mock()
+        runtime_config.get_iso_media_tag_tool.return_value = 'checkmedia'
+        mock_RuntimeConfig.return_value = runtime_config
         Iso.set_media_tag('foo')
         mock_command.assert_called_once_with(
             ['tagmedia', '--digest', 'sha256', '--check', '--pad', '0', 'foo']
+        )
+
+    @patch('kiwi.iso_tools.iso.Command.run')
+    @patch('kiwi.iso_tools.iso.RuntimeConfig')
+    def test_set_media_tag_isomd5sum(self, mock_RuntimeConfig, mock_command):
+        runtime_config = Mock()
+        runtime_config.get_iso_media_tag_tool.return_value = 'isomd5sum'
+        mock_RuntimeConfig.return_value = runtime_config
+        Iso.set_media_tag('foo')
+        mock_command.assert_called_once_with(
+            ['implantisomd5', '--force', 'foo']
         )

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -66,6 +66,7 @@ class TestRuntimeConfig:
             'https://api.example.com'
         assert runtime_config.get_container_compression() is False
         assert runtime_config.get_iso_tool_category() == 'xorriso'
+        assert runtime_config.get_iso_media_tag_tool() == 'isomd5sum'
         assert runtime_config.get_oci_archive_tool() == 'umoci'
         assert runtime_config.get_mapper_tool() == 'partx'
         assert runtime_config.get_package_changes() is True
@@ -96,6 +97,7 @@ class TestRuntimeConfig:
             Defaults.get_obs_api_server_url()
         assert runtime_config.get_container_compression() is True
         assert runtime_config.get_iso_tool_category() == 'xorriso'
+        assert runtime_config.get_iso_media_tag_tool() == 'checkmedia'
         assert runtime_config.get_oci_archive_tool() == 'umoci'
         assert runtime_config.get_mapper_tool() == 'kpartx'
         assert runtime_config.get_package_changes() is False
@@ -120,9 +122,15 @@ class TestRuntimeConfig:
             assert 'Skipping invalid iso tool category: foo' in \
                 self._caplog.text
 
+        with self._caplog.at_level(logging.WARNING):
+            assert runtime_config.get_iso_media_tag_tool() == "checkmedia"
+            assert 'Skipping invalid iso media tag tool: foo' in \
+                self._caplog.text
+
     def test_config_sections_other_settings(self):
         with patch.dict('os.environ', {'HOME': '../data/kiwi_config/other'}):
             runtime_config = RuntimeConfig(reread=True)
 
         assert runtime_config.get_container_compression() is True
         assert runtime_config.get_package_changes() is True
+        assert runtime_config.get_iso_media_tag_tool() == "checkmedia"


### PR DESCRIPTION
The `isomd5sum` tool suite is used and available on all supported distributions except SUSE distributions, and is necessary to produce conformant ISOs for most Linux distributions.

This change adds support for `isomd5sum` tool suite for kiwi, though it does not extend the kiwi-live dracut module to use it. The upstream dracut `dmsquash-live` module must be used instead.
