### PR TITLE
kiwi/schema: Fix allowed value type for ISO publisher and application ID

### DIFF
--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -26,7 +26,7 @@ namespace nul = ""
 
 safe-posix-name = xsd:token {pattern = "[a-zA-Z0-9_\-\.]+"}
 safe-posix-short-name = xsd:token {pattern = "[a-zA-Z0-9_\-\.]{1,32}"}
-safe-posix-long-name = xsd:token {pattern = "[a-zA-Z0-9_\-\.]{1,128}"}
+ecma-119-achar-128-text = xsd:token {pattern = "[a-zA-Z0-9_\-\. ]{1,128}"}
 locale-name = xsd:token {pattern = "(POSIX|[a-z]{2,3}_[A-Z]{2})(,[a-z]{2,3}_[A-Z]{2})*"}
 mac-address-type = xsd:token {pattern = "([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}"}
 size-type = xsd:token {pattern = "(\d*|image)"}
@@ -2145,7 +2145,7 @@ div {
         ## for the iso/(oem install iso) type only:
         ## Specifies the Application ID to be written
         ## into the master block. There is space for 128 characters.
-        attribute application_id { safe-posix-long-name }
+        attribute application_id { ecma-119-achar-128-text }
         >> sch:pattern [ id = "application_id" is-a = "image_type"
             sch:param [ name = "attr" value = "application_id" ]
             sch:param [ name = "types" value = "iso oem" ]
@@ -2185,7 +2185,7 @@ div {
         ]
     k.type.publisher.attribute =
         ## Specifies the publisher name of the ISO.
-        attribute publisher { text }
+        attribute publisher { ecma-119-achar-128-text }
         >> sch:pattern [ id = "publisher" is-a = "image_type"
             sch:param [ name = "attr" value = "publisher" ]
             sch:param [ name = "types" value = "iso" ]

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -31,9 +31,9 @@
       <param name="pattern">[a-zA-Z0-9_\-\.]{1,32}</param>
     </data>
   </define>
-  <define name="safe-posix-long-name">
+  <define name="ecma-119-achar-128-text">
     <data type="token">
-      <param name="pattern">[a-zA-Z0-9_\-\.]{1,128}</param>
+      <param name="pattern">[a-zA-Z0-9_\-\. ]{1,128}</param>
     </data>
   </define>
   <define name="locale-name">
@@ -3074,7 +3074,7 @@ into the master block. There is space for 32 characters.</a:documentation>
         <a:documentation>for the iso/(oem install iso) type only:
 Specifies the Application ID to be written
 into the master block. There is space for 128 characters.</a:documentation>
-        <ref name="safe-posix-long-name"/>
+        <ref name="ecma-119-achar-128-text"/>
       </attribute>
       <sch:pattern id="application_id" is-a="image_type">
         <sch:param name="attr" value="application_id"/>
@@ -3128,6 +3128,7 @@ container image created by Kiwi.  Default is true.</a:documentation>
     <define name="k.type.publisher.attribute">
       <attribute name="publisher">
         <a:documentation>Specifies the publisher name of the ISO.</a:documentation>
+        <ref name="ecma-119-achar-128-text"/>
       </attribute>
       <sch:pattern id="publisher" is-a="image_type">
         <sch:param name="attr" value="publisher"/>


### PR DESCRIPTION
According to the spec, this should be constrained to 128 characters but also allow whitespaces. We didn't allow spaces in application ID, but allowed too much for Publisher.

Now we set up both correctly.

Fixes #2617.