### PR TITLE
Allow string versions and test "word" versions

### DIFF
--- a/kiwi/system/result.py
+++ b/kiwi/system/result.py
@@ -47,9 +47,9 @@ result_name_tags = NamedTuple(
         ('A', str),  # architecture name
         ('I', str),  # custom ID setting
         ('T', str),  # image type name
-        ('M', int),  # Major version number
-        ('m', int),  # Minor version number
-        ('p', int),  # Patch version number
+        ('M', str),  # Major version number
+        ('m', str),  # Minor version number
+        ('p', str),  # Patch version number
         ('v', str)   # Version string
     ]
 )
@@ -76,7 +76,11 @@ class Result:
         self.xml_state = xml_state
 
     def add_bundle_format(self, pattern: str):
-        (major, minor, patch) = self.xml_state.get_image_version().split('.')
+        version_string = self.xml_state.get_image_version()
+        if '.' in version_string:
+            (major, minor, patch) = version_string.split(sep='.', maxsplit=2)
+        else:
+            (major, minor, patch) = (version_string, '', '')
         self.name_tags = result_name_tags(
             N=self.xml_state.xml_data.get_name(),
             P='_'.join(
@@ -85,10 +89,10 @@ class Result:
             A=self.xml_state.host_architecture,
             I='',
             T=self.xml_state.get_build_type_name(),
-            M=int(major),
-            m=int(minor),
-            p=int(patch),
-            v=self.xml_state.get_image_version()
+            M=major,
+            m=minor,
+            p=patch,
+            v=version_string
         )
         self.result_files['bundle_format'] = {
             'pattern': pattern,

--- a/test/unit/system/result_test.py
+++ b/test/unit/system/result_test.py
@@ -35,8 +35,15 @@ class TestResult:
         assert self.result.print_results() is None
         assert not self._caplog.text
 
-    def test_print_results_data(self):
+    def test_print_results_data_number_version(self):
         self.xml_state.get_image_version.return_value = '1.1.1'
+        self.result.add('foo', 'bar')
+        self.result.add_bundle_format('%N')
+        with self._caplog.at_level(logging.INFO):
+            self.result.print_results()
+
+    def test_print_results_data_word_version(self):
+        self.xml_state.get_image_version.return_value = 'test'
         self.result.add('foo', 'bar')
         self.result.add_bundle_format('%N')
         with self._caplog.at_level(logging.INFO):


### PR DESCRIPTION
There are descriptions out in the wild that use "non-numeric" versions in their descriptions, particularly without separators for splitting.

This change switches all of this to strings rather than assuming numbers and gracefully handles the single word case.

Fixes #2621.
