### PR TITLE
kiwi/builder/live: Cleanup leftover dracut config file and log correct application id

### DIFF
--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -190,6 +190,8 @@ class LiveImageBuilder:
                 config_file=self.root_dir + '/etc/dracut.conf.d/02-livecd.conf'
             )
             self.boot_image.create_initrd(self.mbrid)
+            # Clean up leftover dracut config file (which can break installs)
+            os.unlink(self.root_dir + '/etc/dracut.conf.d/02-livecd.conf')
             if self.bootloader == 'systemd_boot':
                 # make sure the initrd name follows the dracut
                 # naming conventions

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -74,6 +74,8 @@ class LiveImageBuilder:
             Defaults.get_volume_id()
         self.mbrid = SystemIdentifier()
         self.mbrid.calculate_id()
+        self.application_id = self.xml_state.build_type.get_application_id() or \
+            self.mbrid.get_id()
         self.publisher = xml_state.build_type.get_publisher() or \
             Defaults.get_publisher()
         self.custom_args = custom_args
@@ -131,7 +133,7 @@ class LiveImageBuilder:
 
         # custom iso metadata
         log.info('Using following live ISO metadata:')
-        log.info('--> Application id: {0}'.format(self.mbrid.get_id()))
+        log.info('--> Application id: {0}'.format(self.application_id))
         log.info('--> Publisher: {0}'.format(self.publisher))
         log.info('--> Volume id: {0}'.format(self.volume_id))
         custom_iso_args = {
@@ -140,7 +142,7 @@ class LiveImageBuilder:
                 'preparer': Defaults.get_preparer(),
                 'volume_id': self.volume_id,
                 'mbr_id': self.mbrid.get_id(),
-                'application_id': self.xml_state.build_type.get_application_id(),
+                'application_id': self.application_id,
                 'efi_mode': self.firmware.efi_mode(),
                 'legacy_bios_mode': self.firmware.legacy_bios_mode()
             }

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -152,10 +152,11 @@ class TestLiveImageBuilder:
     @patch('kiwi.builder.live.FileSystem.new')
     @patch('kiwi.builder.live.SystemSize')
     @patch('kiwi.builder.live.Defaults.get_grub_boot_directory_name')
+    @patch('os.unlink')
     @patch('os.path.exists')
     @patch('os.chmod')
     def test_create_overlay_structure_boot_on_systemd_boot(
-        self, mock_chmod, mock_exists, mock_grub_dir, mock_size,
+        self, mock_chmod, mock_exists, mock_unlink, mock_grub_dir, mock_size,
         mock_filesystem, mock_isofs, mock_Iso, mock_tag, mock_shutil,
         mock_Temporary, mock_setup_media_loader_directory, mock_DeviceProvider,
         mock_Command_run, mock_LoopDevice, mock_create_boot_loader_config
@@ -190,10 +191,11 @@ class TestLiveImageBuilder:
     @patch('kiwi.builder.live.FileSystem.new')
     @patch('kiwi.builder.live.SystemSize')
     @patch('kiwi.builder.live.Defaults.get_grub_boot_directory_name')
+    @patch('os.unlink')
     @patch('os.path.exists')
     @patch('os.chmod')
     def test_create_overlay_structure_boot_on_grub(
-        self, mock_chmod, mock_exists, mock_grub_dir, mock_size,
+        self, mock_chmod, mock_exists, mock_unlink, mock_grub_dir, mock_size,
         mock_filesystem, mock_isofs, mock_Iso, mock_tag, mock_shutil,
         mock_Temporary, mock_setup_media_loader_directory, mock_DeviceProvider,
         mock_LoopDevice, mock_create_boot_loader_config, xml_filesystem
@@ -204,6 +206,7 @@ class TestLiveImageBuilder:
         loop_provider = Mock()
         mock_LoopDevice.return_value.__enter__.return_value = loop_provider
         mock_exists.return_value = True
+        mock_unlink.return_value = True
         mock_grub_dir.return_value = 'grub2'
 
         temp_squashfs = Mock()
@@ -413,9 +416,10 @@ class TestLiveImageBuilder:
     @patch('kiwi.builder.live.IsoToolsBase.setup_media_loader_directory')
     @patch('kiwi.builder.live.Temporary')
     @patch('kiwi.builder.live.shutil')
+    @patch('os.unlink')
     def test_create_no_kernel_found(
-        self, mock_shutil, mock_Temporary, mock_setup_media_loader_directory,
-        mock_create_boot_loader_config
+        self, mock_unlink, mock_shutil, mock_Temporary,
+        mock_setup_media_loader_directory, mock_create_boot_loader_config
     ):
         self.firmware.bios_mode.return_value = False
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
@@ -427,9 +431,10 @@ class TestLiveImageBuilder:
     @patch('kiwi.builder.live.IsoToolsBase.setup_media_loader_directory')
     @patch('kiwi.builder.live.Temporary')
     @patch('kiwi.builder.live.shutil')
+    @patch('os.unlink')
     def test_create_no_hypervisor_found(
-        self, mock_shutil, mock_Temporary, mock_setup_media_loader_directory,
-        mock_create_boot_loader_config
+        self, mock_unlink, mock_shutil, mock_Temporary,
+        mock_setup_media_loader_directory, mock_create_boot_loader_config
     ):
         self.firmware.bios_mode.return_value = False
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
@@ -441,14 +446,16 @@ class TestLiveImageBuilder:
     @patch('kiwi.builder.live.IsoToolsBase.setup_media_loader_directory')
     @patch('kiwi.builder.live.Temporary')
     @patch('kiwi.builder.live.shutil')
+    @patch('os.unlink')
     @patch('os.path.exists')
     def test_create_no_initrd_found(
-        self, mock_exists, mock_shutil, mock_Temporary,
+        self, mock_exists, mock_unlink, mock_shutil, mock_Temporary,
         mock_setup_media_loader_directory,
         mock_create_boot_loader_config
     ):
         self.firmware.bios_mode.return_value = False
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
         mock_exists.return_value = False
+        mock_unlink.return_value = True
         with raises(KiwiLiveBootImageError):
             self.live_image.create()


### PR DESCRIPTION
This pull request contains two small fixes for building live ISOs:
* A commit to clean up a leftover dracut config file that caused Fedora live media to become non-installable
* A commit to correctly log the application id whenever a custom one is set