### PR TITLE
remove dependency on /usr/bin/python

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -729,6 +729,11 @@ done
 %fdupes %{buildroot}/srv/tftpboot
 %endif
 
+%if 0%{?suse_version}
+# bsc#1212476
+%python3_fix_shebang
+%endif
+
 %if "%{_vendor}" != "debbuild" && 0%{?suse_version} < 1550
 %ifarch %{ix86} x86_64
 %pre -n kiwi-pxeboot


### PR DESCRIPTION
Fixes bsc#1212476.

Changes proposed in this pull request:
* shebangs include /usr/bin/python3.11 instead of /usr/bin/python3, thus 
```
:/ # rpm -qR python3-kiwi | grep bin
/usr/bin/python3.11
:/ #
```