### PR TITLE
Fix bundle extension for archive types

### DIFF
--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -286,7 +286,10 @@ class ResultBundleTask(CliTask):
     ) -> str:
         image_version = result.xml_state.get_image_version()
         image_name = result.xml_state.xml_data.get_name()
-        extension = result_file.filename.split('.').pop()
+        if '.tar.' in result_file.filename:
+            extension = f'tar.{result_file.filename.split(".").pop()}'
+        else:
+            extension = result_file.filename.split('.').pop()
         if bundle_file_format_name:
             bundle_file_basename = '.'.join(
                 [bundle_file_format_name, extension]


### PR DESCRIPTION
When bundling result files that uses an archive type like tbz or docker, kiwi creates them with the extension tar.xz/tar.gz The bundler code only uses the extension from the last tuple in a "." split which is wrong for "tar." filenames. This commit adds an exception to the prefix rule for this output filenames and Fixes #2628

