### PR TITLE
Fixed ramdisk size setup

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -50,6 +50,7 @@ function get_disk_list {
         local rd_size
         local modfile=/etc/modprobe.d/99-brd.conf
         rd_size=$(getarg ramdisk_size=)
+        mkdir -p /etc/modprobe.d
         if [ -n "${rd_size}" ];then
             echo "options brd rd_size=${rd_size}" > ${modfile}
         fi


### PR DESCRIPTION
For setting up the brd rd_size option kiwi creates 99-brd.conf used at load time of the kernel brd driver. The location for the conf file is set to /etc/modprobe.d/ However, in newer versions the location has changed to /usr/lib/modprobe.d/ and /etc/modprobe.d no longer exists. This commit allows to handle both systems

