### PR TITLE
Fix initrd permissions

### DIFF
--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -235,6 +235,9 @@ class BootImageDracut(BootImageBase):
             self.initrd_filename = os.sep.join(
                 [self.target_dir, dracut_initrd_basename]
             )
+            Command.run(
+                ['chmod', '644', self.initrd_filename]
+            )
 
     def _get_modules(self) -> List[str]:
         cmd = Command.run(

--- a/test/unit/boot/image/dracut_test.py
+++ b/test/unit/boot/image/dracut_test.py
@@ -152,6 +152,9 @@ class TestBootImageKiwi:
                     'LimeJeOS.x86_64-1.13.2.initrd',
                     'some-target-dir'
                 ]
+            ),
+            call(
+                ['chmod', '644', 'some-target-dir/LimeJeOS.x86_64-1.13.2.initrd']
             )
         ]
         mock_command.reset_mock()
@@ -172,6 +175,9 @@ class TestBootImageKiwi:
                     'system-directory/foo',
                     'some-target-dir'
                 ]
+            ),
+            call(
+                ['chmod', '644', 'some-target-dir/foo']
             )
         ]
 


### PR DESCRIPTION
kiwi stored the initrd for ISO images as 600 which might be too restrictive. This commit makes sure the initrd is stored as 644 and Fixes bsc#1229257


