### PR TITLE
CHRP boot

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 from string import Template
+from textwrap import dedent
 import re
 import os
 import logging
@@ -610,7 +611,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
 
     def _supports_bios_modules(self):
-        if self.arch == 'ix86' or self.arch == 'x86_64':
+        if self.arch == 'ix86' or self.arch == 'x86_64' or Defaults.is_ppc64_arch(self.arch):
             return True
         return False
 
@@ -927,6 +928,30 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 uuid, mbrid, lookup_path
             )
 
+    def _setup_chrp_config(self, mbrid):
+        early_boot_script = os.path.normpath(
+            os.sep.join(
+                [self._get_grub2_boot_path(), 'powerpc-ieee1275', 'grub.cfg']
+            )
+        )
+        self._create_early_boot_script_for_mbrid_search(
+            early_boot_script, mbrid
+        )
+        chrp_dir = os.path.normpath(os.sep.join([self.boot_dir, 'ppc']))
+        Path.create(chrp_dir)
+        chrp_bootinfo_file = os.sep.join([chrp_dir, 'bootinfo.txt'])
+        chrp_config = dedent('''
+            <chrp-boot>
+            <description>{os_name}</description>
+            <os-name>{os_name}</os-name>
+            <boot-script>boot &device;:1,\boot\grub2\powerpc-ieee1275\grub.elf</boot-script>
+            </chrp-boot>
+        ''')
+        with open(chrp_bootinfo_file, 'w') as chrp_bootinfo:
+            chrp_bootinfo.write(
+                chrp_config.format(os_name=self.get_menu_entry_install_title())
+            )
+
     def _setup_bios_image(self, mbrid, lookup_path=None):
         """
         Provide bios grub image
@@ -941,6 +966,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             self._create_bios_image(
                 mbrid, lookup_path
             )
+        if Defaults.is_ppc64_arch(Defaults.get_platform_name()):
+            self._setup_chrp_config(mbrid)
+            return
         bash_command = ' '.join(
             [
                 'cat',
@@ -1212,7 +1240,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         )
 
     def _get_bios_modules_path(self, lookup_path=None):
-        return self._get_module_path('i386-pc', lookup_path)
+        return self._get_module_path(Defaults.get_bios_module_directory_name(), lookup_path)
 
     def _get_xen_modules_path(self, lookup_path=None):
         return self._get_module_path(

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -480,7 +480,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         :param string lookup_path: custom module lookup path
         """
         log.info('Creating grub2 bootloader images')
-        self.efi_boot_path = self.create_efi_path(in_sub_dir='')
+        if self.firmware.efi_mode():
+            self.efi_boot_path = self.create_efi_path(in_sub_dir='')
 
         log.info('--> Creating identifier file %s', mbrid.get_id())
         grub_boot_path = self._get_grub2_boot_path()

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -208,6 +208,24 @@ class Defaults:
         return False
 
     @staticmethod
+    def is_ppc64_arch(arch):
+        """
+        Checks if machine architecture is ppc64 based
+
+        Any arch that matches little endian or big endian ppc64 architecture
+        causes the method to return True. Anything else will
+        cause the method to return False
+
+        :rtype: bool
+        """
+        ppc64_arch_names = [
+            'ppc64', 'ppc64le'
+        ]
+        if arch in ppc64_arch_names:
+            return True
+        return False
+
+    @staticmethod
     def is_buildservice_worker():
         """
         Checks if build host is an open buildservice machine
@@ -956,11 +974,11 @@ class Defaults:
         :rtype: str
         """
         bios_grub_core_patterns = [
-            '/usr/share/grub*/i386-pc/{0}'.format(
-                Defaults.get_bios_image_name()
+            '/usr/share/grub*/{0}/{1}'.format(
+                Defaults.get_bios_module_directory_name(), Defaults.get_bios_image_name()
             ),
-            '/usr/lib/grub*/i386-pc/{0}'.format(
-                Defaults.get_bios_image_name()
+            '/usr/lib/grub*/{0}/{1}'.format(
+                Defaults.get_bios_module_directory_name(), Defaults.get_bios_image_name()
             )
         ]
         for bios_grub_core_pattern in bios_grub_core_patterns:
@@ -1382,13 +1400,13 @@ class Defaults:
     @staticmethod
     def get_bios_module_directory_name():
         """
-        Provides x86 BIOS directory name which stores the pc binaries
+        Provides BIOS directory name which stores the pc binaries
 
         :return: directory name
 
         :rtype: str
         """
-        return 'i386-pc'
+        return 'powerpc-ieee1275' if Defaults.is_ppc64_arch(Defaults.get_platform_name()) else 'i386-pc'
 
     @staticmethod
     def get_efi_image_name(arch):
@@ -1424,7 +1442,7 @@ class Defaults:
 
         :rtype: str
         """
-        return 'core.img'
+        return 'grub.elf' if Defaults.is_ppc64_arch(Defaults.get_platform_name()) else 'core.img'
 
     @staticmethod
     def get_default_boot_timeout_seconds():

--- a/kiwi/iso_tools/xorriso.py
+++ b/kiwi/iso_tools/xorriso.py
@@ -99,6 +99,10 @@ class IsoToolsXorrIso(IsoToolsBase):
         self.iso_parameters += [
             '-joliet', 'on', '-padding', '0'
         ]
+        if Defaults.is_ppc64_arch(self.arch):
+            self.iso_parameters += [
+                '-compliance', 'untranslated_names'
+            ]
 
         if Defaults.is_x86_arch(self.arch) and legacy_bios_mode:
             mbr_file = os.sep.join(
@@ -126,15 +130,20 @@ class IsoToolsXorrIso(IsoToolsBase):
                 '-boot_image', 'grub', 'grub2_boot_info=on'
             ]
 
-        self.iso_loaders += [
-            '-boot_image', 'any', 'partition_offset=16',
-            '-boot_image', 'any', 'cat_path={0}'.format(catalog_file),
-            '-boot_image', 'any', 'cat_hidden=on',
-            '-boot_image', 'any', 'boot_info_table=on',
-            '-boot_image', 'any', 'platform_id=0x00',
-            '-boot_image', 'any', 'emul_type=no_emulation',
-            '-boot_image', 'any', 'load_size=2048'
-        ]
+        if Defaults.is_ppc64_arch(self.arch):
+            self.iso_loaders += [
+                '-boot_image', 'any', 'chrp_boot_part=on'
+            ]
+        else:
+            self.iso_loaders += [
+                '-boot_image', 'any', 'partition_offset=16',
+                '-boot_image', 'any', 'cat_path={0}'.format(catalog_file),
+                '-boot_image', 'any', 'cat_hidden=on',
+                '-boot_image', 'any', 'boot_info_table=on',
+                '-boot_image', 'any', 'platform_id=0x00',
+                '-boot_image', 'any', 'emul_type=no_emulation',
+                '-boot_image', 'any', 'load_size=2048'
+            ]
 
     def add_efi_loader_parameters(self, loader_file: str) -> None:
         """

--- a/test/unit/iso_tools/xorriso_test.py
+++ b/test/unit/iso_tools/xorriso_test.py
@@ -52,6 +52,30 @@ class TestIsoToolsXorrIso:
             assert 'No hybrid MBR file found' in self._caplog.text
 
     @patch('os.path.exists')
+    def test_init_iso_creation_parameters_ppc(self, mock_os_path_exists):
+        mock_os_path_exists.return_value = True
+        self.iso_tool.arch = 'ppc64le'
+        self.iso_tool.init_iso_creation_parameters(
+            {
+                'mbr_id': 'app_id',
+                'publisher': 'org',
+                'preparer': 'preparer',
+                'volume_id': 'vol_id',
+                'efi_mode': 'ofw',
+                'legacy_bios_mode': False
+            }
+        )
+        assert self.iso_tool.iso_parameters == [
+            '-application_id', 'app_id',
+            '-publisher', 'org',
+            '-preparer_id', 'preparer',
+            '-volid', 'vol_id',
+            '-joliet', 'on',
+            '-padding', '0',
+            '-compliance', 'untranslated_names'
+        ]
+
+    @patch('os.path.exists')
     def test_init_iso_creation_parameters_efi(self, mock_os_path_exists):
         mock_os_path_exists.return_value = True
         self.iso_tool.init_iso_creation_parameters(


### PR DESCRIPTION
## This adds CHRP boot support to get ppc64 ISO media bootable

What is needed for that is a file `/ppc/bootinfo.txt` with this sample content:
```
<chrp-boot>
<description>Some Name</description>
<os-name>Some Name</os-name>
<boot-script>boot &device;:1,\boot\grub2\powerpc-ieee1275\grub.elf</boot-script>
</chrp-boot>
```
Note the backslashes in the path to `grub.elf`. `grub.elf` is the default grub boot image as provided in the `grub2-powerpc-ieee1275` package.

Note also that the grub2 directory `powerpc-ieee1275` contains a '`-`' - this is not possible with the default setting which  merges file names into the ancient 8.3 format. To avoid this, `-compliance  untranslated_names` is added to xorriso.
I've added this only to ppc64 for now but IMHO this should be done for all architectures.

And, these are the CHRP xorriso boot options:
```
-boot_image any chrp_boot_part=on
```

Finally, fix  a bug that creates an empty `EFI/BOOT` directory on all architectures.