### PR TITLE
Fix oci security sync filters

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-docker/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-docker/appliance.kiwi
@@ -27,6 +27,7 @@
         <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
+        <package name="libcap-progs"/>
         <package name="grub2"/>
         <package name="ncurses-utils"/>
         <package name="patterns-openSUSE-base"/>
@@ -39,7 +40,6 @@
         <package name="dracut"/>
         <package name="pigz"/>
         <package name="elfutils"/>
-        <package name="systemd-presets-branding-openSUSE"/>
         <package name="iputils"/>
         <package name="tar"/>
         <package name="psmisc"/>
@@ -57,7 +57,12 @@
         <package name="fipscheck"/>
     </packages>
     <packages type="bootstrap">
+        <package name="gawk"/>
+        <package name="grep"/>
+        <package name="gzip"/>
         <package name="udev"/>
+        <package name="xz"/>
+        <package name="shadow"/>
         <package name="filesystem"/>
         <package name="glibc-locale"/>
         <package name="cracklib-dict-full"/>

--- a/kiwi/oci_tools/umoci.py
+++ b/kiwi/oci_tools/umoci.py
@@ -137,9 +137,6 @@ class OCIUmoci(OCIBase):
             os.sep.join([self.oci_root_dir, 'rootfs']),
             exclude_list=exclude_list,
             options=Defaults.get_sync_options() + [
-                '--filter', '-x! user.*',
-                '--filter', '-x! security.ima*',
-                '--filter', '-x! security.capability*',
                 '--delete'
             ]
         )

--- a/test/unit/oci_tools/umoci_test.py
+++ b/test/unit/oci_tools/umoci_test.py
@@ -60,9 +60,6 @@ class TestOCIUmoci:
             options=[
                 '--archive', '--hard-links', '--xattrs', '--acls',
                 '--one-file-system', '--inplace',
-                '--filter', '-x! user.*',
-                '--filter', '-x! security.ima*',
-                '--filter', '-x! security.capability*',
                 '--delete'
             ]
         )


### PR DESCRIPTION
This patch is two fold

**Fixed container sync options**

Do not exclude/filter any security/xattr capabilities.

**Update container integration test**
    
Add getcap to check on filesystem capabilities