### PR TITLE
bootloader: Fix up ppc64 bootinfo again

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -947,7 +947,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             <os-name>{os_name}</os-name>
             <boot-script>boot &device;:1,\\boot\\grub2\\powerpc-ieee1275\\grub.elf</boot-script>
             </chrp-boot>
-        ''')
+        ''').strip() + os.linesep
         with open(chrp_bootinfo_file, 'w') as chrp_bootinfo:
             chrp_bootinfo.write(
                 chrp_config.format(os_name=self.get_menu_entry_install_title())

--- a/test/data/bootinfo.txt
+++ b/test/data/bootinfo.txt
@@ -1,4 +1,3 @@
-
 <chrp-boot>
 <description>Bob</description>
 <os-name>Bob</os-name>


### PR DESCRIPTION
To make the code look pretty extra newline is inserted at the start of bootinfo file. This appears to break boot on Power9 PowerVM LPARs.

Fixes bsc#1210888

Changes proposed in this pull request:
* Remove newline at the start of bootinfo.txt
