### PR TITLE
Add support for erofs

### DIFF
--- a/build-tests/x86/rawhide/test-image-erofs/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-erofs/appliance.kiwi
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="7.5" name="kiwi-test-image-erofs">
+    <description type="system">
+        <author>Marcus Schaefer</author>
+        <contact>marcus.schaefer@suse.com</contact>
+        <specification>Fedora Appliance, Testing erofs filesystem image</specification>
+    </description>
+    <preferences>
+        <version>2.0.0</version>
+        <packagemanager>dnf5</packagemanager>
+        <rpm-check-signatures>false</rpm-check-signatures>
+    </preferences>
+    <preferences>
+        <type image="erofs"/>
+    </preferences>
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
+    </users>
+    <repository type="rpm-md" alias="kiwi-next-generation" priority="1">
+        <source path="obs://Virtualization:Appliances:Staging/Fedora_Rawhide"/>
+    </repository>
+    <repository type="rpm-md" alias="Fedora_Rawhide">
+        <source path="obs://Fedora:Rawhide/standard"/>
+    </repository>
+    <packages type="image">
+        <package name="kernel"/>
+        <package name="selinux-policy-targeted"/>
+        <package name="dhclient"/>
+        <package name="glibc-all-langpacks"/>
+        <package name="vim"/>
+        <package name="tzdata"/>
+        <package name="NetworkManager"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="filesystem"/>
+        <package name="basesystem"/>
+        <package name="fedora-release"/>
+    </packages>
+</image>

--- a/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
@@ -11,6 +11,7 @@
     </description>
     <profiles>
         <profile name="Live" description="Live image of Fedora Rawhide"/>
+        <profile name="LiveEroFS" description="Live Root via EroFS"/>
         <profile name="Virtual" description="Virtual image of Fedora Rawhide"/>
         <profile name="Disk" description="OEM image of Fedora Rawhide"/>
     </profiles>
@@ -23,6 +24,11 @@
         <keytable>us</keytable>
         <timezone>UTC</timezone>
         <rpm-check-signatures>false</rpm-check-signatures>
+    </preferences>
+    <preferences profiles="LiveEroFS">
+        <type image="iso" flags="overlay" firmware="uefi" hybridpersistent_filesystem="ext4" hybridpersistent="true" kernelcmdline="console=ttyS0" filesystem="erofs" erofscompression="zstd,level=12">
+            <bootloader name="grub2" console="serial" timeout="10"/>
+        </type>
     </preferences>
     <preferences profiles="Live">
         <type image="iso" flags="overlay" firmware="uefi" hybridpersistent_filesystem="ext4" hybridpersistent="true" kernelcmdline="console=ttyS0">
@@ -71,7 +77,7 @@
         <package name="tzdata"/>
         <package name="NetworkManager"/>
     </packages>
-    <packages type="image" profiles="Live">
+    <packages type="image" profiles="Live,LiveEroFS">
         <package name="dracut-kiwi-live"/>
     </packages>
     <packages type="image" profiles="Disk">

--- a/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
@@ -14,6 +14,7 @@
         <profile name="Standard" description="Standard EFI/BIOS Live Boot"/>
         <profile name="Secure" description="SecureBoot/BIOS Live Boot"/>
         <profile name="SDBoot" description="EFI Boot via systemd-boot"/>
+        <profile name="EroFS" description="Live Root via EroFS"/>
     </profiles>
     <preferences>
         <version>1.42.3</version>
@@ -29,6 +30,11 @@
     <preferences profiles="SDBoot">
         <type image="iso" flags="overlay" firmware="efi" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="false">
             <bootloader name="systemd_boot"/>
+        </type>
+    </preferences>
+    <preferences profiles="EroFS">
+        <type image="iso" flags="overlay" firmware="efi" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="true" filesystem="erofs">
+            <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <preferences profiles="Standard">
@@ -50,7 +56,7 @@
     <packages type="image" profiles="SDBoot">
         <package name="systemd-boot"/>
     </packages>
-    <packages type="image" profiles="Standard,Secure">
+    <packages type="image" profiles="Standard,Secure,EroFS">
         <package name="grub2-branding-openSUSE"/>
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>
@@ -58,6 +64,7 @@
         <package name="shim"/>
     </packages>
     <packages type="image">
+        <package name="curl"/>
         <package name="bind-utils"/>
         <package name="patterns-openSUSE-base"/>
         <package name="procps"/>

--- a/build-tests/x86/tumbleweed/test-image-live/config.sh
+++ b/build-tests/x86/tumbleweed/test-image-live/config.sh
@@ -1,22 +1,9 @@
 #!/bin/bash
-#================
-# FILE          : config.sh
-#----------------
-# PROJECT       : OpenSuSE KIWI Image System
-# COPYRIGHT     : (c) 2006 SUSE LINUX Products GmbH. All rights reserved
-#               :
-# AUTHOR        : Marcus Schaefer <ms@suse.de>
-#               :
-# BELONGS TO    : Operating System images
-#               :
-# DESCRIPTION   : configuration script for SUSE based
-#               : operating systems
-#----------------
-#======================================
-# Functions...
-#--------------------------------------
-test -f /.kconfig && . /.kconfig
-test -f /.profile && . /.profile
+
+set -ex
+
+declare kiwi_profiles=${kiwi_profiles}
+declare kiwi_iname=${kiwi_iname}
 
 #======================================
 # Greeting...
@@ -24,16 +11,16 @@ test -f /.profile && . /.profile
 echo "Configure image: [$kiwi_iname]..."
 
 #======================================
-# Setup baseproduct link
-#--------------------------------------
-suseSetupProduct
-
-#======================================
 # Activate services
 #--------------------------------------
-suseInsertService sshd
+systemctl enable sshd
 
 #======================================
-# Setup default target, multi-user
+# Include erofs module
 #--------------------------------------
-baseSetRunlevel 3
+for profile in ${kiwi_profiles//,/ }; do
+    if [ "${profile}" = "EroFS" ]; then
+        # remove from blacklist
+        rm -f /usr/lib/modprobe.d/60-blacklist_fs-erofs.conf
+    fi
+done

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -652,6 +652,13 @@ devicepersistency="by-uuid|by-label":
 squashfscompression="uncompressed|gzip|lzo|lz4|xz|zstd":
   Specifies the compression type for mksquashfs
 
+erofscompression="text"
+  Specifies the compression type and level for erofs.
+  The attribute is a free form text because erofs allows paramters
+  for the different compression types. Please consult the erofs
+  man page for details how to specify a value for the `-z` option
+  on `mkfs.erofs` and pass a proper value as erofscompression
+
 standalone_integrity="true|false":
   For the `oem` type only, specifies to create a standalone
   `dm_integrity` layer on top of the root filesystem

--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -89,7 +89,7 @@ class FileSystemBuilder:
         self.blocksize = xml_state.build_type.get_target_blocksize()
         self.filesystem_setup = FileSystemSetup(xml_state, root_dir)
         self.filesystems_no_device_node = [
-            'squashfs'
+            'squashfs', 'erofs'
         ]
         self.luks = xml_state.get_luks_credentials()
         self.result = Result(xml_state)

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1523,7 +1523,7 @@ class Defaults:
         """
         return [
             'ext2', 'ext3', 'ext4', 'btrfs', 'squashfs',
-            'xfs', 'fat16', 'fat32'
+            'xfs', 'fat16', 'fat32', 'erofs'
         ]
 
     @staticmethod

--- a/kiwi/filesystem/__init__.py
+++ b/kiwi/filesystem/__init__.py
@@ -54,7 +54,8 @@ class FileSystem(metaclass=ABCMeta):
             'fat16': 'Fat16',
             'fat32': 'Fat32',
             'squashfs': 'SquashFs',
-            'swap': 'Swap'
+            'swap': 'Swap',
+            'erofs': 'EroFs'
         }
         try:
             filesystem = importlib.import_module(

--- a/kiwi/filesystem/erofs.py
+++ b/kiwi/filesystem/erofs.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2024 SUSE Software Solutions Germany GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+from typing import List
+
+# project
+from kiwi.filesystem.base import FileSystemBase
+from kiwi.command import Command
+
+
+class FileSystemEroFs(FileSystemBase):
+    """
+    **Implements creation of erofs filesystem**
+    """
+    def create_on_file(
+        self, filename, label: str = None, exclude: List[str] = None
+    ):
+        """
+        Create erofs filesystem from data tree
+
+        :param string filename: result file path name
+        :param string label: volume label
+        :param list exclude: list of exclude dirs/files
+        """
+        self.filename = filename
+        exclude_options = []
+        compression = self.custom_args.get('compression')
+        if compression:
+            self.custom_args['create_options'].append('-z')
+            self.custom_args['create_options'].append(compression)
+
+        if exclude:
+            for item in exclude:
+                exclude_options.append(f'--exclude-regex={item}')
+
+        if label:
+            self.custom_args['create_options'].append('-L')
+            self.custom_args['create_options'].append(label)
+
+        Command.run(
+            [
+                'mkfs.erofs'
+            ] + self.custom_args['create_options'] + exclude_options + [
+                self.filename, self.root_dir
+            ]
+        )

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1671,7 +1671,7 @@ div {
     k.type.filesystem.attribute =
         ## Specifies the root filesystem type
         attribute filesystem {
-            "btrfs" | "ext2" | "ext3" | "ext4" | "squashfs" | "xfs"
+            "btrfs" | "ext2" | "ext3" | "ext4" | "squashfs" | "erofs" | "xfs"
         }
         >> sch:pattern [ id = "filesystem" is-a = "image_type"
             sch:param [ name = "attr" value = "filesystem" ]
@@ -1681,6 +1681,13 @@ div {
             id = "filesystem_mandatory" is-a = "image_type_requirement"
             sch:param [ name = "attr" value = "filesystem" ]
             sch:param [ name = "types" value = "oem" ]
+        ]
+	k.type.erofscompression.attribute =
+        ## Specifies the compression type for erofs
+        attribute erofscompression { text }
+        >> sch:pattern [ id = "erofscompression" is-a = "image_type"
+            sch:param [ name = "attr" value = "erofscompression" ]
+            sch:param [ name = "types" value = "oem pxe kis iso erofs" ]
         ]
 	k.type.squashfscompression.attribute =
         ## Specifies the compression type for mksquashfs
@@ -1958,7 +1965,7 @@ div {
         ## Specifies the image type
         attribute image {
             "btrfs" | "cpio" | "docker" | "ext2" | "ext3" |
-            "ext4" | "iso" | "oem" | "pxe" | "kis" | "squashfs" | "tbz" |
+            "ext4" | "iso" | "oem" | "pxe" | "kis" | "squashfs" | "erofs" | "tbz" |
             "xfs" | "oci" | "appx" | "enclave"
         }
         >> sch:pattern [
@@ -2284,6 +2291,7 @@ div {
         k.type.fsmountoptions.attribute? &
         k.type.fscreateoptions.attribute? &
         k.type.squashfscompression.attribute? &
+        k.type.erofscompression.attribute? &
         k.type.gcelicense.attribute? &
         k.type.hybridpersistent.attribute? &
         k.type.hybridpersistent_filesystem.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2435,6 +2435,7 @@ structure</a:documentation>
           <value>ext3</value>
           <value>ext4</value>
           <value>squashfs</value>
+          <value>erofs</value>
           <value>xfs</value>
         </choice>
       </attribute>
@@ -2445,6 +2446,15 @@ structure</a:documentation>
       <sch:pattern id="filesystem_mandatory" is-a="image_type_requirement">
         <sch:param name="attr" value="filesystem"/>
         <sch:param name="types" value="oem"/>
+      </sch:pattern>
+    </define>
+    <define name="k.type.erofscompression.attribute">
+      <attribute name="erofscompression">
+        <a:documentation>Specifies the compression type for erofs</a:documentation>
+      </attribute>
+      <sch:pattern id="erofscompression" is-a="image_type">
+        <sch:param name="attr" value="erofscompression"/>
+        <sch:param name="types" value="oem pxe kis iso erofs"/>
       </sch:pattern>
     </define>
     <define name="k.type.squashfscompression.attribute">
@@ -2822,6 +2832,7 @@ initrd architecture.</a:documentation>
           <value>pxe</value>
           <value>kis</value>
           <value>squashfs</value>
+          <value>erofs</value>
           <value>tbz</value>
           <value>xfs</value>
           <value>oci</value>
@@ -3309,6 +3320,9 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.squashfscompression.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.erofscompression.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.gcelicense.attribute"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3094,7 +3094,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, eficsm=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_subvolume=None, btrfs_set_default_volume=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, enclave_format=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, application_id=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, eficsm=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_subvolume=None, btrfs_set_default_volume=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, enclave_format=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, erofscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, application_id=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -3125,6 +3125,7 @@ class type_(GeneratedsSuper):
         self.fsmountoptions = _cast(None, fsmountoptions)
         self.fscreateoptions = _cast(None, fscreateoptions)
         self.squashfscompression = _cast(None, squashfscompression)
+        self.erofscompression = _cast(None, erofscompression)
         self.gcelicense = _cast(None, gcelicense)
         self.hybridpersistent = _cast(bool, hybridpersistent)
         self.hybridpersistent_filesystem = _cast(None, hybridpersistent_filesystem)
@@ -3341,6 +3342,8 @@ class type_(GeneratedsSuper):
     def set_fscreateoptions(self, fscreateoptions): self.fscreateoptions = fscreateoptions
     def get_squashfscompression(self): return self.squashfscompression
     def set_squashfscompression(self, squashfscompression): self.squashfscompression = squashfscompression
+    def get_erofscompression(self): return self.erofscompression
+    def set_erofscompression(self, erofscompression): self.erofscompression = erofscompression
     def get_gcelicense(self): return self.gcelicense
     def set_gcelicense(self, gcelicense): self.gcelicense = gcelicense
     def get_hybridpersistent(self): return self.hybridpersistent
@@ -3629,6 +3632,9 @@ class type_(GeneratedsSuper):
         if self.squashfscompression is not None and 'squashfscompression' not in already_processed:
             already_processed.add('squashfscompression')
             outfile.write(' squashfscompression=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.squashfscompression), input_name='squashfscompression')), ))
+        if self.erofscompression is not None and 'erofscompression' not in already_processed:
+            already_processed.add('erofscompression')
+            outfile.write(' erofscompression=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.erofscompression), input_name='erofscompression')), ))
         if self.gcelicense is not None and 'gcelicense' not in already_processed:
             already_processed.add('gcelicense')
             outfile.write(' gcelicense=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.gcelicense), input_name='gcelicense')), ))
@@ -4018,6 +4024,10 @@ class type_(GeneratedsSuper):
             already_processed.add('squashfscompression')
             self.squashfscompression = value
             self.squashfscompression = ' '.join(self.squashfscompression.split())
+        value = find_attr_value_('erofscompression', node)
+        if value is not None and 'erofscompression' not in already_processed:
+            already_processed.add('erofscompression')
+            self.erofscompression = value
         value = find_attr_value_('gcelicense', node)
         if value is not None and 'gcelicense' not in already_processed:
             already_processed.add('gcelicense')

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -291,10 +291,17 @@ Provides:       kiwi-filesystem:ext3
 Provides:       kiwi-filesystem:ext4
 Provides:       kiwi-filesystem:squashfs
 Provides:       kiwi-filesystem:xfs
+%if ! (0%{?suse_version} && 0%{?suse_version} < 1600)
+Provides:       kiwi-filesystem:erofs
+Provides:       kiwi-image:erofs
+%endif
 %endif
 Requires:       dosfstools
 Requires:       e2fsprogs
 Requires:       xfsprogs
+%if ! (0%{?suse_version} && 0%{?suse_version} < 1600)
+Requires:       erofs-utils
+%endif
 %if 0%{?suse_version}
 Requires:       btrfsprogs
 %else

--- a/test/unit/filesystem/erofs_test.py
+++ b/test/unit/filesystem/erofs_test.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+
+import unittest.mock as mock
+
+from kiwi.defaults import Defaults
+from kiwi.filesystem.erofs import FileSystemEroFs
+
+
+class TestFileSystemEroFs:
+    @patch('os.path.exists')
+    def setup(self, mock_exists):
+        mock_exists.return_value = True
+        self.erofs = FileSystemEroFs(
+            mock.Mock(), 'root_dir',
+            custom_args={'compression': 'zstd,level=21'}
+        )
+
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
+    @patch('kiwi.filesystem.erofs.Command.run')
+    def test_create_on_file(self, mock_command):
+        Defaults.set_platform_name('x86_64')
+        self.erofs.create_on_file('myimage', 'label')
+        mock_command.assert_called_once_with(
+            [
+                'mkfs.erofs', '-z', 'zstd,level=21',
+                '-L', 'label', 'myimage', 'root_dir'
+            ]
+        )
+
+    @patch('kiwi.filesystem.erofs.Command.run')
+    def test_create_on_file_exclude_data(self, mock_command):
+        Defaults.set_platform_name('x86_64')
+        self.erofs.create_on_file('myimage', 'label', ['foo'])
+        mock_command.assert_called_once_with(
+            [
+                'mkfs.erofs', '-z', 'zstd,level=21',
+                '-L', 'label', '--exclude-regex=foo',
+                'myimage', 'root_dir'
+            ]
+        )


### PR DESCRIPTION
erofs is an alternative readonly filesystem that can be used as alternative to squashfs. This Fixes #2633

Please find an integration test build here:

* https://build.opensuse.org/package/show/Virtualization:Appliances:Images:Testing_x86:tumbleweed/test-image-live