### PR TITLE
Include PI and comments in XSL stylesheets

### DIFF
--- a/helper/xsl_to_v74/convert14to20.xsl
+++ b/helper/xsl_to_v74/convert14to20.xsl
@@ -10,7 +10,7 @@
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv14to20"/>
-    </xsl:copy>  
+    </xsl:copy>
 </xsl:template>
 
 <!-- version update -->
@@ -22,7 +22,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 2.0 -->
         <xsl:when test="@schemeversion > 1.4 or @schemaversion > 1.4">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -32,6 +32,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv14to20">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv14to20"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- split section update -->

--- a/helper/xsl_to_v74/convert20to24.xsl
+++ b/helper/xsl_to_v74/convert20to24.xsl
@@ -22,7 +22,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 2.4 -->
         <xsl:when test="@schemeversion > 2.0 or @schemaversion > 2.0">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -32,6 +32,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv20to24">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv20to24"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- remove attributes and add info -->

--- a/helper/xsl_to_v74/convert24to35.xsl
+++ b/helper/xsl_to_v74/convert24to35.xsl
@@ -23,7 +23,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 3.5 -->
         <xsl:when test="@schemaversion > 2.4 or @schemeversion > 2.4">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -33,6 +33,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv24to35">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv24to35"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- remove compressed element -->

--- a/helper/xsl_to_v74/convert35to37.xsl
+++ b/helper/xsl_to_v74/convert35to37.xsl
@@ -27,7 +27,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 3.7 -->
         <xsl:when test="@schemaversion > 3.5">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -37,6 +37,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv35to37">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv35to37"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- update bool types -->

--- a/helper/xsl_to_v74/convert37to38.xsl
+++ b/helper/xsl_to_v74/convert37to38.xsl
@@ -23,7 +23,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 3.8 -->
         <xsl:when test="@schemaversion > 3.7">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -33,6 +33,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv37to38">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv37to38"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- update deploy / pxedeploy -->

--- a/helper/xsl_to_v74/convert38to39.xsl
+++ b/helper/xsl_to_v74/convert38to39.xsl
@@ -23,7 +23,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 3.9 -->
         <xsl:when test="@schemaversion > 3.8">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -33,6 +33,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv38to39">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv38to39"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- create new element oemconfig -->

--- a/helper/xsl_to_v74/convert39to41.xsl
+++ b/helper/xsl_to_v74/convert39to41.xsl
@@ -25,7 +25,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 4.1 -->
         <xsl:when test="@schemaversion > 3.9">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -35,6 +35,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv39to41">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv39to41"/>
+    </xsl:copy>
 </xsl:template>
 
 <xsl:template match="preferences" mode="conv39to41">

--- a/helper/xsl_to_v74/convert41to42.xsl
+++ b/helper/xsl_to_v74/convert41to42.xsl
@@ -31,7 +31,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 4.2 -->
         <xsl:when test="@schemaversion > 4.1">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -41,6 +41,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv41to42">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv41to42"/>
+    </xsl:copy>
 </xsl:template>
 
 <xsl:template match="preferences" mode="conv41to42">

--- a/helper/xsl_to_v74/convert42to43.xsl
+++ b/helper/xsl_to_v74/convert42to43.xsl
@@ -25,7 +25,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 4.3 -->
         <xsl:when test="@schemaversion > 4.2">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -35,6 +35,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv42to43">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv42to43"/>
+    </xsl:copy>
 </xsl:template>
 
 <xsl:template match="preferences" mode="conv42to43">

--- a/helper/xsl_to_v74/convert43to44.xsl
+++ b/helper/xsl_to_v74/convert43to44.xsl
@@ -23,7 +23,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 4.4 -->
         <xsl:when test="@schemaversion > 4.3">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -33,6 +33,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv43to44">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv43to44"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- remove commandline element -->

--- a/helper/xsl_to_v74/convert44to45.xsl
+++ b/helper/xsl_to_v74/convert44to45.xsl
@@ -23,7 +23,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 4.5 -->
         <xsl:when test="@schemaversion > 4.4">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -33,6 +33,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv44to45">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv44to45"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- remove patternPackageType attribute -->

--- a/helper/xsl_to_v74/convert45to46.xsl
+++ b/helper/xsl_to_v74/convert45to46.xsl
@@ -23,7 +23,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 4.6 -->
         <xsl:when test="@schemaversion > 4.5">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -33,6 +33,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv45to46">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv45to46"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- update vmware / vmx -->

--- a/helper/xsl_to_v74/convert46to47.xsl
+++ b/helper/xsl_to_v74/convert46to47.xsl
@@ -23,7 +23,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 4.7 -->
         <xsl:when test="@schemaversion > 4.6">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -33,6 +33,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv46to47">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv46to47"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- turn vmwareconfig into machine, ignore usb attribute -->

--- a/helper/xsl_to_v74/convert47to48.xsl
+++ b/helper/xsl_to_v74/convert47to48.xsl
@@ -47,7 +47,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 4.8 -->
         <xsl:when test="@schemaversion > 4.7">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -57,6 +57,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv47to48">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv47to48"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- remove lvm attribute, call add-systemdisk if no lvmvolumes exists and

--- a/helper/xsl_to_v74/convert48to49.xsl
+++ b/helper/xsl_to_v74/convert48to49.xsl
@@ -27,7 +27,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 4.9 -->
         <xsl:when test="@schemaversion > 4.8">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -37,6 +37,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv48to49">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv48to49"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- transform oem-dumphalt to oem-bootwait -->

--- a/helper/xsl_to_v74/convert49to50.xsl
+++ b/helper/xsl_to_v74/convert49to50.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 5.0 -->
         <xsl:when test="@schemaversion > 4.9">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv49to50">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv49to50"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- convert xen image type to vmx -->

--- a/helper/xsl_to_v74/convert50to51.xsl
+++ b/helper/xsl_to_v74/convert50to51.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 5.1 -->
         <xsl:when test="@schemaversion > 5.0">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv50to51">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv50to51"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- remove baseroot attribute from type -->

--- a/helper/xsl_to_v74/convert51to52.xsl
+++ b/helper/xsl_to_v74/convert51to52.xsl
@@ -22,7 +22,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 5.2 -->
         <xsl:when test="@schemaversion > 5.1">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -32,6 +32,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv51to52">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv51to52"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- remove obsolete usb image type -->

--- a/helper/xsl_to_v74/convert52to53.xsl
+++ b/helper/xsl_to_v74/convert52to53.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 5.3-->
         <xsl:when test="@schemaversion > 5.2">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv52to53">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv52to53"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- convert ec2region names -->

--- a/helper/xsl_to_v74/convert53to54.xsl
+++ b/helper/xsl_to_v74/convert53to54.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 5.4 -->
         <xsl:when test="@schemaversion > 5.3">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv53to54">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv53to54"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- remove type attribute from drivers -->

--- a/helper/xsl_to_v74/convert54to55.xsl
+++ b/helper/xsl_to_v74/convert54to55.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 5.5 -->
         <xsl:when test="@schemaversion > 5.4">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv54to55">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv54to55"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- transform boot-theme to bootloader-theme and bootsplash-theme -->

--- a/helper/xsl_to_v74/convert55to56.xsl
+++ b/helper/xsl_to_v74/convert55to56.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 5.6 -->
         <xsl:when test="@schemaversion > 5.5">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv55to56">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv55to56"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- transform the pwd attribute of the instrepo element to password -->

--- a/helper/xsl_to_v74/convert56to57.xsl
+++ b/helper/xsl_to_v74/convert56to57.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 5.7 -->
         <xsl:when test="@schemaversion > 5.6">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv56to57">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv56to57"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- transform the opensusePattern element into a namedCollection -->

--- a/helper/xsl_to_v74/convert57to58.xsl
+++ b/helper/xsl_to_v74/convert57to58.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 5.8 -->
         <xsl:when test="@schemaversion > 5.7">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv57to58">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv57to58"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- remove syncMBR attribute from type -->

--- a/helper/xsl_to_v74/convert58to59.xsl
+++ b/helper/xsl_to_v74/convert58to59.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 5.9 -->
         <xsl:when test="@schemaversion > 5.8">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv58to59">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv58to59"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- rename controller="scsi" to controller="lsilogic" in vmdisk -->

--- a/helper/xsl_to_v74/convert59to60.xsl
+++ b/helper/xsl_to_v74/convert59to60.xsl
@@ -22,7 +22,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 6.0 -->
         <xsl:when test="@schemaversion > 5.9">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -32,6 +32,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv59to60">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv59to60"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- remove oem-align-partition -->

--- a/helper/xsl_to_v74/convert60to61.xsl
+++ b/helper/xsl_to_v74/convert60to61.xsl
@@ -22,7 +22,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 6.1 -->
         <xsl:when test="@schemaversion > 6.0">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -32,6 +32,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv60to61">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv60to61"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- rename opensuseProduct -->

--- a/helper/xsl_to_v74/convert61to62.xsl
+++ b/helper/xsl_to_v74/convert61to62.xsl
@@ -22,7 +22,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 6.2 -->
         <xsl:when test="@schemaversion > 6.1">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -32,6 +32,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv61to62">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv61to62"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- add default bootloader if not specified -->

--- a/helper/xsl_to_v74/convert62to63.xsl
+++ b/helper/xsl_to_v74/convert62to63.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 6.3 -->
         <xsl:when test="@schemaversion > 6.2">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv62to63">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv62to63"/>
+    </xsl:copy>
 </xsl:template>
 
 <para xmlns="http://docbook.org/ns/docbook">

--- a/helper/xsl_to_v74/convert63to64.xsl
+++ b/helper/xsl_to_v74/convert63to64.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 6.4 -->
         <xsl:when test="@schemaversion > 6.3">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv63to64">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv63to64"/>
+    </xsl:copy>
 </xsl:template>
 
 <para xmlns="http://docbook.org/ns/docbook">

--- a/helper/xsl_to_v74/convert64to65.xsl
+++ b/helper/xsl_to_v74/convert64to65.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 6.5 -->
         <xsl:when test="@schemaversion > 6.4">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv64to65">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv64to65"/>
+    </xsl:copy>
 </xsl:template>
 
 <para xmlns="http://docbook.org/ns/docbook">

--- a/helper/xsl_to_v74/convert65to66.xsl
+++ b/helper/xsl_to_v74/convert65to66.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 6.6 -->
         <xsl:when test="@schemaversion > 6.5">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv65to66">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv65to66"/>
+    </xsl:copy>
 </xsl:template>
 
 <para xmlns="http://docbook.org/ns/docbook">

--- a/helper/xsl_to_v74/convert66to67.xsl
+++ b/helper/xsl_to_v74/convert66to67.xsl
@@ -22,7 +22,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 6.7 -->
         <xsl:when test="@schemaversion > 6.6">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -32,6 +32,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv66to67">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv66to67"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- delete checkprebuilt and fsnocheck attributes from type -->

--- a/helper/xsl_to_v74/convert67to68.xsl
+++ b/helper/xsl_to_v74/convert67to68.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 6.8 -->
         <xsl:when test="@schemaversion > 6.7">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv67to68">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv67to68"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- Delete hwclock section -->

--- a/helper/xsl_to_v74/convert68to69.xsl
+++ b/helper/xsl_to_v74/convert68to69.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 6.9 -->
         <xsl:when test="@schemaversion > 6.8">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv68to69">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv68to69"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- delete hybrid attribute from type -->

--- a/helper/xsl_to_v74/convert69to70.xsl
+++ b/helper/xsl_to_v74/convert69to70.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 7.0 -->
         <xsl:when test="@schemaversion > 6.9">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv69to70">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv69to70"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- delete pxedeploy element from type -->

--- a/helper/xsl_to_v74/convert70to71.xsl
+++ b/helper/xsl_to_v74/convert70to71.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 7.1 -->
         <xsl:when test="@schemaversion > 7.0">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv70to71">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv70to71"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- delete type from repository if obsolete type spec is used -->

--- a/helper/xsl_to_v74/convert71to72.xsl
+++ b/helper/xsl_to_v74/convert71to72.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 7.2 -->
         <xsl:when test="@schemaversion > 7.1">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv71to72">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv71to72"/>
+    </xsl:copy>
 </xsl:template>
 
 <para xmlns="http://docbook.org/ns/docbook">

--- a/helper/xsl_to_v74/convert72to73.xsl
+++ b/helper/xsl_to_v74/convert72to73.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 7.3 -->
         <xsl:when test="@schemaversion > 7.2">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv72to73">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv72to73"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- change vmx type to oem type with oem-resize set to false-->

--- a/helper/xsl_to_v74/convert73to74.xsl
+++ b/helper/xsl_to_v74/convert73to74.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 7.4 -->
         <xsl:when test="@schemaversion > 7.3">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv73to74">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv73to74"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- change packagemanager to apt if set to apt-get -->

--- a/helper/xsl_to_v74/include.xsl
+++ b/helper/xsl_to_v74/include.xsl
@@ -14,6 +14,14 @@
     </xsl:copy>
 </xsl:template>
 
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="include">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="include"/>
+    </xsl:copy>
+</xsl:template>
+
 <!-- incorporate optional include file(s) -->
 <xsl:template match="image/include" mode="include">
     <xsl:param name="include_file_name" select="@from"/>

--- a/helper/xsl_to_v74/update.xsl
+++ b/helper/xsl_to_v74/update.xsl
@@ -48,7 +48,7 @@
 <xsl:import href="convert73to74.xsl"/>
 <xsl:import href="pretty.xsl"/>
 
-<xsl:output encoding="utf-8"/>
+<xsl:output encoding="utf-8" indent="yes"/>
 
 <xsl:template match="/">
     <xsl:variable name="preprocess">

--- a/kiwi/xsl/convert74to75.xsl
+++ b/kiwi/xsl/convert74to75.xsl
@@ -26,7 +26,7 @@
         </xsl:when>
         <!-- nothing to do if already at 7.5 -->
         <xsl:when test="@schemaversion > 7.4">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -38,6 +38,13 @@
     </xsl:choose>
 </xsl:template>
 
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv74to75">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv74to75"/>
+    </xsl:copy>
+</xsl:template>
 
 <!-- rename additionaltags attribute to additionalnames and add a colon before each tag -->
 <xsl:template match="containerconfig" mode="conv74to75">

--- a/kiwi/xsl/convert75to76.xsl
+++ b/kiwi/xsl/convert75to76.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 7.6 -->
         <xsl:when test="@schemaversion > 7.5">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv75to76">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv75to76"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- change packagemanager to dnf4 if set to dnf -->

--- a/kiwi/xsl/convert76to80.xsl
+++ b/kiwi/xsl/convert76to80.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 8.0 -->
         <xsl:when test="@schemaversion > 7.6">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv76to80">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv76to80"/>
+    </xsl:copy>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/kiwi/xsl/convert80to81.xsl
+++ b/kiwi/xsl/convert80to81.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 8.1 -->
         <xsl:when test="@schemaversion > 8.0">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv80to81">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv80to81"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- delete type from repository if rpm-dir type spec is used -->

--- a/kiwi/xsl/convert81to82.xsl
+++ b/kiwi/xsl/convert81to82.xsl
@@ -21,7 +21,7 @@
     <xsl:choose>
         <!-- nothing to do if already at 8.2 -->
         <xsl:when test="@schemaversion > 8.1">
-            <xsl:copy-of select="/"/>
+            <xsl:copy-of select="."/>
         </xsl:when>
         <!-- otherwise apply templates -->
         <xsl:otherwise>
@@ -31,6 +31,14 @@
             </image>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="conv81to82">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv81to82"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- delete use_for_bootstrap attribute from repository -->

--- a/kiwi/xsl/include.xsl
+++ b/kiwi/xsl/include.xsl
@@ -14,6 +14,14 @@
     </xsl:copy>
 </xsl:template>
 
+<!-- toplevel processing instructions and comments -->
+<xsl:template match="processing-instruction()|comment()" mode="include">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="include"/>
+    </xsl:copy>
+</xsl:template>
+
 <!-- incorporate optional include file(s) -->
 <xsl:template match="image/include" mode="include">
     <xsl:param name="include_file_name" select="@from"/>

--- a/kiwi/xsl/master.xsl
+++ b/kiwi/xsl/master.xsl
@@ -13,7 +13,7 @@
 <xsl:import href="convert81to82.xsl"/>
 <xsl:import href="pretty.xsl"/>
 
-<xsl:output encoding="utf-8"/>
+<xsl:output encoding="utf-8" indent="yes"/>
 
 <xsl:template match="/">
     <xsl:variable name="preprocess">


### PR DESCRIPTION
So far comments and processing instructions (PI) were ignored when applying the XSL stylesheets. This commit updates all stylesheets to take them into account

