### PR TITLE
storage: clone_device: increase dd block size

### DIFF
--- a/kiwi/storage/clone_device.py
+++ b/kiwi/storage/clone_device.py
@@ -56,7 +56,8 @@ class CloneDevice(DeviceProvider):
                 [
                     'dd',
                     'if={0}'.format(self.source_provider.get_device()),
-                    'of={0}'.format(target_device.get_device())
+                    'of={0}'.format(target_device.get_device()),
+                    'bs=1M'
                 ]
             )
             clone_id = BlockID(target_device.get_device())

--- a/test/unit/storage/clone_device_test.py
+++ b/test/unit/storage/clone_device_test.py
@@ -39,7 +39,7 @@ class TestCloneDevice:
         self.clone_device.clone([self.target_device])
 
         mock_Command_run.assert_called_once_with(
-            ['dd', 'if=/dev/source-device', 'of=/dev/target-device']
+            ['dd', 'if=/dev/source-device', 'of=/dev/target-device', 'bs=1M']
         )
         mock_FileSystem_new.assert_called_once_with(
             'ext3', self.target_device
@@ -57,7 +57,10 @@ class TestCloneDevice:
 
         assert mock_Command_run.call_args_list == [
             call(
-                ['dd', 'if=/dev/source-device', 'of=/dev/target-device']
+                [
+                    'dd', 'if=/dev/source-device', 'of=/dev/target-device',
+                    'bs=1M'
+                ]
             ),
             call(
                 ['vgimportclone', '/dev/target-device']
@@ -76,7 +79,10 @@ class TestCloneDevice:
 
         assert mock_Command_run.call_args_list == [
             call(
-                ['dd', 'if=/dev/source-device', 'of=/dev/target-device']
+                [
+                    'dd', 'if=/dev/source-device', 'of=/dev/target-device',
+                    'bs=1M'
+                ]
             ),
             call(
                 [
@@ -114,7 +120,10 @@ class TestCloneDevice:
             .return_value.set_uuid.assert_called_once_with()
         assert mock_Command_run.call_args_list == [
             call(
-                ['dd', 'if=/dev/source-device', 'of=/dev/target-device']
+                [
+                    'dd', 'if=/dev/source-device', 'of=/dev/target-device',
+                    'bs=1M'
+                ]
             ),
             call(
                 ['mdadm', '--stop', '/dev/md0']


### PR DESCRIPTION
Changes proposed in this pull request:
* Increase the block size used for `dd` reduces the time needed to clone a device.

`dd` operations take a long time, especially on cross-architecture builds using `kiwi-boxed-plugin`. This should help to speed it up a bit.