### PR TITLE
Honour custom exclude for filesystem builds

### DIFF
--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -205,5 +205,6 @@ class FileSystemBuilder:
         ) as filesystem:
             filesystem.create_on_file(
                 self.filename, self.label,
-                Defaults.get_exclude_list_for_root_data_sync()
+                Defaults.get_exclude_list_for_root_data_sync() + Defaults.
+                get_exclude_list_from_custom_exclude_files(self.root_dir)
             )


### PR DESCRIPTION
All other call sites honour the custom exclude file, it's just this one that needs to be fixed. This unblocks use of Kiwi for generating FEX rootfs.

Closes: #2652