### PR TITLE
Fix globbing with exclude with regex

### DIFF
--- a/kiwi/filesystem/erofs.py
+++ b/kiwi/filesystem/erofs.py
@@ -45,7 +45,12 @@ class FileSystemEroFs(FileSystemBase):
 
         if exclude:
             for item in exclude:
-                exclude_options.append(f'--exclude-regex={item}')
+                # item is a glob, but erofs requires a POSIX extended regex.
+                # Translate the glob to a regex for correct behaviour.
+                #
+                # We can't use fnmatch.translate, as that produces a Python regex.
+                as_regex = '^' + item.replace('*', '.*') + '$'
+                exclude_options.append(f'--exclude-regex={as_regex}')
 
         if label:
             self.custom_args['create_options'].append('-L')

--- a/test/unit/filesystem/erofs_test.py
+++ b/test/unit/filesystem/erofs_test.py
@@ -37,7 +37,7 @@ class TestFileSystemEroFs:
         mock_command.assert_called_once_with(
             [
                 'mkfs.erofs', '-z', 'zstd,level=21',
-                '-L', 'label', '--exclude-regex=foo',
+                '-L', 'label', '--exclude-regex=^foo$',
                 'myimage', 'root_dir'
             ]
         )


### PR DESCRIPTION
Changes proposed in this pull request:

This fixes a collection of bugs when producing erofs images.

On one hand, this ensures that an exclude of `/sys` doesn't accidentally match `/lib/libsystemd.so`, only `/sys/whatever`.

On the other hand, this ensures that `/dev/*` does match `/dev/vda` and not just `/dev///////////`.

This fixes libsystemd.so getting dropped in Kiwi-built FEX images.