### PR TITLE
Fix bundle extension for vagrant type

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-vagrant/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-vagrant/appliance.kiwi
@@ -17,7 +17,7 @@
         <profile name="virtualbox" description="Vagrant Box for VirtualBox"/>
     </profiles>
     <preferences>
-        <version>1.0</version>
+        <version>1.0.1</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_US</locale>
         <keytable>us</keytable>
@@ -28,7 +28,7 @@
         <bootloader-theme>openSUSE</bootloader-theme>
     </preferences>
     <preferences profiles="libvirt">
-        <type image="oem" filesystem="ext4" format="vagrant" firmware="efi" kernelcmdline="net.ifnames=0 console=ttyS0">
+        <type image="oem" filesystem="ext4" format="vagrant" firmware="efi" kernelcmdline="net.ifnames=0 console=ttyS0" bundle_format="%N-%v-%I.%A">
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
@@ -38,7 +38,7 @@
         </type>
     </preferences>
     <preferences profiles="virtualbox">
-        <type image="oem" filesystem="ext4" format="vagrant" kernelcmdline="net.ifnames=0 console=ttyS0">
+        <type image="oem" filesystem="ext4" format="vagrant" kernelcmdline="net.ifnames=0 console=ttyS0" bundle_format="%N-%v-%I.%A">
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
@@ -86,11 +86,17 @@
         <package name="virtualbox-kmp-default"/>
     </packages>
     <packages type="bootstrap">
+        <package name="gawk"/>
+        <package name="grep"/>
+        <package name="gzip"/>
         <package name="udev"/>
+        <package name="xz"/>
+        <package name="shadow"/>
         <package name="filesystem"/>
         <package name="glibc-locale"/>
         <package name="cracklib-dict-full"/>
         <package name="ca-certificates"/>
+        <package name="ca-certificates-mozilla"/>
         <package name="openSUSE-release"/>
         <package name="openSUSE-release-appliance-vagrant"/>
     </packages>

--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -288,6 +288,8 @@ class ResultBundleTask(CliTask):
         image_name = result.xml_state.xml_data.get_name()
         if '.tar.' in result_file.filename:
             extension = f'tar.{result_file.filename.split(".").pop()}'
+        elif '.vagrant.' in result_file.filename:
+            extension = f'vagrant.{".".join(result_file.filename.split(".")[-2:])}'
         else:
             extension = result_file.filename.split('.').pop()
         if bundle_file_format_name:

--- a/test/unit/tasks/result_bundle_test.py
+++ b/test/unit/tasks/result_bundle_test.py
@@ -323,6 +323,62 @@ class TestResultBundleTask:
     @patch('os.unlink')
     @patch('os.symlink')
     @patch('os.readlink')
+    def test_process_result_bundle_with_bundle_format_for_vagrant_types(
+        self, mock_os_readlink, mock_os_symlink, mock_os_unlink,
+        mock_os_path_islink, mock_exists, mock_path_create, mock_command,
+        mock_load
+    ):
+        self.xml_state.profiles = None
+        self.xml_state.host_architecture = 'x86_64'
+        self.xml_state.get_build_type_name = Mock(
+            return_value='oem'
+        )
+        self.xml_state.xml_data.get_name = Mock(
+            return_value='Leap-15.2'
+        )
+
+        result = Result(self.xml_state)
+        result.add_bundle_format('%N-%T:%M')
+        result.add(
+            key='disk_image',
+            filename='/tmp/mytest/Leap-15.2.x86_64-1.15.2.vagrant.virtualbox.box',
+            use_for_bundle=True, compress=False, shasum=False
+        )
+
+        mock_exists.return_value = False
+        mock_load.return_value = result
+        self._init_command_args()
+
+        self.task.process()
+
+        assert mock_command.call_args_list == [
+            call(
+                [
+                    'cp',
+                    '/tmp/mytest/Leap-15.2.x86_64-1.15.2.vagrant.virtualbox.box',
+                    os.sep.join(
+                        [self.abs_bundle_dir, 'Leap-15.2-oem:1.vagrant.virtualbox.box']
+                    )
+                ]
+            ),
+            call(
+                [
+                    'file',
+                    os.sep.join(
+                        [self.abs_bundle_dir, 'Leap-15.2-oem:1.vagrant.virtualbox.box']
+                    )
+                ]
+            )
+        ]
+
+    @patch('kiwi.tasks.result_bundle.Result.load')
+    @patch('kiwi.tasks.result_bundle.Command.run')
+    @patch('kiwi.tasks.result_bundle.Path.create')
+    @patch('os.path.exists')
+    @patch('os.path.islink')
+    @patch('os.unlink')
+    @patch('os.symlink')
+    @patch('os.readlink')
     def test_process_result_bundle_with_bundle_format_for_archive_types(
         self, mock_os_readlink, mock_os_symlink, mock_os_unlink,
         mock_os_path_islink, mock_exists, mock_path_create, mock_command,


### PR DESCRIPTION
When bundling result files that uses a vagrant type, kiwi creates them with the extension .vagrant.virtualbox.box or .vagrant.libvirt.box. The bundler code renames them using only the .box suffix which is too short as it is missing the subformat information. This commit fixes it and keeps this information in the result bundle file name.
This Fixes #2656


