### PR TITLE
package_manager: apt: run postinst scripts for ca-certificates

### DIFF
--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -261,7 +261,7 @@ class PackageManagerApt(PackageManagerBase):
                 done < {1}
                 while read -r deb;do
                     pushd "$(dirname "$deb")" >/dev/null || exit 1
-                    if [[ "$(basename "$deb")" == base-passwd* ]];then
+                    if [[ "$(basename "$deb")" == base-passwd* ]] || [[ "$(basename "$deb")" == ca-certificates* ]]; then
                         echo "Running pre/post package scripts for $(basename "$deb")"
                         dpkg -e "$deb" "{0}/DEBIAN"
                         test -e {0}/DEBIAN/preinst && chroot {0} bash -c "/DEBIAN/preinst install"

--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -265,7 +265,7 @@ class PackageManagerApt(PackageManagerBase):
                         echo "Running pre/post package scripts for $(basename "$deb")"
                         dpkg -e "$deb" "{0}/DEBIAN"
                         test -e {0}/DEBIAN/preinst && chroot {0} bash -c "/DEBIAN/preinst install"
-                        test -e {0}/DEBIAN/postinst && chroot {0} bash -c "/DEBIAN/postinst"
+                        test -e {0}/DEBIAN/postinst && chroot {0} bash -c "/DEBIAN/postinst configure"
                         rm -rf {0}/DEBIAN
                     fi
                     popd >/dev/null || exit 1

--- a/test/unit/package_manager/apt_test.py
+++ b/test/unit/package_manager/apt_test.py
@@ -136,7 +136,7 @@ class TestPackageManagerApt:
                 done < {1}
                 while read -r deb;do
                     pushd "$(dirname "$deb")" >/dev/null || exit 1
-                    if [[ "$(basename "$deb")" == base-passwd* ]];then
+                    if [[ "$(basename "$deb")" == base-passwd* ]] || [[ "$(basename "$deb")" == ca-certificates* ]]; then
                         echo "Running pre/post package scripts for $(basename "$deb")"
                         dpkg -e "$deb" "{0}/DEBIAN"
                         test -e {0}/DEBIAN/preinst && chroot {0} bash -c "/DEBIAN/preinst install"

--- a/test/unit/package_manager/apt_test.py
+++ b/test/unit/package_manager/apt_test.py
@@ -140,7 +140,7 @@ class TestPackageManagerApt:
                         echo "Running pre/post package scripts for $(basename "$deb")"
                         dpkg -e "$deb" "{0}/DEBIAN"
                         test -e {0}/DEBIAN/preinst && chroot {0} bash -c "/DEBIAN/preinst install"
-                        test -e {0}/DEBIAN/postinst && chroot {0} bash -c "/DEBIAN/postinst"
+                        test -e {0}/DEBIAN/postinst && chroot {0} bash -c "/DEBIAN/postinst configure"
                         rm -rf {0}/DEBIAN
                     fi
                     popd >/dev/null || exit 1


### PR DESCRIPTION
The ca-certificates package is required when any of the repositories
being used for the image use HTTPS. In order to support this, the
package needs to be added to the bootstrap packages. However, the
bootstrap package installer will not run the postinst script, which is
required to configure the system to use the SSL certificates.

This patch adjusts the bootstrap package installer to additionally run
the postinst scripts for ca-certificates.

If the ca-certificates package has not been configured, the build will
fail with the following error:

` Certificate verification failed: The certificate is NOT trusted. The certificate issuer is unknown.  Could not handshake: Error in the certificate verification. `
