### PR TITLE
Debian bootstrap and csm fixes

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -66,6 +66,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
 
                 {'grub_directory_name': 'grub|grub2'}
         """
+        self.efi_csm = True if self.xml_state.build_type.get_eficsm() is None \
+            else self.xml_state.build_type.get_eficsm()
         self.custom_args = custom_args
         self.config_options = []
         arch = Defaults.get_platform_name()
@@ -612,7 +614,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
 
     def _supports_bios_modules(self):
-        if self.arch == 'ix86' or self.arch == 'x86_64' or Defaults.is_ppc64_arch(self.arch):
+        if self.efi_csm and (
+            self.arch == 'ix86' or self.arch == 'x86_64' or Defaults.is_ppc64_arch(self.arch)
+        ):
             return True
         return False
 

--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -557,17 +557,19 @@ class PackageManagerApt(PackageManagerBase):
             script_post = f'{package_metadata_dir}/postinst'
             # 1. preinst
             if os.path.exists(script_pre):
+                Command.run(['chmod', '755', script_pre])
                 Command.run(
                     [
-                        'chroot', self.root_dir, 'bash',
+                        'chroot', self.root_dir,
                         f'{script_pre.replace(self.root_dir, "")}', 'install'
                     ], self.command_env
                 )
             # 2. postinst
             if os.path.exists(script_post):
+                Command.run(['chmod', '755', script_post])
                 Command.run(
                     [
-                        'chroot', self.root_dir, 'bash',
+                        'chroot', self.root_dir,
                         f'{script_post.replace(self.root_dir, "")}', 'configure'
                     ], self.command_env
                 )

--- a/test/unit/package_manager/apt_test.py
+++ b/test/unit/package_manager/apt_test.py
@@ -182,13 +182,23 @@ class TestPackageManagerApt:
             ),
             call(
                 [
-                    'chroot', 'root-dir', 'bash',
+                    'chmod', '755', 'tempdir/base-passwd/preinst'
+                ]
+            ),
+            call(
+                [
+                    'chroot', 'root-dir',
                     'tempdir/base-passwd/preinst', 'install'
                 ], new_env
             ),
             call(
                 [
-                    'chroot', 'root-dir', 'bash',
+                    'chmod', '755', 'tempdir/base-passwd/postinst'
+                ]
+            ),
+            call(
+                [
+                    'chroot', 'root-dir',
                     'tempdir/base-passwd/postinst', 'configure'
                 ], new_env
             ),
@@ -197,13 +207,23 @@ class TestPackageManagerApt:
             ),
             call(
                 [
-                    'chroot', 'root-dir', 'bash',
+                    'chmod', '755', 'tempdir/base-passwd/preinst'
+                ]
+            ),
+            call(
+                [
+                    'chroot', 'root-dir',
                     'tempdir/base-passwd/preinst', 'install'
                 ], new_env
             ),
             call(
                 [
-                    'chroot', 'root-dir', 'bash',
+                    'chmod', '755', 'tempdir/base-passwd/postinst'
+                ]
+            ),
+            call(
+                [
+                    'chroot', 'root-dir',
                     'tempdir/base-passwd/postinst', 'configure'
                 ], new_env
             ),
@@ -212,13 +232,23 @@ class TestPackageManagerApt:
             ),
             call(
                 [
-                    'chroot', 'root-dir', 'bash',
+                    'chmod', '755', 'tempdir/vim/preinst'
+                ]
+            ),
+            call(
+                [
+                    'chroot', 'root-dir',
                     'tempdir/vim/preinst', 'install'
                 ], new_env
             ),
             call(
                 [
-                    'chroot', 'root-dir', 'bash',
+                    'chmod', '755', 'tempdir/vim/postinst'
+                ]
+            ),
+            call(
+                [
+                    'chroot', 'root-dir',
                     'tempdir/vim/postinst', 'configure'
                 ], new_env
             )


### PR DESCRIPTION
This patch is two fold

**Fixed debian bootstrap script calls**
    
Run scripts as commands with their native shebang and not through bash. Not all debian package scripts uses bash, some of them uses sh which can be a link to dash or other interpreters. This Fixes #2660

**Evaluate eficsm everywhere**
    
Fixed _supports_bios_modules() to take an eventually provided eficsm setup into account. The grub config still searches for i386 grub modules even if eficsm="false" is set.

