### PR TITLE
Add vagrantconfig rule for vagrant format

### DIFF
--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1426,6 +1426,13 @@ div {
                 "image types: $types"
             ]
         ]
+        sch:rule [
+            context = "type[@format='vagrant']"
+            sch:assert [
+                test = "vagrantconfig[@provider]"
+                "<vagrantconfig> section is required for the vagrant format"
+            ]
+        ]
     ]
     sch:pattern [
         abstract = "true"

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2165,6 +2165,9 @@ volume management system</a:documentation>
       <sch:rule context="type[contains('$types', @image)]">
         <sch:assert test="@$attr">$attr attribute must be set for the following image types: $types</sch:assert>
       </sch:rule>
+      <sch:rule context="type[@format='vagrant']">
+        <sch:assert test="vagrantconfig[@provider]">&lt;vagrantconfig&gt; section is required for the vagrant format</sch:assert>
+      </sch:rule>
     </sch:pattern>
     <sch:pattern abstract="true" id="image_expandable">
       <sch:rule context="type[@$attr='true']">


### PR DESCRIPTION
If the format="vagrant" attribute is set, a vagrantconfig section becomes mandatory. This commit enforces this rule on the schema. This Fixes #2666

