### PR TITLE
Fix erofs requires in spec

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -291,7 +291,7 @@ Provides:       kiwi-filesystem:ext3
 Provides:       kiwi-filesystem:ext4
 Provides:       kiwi-filesystem:squashfs
 Provides:       kiwi-filesystem:xfs
-%if ! (0%{?suse_version} && 0%{?suse_version} < 1600)
+%if ! (0%{?suse_version} && 0%{?suse_version} <= 1600)
 Provides:       kiwi-filesystem:erofs
 Provides:       kiwi-image:erofs
 %endif
@@ -299,7 +299,7 @@ Provides:       kiwi-image:erofs
 Requires:       dosfstools
 Requires:       e2fsprogs
 Requires:       xfsprogs
-%if ! (0%{?suse_version} && 0%{?suse_version} < 1600)
+%if ! (0%{?suse_version} && 0%{?suse_version} <= 1600)
 Requires:       erofs-utils
 %endif
 %if 0%{?suse_version}


### PR DESCRIPTION
erofs-utils for SUSE only exists in Tumbleweed. The former conditon would also add the requirement for SLFO which is wrong. This commit fixes it

