### PR TITLE
Add pytest-container as optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ xmltodict = { version = ">=0.12.0", optional = true }
 
 [tool.poetry.extras]
 markup = [ "anymarkup-core", "xmltodict" ]
+integration_tests = ["pytest-container"]
 
 [tool.poetry.plugins]
 [tool.poetry.plugins."kiwi.tasks"]
@@ -87,7 +88,8 @@ kiwi-ng = "kiwi.kiwi:main"
 pytest = ">=6.2.0"
 pytest-cov = "*"
 pytest-xdist = "*"
-pytest-container = "*"
+# Optional dependencies for shell functions integration tests
+pytest-container = {version = "*", optional = true}
 # type checking
 mypy = ">=0.971"
 types-requests = "*"


### PR DESCRIPTION
The pyproject.toml listed pytest-container as dependency but it is used only to run the container based integration tests for the shell helper methods. For building the package this dependency should not be pulled in


