### PR TITLE
Fix setup of kiwi environment variables

### DIFF
--- a/doc/source/commands/image_info.rst
+++ b/doc/source/commands/image_info.rst
@@ -14,6 +14,7 @@ SYNOPSIS
    kiwi-ng image info --description=<directory>
        [--resolve-package-list]
        [--list-profiles]
+       [--print-kiwi-env]
        [--ignore-repos]
        [--add-repo=<source,type,alias,priority>...]
        [--print-xml|--print-yaml]
@@ -63,6 +64,19 @@ OPTIONS
   type is also profiled, it's required to provide this
   information to kiwi to list further profiles for this type.
   For example: kiwi-ng --profile top_level_entry_profile image info ...
+
+--print-kiwi-env
+
+  print kiwi profile environment variables. The listed variables
+  are available in the shell environment of the kiwi hook scripts.
+
+  NOTE:
+  The kiwi profile environment grows during the build process.
+  When used in early stages e.g. in a post_bootstrap.sh script
+  it can happen that not all variables have a value. The setup
+  of the kiwi profile environment in the image info output can
+  therefore also only list the static configuration values
+  which are known at the beginning of a build process.
 
 --resolve-package-list
 

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -245,25 +245,25 @@ class Profile:
         # kiwi_splash_theme
         # kiwi_loader_theme
         for preferences in reversed(self.xml_state.get_preferences_sections()):
-            if 'kiwi_iversion' not in self.dot_profile:
+            if 'kiwi_iversion' not in self.dot_profile and preferences.get_version():
                 self.dot_profile['kiwi_iversion'] = \
                     self._text(preferences.get_version())
             if 'kiwi_showlicense' not in self.dot_profile:
                 self.dot_profile['kiwi_showlicense'] = \
                     self._text(preferences.get_showlicense())
-            if 'kiwi_keytable' not in self.dot_profile:
+            if 'kiwi_keytable' not in self.dot_profile and preferences.get_keytable():
                 self.dot_profile['kiwi_keytable'] = \
                     self._text(preferences.get_keytable())
-            if 'kiwi_timezone' not in self.dot_profile:
+            if 'kiwi_timezone' not in self.dot_profile and preferences.get_timezone():
                 self.dot_profile['kiwi_timezone'] = \
                     self._text(preferences.get_timezone())
-            if 'kiwi_language' not in self.dot_profile:
+            if 'kiwi_language' not in self.dot_profile and preferences.get_locale():
                 self.dot_profile['kiwi_language'] = \
                     self._text(preferences.get_locale())
-            if 'kiwi_splash_theme' not in self.dot_profile:
+            if 'kiwi_splash_theme' not in self.dot_profile and preferences.get_bootsplash_theme():
                 self.dot_profile['kiwi_splash_theme'] = \
                     self._text(preferences.get_bootsplash_theme())
-            if 'kiwi_loader_theme' not in self.dot_profile:
+            if 'kiwi_loader_theme' not in self.dot_profile and preferences.get_bootloader_theme():
                 self.dot_profile['kiwi_loader_theme'] = \
                     self._text(preferences.get_bootloader_theme())
 

--- a/kiwi/tasks/image_info.py
+++ b/kiwi/tasks/image_info.py
@@ -20,6 +20,7 @@ usage: kiwi-ng image info -h | --help
        kiwi-ng image info --description=<directory>
            [--resolve-package-list]
            [--list-profiles]
+           [--print-kiwi-env]
            [--ignore-repos]
            [--add-repo=<source,type,alias,priority>...]
            [--print-xml|--print-yaml|--print-toml]
@@ -43,6 +44,8 @@ options:
         shasum, etc...
     --list-profiles
         list profiles available for the selected/default type
+    --print-kiwi-env
+        print kiwi profile environment variables
     --print-xml|--print-yaml|--print-toml
         print image description in specified format
 """
@@ -56,6 +59,8 @@ from kiwi.solver.sat import Sat
 from kiwi.solver.repository import SolverRepository
 from kiwi.solver.repository.base import SolverRepositoryBase
 from kiwi.system.uri import Uri
+from kiwi.system.profile import Profile
+from kiwi.defaults import Defaults
 
 
 class ImageInfoTask(CliTask):
@@ -95,6 +100,12 @@ class ImageInfoTask(CliTask):
         result = {
             'image': self.xml_state.xml_data.get_name()
         }
+
+        if self.command_args['--print-kiwi-env']:
+            profile = Profile(self.xml_state)
+            defaults = Defaults()
+            defaults.to_profile(profile)
+            result['kiwi_env'] = profile.get_settings()
 
         if self.command_args['--list-profiles']:
             result['profile_names'] = []

--- a/test/unit/system/profile_test.py
+++ b/test/unit/system/profile_test.py
@@ -65,8 +65,6 @@ class TestProfile:
             'kiwi_keytable': 'us.map.gz',
             'kiwi_timezone': 'Europe/Berlin',
             'kiwi_language': 'en_US',
-            'kiwi_splash_theme': None,
-            'kiwi_loader_theme': None,
             'kiwi_strip_delete': '',
             'kiwi_strip_tools': '',
             'kiwi_strip_libs': '',

--- a/test/unit/tasks/image_info_test.py
+++ b/test/unit/tasks/image_info_test.py
@@ -10,7 +10,9 @@ from ..test_helper import argv_kiwi_tests
 
 from kiwi.tasks.image_info import ImageInfoTask
 
-from collections import namedtuple
+from collections import (
+    namedtuple, OrderedDict
+)
 
 
 class TestImageInfoTask:
@@ -93,6 +95,7 @@ class TestImageInfoTask:
         self.task.command_args['--ignore-repos'] = False
         self.task.command_args['--resolve-package-list'] = False
         self.task.command_args['--list-profiles'] = False
+        self.task.command_args['--print-kiwi-env'] = False
         self.task.command_args['--print-xml'] = False
         self.task.command_args['--print-yaml'] = False
         self.task.command_args['--print-toml'] = False
@@ -126,6 +129,68 @@ class TestImageInfoTask:
         self.runtime_checker.check_repositories_configured.assert_called_once_with()
         mock_out.assert_called_once_with(
             {'image': 'LimeJeOS', 'profile_names': ['some']}
+        )
+
+    @patch('kiwi.tasks.image_info.DataOutput')
+    def test_process_image_info_print_kiwi_env(self, mock_out):
+        self._init_command_args()
+        self.task.command_args['info'] = True
+        self.task.command_args['--print-kiwi-env'] = True
+        self.task.process()
+        self.runtime_checker.check_repositories_configured.assert_called_once_with()
+
+        mock_out.assert_called_once_with(
+            {
+                'image': 'LimeJeOS',
+                'kiwi_env': OrderedDict(
+                    [
+                        ('kiwi_align', '1048576'),
+                        ('kiwi_boot_timeout', ''),
+                        ('kiwi_bootkernel', ''),
+                        ('kiwi_bootloader', 'grub2'),
+                        ('kiwi_bootloader_console', 'default:default'),
+                        ('kiwi_bootprofile', ''),
+                        ('kiwi_btrfs_root_is_snapshot', ''),
+                        ('kiwi_cmdline', ''),
+                        ('kiwi_compressed', ''),
+                        ('kiwi_delete', ''),
+                        ('kiwi_devicepersistency', ''),
+                        ('kiwi_displayname', 'Bob'),
+                        ('kiwi_drivers', ''),
+                        ('kiwi_firmware', ''),
+                        ('kiwi_fsmountoptions', ''),
+                        ('kiwi_gpt_hybrid_mbr', ''),
+                        ('kiwi_hybridpersistent', ''),
+                        ('kiwi_hybridpersistent_filesystem', ''),
+                        ('kiwi_iname', 'LimeJeOS'),
+                        ('kiwi_initrd_system', 'dracut'),
+                        ('kiwi_installboot', ''),
+                        ('kiwi_iversion', '1.13.2'),
+                        ('kiwi_keytable', 'us.map.gz'),
+                        ('kiwi_language', 'en_US'),
+                        ('kiwi_live_volid', 'CDROM'),
+                        ('kiwi_loader_theme', 'openSUSE'),
+                        ('kiwi_luks_empty_passphrase', 'false'),
+                        ('kiwi_profiles', ''),
+                        ('kiwi_ramonly', ''),
+                        ('kiwi_revision', '$Format:%H$'),
+                        ('kiwi_rootpartuuid', ''),
+                        ('kiwi_sectorsize', '512'),
+                        ('kiwi_showlicense', ''),
+                        ('kiwi_splash_theme', 'openSUSE'),
+                        ('kiwi_startsector', '2048'),
+                        ('kiwi_strip_delete', ''),
+                        ('kiwi_strip_libs', ''),
+                        ('kiwi_strip_tools', ''),
+                        ('kiwi_target_blocksize', ''),
+                        ('kiwi_target_removable', ''),
+                        ('kiwi_timezone', 'Europe/Berlin'),
+                        ('kiwi_type', 'iso'),
+                        ('kiwi_vga', ''),
+                        ('kiwi_wwid_wait_timeout', '')
+                    ]
+                )
+            }
         )
 
     @patch('kiwi.tasks.image_info.DataOutput')


### PR DESCRIPTION
Some kiwi env vars are initialized with an empty value and not overwritten if another value is provided. For the selected variables an empty value setting is not allowed because the schema also enforces the value to be set at least once. In addition a helpful option named --print-kiwi-env was added to the 'image info' command which allows to print the environment variables and their values.


