### PR TITLE
Allow to derive from multiple containers

### DIFF
--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -65,9 +65,9 @@ class ContainerBuilder:
             xml_state.build_type.get_metadata_path()
 
         if xml_state.get_derived_from_image_uri() and not self.delta_root:
-            # The base image is expected to be unpacked by the kiwi
-            # prepare step and stored inside of the root_dir/image directory.
-            # In addition a md5 file of the image is expected too
+            # The base image(all derived imports) is expected to be unpacked
+            # by the kiwi prepare step and stored inside of the root_dir/image
+            # directory. In addition a md5 file of the image is expected too
             self.base_image = Defaults.get_imported_root_image(
                 self.root_dir
             )

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -82,12 +82,12 @@ class SystemPrepare:
             root_dir, allow_existing
         )
         root.create()
-        image_uri = xml_state.get_derived_from_image_uri()
+        image_uris = xml_state.get_derived_from_image_uri()
         delta_root = xml_state.build_type.get_delta_root()
 
-        if image_uri:
+        if image_uris:
             self.root_import = RootImport.new(
-                root_dir, image_uri, xml_state.build_type.get_image()
+                root_dir, image_uris, xml_state.build_type.get_image()
             )
             if delta_root:
                 self.root_import.overlay_data()

--- a/kiwi/system/root_import/__init__.py
+++ b/kiwi/system/root_import/__init__.py
@@ -17,6 +17,7 @@
 #
 import logging
 import importlib
+from typing import List
 from abc import (
     ABCMeta,
     abstractmethod
@@ -49,7 +50,7 @@ class RootImport(metaclass=ABCMeta):
         return None  # pragma: no cover
 
     @staticmethod
-    def new(root_dir: str, image_uri: Uri, image_type: str):
+    def new(root_dir: str, image_uri: List[Uri], image_type: str):
         name_map = {
             'docker': 'OCI',
             'oci': 'OCI'

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -2781,22 +2781,26 @@ class XMLState:
             result.append(luks_pbkdf)
         return result
 
-    def get_derived_from_image_uri(self) -> Optional[Uri]:
+    def get_derived_from_image_uri(self) -> List[Uri]:
         """
-        Uri object of derived image if configured
+        Uri object(s) of derived image if configured
 
-        Specific image types can be based on a master image.
-        This method returns the location of this image when
-        configured in the XML description
+        Specific image types can be based on one ore more derived
+        images. This method returns the location of this image(s)
+        when configured in the XML description
 
-        :return: Instance of Uri
+        :return: List of Uri instances
 
-        :rtype: object
+        :rtype: list
         """
-        derived_image = self.build_type.get_derived_from()
-        if derived_image:
-            return Uri(derived_image, repo_type='container')
-        return None
+        image_uris = []
+        derived_images = self.build_type.get_derived_from()
+        if derived_images:
+            for derived_image in derived_images.split(','):
+                image_uris.append(
+                    Uri(derived_image, repo_type='container')
+                )
+        return image_uris
 
     def set_derived_from_image_uri(self, uri: str) -> None:
         """

--- a/test/unit/system/root_import/base_test.py
+++ b/test/unit/system/root_import/base_test.py
@@ -18,17 +18,17 @@ class TestRootImportBase:
         mock_buildservice.return_value = False
         mock_path.return_value = True
         with patch.dict('os.environ', {'HOME': '../data'}):
-            RootImportBase('root_dir', Uri('file:///image.tar.xz'))
+            RootImportBase('root_dir', [Uri('file:///image.tar.xz')])
         assert call('/image.tar.xz') in mock_path.call_args_list
 
     def test_init_remote_uri(self):
         with raises(KiwiRootImportError):
-            RootImportBase('root_dir', Uri('http://example.com/image.tar.xz'))
+            RootImportBase('root_dir', [Uri('http://example.com/image.tar.xz')])
 
     @patch('kiwi.system.root_import.base.log.warning')
     def test_init_unknown_uri(self, mock_log_warn):
-        root = RootImportBase('root_dir', Uri('docker://opensuse:leap'))
-        assert root.unknown_uri == 'docker://opensuse:leap'
+        root = RootImportBase('root_dir', [Uri('docker://opensuse:leap')])
+        assert root.raw_urls == ['docker://opensuse:leap']
         assert mock_log_warn.called
 
     @patch('os.path.exists')
@@ -36,14 +36,14 @@ class TestRootImportBase:
         mock_path.return_value = False
         with patch.dict('os.environ', {'HOME': '../data'}):
             with raises(KiwiRootImportError):
-                RootImportBase('root_dir', Uri('file:///image.tar.xz'))
+                RootImportBase('root_dir', [Uri('file:///image.tar.xz')])
 
     @patch('os.path.exists')
     def test_data_sync(self, mock_path):
         mock_path.return_value = True
         with patch.dict('os.environ', {'HOME': '../data'}):
             root_import = RootImportBase(
-                'root_dir', Uri('file:///image.tar.xz')
+                'root_dir', [Uri('file:///image.tar.xz')]
             )
         with raises(NotImplementedError):
             root_import.sync_data()
@@ -53,7 +53,7 @@ class TestRootImportBase:
         mock_path.return_value = True
         with patch.dict('os.environ', {'HOME': '../data'}):
             root_import = RootImportBase(
-                'root_dir', Uri('docker://opensuse:leap')
+                'root_dir', [Uri('docker://opensuse:leap')]
             )
         with raises(NotImplementedError):
             root_import.overlay_data()
@@ -77,7 +77,7 @@ class TestRootImportBase:
             xml_state = Mock()
             mock_Command_run.return_value.output = '/file_a\n/file_b'
             with patch.dict('os.environ', {'HOME': '../data'}):
-                root = RootImportBase('root_dir', Uri('docker://opensuse:leap'))
+                root = RootImportBase('root_dir', [Uri('docker://opensuse:leap')])
                 root.overlay = Mock()
                 mock_pathlib.Path = Mock()
                 root_overlay_path_mock = Mock()

--- a/test/unit/system/root_import/oci_test.py
+++ b/test/unit/system/root_import/oci_test.py
@@ -22,10 +22,10 @@ class TestRootImportOCI:
         mock_path.return_value = True
         with patch.dict('os.environ', {'HOME': '../data'}):
             self.oci_import = RootImportOCI(
-                'root_dir', Uri('file:///image.tar'),
+                'root_dir', [Uri('file:///image.tar')],
                 {'archive_transport': 'oci-archive'}
             )
-        assert self.oci_import.image_file == '/image.tar'
+        assert self.oci_import.image_files == ['/image.tar']
 
     @patch('os.path.exists')
     def setup_method(self, cls, mock_path):
@@ -36,7 +36,7 @@ class TestRootImportOCI:
         mock_path.return_value = False
         with raises(KiwiRootImportError):
             RootImportOCI(
-                'root_dir', Uri('file:///image.tar.xz'),
+                'root_dir', [Uri('file:///image.tar.xz')],
                 {'archive_transport': 'oci-archive'}
             )
 
@@ -137,7 +137,7 @@ class TestRootImportOCI:
         mock_md5.return_value = Mock()
         with patch.dict('os.environ', {'HOME': '../data'}):
             oci_import = RootImportOCI(
-                'root_dir', Uri('docker:image:tag'),
+                'root_dir', [Uri('docker:image:tag')],
                 {'archive_transport': 'docker-archive'}
             )
 

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1105,14 +1105,14 @@ class TestXMLState:
     def test_get_derived_from_image_uri(self):
         xml_data = self.description.load()
         state = XMLState(xml_data, ['derivedContainer'], 'docker')
-        assert state.get_derived_from_image_uri().uri == \
+        assert state.get_derived_from_image_uri()[0].uri == \
             'obs://project/repo/image#mytag'
 
     def test_set_derived_from_image_uri(self):
         xml_data = self.description.load()
         state = XMLState(xml_data, ['derivedContainer'], 'docker')
         state.set_derived_from_image_uri('file:///new_uri')
-        assert state.get_derived_from_image_uri().translate() == '/new_uri'
+        assert state.get_derived_from_image_uri()[0].translate() == '/new_uri'
 
     def test_set_derived_from_image_uri_not_applied(self):
         with self._caplog.at_level(logging.WARNING):


### PR DESCRIPTION
Add support for multi inheritance to the derived_from attribute In the order of a comma separated list of docker source URI's a base tree is created. This was possible only with one container so far and Fixes #2680 as well as jira#OBS-354

