### PR TITLE
Fixed use of fscreateoptions for iso type

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
@@ -33,7 +33,7 @@
         </type>
     </preferences>
     <preferences profiles="EroFS">
-        <type image="iso" flags="overlay" firmware="uefi" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="xfs" hybridpersistent="true" mediacheck="true" filesystem="erofs">
+        <type image="iso" flags="overlay" firmware="uefi" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="xfs" hybridpersistent="true" mediacheck="true" filesystem="erofs" fscreateoptions="-Ededupe,all-fragments -C 65536">
             <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -301,17 +301,20 @@ class LiveImageBuilder:
                 )
         else:
             # Put the root filesystem into SquashFS directly
-            with FileSystem.new(
-                name=root_filesystem,
-                device_provider=DeviceProvider(),
-                root_dir=self.root_dir + os.sep,
-                custom_args={
+            filesystem_custom_parameters.update(
+                {
                     'compression':
                         self.xml_state.build_type.get_squashfscompression()
                 } if root_filesystem == 'squashfs' else {
                     'compression':
                         self.xml_state.build_type.get_erofscompression()
                 }
+            )
+            with FileSystem.new(
+                name=root_filesystem,
+                device_provider=DeviceProvider(),
+                root_dir=self.root_dir + os.sep,
+                custom_args=filesystem_custom_parameters
             ) as live_container_image:
                 container_image = Temporary().new_file()
                 live_container_image.create_on_file(

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -257,7 +257,11 @@ class TestLiveImageBuilder:
                     device_provider=mock_DeviceProvider.return_value,
                     name='squashfs',
                     root_dir='root_dir/',
-                    custom_args={'compression': 'lzo'}
+                    custom_args={
+                        'mount_options': ['async'],
+                        'create_options': ['-O', 'option'],
+                        'compression': 'lzo'
+                    }
                 )
             ]
 


### PR DESCRIPTION
The information for fscreateoptions was not passed along to the tooling if a custom filesystem attribute was specified. This Fixes #2681

