### PR TITLE
Added /dev/pts to bind mount locations

### DIFF
--- a/kiwi/system/root_bind.py
+++ b/kiwi/system/root_bind.py
@@ -68,6 +68,7 @@ class RootBind:
         self.bind_locations = [
             '/proc',
             '/dev',
+            '/dev/pts',
             '/var/run/dbus',
             '/sys'
         ]

--- a/test/unit/system/root_bind_test.py
+++ b/test/unit/system/root_bind_test.py
@@ -28,6 +28,15 @@ class TestRootBind:
         root.root_dir = 'root-dir'
         self.bind_root = RootBind(root)
 
+        # test expected real bind mount locations
+        assert self.bind_root.bind_locations == [
+            '/proc',
+            '/dev',
+            '/dev/pts',
+            '/var/run/dbus',
+            '/sys'
+        ]
+
         # stub config files and bind locations
         self.bind_root.config_files = ['/etc/sysconfig/proxy']
         self.bind_root.bind_locations = ['/proc']


### PR DESCRIPTION
During runtime several kernel filesystems are bind mounted into the image root system such that programs expecting it can work. /dev/pts was not needed so far but seems to be a good addition to the list to make tools like sudo to work properly when called e.g. from a config.sh script. This Fixes #2686


