### PR TITLE
Fix legacy_bios_mode detection

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
@@ -12,9 +12,10 @@
     </description>
     <profiles>
         <profile name="Standard" description="Standard EFI/BIOS Live Boot"/>
-        <profile name="Secure" description="SecureBoot/BIOS Live Boot"/>
+        <profile name="Secure" description="SecureBoot EFI Live Boot"/>
         <profile name="SDBoot" description="EFI Boot via systemd-boot"/>
-        <profile name="EroFS" description="Live Root via EroFS"/>
+        <profile name="EroFS" description="EFI/BIOS Boot Live Root via EroFS"/>
+        <profile name="BIOS" description="Legacy BIOS Live Boot only"/>
     </profiles>
     <preferences>
         <version>1.42.3</version>
@@ -47,6 +48,11 @@
             <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
+    <preferences profiles="BIOS">
+        <type image="iso" flags="overlay" firmware="bios" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="true">
+            <bootloader name="grub2" console="serial" timeout="10"/>
+        </type>
+    </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
@@ -56,7 +62,7 @@
     <packages type="image" profiles="SDBoot">
         <package name="systemd-boot"/>
     </packages>
-    <packages type="image" profiles="Standard,Secure,EroFS">
+    <packages type="image" profiles="Standard,Secure,EroFS,BIOS">
         <package name="grub2-branding-openSUSE"/>
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1038,7 +1038,7 @@ class DiskBuilder:
     ) -> Dict:
         disk.wipe()
         disksize_used_mbytes = 0
-        if self.firmware.legacy_bios_mode():
+        if self.firmware.get_legacy_bios_partition_size():
             log.info('--> creating EFI CSM(legacy bios) partition')
             partition_mbsize = self.firmware.get_legacy_bios_partition_size()
             disk.create_efi_csm_partition(

--- a/kiwi/firmware.py
+++ b/kiwi/firmware.py
@@ -92,6 +92,11 @@ class FirmWare:
                 return True
             else:
                 return False
+        elif self.get_partition_table_type() == 'msdos':
+            if self.arch == 'x86_64' or re.match('i.86', self.arch):
+                return True
+            else:
+                return False
         else:
             return False
 
@@ -166,7 +171,7 @@ class FirmWare:
 
         :rtype: int
         """
-        if self.legacy_bios_mode():
+        if self.legacy_bios_mode() and self.efi_mode():
             return Defaults.get_default_legacy_bios_mbytes()
         else:
             return 0

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -293,6 +293,7 @@ class TestDiskBuilder:
         filesystem = MagicMock()
         mock_fs.return_value = filesystem
 
+        self.firmware.get_legacy_bios_partition_size.return_value = 2
         self.disk_builder.volume_manager_name = None
         self.disk_builder.initrd_system = 'kiwi'
 
@@ -713,6 +714,7 @@ class TestDiskBuilder:
         mock_rand.return_value = 15
         filesystem = MagicMock()
         mock_fs.return_value = filesystem
+        self.firmware.get_legacy_bios_partition_size.return_value = 2
         self.disk_builder.root_filesystem_verity_blocks = 10
         self.disk_builder.root_filesystem_embed_verity_metadata = True
         self.disk_builder.root_filesystem_is_overlay = False

--- a/test/unit/firmware_test.py
+++ b/test/unit/firmware_test.py
@@ -75,12 +75,15 @@ class TestFirmWare:
         assert self.firmware_opal.get_partition_table_type() == 'gpt'
 
     def test_legacy_bios_mode(self):
-        assert self.firmware_bios.legacy_bios_mode() is False
+        assert self.firmware_bios.legacy_bios_mode() is True
         assert self.firmware_efi.legacy_bios_mode() is True
 
     def test_legacy_bios_mode_non_x86_platform(self):
         self.firmware_efi.arch = 'arm64'
         assert self.firmware_efi.legacy_bios_mode() is False
+        self.firmware_bios.arch = 'arm64'
+        assert self.firmware_bios.legacy_bios_mode() is False
+        assert self.firmware_s390_cdl.legacy_bios_mode() is False
 
     def test_ec2_mode(self):
         assert self.firmware_ec2.ec2_mode() == 'ec2'


### PR DESCRIPTION
The code in this method does not work correctly if the firmware is set to 'bios'. In bios only mode the method returned a false value which is incorrect as it should return a true value in this case. Without this patch ISO images will fail to boot because no loader gets configured.
