### PR TITLE
Drop /dev/pts from bind mount locations

### DIFF
--- a/kiwi/system/root_bind.py
+++ b/kiwi/system/root_bind.py
@@ -68,7 +68,6 @@ class RootBind:
         self.bind_locations = [
             '/proc',
             '/dev',
-            '/dev/pts',
             '/var/run/dbus',
             '/sys'
         ]

--- a/test/unit/system/root_bind_test.py
+++ b/test/unit/system/root_bind_test.py
@@ -32,7 +32,6 @@ class TestRootBind:
         assert self.bind_root.bind_locations == [
             '/proc',
             '/dev',
-            '/dev/pts',
             '/var/run/dbus',
             '/sys'
         ]


### PR DESCRIPTION
This has created havoc in the Fedora build environments by fully unmounting /dev/pts and breaking the builders for subsquent tasks.

This is a partial revert of commit daf1323c5ded7e4e7783205f5e30457b40eb322f.
