### PR TITLE
xorriso: respect efiparttable and gpt_hybrid_mbr

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -402,7 +402,7 @@ efifatimagesize="nonNegativeInteger":
 efiparttable="msdos|gpt":
   For images with an EFI firmware specifies the partition
   table type to use. If not set defaults to the GPT partition
-  table type
+  table type for disk images, MBR (msdos) for ISO images.
 
 dosparttable_extended_layout="true|false":
   For oem disk images, specifies to make use of logical partitions
@@ -889,7 +889,14 @@ force_mbr="true|false":
   partitions
 
 gpt_hybrid_mbr="true|false":
-  For GPT disk types only: Create a hybrid GPT/MBR partition table
+  For disk types, create a hybrid GPT/MBR partition table with an
+  'accurate' MBR table that will have no 'bootable' flagged partition
+  For ISO types, create a hybrid GPT/MBR partition table where the
+  MBR partition table contains a whole-disk 'protective' partition
+  and a second bootable-flagged partition (intended to make the image
+  bootable in both UEFI and BIOS modes on as much hardware as possible)
+  In both cases, only has any effect if the EFI partition table
+  type is GPT
 
 hybridpersistent="true|false":
   For the live ISO type, triggers the creation of a partition for

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -161,6 +161,8 @@ class InstallImageBuilder:
                 'mbr_id': self.mbrid.get_id(),
                 'application_id': self.xml_state.build_type.get_application_id(),
                 'efi_mode': self.firmware.efi_mode(),
+                'efi_partition_table': self.firmware.get_partition_table_type(),
+                'gpt_hybrid_mbr': self.firmware.gpt_hybrid_mbr,
                 'ofw_mode': self.firmware.ofw_mode(),
                 'legacy_bios_mode': self.firmware.legacy_bios_mode()
             }

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -144,6 +144,8 @@ class LiveImageBuilder:
                 'mbr_id': self.mbrid.get_id(),
                 'application_id': self.application_id,
                 'efi_mode': self.firmware.efi_mode(),
+                'efi_partition_table': self.firmware.get_partition_table_type(),
+                'gpt_hybrid_mbr': self.firmware.gpt_hybrid_mbr,
                 'legacy_bios_mode': self.firmware.legacy_bios_mode()
             }
         }

--- a/kiwi/filesystem/isofs.py
+++ b/kiwi/filesystem/isofs.py
@@ -50,6 +50,6 @@ class FileSystemIsoFs(FileSystemBase):
         iso_tool.init_iso_creation_parameters(meta_data)
 
         if efi_loader:
-            iso_tool.add_efi_loader_parameters(efi_loader)
+            iso_tool.add_efi_loader_parameters(efi_loader, meta_data)
 
         iso_tool.create_iso(self.filename)

--- a/kiwi/firmware.py
+++ b/kiwi/firmware.py
@@ -42,6 +42,7 @@ class FirmWare:
         self.firmware = xml_state.build_type.get_firmware()
         self.efipart_mbytes = xml_state.build_type.get_efipartsize()
         self.efi_partition_table = xml_state.build_type.get_efiparttable()
+        self.gpt_hybrid_mbr = xml_state.build_type.get_gpt_hybrid_mbr()
         self.efi_csm = True if xml_state.build_type.get_eficsm() is None \
             else xml_state.build_type.get_eficsm()
 

--- a/kiwi/iso_tools/base.py
+++ b/kiwi/iso_tools/base.py
@@ -19,7 +19,7 @@ import os
 import shutil
 import logging
 from typing import (
-    Dict, List, Union
+    Dict, List, Optional, Union
 )
 
 # project
@@ -72,7 +72,9 @@ class IsoToolsBase:
         """
         raise NotImplementedError
 
-    def add_efi_loader_parameters(self, loader_file: str) -> None:
+    def add_efi_loader_parameters(
+        self, loader_file: str, custom_args: Optional[Dict[str, Union[str, bool]]] = None
+    ) -> None:
         """
         Add ISO creation parameters to embed the EFI loader
 

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1687,7 +1687,7 @@ div {
         attribute efiparttable { "msdos" | "gpt" }
         >> sch:pattern [ id = "efiparttable" is-a = "image_type"
             sch:param [ name = "attr" value = "efiparttable" ]
-            sch:param [ name = "types" value = "oem" ]
+            sch:param [ name = "types" value = "oem iso" ]
         ]
     k.type.bootprofile.attribute =
         ## Specifies the boot profile defined in the boot image
@@ -2012,7 +2012,7 @@ div {
         attribute gpt_hybrid_mbr { xsd:boolean }
         >> sch:pattern [ id = "gpt_hybrid_mbr" is-a = "image_type"
             sch:param [ name = "attr" value = "gpt_hybrid_mbr" ]
-            sch:param [ name = "types" value = "oem" ]
+            sch:param [ name = "types" value = "oem iso" ]
         ]
     k.type.initrd_system.attribute =
         ## specify which initrd builder to use, default is dracut

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2473,7 +2473,7 @@ table type.</a:documentation>
       </attribute>
       <sch:pattern id="efiparttable" is-a="image_type">
         <sch:param name="attr" value="efiparttable"/>
-        <sch:param name="types" value="oem"/>
+        <sch:param name="types" value="oem iso"/>
       </sch:pattern>
     </define>
     <define name="k.type.bootprofile.attribute">
@@ -2907,7 +2907,7 @@ create a hybrid GPT/MBR partition table</a:documentation>
       </attribute>
       <sch:pattern id="gpt_hybrid_mbr" is-a="image_type">
         <sch:param name="attr" value="gpt_hybrid_mbr"/>
-        <sch:param name="types" value="oem"/>
+        <sch:param name="types" value="oem iso"/>
       </sch:pattern>
     </define>
     <define name="k.type.initrd_system.attribute">

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -247,6 +247,8 @@ class TestLiveImageBuilder:
         self.setup.export_package_list.return_value = '.packages'
 
         self.firmware.bios_mode.return_value = False
+        self.firmware.get_partition_table_type.return_value = 'gpt'
+        self.firmware.gpt_hybrid_mbr = False
         self.live_image.create()
 
         self.setup.import_cdroot_files.assert_called_once_with('temp_media_dir')
@@ -369,6 +371,8 @@ class TestLiveImageBuilder:
                     'volume_id': 'volid',
                     'efi_mode': 'uefi',
                     'efi_loader': 'kiwi-tmpfile',
+                    'efi_partition_table': 'gpt',
+                    'gpt_hybrid_mbr': False,
                     'udf': True,
                     'legacy_bios_mode': True
                 }

--- a/test/unit/filesystem/isofs_test.py
+++ b/test/unit/filesystem/isofs_test.py
@@ -58,5 +58,6 @@ class TestFileSystemIsoFs:
             self.isofs.create_on_file('myimage')
             iso_tool.create_iso.assert_called_once_with('myimage')
             iso_tool.add_efi_loader_parameters.assert_called_once_with(
-                'esp-image-file'
+                'esp-image-file',
+                {'efi_mode': 'uefi', 'efi_loader': 'esp-image-file'}
             )


### PR DESCRIPTION
This should make the xorriso-based ISO build path respect the 'efiparttable' and 'gpt_hybrid_mbr' settings when building a UEFI-compatible image, making it write a GPT disk label by default instead of an MBR (msdos) one. If it's building an image that is not UEFI-compatible it will always write an MBR label, regardless of this setting.

If 'gpt_hybrid_mbr' is set, xorriso will write an Ubuntu-style MBR/GPT hybrid partition table, where the MBR partition table includes a partition with type 00 and the bootable flag, as well as the partition with type ee required by the UEFI spec. This mildly violates the UEFI spec but may make the image bootable on native BIOS or CSM firmwares which refuse to boot from a disk with no partition marked 'bootable' in the MBR. If 'gpt_hybrid_mbr' is not set, xorriso will write a strictly UEFI-spec compliant label, with just the 'protective MBR' required by the UEFI spec (no bootable partition) and the correct GPT partition table. Note this is somewhat different from what gpt_hybrid_mbr does for disk images.

Also, we now pass -compliance no_emul_toc when building ISOs, as recommended by upstream in
https://lists.gnu.org/archive/html/bug-xorriso/2024-11/msg00012.html This tool is generally always going to be building ISOs intended for write-once use, not multi-session use (and which are rarely, these days, written to physical discs at all anyway).

Fixes #2685 .