### PR TITLE
Drop insecure and unsupported md5 digest

### DIFF
--- a/doc/source/building_images/build_expandable_disk.rst
+++ b/doc/source/building_images/build_expandable_disk.rst
@@ -183,18 +183,18 @@ a target system:
           scp pxeboot.{exc_image_base_name_disk}.x86_64-{exc_image_version}.initrd PXE_SERVER_IP:/srv/tftpboot/boot/initrd
           scp pxeboot.{exc_image_base_name_disk}.x86_64-{exc_image_version}.kernel PXE_SERVER_IP:/srv/tftpboot/boot/linux
 
-3. Copy the disk image, MD5 file, system kernel, initrd and bootoptions to
+3. Copy the disk image, SHA256 file, system kernel, initrd and bootoptions to
    the PXE boot server.
 
    Activation of the deployed system is done via `kexec` of the kernel
    and initrd provided here.
 
-   a) Copy system image and MD5 checksum:
+   a) Copy system image and SHA256 checksum:
 
       .. code:: bash
 
           scp {exc_image_base_name_disk}.x86_64-{exc_image_version}.xz PXE_SERVER_IP:/srv/tftpboot/image/
-          scp {exc_image_base_name_disk}.x86_64-{exc_image_version}.md5 PXE_SERVER_IP:/srv/tftpboot/image/
+          scp {exc_image_base_name_disk}.x86_64-{exc_image_version}.sha256 PXE_SERVER_IP:/srv/tftpboot/image/
 
    b) Copy kernel, initrd and bootoptions used for booting the system via kexec:
 
@@ -224,7 +224,7 @@ a target system:
 
    The location of the image is specified as a source URI that can point
    to any location supported by the `curl` command. {kiwi} uses `curl` to fetch
-   the data from this URI. This means that the image, MD5 file, system kernel
+   the data from this URI. This means that the image, checksum file, system kernel
    and initrd can be fetched from any server, and they do not need to be stored
    on the `PXE_SERVER`.
 

--- a/doc/source/working_with_images/legacy_netboot_root_filesystem.rst
+++ b/doc/source/working_with_images/legacy_netboot_root_filesystem.rst
@@ -90,12 +90,12 @@ system. As diskless client, a QEMU virtual machine is used.
        $ cp *.initrd /srv/tftpboot/boot/initrd
        $ cp *.kernel /srv/tftpboot/boot/linux
 
-5. Copy the system image and its MD5 sum to :file:`/srv/tftpboot/image`:
+5. Copy the system image and its SHA256 sum to :file:`/srv/tftpboot/image`:
 
    .. code:: bash
 
        $ cp {exc_image_base_name_pxe}.x86_64-{exc_image_version} /srv/tftpboot/image
-       $ cp {exc_image_base_name_pxe}.x86_64-{exc_image_version}.md5 /srv/tftpboot/image
+       $ cp {exc_image_base_name_pxe}.x86_64-{exc_image_version}.sha256 /srv/tftpboot/image
 
 6. Adjust the PXE configuration file.
    The configuration file controls which kernel and initrd is
@@ -317,7 +317,7 @@ CONF, the following setup is required:
    RELOAD_CONFIG=1
 
 By default only configuration files which has changed according to
-their md5sum value will be reloaded. With the above setup all files
+their checksum value will be reloaded. With the above setup all files
 will be reloaded from the PXE server. The option only applies to
 configurations with a DISK/PART setup
 

--- a/dracut/modules.d/90kiwi-dump/module-setup.sh
+++ b/dracut/modules.d/90kiwi-dump/module-setup.sh
@@ -21,7 +21,7 @@ install() {
     declare moddir=${moddir}
     declare systemdutildir=${systemdutildir}
     inst_multiple \
-        tr lsblk dd md5sum head pv kexec basename awk kpartx
+        tr lsblk dd sha256sum head pv kexec basename awk kpartx
 
     inst_hook pre-udev 30 "${moddir}/kiwi-installer-genrules.sh"
 

--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -55,7 +55,7 @@ class ContainerBuilder:
         self.requested_container_type = xml_state.get_build_type_name()
         self.delta_root = xml_state.build_type.get_delta_root()
         self.base_image = None
-        self.base_image_md5 = None
+        self.base_image_sha256 = None
         self.ensure_empty_tmpdirs = True
 
         self.container_config['xz_options'] = \
@@ -67,11 +67,11 @@ class ContainerBuilder:
         if xml_state.get_derived_from_image_uri() and not self.delta_root:
             # The base image(all derived imports) is expected to be unpacked
             # by the kiwi prepare step and stored inside of the root_dir/image
-            # directory. In addition a md5 file of the image is expected too
+            # directory. In addition a sha256 file of the image is expected too
             self.base_image = Defaults.get_imported_root_image(
                 self.root_dir
             )
-            self.base_image_md5 = ''.join([self.base_image, '.md5'])
+            self.base_image_sha256 = ''.join([self.base_image, '.sha256'])
 
             if not os.path.exists(self.base_image):
                 raise KiwiContainerBuilderError(
@@ -79,10 +79,10 @@ class ContainerBuilder:
                         self.base_image
                     )
                 )
-            if not os.path.exists(self.base_image_md5):
+            if not os.path.exists(self.base_image_sha256):
                 raise KiwiContainerBuilderError(
-                    'Base image MD5 sum {0} not found at'.format(
-                        self.base_image_md5
+                    'Base image SHA256 sum {0} not found at'.format(
+                        self.base_image_sha256
                     )
                 )
 
@@ -131,7 +131,7 @@ class ContainerBuilder:
             container_setup.setup()
         else:
             checksum = Checksum(self.base_image)
-            if not checksum.matches(checksum.md5(), self.base_image_md5):
+            if not checksum.matches(checksum.sha256(), self.base_image_sha256):
                 raise KiwiContainerBuilderError(
                     'base image file {0} checksum validation failed'.format(
                         self.base_image

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -119,8 +119,8 @@ class InstallImageBuilder:
         self.squashed_diskname = ''.join(
             [xml_state.xml_data.get_name(), '.raw']
         )
-        self.md5name = ''.join(
-            [xml_state.xml_data.get_name(), '.md5']
+        self.sha256name = ''.join(
+            [xml_state.xml_data.get_name(), '.sha256']
         )
         self.xz_options = custom_args['xz_options'] if custom_args \
             and 'xz_options' in custom_args else None
@@ -174,7 +174,7 @@ class InstallImageBuilder:
             prefix='kiwi_install_squashfs.', path=self.target_dir
         ).new_dir()
         checksum = Checksum(self.diskname)
-        checksum.md5(self.squashed_contents.name + '/' + self.md5name)
+        checksum.sha256(self.squashed_contents.name + '/' + self.sha256name)
 
         # the system image name is stored in a config file
         self._write_install_image_info_to_iso_image()
@@ -291,14 +291,14 @@ class InstallImageBuilder:
 
         # the system image transfer is checked against a checksum
         log.info('Creating disk image checksum')
-        pxe_md5_filename = ''.join(
+        pxe_sha256_filename = ''.join(
             [
                 self.pxe_dir.name, '/',
-                self.pxename, '.md5'
+                self.pxename, '.sha256'
             ]
         )
         checksum = Checksum(self.diskname)
-        checksum.md5(pxe_md5_filename)
+        checksum.sha256(pxe_sha256_filename)
 
         # the install image name is stored in a config file
         if self.initrd_system == 'kiwi':

--- a/kiwi/builder/kis.py
+++ b/kiwi/builder/kis.py
@@ -88,7 +88,7 @@ class KisBuilder:
         self.image: str = ''
         self.append_file = ''.join([self.image_name, '.append'])
         self.archive_name = ''.join([self.image_name, '.tar'])
-        self.checksum_name = ''.join([self.image_name, '.md5'])
+        self.checksum_name = ''.join([self.image_name, '.sha256'])
         self.kernel_filename: str = ''
         self.hypervisor_filename: str = ''
         self.result = Result(xml_state)
@@ -126,9 +126,9 @@ class KisBuilder:
                 compress = Compress(self.image)
                 self.image = compress.xz(self.xz_options)
 
-            log.info('Creating root filesystem MD5 checksum')
+            log.info('Creating root filesystem SHA256 checksum')
             checksum = Checksum(self.image)
-            checksum.md5(self.checksum_name)
+            checksum.sha256(self.checksum_name)
 
         # prepare initrd
         if self.boot_image_task.has_initrd_support():

--- a/kiwi/config/strip.xml
+++ b/kiwi/config/strip.xml
@@ -179,7 +179,6 @@
         <file name="lvextend"/>
         <file name="lvm"/>
         <file name="lvresize"/>
-        <file name="md5sum"/>
         <file name="mdadm"/>
         <file name="mdmon"/>
         <file name="mkdir"/>

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -713,7 +713,7 @@ div {
     k.oem-skip-verify.content = xsd:boolean
     k.oem-skip-verify.attlist = empty
     k.oem-skip-verify =
-        ## For oemboot driven images: do not perform the md5
+        ## For oemboot driven images: do not perform the checksum
         ## verification process, true/false
         element oem-skip-verify {
             k.oem-skip-verify.attlist,
@@ -1130,7 +1130,7 @@ div {
         ## Alias name to be used for this repository. This is an
         ## optional free-form text restricted to characters from the
         ## POSIX standard. If not set the source attribute
-        ## value is used and builds the alias name by running a md5 digest
+        ## value is used and builds the alias name by running a checksum digest
         ## of the defined URI of the repository. An alias name should be
         ## set if the source argument doesn't really explain what this
         ## repository contains.

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1115,7 +1115,7 @@ dump process, true/false</a:documentation>
     </define>
     <define name="k.oem-skip-verify">
       <element name="oem-skip-verify">
-        <a:documentation>For oemboot driven images: do not perform the md5
+        <a:documentation>For oemboot driven images: do not perform the checksum
 verification process, true/false</a:documentation>
         <ref name="k.oem-skip-verify.attlist"/>
         <ref name="k.oem-skip-verify.content"/>
@@ -1740,7 +1740,7 @@ loading of the container at first boot</a:documentation>
         <a:documentation>Alias name to be used for this repository. This is an
 optional free-form text restricted to characters from the
 POSIX standard. If not set the source attribute
-value is used and builds the alias name by running a md5 digest
+value is used and builds the alias name by running a checksum digest
 of the defined URI of the repository. An alias name should be
 set if the source argument doesn't really explain what this
 repository contains.</a:documentation>

--- a/kiwi/system/root_import/base.py
+++ b/kiwi/system/root_import/base.py
@@ -186,4 +186,4 @@ class RootImportBase:
 
     def _make_checksum(self, image):
         checksum = Checksum(image)
-        checksum.md5(''.join([image, '.md5']))
+        checksum.sha256(''.join([image, '.sha256']))

--- a/kiwi/utils/checksum.py
+++ b/kiwi/utils/checksum.py
@@ -21,6 +21,7 @@ import hashlib
 import encodings.ascii as encoding
 
 # project
+from kiwi.api_helper import decommissioned
 from kiwi.utils.compress import Compress
 from kiwi.utils.primes import factors
 
@@ -70,24 +71,9 @@ class Checksum:
                 return True
         return False
 
+    @decommissioned
     def md5(self, filename=None):
-        """
-        Create md5 checksum
-
-        :param str filename: filename for checksum
-
-        :return: checksum
-
-        :rtype: str
-        """
-        md5_checksum = self._calculate_hash_hexdigest(
-            hashlib.md5(), self.source_filename
-        )
-        if filename:
-            self._create_checksum_file(
-                md5_checksum, filename
-            )
-        return md5_checksum
+        pass  # pragma: no cover
 
     def sha256(self, filename=None):
         """
@@ -122,7 +108,7 @@ class Checksum:
                 os.path.getsize(compress.uncompressed_filename)
             )
             checksum = self._calculate_hash_hexdigest(
-                hashlib.md5(), compress.uncompressed_filename
+                hashlib.sha256(), compress.uncompressed_filename
             )
         else:
             blocks = self._block_list(

--- a/test/unit/builder/container_test.py
+++ b/test/unit/builder/container_test.py
@@ -81,7 +81,7 @@ class TestContainerBuilder:
             )
 
     @patch('os.path.exists')
-    def test_init_derived_base_image_md5_not_existing(self, mock_exists):
+    def test_init_derived_base_image_sha256_not_existing(self, mock_exists):
         exists_results = [False, False, True]
 
         def side_effect(self):
@@ -210,7 +210,7 @@ class TestContainerBuilder:
         container.result = mock.Mock()
 
         checksum = mock.Mock()
-        checksum.md5 = mock.Mock(
+        checksum.sha256 = mock.Mock(
             return_value='checksumvalue'
         )
         mock_checksum.return_value = checksum
@@ -223,7 +223,7 @@ class TestContainerBuilder:
 
         mock_checksum.assert_called_once_with('root_dir/image/imported_root')
         checksum.matches.assert_called_once_with(
-            'checksumvalue', 'root_dir/image/imported_root.md5'
+            'checksumvalue', 'root_dir/image/imported_root.sha256'
         )
 
         mock_image.new.assert_called_once_with(
@@ -272,10 +272,10 @@ class TestContainerBuilder:
         )
 
     @patch('kiwi.builder.container.Checksum')
-    def test_create_derived_with_different_md5(self, mock_md5):
-        md5 = mock.Mock()
-        md5.md5.return_value = 'diffchecksumvalue'
-        mock_md5.return_value = md5
+    def test_create_derived_with_different_sha256(self, mock_sha256):
+        sha256 = mock.Mock()
+        sha256.sha256.return_value = 'diffchecksumvalue'
+        mock_sha256.return_value = sha256
 
         m_open = mock_open(read_data='checksum data\n')
         with patch('builtins.open', m_open, create=True):
@@ -286,7 +286,7 @@ class TestContainerBuilder:
                 container.create()
 
     @patch('kiwi.builder.container.Checksum')
-    def test_create_derived_fail_open(self, mock_md5):
+    def test_create_derived_fail_open(self, mock_sha256):
         with patch('builtins.open') as m_open:
             m_open = mock_open()
             m_open.return_value.__enter__.side_effect = Exception(

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -163,8 +163,8 @@ class TestInstallImageBuilder:
 
         self.setup.import_cdroot_files.assert_called_once_with('temp_media_dir')
 
-        self.checksum.md5.assert_called_once_with(
-            'temp-squashfs/result-image.md5'
+        self.checksum.sha256.assert_called_once_with(
+            'temp-squashfs/result-image.sha256'
         )
         mock_copy.assert_called_once_with(
             'root_dir/boot/initrd-kernel_version',
@@ -296,7 +296,7 @@ class TestInstallImageBuilder:
     @patch('kiwi.builder.install.Checksum')
     @patch('kiwi.builder.install.Compress')
     def test_create_install_pxe_no_kernel_found(
-        self, mock_compress, mock_md5, mock_command, mock_Temporary
+        self, mock_compress, mock_sha256, mock_command, mock_Temporary
     ):
         self.firmware.bios_mode.return_value = False
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
@@ -311,7 +311,7 @@ class TestInstallImageBuilder:
     @patch('kiwi.builder.install.Compress')
     @patch('kiwi.builder.install.os.symlink')
     def test_create_install_pxe_no_hypervisor_found(
-        self, mock_symlink, mock_compress, mock_md5, mock_command,
+        self, mock_symlink, mock_compress, mock_sha256, mock_command,
         mock_Temporary
     ):
         self.firmware.bios_mode.return_value = False
@@ -331,7 +331,7 @@ class TestInstallImageBuilder:
     @patch('kiwi.builder.install.os.chmod')
     def test_create_install_pxe_archive(
         self, mock_chmod, mock_symlink, mock_copy, mock_compress,
-        mock_md5, mock_archive, mock_command, mock_Temporary
+        mock_sha256, mock_archive, mock_command, mock_Temporary
     ):
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
 
@@ -339,7 +339,7 @@ class TestInstallImageBuilder:
         mock_archive.return_value = archive
 
         checksum = mock.Mock()
-        mock_md5.return_value = checksum
+        mock_sha256.return_value = checksum
 
         compress = mock.Mock()
         src = 'target_dir/result-image.x86_64-1.2.3.raw'
@@ -357,11 +357,11 @@ class TestInstallImageBuilder:
         assert mock_command.call_args_list[0] == call(
             ['mv', src, 'tmpdir/result-image.x86_64-1.2.3.xz']
         )
-        mock_md5.assert_called_once_with(
+        mock_sha256.assert_called_once_with(
             'target_dir/result-image.x86_64-1.2.3.raw'
         )
-        checksum.md5.assert_called_once_with(
-            'tmpdir/result-image.x86_64-1.2.3.md5'
+        checksum.sha256.assert_called_once_with(
+            'tmpdir/result-image.x86_64-1.2.3.sha256'
         )
         assert m_open.call_args_list == [
             call('initrd_dir/config.vmxsystem', 'w'),

--- a/test/unit/builder/kis_test.py
+++ b/test/unit/builder/kis_test.py
@@ -127,8 +127,8 @@ class TestKisBuilder:
             'myimage.fs', 'myimage'
         )
         compress.xz.assert_called_once_with(None)
-        checksum.md5.assert_called_once_with(
-            'target_dir/some-image.x86_64-1.2.3.md5'
+        checksum.sha256.assert_called_once_with(
+            'target_dir/some-image.x86_64-1.2.3.sha256'
         )
         self.boot_image_task.prepare.assert_called_once_with()
         self.setup.export_modprobe_setup.assert_called_once_with(

--- a/test/unit/system/root_import/oci_test.py
+++ b/test/unit/system/root_import/oci_test.py
@@ -44,10 +44,10 @@ class TestRootImportOCI:
     @patch('kiwi.system.root_import.base.Checksum')
     @patch('kiwi.system.root_import.oci.Path.create')
     @patch('kiwi.system.root_import.oci.OCI')
-    def test_sync_data(self, mock_OCI, mock_path, mock_md5, mock_compress):
+    def test_sync_data(self, mock_OCI, mock_path, mock_sha256, mock_compress):
         oci = Mock()
         mock_OCI.new.return_value.__enter__.return_value = oci
-        mock_md5.return_value = Mock()
+        mock_sha256.return_value = Mock()
 
         uncompress = Mock()
         uncompress.get_format = Mock(return_value=None)
@@ -61,7 +61,7 @@ class TestRootImportOCI:
         oci.import_rootfs.assert_called_once_with(
             'root_dir'
         )
-        mock_md5.assert_called_once_with('root_dir/image/imported_root')
+        mock_sha256.assert_called_once_with('root_dir/image/imported_root')
         uncompress.get_format.assert_called_once_with()
 
     @patch('kiwi.system.root_import.oci.Compress')
@@ -102,11 +102,11 @@ class TestRootImportOCI:
     @patch('kiwi.system.root_import.oci.Path.create')
     @patch('kiwi.system.root_import.oci.OCI')
     def test_sync_data_compressed_image(
-        self, mock_OCI, mock_path, mock_md5, mock_compress
+        self, mock_OCI, mock_path, mock_sha256, mock_compress
     ):
         oci = Mock()
         mock_OCI.new.return_value.__enter__.return_value = oci
-        mock_md5.return_value = Mock()
+        mock_sha256.return_value = Mock()
 
         uncompress = Mock()
         uncompress.get_format = Mock(return_value='xz')
@@ -120,7 +120,7 @@ class TestRootImportOCI:
         oci.import_rootfs.assert_called_once_with(
             'root_dir'
         )
-        mock_md5.assert_called_once_with('root_dir/image/imported_root')
+        mock_sha256.assert_called_once_with('root_dir/image/imported_root')
         uncompress.get_format.assert_called_once_with()
         uncompress.uncompress.assert_called_once_with(True)
 
@@ -129,12 +129,12 @@ class TestRootImportOCI:
     @patch('kiwi.system.root_import.oci.Path.create')
     @patch('kiwi.system.root_import.oci.OCI')
     def test_sync_data_unknown_uri(
-        self, mock_OCI, mock_path, mock_md5, mock_exists
+        self, mock_OCI, mock_path, mock_sha256, mock_exists
     ):
         mock_exists.return_value = True
         oci = Mock()
         mock_OCI.new.return_value.__enter__.return_value = oci
-        mock_md5.return_value = Mock()
+        mock_sha256.return_value = Mock()
         with patch.dict('os.environ', {'HOME': '../data'}):
             oci_import = RootImportOCI(
                 'root_dir', [Uri('docker:image:tag')],
@@ -151,4 +151,4 @@ class TestRootImportOCI:
             oci.import_rootfs.assert_called_once_with(
                 'root_dir'
             )
-            mock_md5.assert_called_once_with('root_dir/image/imported_root')
+            mock_sha256.assert_called_once_with('root_dir/image/imported_root')

--- a/test/unit/utils/checksum_test.py
+++ b/test/unit/utils/checksum_test.py
@@ -56,9 +56,9 @@ class TestChecksum:
 
     @patch('kiwi.path.Path.which')
     @patch('kiwi.utils.checksum.Compress')
-    @patch('hashlib.md5')
+    @patch('hashlib.sha256')
     @patch('os.path.getsize')
-    def test_md5_xz(self, mock_size, mock_md5, mock_compress, mock_which):
+    def test_sha256_xz(self, mock_size, mock_sha256, mock_compress, mock_which):
         checksum = Mock
         checksum.uncompressed_filename = 'some-file-uncompressed'
         mock_which.return_value = 'factor'
@@ -75,11 +75,11 @@ class TestChecksum:
             return_value='xz'
         )
         mock_size.return_value = 1343225856
-        mock_md5.return_value = digest
+        mock_sha256.return_value = digest
         mock_compress.return_value = compress
 
         with patch('builtins.open', self.m_open, create=True):
-            self.checksum.md5('outfile')
+            self.checksum.sha256('outfile')
 
         assert self.m_open.call_args_list == [
             call('some-file', 'rb'),
@@ -92,10 +92,10 @@ class TestChecksum:
 
     @patch('kiwi.path.Path.which')
     @patch('kiwi.utils.checksum.Compress')
-    @patch('hashlib.md5')
+    @patch('hashlib.sha256')
     @patch('os.path.getsize')
-    def test_md5(
-        self, mock_size, mock_md5, mock_compress, mock_which
+    def test_sha256_file(
+        self, mock_size, mock_sha256, mock_compress, mock_which
     ):
         mock_which.return_value = 'factor'
         compress = Mock()
@@ -108,11 +108,11 @@ class TestChecksum:
             return_value=None
         )
         mock_size.return_value = 1343225856
-        mock_md5.return_value = digest
+        mock_sha256.return_value = digest
         mock_compress.return_value = compress
 
         with patch('builtins.open', self.m_open, create=True):
-            self.checksum.md5('outfile')
+            self.checksum.sha256('outfile')
 
         assert self.m_open.call_args_list == [
             call('some-file', 'rb'),
@@ -165,15 +165,3 @@ class TestChecksum:
 
         with patch('builtins.open', self.m_open, create=True):
             assert self.checksum.sha256() == digest.hexdigest.return_value
-
-    @patch('hashlib.md5')
-    def test_md5_plain(self, mock_md5):
-        digest = Mock()
-        digest.block_size = 1024
-        digest.hexdigest = Mock(
-            return_value='sum'
-        )
-        mock_md5.return_value = digest
-
-        with patch('builtins.open', self.m_open, create=True):
-            assert self.checksum.md5() == digest.hexdigest.return_value


### PR DESCRIPTION
Decommission the Checksum.md5() method and move all places in code to sha256(). The md5 digest is considered insecure and has also been removed from hashlib as a supported digest. This Fixes #2696

