### PR TITLE
Fix zypper repo and package gpgchecks setup

### DIFF
--- a/doc/source/concept_and_workflow/repository_setup.rst
+++ b/doc/source/concept_and_workflow/repository_setup.rst
@@ -58,13 +58,13 @@ following optional attributes:
   not specified, {kiwi} generates an alias name using hex representation from
   uuid4.
 
-- `repository_gpgcheck`: Specifies whether the repository is
-  configured to perform repository signature validation. If not set, the
-  package manager's default is used.
+- `repository_gpgcheck`: Specify whether or not this specific repository
+  values the result of the repository signature validation.
+  The default value is `false`.
 
-- `package_gpgcheck`: Boolean value that specifies whether each package's
-  GPG signature is verified. If omitted, the package manager's default
-  is used.
+- `package_gpgcheck`: Specify whether or not this specific repository
+  values the result of the package signature validation for each
+  package taken from this repository. The default value is `false`.
 
 - `components`: Distribution components used for `deb` repositories. Default is `main`.
 

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -1413,13 +1413,19 @@ imageonly="true|false"
   the value is set to false
 
 repository_gpgcheck="true|false"
-  Specifies whether or not this specific repository is configured to
-  to run repository signature validation. If not set, no value is
-  appended into the repository configuration file. If set the
-  relevant key information needs to be provided on the {kiwi}
-  commandline using the `--signing-key` option or via the `<signing>`
-  element as part of the `<repository><source>` setting in the
-  image description.
+  Specifies whether or not this specific repository values the result
+  of the repository signature validation. If not set, the default is
+  `false`. If set the relevant key information needs to be provided
+  on the {kiwi} commandline using the `--signing-key` option or via
+  the `<signing>` element as part of the `<repository><source>`
+  setting in the image description.
+
+package_gpgcheck="true|false"
+  Specify whether or not this specific repository values the result
+  of the package signature validation for each package taken from
+  this repository. If not set, the default value is false.
+  If set, the same key information requirements as for the
+  `repository_gpgcheck` attribute applies.
 
 customize="/path/to/custom_script"
   Custom script hook which is invoked with the repo file as parameter

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1152,14 +1152,15 @@ div {
         ## or false, the default is false.
         attribute imageonly { xsd:boolean }
     k.repository.repository_gpgcheck.attribute =
-        ## Specify whether or not this specific repository is configured to
-        ## to run repository signature validation. If not set, no value is
-        ## appended into the repository configuration file.
+        ## Specify whether or not this specific repository values
+        ## the result of the repository signature validation.
+        ## The default value is false.
         attribute repository_gpgcheck { xsd:boolean }
     k.repository.package_gpgcheck.attribute =
-        ## Specify whether or not this specific repository is configured
-        ## to run package signature validation. If not set, no value is
-        ## appended into the repository configuration file.
+        ## Specify whether or not this specific repository
+        ## values the result of the package signature validation
+        ## for each package taken from this repository. The default
+        ## value is false.
         attribute package_gpgcheck { xsd:boolean }
     k.repository.customize.attribute =
         ## Specify the path to a customization script.

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1775,17 +1775,18 @@ or false, the default is false.</a:documentation>
     </define>
     <define name="k.repository.repository_gpgcheck.attribute">
       <attribute name="repository_gpgcheck">
-        <a:documentation>Specify whether or not this specific repository is configured to
-to run repository signature validation. If not set, no value is
-appended into the repository configuration file.</a:documentation>
+        <a:documentation>Specify whether or not this specific repository values
+the result of the repository signature validation.
+The default value is false.</a:documentation>
         <data type="boolean"/>
       </attribute>
     </define>
     <define name="k.repository.package_gpgcheck.attribute">
       <attribute name="package_gpgcheck">
-        <a:documentation>Specify whether or not this specific repository is configured
-to run package signature validation. If not set, no value is
-appended into the repository configuration file.</a:documentation>
+        <a:documentation>Specify whether or not this specific repository
+values the result of the package signature validation
+for each package taken from this repository. The default
+value is false.</a:documentation>
         <data type="boolean"/>
       </attribute>
     </define>


### PR DESCRIPTION
Only set a value for repo_gpgcheck, pkg_gpgcheck in the zypper repo config file if the respective kiwi attributes repository_gpgcheck and/or package_gpgcheck are set in the kiwi image description. If not provided do not set any value. This Fixes #2273

