### PR TITLE
Added disk validation for duplicate installs

### DIFF
--- a/doc/source/concept_and_workflow/customize_the_boot_process.rst
+++ b/doc/source/concept_and_workflow/customize_the_boot_process.rst
@@ -221,6 +221,18 @@ the available kernel boot parameters for these modules:
   for the passphrase if the image has been built with an initial
   luks passphrase.
 
+``rd.kiwi.oem.disk.consistency``
+  For OEM disk images providing an installation image. If set,
+  the installation image will check against all disks that are
+  not the selected target disk if there is any disk in the system
+  that has the same PTUUID compared to the image that is about
+  to be installed. If such a disk is found this indicates that
+  the same image was already installed to another storage disk
+  on the same system which will cause device id inconsistencies
+  for the entire system. In such a case an error message is
+  displayed providing information about the conflicting device
+  and the installation will be cancelled.
+
 ``rd.kiwi.oem.maxdisk=size[KMGT]``
   Specifies the maximum disk size an unattended OEM installation uses for image
   deployment. Unattended OEM deployments default to deploying on `/dev/sda` (or

--- a/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
@@ -12,6 +12,26 @@ function setup_debug {
     fi
 }
 
+function get_system_id {
+    local disk_device=$1
+    blkid -s PTUUID -o value "${disk_device}"
+}
+
+function disk_matches_system_identifier {
+    local disk_device=$1
+    local system_identifier=/system_identifier
+    local id_disk
+    local id_image
+    if [ -e "${system_identifier}" ];then
+        id_disk=$(get_system_id "${disk_device}")
+        read -r id_image < "${system_identifier}"
+        if [ "${id_disk}" = "${id_image}" ]; then
+            return 0
+        fi
+    fi
+    return 1
+}
+
 function set_root_map {
     root_map=$1
     export root_map

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -34,6 +34,7 @@ from kiwi.filesystem.isofs import FileSystemIsoFs
 from kiwi.firmware import FirmWare
 from kiwi.system.identifier import SystemIdentifier
 from kiwi.path import Path
+from kiwi.utils.block import BlockID
 from kiwi.defaults import Defaults
 from kiwi.utils.checksum import Checksum
 from kiwi.system.kernel import Kernel
@@ -456,6 +457,7 @@ class InstallImageBuilder:
                 self.xml_state.get_installmedia_initrd_modules('set')
             )
             self._add_system_image_boot_options_to_boot_image()
+            self._add_system_identifier_to_boot_image()
         self.boot_image_task.create_initrd(
             self.mbrid, 'initrd_kiwi_install',
             install_initrd=True
@@ -466,6 +468,15 @@ class InstallImageBuilder:
                 boot_path + '/initrd'
             ]
         )
+
+    def _add_system_identifier_to_boot_image(self) -> None:
+        filename = ''.join(
+            [self.boot_image_task.boot_root_directory, '/system_identifier']
+        )
+        blockid = BlockID(self.diskname)
+        with open(filename, 'w') as system_identifier:
+            system_identifier.write(blockid.get_ptuuid())
+        self.boot_image_task.include_file(os.sep + os.path.basename(filename))
 
     def _add_system_image_boot_options_to_boot_image(self) -> None:
         filename = ''.join(

--- a/kiwi/utils/block.py
+++ b/kiwi/utils/block.py
@@ -61,6 +61,16 @@ class BlockID:
         """
         return self.get_blkid('UUID')
 
+    def get_ptuuid(self):
+        """
+        Retrieve partition uuid from block device
+
+        :return: uuid of the partition table
+
+        :rtype: str
+        """
+        return self.get_blkid('PTUUID')
+
     def get_filesystem(self):
         """
         Retrieve filesystem type from block device

--- a/test/unit/utils/block_test.py
+++ b/test/unit/utils/block_test.py
@@ -42,6 +42,11 @@ class TestBlockID:
         self.blkid.get_uuid()
         mock_get_blkid.assert_called_once_with('UUID')
 
+    @patch('kiwi.utils.block.BlockID.get_blkid')
+    def test_get_ptuuid(self, mock_get_blkid):
+        self.blkid.get_ptuuid()
+        mock_get_blkid.assert_called_once_with('PTUUID')
+
     @patch('kiwi.utils.block.Command.run')
     def test_get_partition_count(self, mock_Command_run):
         lsblk_call = Mock()


### PR DESCRIPTION
Installing the same image to different storage disks on the same machine creates device conflicts with unexpected side effects. This commit adds a validation based on the PTUUID of the disk image to check if another device on the system has the same ID and if yes, does not allow to install the image again including a message which device takes the same identifier. This references bsc#1228741

