### PR TITLE
Fix documentation regarding URI styles

### DIFF
--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -238,11 +238,6 @@ URI_TYPES
   Internal Open Buildservice repository. The source data is translated into
   an HTTP URL pointing to download.suse.de.
 
-- **iso://**
-
-  Local ISO file. {kiwi} loop mounts the file and uses the mount point
-  as temporary directory source type.
-
 - **dir://**
 
   Local directory.

--- a/doc/source/concept_and_workflow/repository_setup.rst
+++ b/doc/source/concept_and_workflow/repository_setup.rst
@@ -123,7 +123,3 @@ following paths types:
 - `dir:///path/to/directory` or `file:///path/to/file`: an absolute path to
   a local directory or file available on the host building the
   appliance.
-
-- `iso:///path/to/image.iso`: the specified ISO image is mounted
-  during the build of the {kiwi} image and a repository is created,
-  pointing to the mounted ISO.

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -1535,12 +1535,6 @@ the following location indicators:
      individual to the used distribution. On SUSE systems as one example
      this would be `openssl-certs` and `cracklib-dict-full`
 
-* ``iso://<iso://>``
-  An absolute path to an .iso file accessible via the local file
-  system. {kiwi} will loop mount the the .iso file to a temporary
-  directory with a generated name. The generated path is provided to
-  the specified package manager as a directory based repository location.
-
 * ``obs://Open:Build:Service:Project:Name``
   A reference to a project in the Open Build Service (OBS). {kiwi}
   translates the given project path into a remote url at which


### PR DESCRIPTION
In reference to commit 760a65558f9e2e91d3eaa3a2f9503ff596984b48 the support for iso:// URI types was dropped some time ago. However, the documentation was not properly updated. This commit fixes it

