### PR TITLE
Add custom CA runtime config option

### DIFF
--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -416,6 +416,37 @@ class RuntimeConfig:
         )
         return disabled_checks or ''
 
+    def get_custom_ca_cert(self):
+        """
+        Returns a custom CA certificate to be injected to the chroot.
+        The value is certificate itself:
+
+        custom_certificates:
+          - ca: |
+            -----BEGIN CERTIFICATE-----
+            MIICGzCCAaGgAwIBAgIQQdKd0XLq7qeAwSxs6S+HUjAKBggqhkjOPQQDAzBPMQsw
+            CQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJuZXQgU2VjdXJpdHkgUmVzZWFyY2gg
+            R3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBYMjAeFw0yMDA5MDQwMDAwMDBaFw00
+            MDA5MTcxNjAwMDBaME8xCzAJBgNVBAYTAlVTMSkwJwYDVQQKEyBJbnRlcm5ldCBT
+            ZWN1cml0eSBSZXNlYXJjaCBHcm91cDEVMBMGA1UEAxMMSVNSRyBSb290IFgyMHYw
+            EAYHKoZIzj0CAQYFK4EEACIDYgAEzZvVn4CDCuwJSvMWSj5cz3es3mcFDR0HttwW
+            +1qLFNvicWDEukWVEYmO6gbf9yoWHKS5xcUy4APgHoIYOIvXRdgKam7mAHf7AlF9
+            ItgKbppbd9/w+kHsOdx1ymgHDB/qo0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0T
+            AQH/BAUwAwEB/zAdBgNVHQ4EFgQUfEKWrt5LSDv6kviejM9ti6lyN5UwCgYIKoZI
+            zj0EAwMDaAAwZQIwe3lORlCEwkSHRhtFcP9Ymd70/aTSVaYgLXTWNLxBo1BfASdW
+            tL4ndQavEi51mI38AjEAi/V3bNTIZargCyzuFJ0nN6T5U6VR5CmD1/iQMVtCnwr1
+            /q4AaOeMSQ+2b1tbFfLn
+            -----END CERTIFICATE-----
+
+        :return: A certificate data
+
+        :rtype: str
+        """
+        custom_ca = self._get_attribute(
+            element='custom_certificates', attribute='ca'
+        )
+        return custom_ca or None
+
     def _get_attribute(self, element, attribute):
         if RUNTIME_CONFIG:
             try:

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -529,6 +529,22 @@ class SystemSetup:
                         ['chroot', self.root_dir, theme_setup, splash_theme]
                     )
 
+    def setup_ca_certificate(self, cacert: str) -> None:
+        """
+        Setup CA certificate to the chroot and call update-ca-certificates
+
+        This is to be used when repositories in later stage require custom CA
+        certificate
+        """
+        log.info('--> Setting up custom CA certificate')
+        ca_file_path = self.root_dir + '/etc/pki/trust/anchors/custom_ca.crt'
+        with open(ca_file_path, 'w') as cafile:
+            cafile.write(cacert)
+
+        Command.run(
+            ['chroot', self.root_dir, 'update-ca-certificates']
+        )
+
     def import_image_identifier(self) -> None:
         """
         Create etc/ImageID identifier file

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -261,6 +261,10 @@ class SystemPrepareTask(CliTask):
                 # call post_bootstrap.sh script if present
                 setup.call_post_bootstrap_script()
 
+                custom_ca = self.runtime_config.get_custom_ca_cert()
+                if custom_ca is not None:
+                    setup.setup_ca_certificate(custom_ca)
+
                 system.install_system(
                     manager
                 )


### PR DESCRIPTION
This commit adds custom_certificates:ca option to the kiwi.yml runtime configuration.

Setting this configuration option will then inject CA certificate to the chroot after bootstrap phase. System phase then can connect to repositories requiring custom CA.

### Draft note

I open this as a draft PR to discuss if this is viable approach.
Our use case is with SUSE Multi-Linux Manager build hosts. We usually have custom PKI in place so to access repositories provided by SMLM we need to have custom CA certificate. Previously we accomplished this by using bootstrap package added by `--add-bootstrap-package` option, however we are moving away from building RPMs with our certificate and need another way to pass plain certificate file.

We cannot use usual means like specifying file in template `root` directory as we need to call update-ca-certificates to load the certificate and also do not want to modify our users templates.

What do you think about this? If this is ok, I will add unit tests to this PR.