### PR TITLE
Fixed profiled overlay imports

### DIFF
--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -284,7 +284,8 @@ class SystemSetup:
         overlay_archive = self.description_dir + '/root.tar.gz'
         if os.path.exists(overlay_directory):
             self._sync_overlay_files(
-                overlay_directory, follow_links, preserve_owner_group
+                f'{os.path.normpath(overlay_directory)}/',
+                follow_links, preserve_owner_group
             )
         elif os.path.exists(overlay_archive):
             log.info('Extracting user defined files from archive to image tree')


### PR DESCRIPTION
When building an image for profile: SOME and providing an overlay directory named SOME/... kiwi will sync the contents of this overlay directory to the root tree. However it took the toplevel name SOME/ into account which is unwanted because only the sub data structure should be synced into the new root tree. This
Fixes #2690


