### PR TITLE
Improve unit test for archive target_dir

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -1729,7 +1729,7 @@ is installed using the `tar` program. Thus the file name is
 expected to be a tar archive. The compression of the archive is
 detected automatically by the tar program. The optional target_dir
 attribute can be used to specify a target directory to unpack the
-archive.
+archive inside the image root tree.
 
 <packages><ignore>
 ~~~~~~~~~~~~~~~~~~

--- a/test/data/example_config_target_dir.xml
+++ b/test/data/example_config_target_dir.xml
@@ -214,6 +214,7 @@
         <namedCollection name="bootstrap-collection"/>
         <product name="kiwi"/>
         <archive name="bootstrap.tgz" target_dir="foo"/>
+        <archive name="some.tgz" target_dir="/etc"/>
     </packages>
     <packages type="delete">
         <package name="kernel-debug"/>

--- a/test/unit/system/prepare_test.py
+++ b/test/unit/system/prepare_test.py
@@ -399,7 +399,10 @@ class TestSystemPrepare:
 
         self.system.install_bootstrap(self.manager)
 
-        tar.extract.assert_called_once_with('root_dir/foo')
+        assert tar.extract.call_args_list == [
+            call('root_dir/foo'),
+            call('root_dir/etc')
+        ]
 
     @patch('kiwi.xml_state.XMLState.get_bootstrap_packages_sections')
     def test_install_bootstrap_skipped(self, mock_bootstrap_section):


### PR DESCRIPTION
Add a test case with absolute path in the target_dir to make sure we never unpack the archive to the host system. The actual issue was resolved together with the implementation in #1953 and commit
78238a993c966d1229cd2fc1f5923673a90de14d
This Fixes #2701

