### PR TITLE
Add rd.kiwi.dialog.timeout option

### DIFF
--- a/doc/source/concept_and_workflow/customize_the_boot_process.rst
+++ b/doc/source/concept_and_workflow/customize_the_boot_process.rst
@@ -194,6 +194,12 @@ the available kernel boot parameters for these modules:
   Activates the debug log file for the {kiwi} part of
   the boot process in :file:`/run/initramfs/log/boot.kiwi`.
 
+``rd.kiwi.dialog.timeout=seconds|off``
+  Sets a timeout value for dialogs invoked by kiwi dracut
+  modules. By default the timeout is set to 60 seconds.
+  If set to the special value `off`, the dialog will never
+  timeout.
+
 ``rd.kiwi.install.pxe``
   Instructs an OEM installation image to lookup the system
   image on a remote location specified in `rd.kiwi.install.image`.

--- a/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
@@ -126,11 +126,25 @@ function _fbiterm_ok {
     return 0
 }
 
+function dialog_timeout {
+    local timeout=60
+    custom_timeout=$(getarg "rd.kiwi.dialog.timeout=")
+    [ -n "${custom_timeout}" ] && timeout="${custom_timeout}"
+    echo "${timeout}"
+}
+
 function show_log_and_quit {
     local text_message="$1"
     local log_file="$2"
-    run_dialog --timeout 60 --backtitle "\"${text_message}\"" \
-        --textbox "${log_file}" 15 80
+    local timeout
+    timeout=$(dialog_timeout)
+    if [ "${timeout}" = "off" ];then
+        run_dialog --backtitle "\"${text_message}\"" \
+            --textbox "${log_file}" 15 80
+    else
+        run_dialog --timeout "${timeout}" --backtitle "\"${text_message}\"" \
+            --textbox "${log_file}" 15 80
+    fi
     if getargbool 0 rd.debug; then
         die "${text_message}"
     else
@@ -140,7 +154,13 @@ function show_log_and_quit {
 
 function report_and_quit {
     local text_message="$1"
-    run_dialog --timeout 60 --msgbox "\"${text_message}\"" 5 80
+    local timeout
+    timeout=$(dialog_timeout)
+    if [ "${timeout}" = "off" ];then
+        run_dialog --msgbox "\"${text_message}\"" 5 80
+    else
+        run_dialog --timeout "${timeout}" --msgbox "\"${text_message}\"" 5 80
+    fi
     if getargbool 0 rd.debug; then
         die "${text_message}"
     else


### PR DESCRIPTION
Allow to configure the timeout value for dialogs displayed by the kiwi dracut code. By default the timeout is set to 60 seconds. With the special value "off" the dialog will never timeout. This Fixes #2718


