### PR TITLE
Classify missing chkstat as debug message

### DIFF
--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -356,7 +356,7 @@ class SystemSetup:
                 ['chroot', self.root_dir, 'chkstat', '--system', '--set']
             )
         else:
-            log.warning(
+            log.debug(
                 'chkstat not found in image. File Permissions Check skipped'
             )
 


### PR DESCRIPTION
chkstat is a distribution specific tool. If it is
present we use it, if not we don't but it's not worth a warning. This Fixes #2711

