### PR TITLE
Poetry build sdist timestamps set to epoch 0

### DIFF
--- a/.github/workflows/ci-publish-to-pypi.yml
+++ b/.github/workflows/ci-publish-to-pypi.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        python -m pip install poetry
+        python -m pip install poetry==1.7.1
     - name: Prepare
       run: |
         make prepare_for_pypi


### PR DESCRIPTION
Newer versions of poetry set the timestamp for all source files to epoch 0. Such sources are not accepted by e.g Debian FTP servers and in general I don't like when tools changes their behavior just like that. This commit forces an older version of poetry for the purpose of creating the sdist tarball which then gets published on pypi. The argumentation for reproducible builds by forcing source files to a certain timestamp doesn't fly for me. I'm open for any better solution though. This Fixes #2730

