### PR TITLE
The ubuntu 20.04 github runner is closing down

### DIFF
--- a/.github/workflows/ci-publish-pages.yml
+++ b/.github/workflows/ci-publish-pages.yml
@@ -8,10 +8,10 @@ on:
 jobs:
   documentation:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci-publish-to-pypi.yml
+++ b/.github/workflows/ci-publish-to-pypi.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     environment:
       name: pypi


### PR DESCRIPTION
Make sure to move to another runner for workloads which still uses ubuntu 20.04

