### PR TITLE
Lookup CHRP loader instead of using a static name

### DIFF
--- a/build-tests/ppc/rawhide/test-image-live/appliance.kiwi
+++ b/build-tests/ppc/rawhide/test-image-live/appliance.kiwi
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="7.5" name="kiwi-test-image-live">
+    <description type="system">
+        <author>Marcus Schaefer</author>
+        <contact>marcus.schaefer@suse.com</contact>
+        <specification>Fedora Rawhide Live</specification>
+    </description>
+    <preferences>
+        <version>2.0.0</version>
+        <packagemanager>dnf5</packagemanager>
+        <bootsplash-theme>charge</bootsplash-theme>
+        <bootloader-theme>breeze</bootloader-theme>
+        <locale>en_US</locale>
+        <keytable>us</keytable>
+        <timezone>UTC</timezone>
+        <rpm-check-signatures>false</rpm-check-signatures>
+    </preferences>
+    <preferences>
+        <type image="iso" flags="overlay" firmware="ofw" hybridpersistent_filesystem="ext4" hybridpersistent="true" kernelcmdline="console=ttyS0">
+            <bootloader name="grub2" console="serial" timeout="10"/>
+        </type>
+    </preferences>
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
+    </users>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
+    </repository>
+    <packages type="image">
+        <package name="grub2"/>
+        <package name="grubby"/>
+        <package name="kernel"/>
+        <package name="plymouth-theme-charge"/>
+        <package name="grub2-breeze-theme"/>
+        <package name="selinux-policy-targeted"/>
+        <package name="dhclient"/>
+        <package name="glibc-all-langpacks"/>
+        <package name="vim"/>
+        <package name="tzdata"/>
+        <package name="NetworkManager"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="filesystem"/>
+        <package name="basesystem"/>
+        <package name="fedora-release"/>
+        <package name="dracut-kiwi-live"/>
+    </packages>
+</image>

--- a/helper/build_status.sh
+++ b/helper/build_status.sh
@@ -8,6 +8,7 @@ for project in \
     Virtualization:Appliances:SelfContained:universal \
     Virtualization:Appliances:Images:Testing_x86:tumbleweed \
     Virtualization:Appliances:Images:Testing_x86:rawhide \
+    Virtualization:Appliances:Images:Testing_ppc:rawhide \
     Virtualization:Appliances:Images:Testing_x86:leap \
     Virtualization:Appliances:Images:Testing_x86:centos \
     Virtualization:Appliances:Images:Testing_x86:fedora \

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -975,12 +975,15 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             <chrp-boot>
             <description>{os_name}</description>
             <os-name>{os_name}</os-name>
-            <boot-script>boot &device;:1,\\boot\\grub2\\powerpc-ieee1275\\grub.elf</boot-script>
+            <boot-script>boot &device;:1,\\boot\\grub2\\powerpc-ieee1275\\{chrp_loader}</boot-script>
             </chrp-boot>
         ''').strip() + os.linesep
         with open(chrp_bootinfo_file, 'w') as chrp_bootinfo:
             chrp_bootinfo.write(
-                chrp_config.format(os_name=self.get_menu_entry_install_title())
+                chrp_config.format(
+                    os_name=self.get_menu_entry_install_title(),
+                    chrp_loader=Defaults.get_grub_chrp_loader(self.boot_dir)
+                )
             )
 
     def _setup_platform_image(self, mbrid, lookup_path=None):

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -976,6 +976,29 @@ class Defaults:
         return None
 
     @staticmethod
+    def get_grub_chrp_loader(boot_path: str) -> str:
+        """
+        Lookup CHRP boot loader (ppc)
+
+        :param string boot_path: boot path
+
+        :return: file base name
+
+        :rtype: str
+        """
+        for chrp_loader in ['grub.elf', 'core.elf']:
+            for grub_chrp in glob.iglob(
+                os.sep.join(
+                    [boot_path, 'boot/grub*/powerpc-ieee1275', chrp_loader]
+                )
+            ):
+                log.info(f'Found CHRP loader at: {grub_chrp}')
+                return os.path.basename(grub_chrp)
+        raise KiwiBootLoaderGrubDataError(
+            f'CHRP loader not found in {boot_path}'
+        )
+
+    @staticmethod
     def get_grub_platform_core_loader(root_path):
         """
         Provides grub bios image

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -1749,6 +1749,7 @@ class TestBootLoaderConfigGrub2:
     @patch('kiwi.bootloader.config.base.BootLoaderConfigBase.get_boot_path')
     @patch('kiwi.bootloader.config.grub2.Defaults.get_unsigned_grub_loader')
     @patch('kiwi.bootloader.config.grub2.Defaults.get_grub_platform_core_loader')
+    @patch('kiwi.bootloader.config.grub2.Defaults.get_grub_chrp_loader')
     @patch('kiwi.bootloader.config.grub2.Command.run')
     @patch('kiwi.bootloader.config.grub2.Path.which')
     @patch('kiwi.bootloader.config.grub2.Path.create')
@@ -1758,10 +1759,11 @@ class TestBootLoaderConfigGrub2:
     def test_setup_install_boot_images_ppc(
         self, mock_shutil_copy2, mock_exists, mock_sync,
         mock_Path_create, mock_Path_which, mock_command,
-        mock_get_grub_platform_core_loader, mock_get_unsigned_grub_loader,
-        mock_get_boot_path
+        mock_get_grub_chrp_loader, mock_get_grub_platform_core_loader,
+        mock_get_unsigned_grub_loader, mock_get_boot_path
     ):
         Defaults.set_platform_name('ppc64le')
+        mock_get_grub_chrp_loader.return_value = 'grub.elf'
         mock_get_grub_platform_core_loader.return_value = None
         mock_Path_which.return_value = '/path/to/grub2-mkimage'
         mock_get_boot_path.return_value = '/boot'


### PR DESCRIPTION
On ppc the CHRP loader name can vary between distributions. This commit adds a search method to lookup different ELF loader names. In addition an integration test image for Fedora was added. This Fixes #2741

