### PR TITLE
Add rd.kiwi.oem.luks.reencrypt_randompass

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
@@ -48,7 +48,7 @@
         </type>
     </preferences>
     <preferences profiles="ReEncryptExtraBootWithPass">
-        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0 rd.kiwi.oem.luks.reencrypt" firmware="uefi" luks="linux" luks_version="luks2" luks_pbkdf="pbkdf2" bootpartition="true">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0 rd.kiwi.oem.luks.reencrypt rd.kiwi.oem.luks.reencrypt_randompass quiet" firmware="uefi" luks="linux" luks_version="luks2" luks_pbkdf="pbkdf2" bootpartition="true">
             <luksformat>
                 <option name="--cipher" value="aes-xts-plain64"/>
                 <option name="--key-size" value="256"/>

--- a/doc/source/concept_and_workflow/customize_the_boot_process.rst
+++ b/doc/source/concept_and_workflow/customize_the_boot_process.rst
@@ -227,6 +227,21 @@ the available kernel boot parameters for these modules:
   for the passphrase if the image has been built with an initial
   luks passphrase.
 
+``rd.kiwi.oem.luks.reencrypt_randompass``
+  For OEM LUKS2 encrypted disk images in combination
+  with `rd.kiwi.oem.luks.reencrypt`. Reset insecure built time
+  passphrase, set via the `luks=` attribute, with a random
+  onetime passphrase that will be stored in memory at
+  `/run/.kiwi_reencrypt.keyfile`.
+
+  .. warning::
+
+     The passphrase will only persist as long as the system
+     does not reboot. Using this option usually requires that
+     the boot process implements code to set a retrievable keyfile
+     information for subsequent boot processes of this system, e.g
+     TPM setup or similar.
+
 ``rd.kiwi.oem.disk.consistency``
   For OEM disk images providing an installation image. If set,
   the installation image will check against all disks that are


### PR DESCRIPTION
For OEM LUKS2 encrypted disk images in combination with rd.kiwi.oem.luks.reencrypt. Reset insecure built time passphrase with a random onetime passphrase

