### PR TITLE
Allow stderr data in CommandProcess

### DIFF
--- a/kiwi/package_manager/dnf5.py
+++ b/kiwi/package_manager/dnf5.py
@@ -308,7 +308,7 @@ class PackageManagerDnf5(PackageManagerBase):
         """
         return bool(
             re.match(
-                '.*Installing.*: {0}.*'.format(re.escape(package_name)),
+                '.*Installing.* {0}.*'.format(re.escape(package_name)),
                 package_manager_output
             )
         )
@@ -328,7 +328,7 @@ class PackageManagerDnf5(PackageManagerBase):
         """
         return bool(
             re.match(
-                '.*Removing.*: {0}.*'.format(re.escape(package_name)),
+                '.*Removing.* {0}.*'.format(re.escape(package_name)),
                 package_manager_output
             )
         )

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -254,6 +254,7 @@ class SystemPrepare:
         bootstrap_archives = self.xml_state.get_bootstrap_archives()
         bootstrap_archives_target_dirs = self.xml_state.get_bootstrap_archives_target_dirs()
         bootstrap_packages_ignored = self.xml_state.get_bootstrap_ignore_packages()
+        package_manager = self.xml_state.get_package_manager()
         # process package installations
         if collection_type == 'onlyRequired':
             manager.process_only_required()
@@ -279,7 +280,8 @@ class SystemPrepare:
                 items_to_complete=all_install_items,
                 match_method=process.create_match_method(
                     manager.match_package_installed
-                )
+                ),
+                with_stderr=True if package_manager == 'dnf5' else False
             )
         except Exception as issue:
             if manager.has_failed(process.returncode()):
@@ -331,6 +333,7 @@ class SystemPrepare:
         system_archives = self.xml_state.get_system_archives()
         system_archives_target_dirs = self.xml_state.get_system_archives_target_dirs()
         system_packages_ignored = self.xml_state.get_system_ignore_packages()
+        package_manager = self.xml_state.get_package_manager()
         # process package installations
         if collection_type == 'onlyRequired':
             manager.process_only_required()
@@ -352,7 +355,8 @@ class SystemPrepare:
                     items_to_complete=all_install_items,
                     match_method=process.create_match_method(
                         manager.match_package_installed
-                    )
+                    ),
+                    with_stderr=True if package_manager == 'dnf5' else False
                 )
             except Exception as issue:
                 if manager.has_failed(process.returncode()):
@@ -447,6 +451,7 @@ class SystemPrepare:
         :raises KiwiSystemInstallPackagesFailed: if installation process fails
         """
         log.info('Installing system packages (chroot)')
+        package_manager = self.xml_state.get_package_manager()
         all_install_items = self._setup_requests(
             manager, packages
         )
@@ -459,7 +464,8 @@ class SystemPrepare:
                     items_to_complete=all_install_items,
                     match_method=process.create_match_method(
                         manager.match_package_installed
-                    )
+                    ),
+                    with_stderr=True if package_manager == 'dnf5' else False
                 )
             except Exception as issue:
                 raise KiwiSystemInstallPackagesFailed(
@@ -484,6 +490,7 @@ class SystemPrepare:
 
         :raises KiwiSystemDeletePackagesFailed: if installation process fails
         """
+        package_manager = self.xml_state.get_package_manager()
         all_delete_items = self._setup_requests(
             manager, packages
         )
@@ -502,7 +509,8 @@ class SystemPrepare:
                     items_to_complete=all_delete_items,
                     match_method=process.create_match_method(
                         manager.match_package_deleted
-                    )
+                    ),
+                    with_stderr=True if package_manager == 'dnf5' else False
                 )
                 manager.post_process_delete_requests(self.root_bind)
             except Exception as issue:

--- a/test/unit/command_process_test.py
+++ b/test/unit/command_process_test.py
@@ -7,8 +7,10 @@ from pytest import (
 )
 from builtins import bytes
 
-from kiwi.command_process import CommandProcess
-from kiwi.command_process import CommandIterator
+from kiwi.command_process import (
+    CommandProcess,
+    CommandIterator
+)
 
 from kiwi.exceptions import KiwiCommandError
 
@@ -42,13 +44,13 @@ class TestCommandProcess:
         return create_method
 
     def setup(self):
-        self.data_flow = [True, None, None, None, None, None, None]
+        self.data_flow = [True, None, None, None, None, None, None, None]
         self.data_out = [
-            bytes(b''), bytes(b'\n'), bytes(b'a'),
+            bytes(b''), bytes(b''), bytes(b'\n'), bytes(b'a'),
             bytes(b't'), bytes(b'a'), bytes(b'd')
         ]
         self.data_err = [
-            bytes(b''), bytes(b'r'), bytes(b'o'),
+            bytes(b''), bytes(b'\n'), bytes(b'r'), bytes(b'o'),
             bytes(b'r'), bytes(b'r'), bytes(b'e')
         ]
         self.flow = self.create_flow_method(self.poll)
@@ -80,7 +82,7 @@ class TestCommandProcess:
         process.command.command.error.read = self.flow_err
         process.command.command.process.returncode = 0
         with self._caplog.at_level(logging.DEBUG):
-            process.poll_show_progress(['a', 'b'], match_method)
+            process.poll_show_progress(['a', 'b'], match_method, True)
             assert 'system: data' in self._caplog.text
 
     @patch('kiwi.command.Command')


### PR DESCRIPTION
Enhance poll_show_progress() method to allow polling on stderr data too. The new parameter with_stderr is used together with the dnf5 package manager. dnf5 has changed in a way that a lot of useful information during the install of packages is printed to stderr. From my perspective a clear regression to former behavior but we can fix this in kiwi to poll on both channels. This Fixes #2748


