### PR TITLE
Drop use of travis-sphinx

### DIFF
--- a/.github/workflows/ci-publish-pages.yml
+++ b/.github/workflows/ci-publish-pages.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Python${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install
@@ -25,9 +25,11 @@ jobs:
         python -m pip install poetry
     - name: Render
       run: |
-        make prepare_for_docs
+        poetry run sphinx-build doc/source doc/build
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       with:
+        publish_branch: gh-pages
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./doc/build_gh_pages
+        publish_dir: ./doc/build
+        force_orphan: true

--- a/Makefile
+++ b/Makefile
@@ -162,15 +162,6 @@ prepare_for_pypi: clean setup
 	# ci-publish-to-pypi.yml github action
 	poetry build --format=sdist
 
-prepare_for_docs: clean setup
-	# documentation man pages
-	poetry run make -C doc man
-	# documentation github pages, the actual publishing via
-	# the ci-publish-pages.yml github action
-	poetry run bash -c 'pushd doc && \
-		travis-sphinx --outdir build_gh_pages build --nowarn --source ./source'
-	bash -c 'touch ./doc/build_gh_pages/.nojekyll'
-
 clean: clean_git_attributes
 	rm -rf dist
 	rm -rf doc/build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,6 @@ sphinx = ">=5.0.0"
 sphinx_rtd_theme = "*"
 sphinxcontrib-spelling = "*"
 pyenchant = "*"
-travis-sphinx = "*"
 ghp-import = "*"
 
 [tool.poetry.group.development]


### PR DESCRIPTION
According to the documentation of peaceiris/actions-gh-pages the sphinx-build output can be directly consumed to publish to github pages

