### PR TITLE
Support sourcetype setting on the commandline

### DIFF
--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -18,9 +18,9 @@ SYNOPSIS
        [--clear-cache]
        [--ignore-repos]
        [--ignore-repos-used-for-build]
-       [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>]
+       [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck,repo_sourcetype>]
        [--set-repo-credentials=<user:pass_or_filename>]
-       [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>...]
+       [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck,repo_sourcetype>...]
        [--add-repo-credentials=<user:pass_or_filename>...]
        [--add-package=<name>...]
        [--add-bootstrap-package=<name>...]
@@ -66,7 +66,7 @@ OPTIONS
   Specify package to add (install). The option can be specified
   multiple times.
 
---add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>
+--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck,repo_sourcetype>
 
   Add a new repository to the existing repository setup in the XML
   description. This option can be specified multiple times.
@@ -120,7 +120,7 @@ OPTIONS
   Works the same way as `--ignore-repos`, except that repository configuration
   with the imageonly attribute set to **true** is not ignored.
 
---set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>
+--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck,repo_sourcetype>
 
   Overwrite the first repository entry in the XML description with the
   provided information:
@@ -177,6 +177,15 @@ OPTIONS
 
     Set to either **true** or **false** to indicate if the repository
     should validate the repository signature.
+
+  - **repo_sourcetype**
+
+    Specify the source type of the repository path. Supported values
+    are baseurl, metalink or mirrorlist. With baseurl the source
+    path is interpreted as simple URI. If metalink is set the source
+    path is resolved as metalink URI and if mirrorlist is set the
+    source path is resolved as a mirrorlist file. If not specified,
+    baseurl is the default
 
 --set-repo-credentials=<user:pass_or_filename>
 

--- a/doc/source/commands/system_prepare.rst
+++ b/doc/source/commands/system_prepare.rst
@@ -16,9 +16,9 @@ SYNOPSIS
        [--clear-cache]
        [--ignore-repos]
        [--ignore-repos-used-for-build]
-       [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>]
+       [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck,repo_sourcetype>]
        [--set-repo-credentials=<user:pass_or_filename>]
-       [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>...]
+       [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck,repo_sourcetype>...]
        [--add-repo-credentials=<user:pass_or_filename>...]
        [--add-package=<name>...]
        [--add-bootstrap-package=<name>...]
@@ -66,7 +66,7 @@ OPTIONS
   Specify a package to add (install). The option can be specified
   multiple times.
 
---add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>
+--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck,repo_sourcetype>
 
   Add a new repository to the existing repository setup in the XML
   description. This option can be specified multiple times.
@@ -121,7 +121,7 @@ OPTIONS
 
   Path to the new root system.
 
---set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>
+--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck,repo_sourcetype>
 
   Overwrite the first repository entry in the XML description with the
   provided information:
@@ -178,6 +178,15 @@ OPTIONS
 
     Set to either **true** or **false** to specify if the repository
     must validate the repository signature.
+
+  - **repo_sourcetype**
+
+    Specify the source type of the repository path. Supported values
+    are baseurl, metalink or mirrorlist. With baseurl the source
+    path is interpreted as simple URI. If metalink is set the source
+    path is resolved as metalink URI and if mirrorlist is set the
+    source path is resolved as a mirrorlist file. If not specified,
+    baseurl is the default
 
 --set-repo-credentials=<user:pass_or_filename>
 

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -222,12 +222,12 @@ class CliTask:
         """
         return self._ntuple_token(option, 4)
 
-    def tentuple_token(
+    def eleventuple_token(
         self, option: str
     ) -> List[Union[bool, str, List[str], None]]:
         """
         Helper method for commandline options of the
-        form --option a,b,c,d,e,f,g,h,i,j
+        form --option a,b,c,d,e,f,g,h,i,j,k
 
         Make sure to provide a common result for option values which
         separates the information in a comma separated list of values
@@ -238,7 +238,7 @@ class CliTask:
 
         :rtype: list
         """
-        return self._ntuple_token(option, 10)
+        return self._ntuple_token(option, 11)
 
     def attr_token(
         self, option: str

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -22,9 +22,9 @@ usage: kiwi-ng system build -h | --help
            [--clear-cache]
            [--ignore-repos]
            [--ignore-repos-used-for-build]
-           [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>]
+           [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck,repo_sourcetype>]
            [--set-repo-credentials=<user:pass_or_filename>]
-           [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>...]
+           [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck,repo_sourcetype>...]
            [--add-repo-credentials=<user:pass_or_filename>...]
            [--add-package=<name>...]
            [--add-bootstrap-package=<name>...]
@@ -54,8 +54,8 @@ options:
         priority, imageinclude(true|false), package_gpgcheck(true|false),
         list of signing_keys enclosed in curly brackets delimited by a colon,
         component list for debian based repos as string delimited by a space,
-        main distribution name for debian based repos and
-        repo_gpgcheck(true|false)
+        main distribution name for debian based repos,
+        repo_gpgcheck(true|false) and repo_sourcetype(metalink|baseurl|mirrorlist)
     --add-repo-credentials=<user:pass_or_filename>
         for uri://user:pass@location type repositories, set the user and
         password connected with an add-repo specification. The first
@@ -94,13 +94,13 @@ options:
         add a container label in the container configuration metadata. It
         overwrites the label with the provided key-value pair in case it was
         already defined in the XML description
-    --set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>
+    --set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck,repo_sourcetype>
         overwrite the first XML listed repository source, type, alias,
         priority, imageinclude(true|false), package_gpgcheck(true|false),
         list of signing_keys enclosed in curly brackets delimited by a colon,
         component list for debian based repos as string delimited by a space,
-        main distribution name for debian based repos and
-        repo_gpgcheck(true|false)
+        main distribution name for debian based repos,
+        repo_gpgcheck(true|false) and repo_sourcetype(metalink|baseurl|mirrorlist)
     --set-repo-credentials=<user:pass_or_filename>
         for uri://user:pass@location type repositories, set the user and
         password connected to the set-repo specification. If the provided
@@ -366,7 +366,7 @@ class SystemBuildTask(CliTask):
         return self.manual
 
     def _get_repo_parameters(self, tokens, credentials):
-        parameters = self.tentuple_token(tokens)
+        parameters = self.eleventuple_token(tokens)
         signing_keys_index = 6
         repo_source_index = 0
         if not parameters[signing_keys_index]:

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -22,9 +22,9 @@ usage: kiwi-ng system prepare -h | --help
            [--clear-cache]
            [--ignore-repos]
            [--ignore-repos-used-for-build]
-           [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>]
+           [--set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck,repo_sourcetype>]
            [--set-repo-credentials=<user:pass_or_filename>]
-           [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>...]
+           [--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck,repo_sourcetype>...]
            [--add-repo-credentials=<user:pass_or_filename>...]
            [--add-package=<name>...]
            [--add-bootstrap-package=<name>...]
@@ -48,13 +48,13 @@ options:
         install the given package name as part of the early bootstrap process
     --add-package=<name>
         install the given package name
-    --add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>
+    --add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck,repo_sourcetype>
         add repository with given source, type, alias,
         priority, imageinclude(true|false), package_gpgcheck(true|false),
         list of signing_keys enclosed in curly brackets delimited by a colon,
         component list for debian based repos as string delimited by a space,
-        main distribution name for debian based repos and
-        repo_gpgcheck(true|false)
+        main distribution name for debian based repos,
+        repo_gpgcheck(true|false) and repo_sourcetype(metalink|baseurl|mirrorlist)
     --add-repo-credentials=<user:pass_or_filename>
         for uri://user:pass@location type repositories, set the user and
         password connected with an add-repo specification. The first
@@ -94,13 +94,13 @@ options:
         add a container label in the container configuration metadata. It
         overwrites the label with the provided key-value pair in case it was
         already defined in the XML description
-    --set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck>
+    --set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck,repo_sourcetype>
         overwrite the first XML listed repository source, type, alias,
         priority, imageinclude(true|false), package_gpgcheck(true|false),
         list of signing_keys enclosed in curly brackets delimited by a colon,
         component list for debian based repos as string delimited by a space,
-        main distribution name for debian based repos and
-        repo_gpgcheck(true|false)
+        main distribution name for debian based repos,
+        repo_gpgcheck(true|false) and repo_sourcetype(metalink|baseurl|mirrorlist)
      --set-repo-credentials=<user:pass_or_filename>
         for uri://user:pass@location type repositories, set the user and
         password connected to the set-repo specification. If the provided
@@ -326,7 +326,7 @@ class SystemPrepareTask(CliTask):
         return self.manual
 
     def _get_repo_parameters(self, tokens, credentials):
-        parameters = self.tentuple_token(tokens)
+        parameters = self.eleventuple_token(tokens)
         signing_keys_index = 6
         repo_source_index = 0
         if not parameters[signing_keys_index]:

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -2308,7 +2308,8 @@ class XMLState:
         repo_prio: str, repo_imageinclude: bool = False,
         repo_package_gpgcheck: Optional[bool] = None,
         repo_signing_keys: List[str] = [], components: str = None,
-        distribution: str = None, repo_gpgcheck: Optional[bool] = None
+        distribution: str = None, repo_gpgcheck: Optional[bool] = None,
+        repo_sourcetype: str = None
     ) -> None:
         """
         Overwrite repository data of the first repository
@@ -2349,13 +2350,16 @@ class XMLState:
                 repository.set_distribution(distribution)
             if repo_gpgcheck is not None:
                 repository.set_repository_gpgcheck(repo_gpgcheck)
+            if repo_sourcetype:
+                repository.set_sourcetype(repo_sourcetype)
 
     def add_repository(
         self, repo_source: str, repo_type: str, repo_alias: str = None,
         repo_prio: str = '', repo_imageinclude: bool = False,
         repo_package_gpgcheck: Optional[bool] = None,
         repo_signing_keys: List[str] = [], components: str = None,
-        distribution: str = None, repo_gpgcheck: Optional[bool] = None
+        distribution: str = None, repo_gpgcheck: Optional[bool] = None,
+        repo_sourcetype: str = None
     ) -> None:
         """
         Add a new repository section at the end of the list
@@ -2392,7 +2396,8 @@ class XMLState:
                 package_gpgcheck=repo_package_gpgcheck,
                 repository_gpgcheck=repo_gpgcheck,
                 components=components,
-                distribution=distribution
+                distribution=distribution,
+                sourcetype=repo_sourcetype
             )
         )
 

--- a/test/unit/tasks/base_test.py
+++ b/test/unit/tasks/base_test.py
@@ -148,16 +148,16 @@ class TestCliTask:
     def test_quadruple_token(self):
         assert self.task.quadruple_token('a,b') == ['a', 'b', None, None]
 
-    def test_tentuple_token(self):
-        assert self.task.tentuple_token(
-            'a,b,,d,e,f,{1;2;3},x y z,jammy,false'
+    def test_eleventuple_token(self):
+        assert self.task.eleventuple_token(
+            'a,b,,d,e,f,{1;2;3},x y z,jammy,false,metalink'
         ) == [
             'a', 'b', '', 'd', 'e', 'f', ['1', '2', '3'], 'x y z',
-            'jammy', False
+            'jammy', False, 'metalink'
         ]
-        assert self.task.tentuple_token('a,b,,d,e,f,{1;2;3}') == [
+        assert self.task.eleventuple_token('a,b,,d,e,f,{1;2;3}') == [
             'a', 'b', '', 'd', 'e', 'f', ['1', '2', '3'],
-            None, None, None
+            None, None, None, None
         ]
 
     def test_attr_token(self):

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -342,14 +342,14 @@ class TestSystemBuildTask:
         self.task.process()
         mock_set_repo.assert_called_once_with(
             'http://example.com', 'yast2', 'alias',
-            None, None, None, [], None, None, None
+            None, None, None, [], None, None, None, None
         )
         self.task.command_args['--set-repo-credentials'] = 'user:pass'
         mock_set_repo.reset_mock()
         self.task.process()
         mock_set_repo.assert_called_once_with(
             'http://user:pass@example.com', 'yast2', 'alias',
-            None, None, None, [], None, None, None
+            None, None, None, [], None, None, None, None
         )
         self.task.command_args['--set-repo-credentials'] = '../data/credentials'
         mock_os_path_is_file.return_value = True
@@ -357,7 +357,7 @@ class TestSystemBuildTask:
         self.task.process()
         mock_set_repo.assert_called_once_with(
             'http://user:pass@example.com', 'yast2', 'alias',
-            None, None, None, [], None, None, None
+            None, None, None, [], None, None, None, None
         )
         mock_os_unlink.assert_called_once_with('../data/credentials')
 
@@ -377,15 +377,15 @@ class TestSystemBuildTask:
         assert mock_add_repo.call_args_list == [
             call(
                 'http://example1.com', 'yast2', 'alias', '99',
-                False, True, [], None, None, None
+                False, True, [], None, None, None, None
             ),
             call(
                 'http://example2.com', 'yast2', 'alias', '99',
-                False, True, [], None, None, None
+                False, True, [], None, None, None, None
             ),
             call(
                 'http://example3.com', 'yast2', 'alias', '99',
-                False, True, [], None, None, None
+                False, True, [], None, None, None, None
             )
         ]
         self.task.command_args['--add-repo-credentials'] = [
@@ -397,15 +397,15 @@ class TestSystemBuildTask:
         assert mock_add_repo.call_args_list == [
             call(
                 'http://user1:pass1@example1.com', 'yast2', 'alias', '99',
-                False, True, [], None, None, None
+                False, True, [], None, None, None, None
             ),
             call(
                 'http://user2:pass2@example2.com', 'yast2', 'alias', '99',
-                False, True, [], None, None, None
+                False, True, [], None, None, None, None
             ),
             call(
                 'http://example3.com', 'yast2', 'alias', '99',
-                False, True, [], None, None, None
+                False, True, [], None, None, None, None
             )
         ]
 

--- a/test/unit/tasks/system_prepare_test.py
+++ b/test/unit/tasks/system_prepare_test.py
@@ -309,18 +309,23 @@ class TestSystemPrepareTask:
     ):
         mock_os_path_is_file.return_value = False
         self._init_command_args()
-        self.task.command_args['--set-repo'] = 'http://example.com,yast2,alias'
+        self.task.command_args['--set-repo'] = \
+            'http://example.com,yast2,alias,prio,imageinclude,' + \
+            'package_gpgcheck,{file:///key.asc},components,dist,' + \
+            'repo_gpgcheck,repo_sourcetype'
         self.task.process()
         mock_set_repo.assert_called_once_with(
             'http://example.com', 'yast2', 'alias',
-            None, None, None, [], None, None, None
+            'prio', 'imageinclude', 'package_gpgcheck', ['file:///key.asc'],
+            'components', 'dist', 'repo_gpgcheck', 'repo_sourcetype'
         )
         self.task.command_args['--set-repo-credentials'] = 'user:pass'
         mock_set_repo.reset_mock()
         self.task.process()
         mock_set_repo.assert_called_once_with(
             'http://user:pass@example.com', 'yast2', 'alias',
-            None, None, None, [], None, None, None
+            'prio', 'imageinclude', 'package_gpgcheck', ['file:///key.asc'],
+            'components', 'dist', 'repo_gpgcheck', 'repo_sourcetype'
         )
         self.task.command_args['--set-repo-credentials'] = '../data/credentials'
         mock_os_path_is_file.return_value = True
@@ -328,7 +333,8 @@ class TestSystemPrepareTask:
         self.task.process()
         mock_set_repo.assert_called_once_with(
             'http://user:pass@example.com', 'yast2', 'alias',
-            None, None, None, [], None, None, None
+            'prio', 'imageinclude', 'package_gpgcheck', ['file:///key.asc'],
+            'components', 'dist', 'repo_gpgcheck', 'repo_sourcetype'
         )
         mock_os_unlink.assert_called_once_with('../data/credentials')
 
@@ -347,15 +353,15 @@ class TestSystemPrepareTask:
         assert mock_add_repo.call_args_list == [
             call(
                 'http://example1.com', 'yast2', 'alias', '99',
-                True, None, [], None, None, None
+                True, None, [], None, None, None, None
             ),
             call(
                 'http://example2.com', 'yast2', 'alias', '99',
-                False, True, [], None, None, None
+                False, True, [], None, None, None, None
             ),
             call(
                 'http://example3.com', 'yast2', 'alias', '99',
-                False, True, [], None, None, None
+                False, True, [], None, None, None, None
             )
         ]
         self.task.command_args['--add-repo-credentials'] = [
@@ -367,15 +373,15 @@ class TestSystemPrepareTask:
         assert mock_add_repo.call_args_list == [
             call(
                 'http://user1:pass1@example1.com', 'yast2', 'alias', '99',
-                True, None, [], None, None, None
+                True, None, [], None, None, None, None
             ),
             call(
                 'http://user2:pass2@example2.com', 'yast2', 'alias', '99',
-                False, True, [], None, None, None
+                False, True, [], None, None, None, None
             ),
             call(
                 'http://example3.com', 'yast2', 'alias', '99',
-                False, True, [], None, None, None
+                False, True, [], None, None, None, None
             )
         ]
 

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -250,7 +250,7 @@ class TestXMLState:
     def test_set_repository(self):
         self.state.set_repository(
             'repo', 'type', 'alias', 1, True, False, ['key_a', 'key_b'],
-            'main universe', 'jammy', False
+            'main universe', 'jammy', False, 'metalink'
         )
         assert self.state.xml_data.get_repository()[0].get_source().get_path() \
             == 'repo'
@@ -271,11 +271,13 @@ class TestXMLState:
             == 'jammy'
         assert self.state.xml_data.get_repository()[0] \
             .get_repository_gpgcheck() is False
+        assert self.state.xml_data.get_repository()[0] \
+            .get_sourcetype() == 'metalink'
 
     def test_add_repository(self):
         self.state.add_repository(
             'repo', 'type', 'alias', 1, True, None, ['key_a', 'key_b'],
-            'main universe', 'jammy', False
+            'main universe', 'jammy', False, 'metalink'
         )
         assert self.state.xml_data.get_repository()[3].get_source().get_path() \
             == 'repo'
@@ -294,6 +296,8 @@ class TestXMLState:
             == 'jammy'
         assert self.state.xml_data.get_repository()[3] \
             .get_repository_gpgcheck() is False
+        assert self.state.xml_data.get_repository()[3] \
+            .get_sourcetype() == 'metalink'
 
     def test_add_repository_with_empty_values(self):
         self.state.add_repository('repo', 'type', '', '', True)
@@ -304,6 +308,8 @@ class TestXMLState:
         assert self.state.xml_data.get_repository()[3].get_priority() is None
         assert self.state.xml_data.get_repository()[3] \
             .get_imageinclude() is True
+        assert self.state.xml_data.get_repository()[3] \
+            .get_sourcetype() is None
 
     def test_get_to_become_deleted_packages(self):
         assert self.state.get_to_become_deleted_packages() == [


### PR DESCRIPTION
Allow to specifiy the sourcetype(metalink|baseurl|mirrorlist) also on the commandline via --set-repo/--add-repo options. So far this was only possible as part of the kiwi description file

