### PR TITLE
schema: Allow C.UTF-8 as a valid locale

### DIFF
--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -27,7 +27,7 @@ namespace nul = ""
 safe-posix-name = xsd:token {pattern = "[a-zA-Z0-9_\-\.]+"}
 safe-posix-short-name = xsd:token {pattern = "[a-zA-Z0-9_\-\.]{1,32}"}
 ecma-119-achar-128-text = xsd:token {pattern = "[a-zA-Z0-9!-/:-?_ ]{1,128}"}
-locale-name = xsd:token {pattern = "(POSIX|[a-z]{2,3}_[A-Z]{2})(,[a-z]{2,3}_[A-Z]{2})*"}
+locale-name = xsd:token {pattern = "(C.UTF-8|POSIX|[a-z]{2,3}_[A-Z]{2})(,[a-z]{2,3}_[A-Z]{2})*"}
 mac-address-type = xsd:token {pattern = "([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}"}
 size-type = xsd:token {pattern = "(\d*|image)"}
 number-type = xsd:token {pattern = "\d+"}

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -38,7 +38,7 @@
   </define>
   <define name="locale-name">
     <data type="token">
-      <param name="pattern">(POSIX|[a-z]{2,3}_[A-Z]{2})(,[a-z]{2,3}_[A-Z]{2})*</param>
+      <param name="pattern">(C.UTF-8|POSIX|[a-z]{2,3}_[A-Z]{2})(,[a-z]{2,3}_[A-Z]{2})*</param>
     </data>
   </define>
   <define name="mac-address-type">


### PR DESCRIPTION
It should be permitted to set the "C.UTF-8" locale for minimal images that are not preloaded with locales. The "C.UTF-8" locale has been supported in Linux distributions for many years.
