### PR TITLE
also keep the ts binary, might be needed to provide timestamped logfiles

### DIFF
--- a/kiwi/config/strip.xml
+++ b/kiwi/config/strip.xml
@@ -280,6 +280,7 @@
         <file name="touch"/>
         <file name="tr"/>
         <file name="true"/>
+        <file name="ts"/>
         <file name="tty"/>
         <file name="tune2fs"/>
         <file name="udevadm"/>


### PR DESCRIPTION
Fixes the problem to provide timestamped logs in custom initrd

Changes proposed in this pull request:
* keep the ts binary if present in the initrd
