### PR TITLE
Better logging which kiwi file is read

### DIFF
--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -160,7 +160,6 @@ class CliTask:
             kiwi searches for a file named config.xml or
             a file matching .kiwi
         """
-        log.info('Loading XML description')
         if kiwi_file:
             config_file = os.sep.join([description_directory, kiwi_file])
         else:

--- a/kiwi/xml_description.py
+++ b/kiwi/xml_description.py
@@ -64,6 +64,7 @@ class XMLDescription:
     def __init__(
         self, description: str = '', derived_from: str = None
     ):
+        log.info(f'Loading XML description: {description}')
         self.markup = Markup.new(description)
         self.description = self.markup.get_xml_description()
         self.derived_from = derived_from


### PR DESCRIPTION
Improve the log message that tells about reading the kiwi config file to actually show the file path that is read in. This is especially an issue if more than one kiwi file is read in during the build process.

