### PR TITLE
package: Add kiwi-image:oci Provides to -systemdeps-containers

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -187,6 +187,7 @@ Provides:       kiwi-image-docker-requires = %{version}-%{release}
 Obsoletes:      kiwi-image-docker-requires < %{version}-%{release}
 %if "%{_vendor}" != "debbuild"
 Provides:       kiwi-image:docker
+Provides:       kiwi-image:oci
 %endif
 %if 0%{?suse_version}
 Requires:       umoci


### PR DESCRIPTION
This allows the Open Build Service to correctly resolve dependencies when building OCI images.