### PR TITLE
keep /usr/bin/sha256sum

### DIFF
--- a/kiwi/config/strip.xml
+++ b/kiwi/config/strip.xml
@@ -259,6 +259,7 @@
         <file name="sfdisk"/>
         <file name="sg_inq"/>
         <file name="sh"/>
+        <file name="sha256sum"/>
         <file name="showconsole"/>
         <file name="shutdown"/>
         <file name="sleep"/>


### PR DESCRIPTION
dropping md5sum was okay, but now we need
the current tool to verify the checksum

Fixes # .

Changes proposed in this pull request:
*
*
