### PR TITLE
Fixed restore of keyfile after reencryption

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
@@ -48,7 +48,7 @@
         </type>
     </preferences>
     <preferences profiles="ReEncryptExtraBootWithPass">
-        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0 rd.kiwi.oem.luks.reencrypt rd.kiwi.oem.luks.reencrypt_randompass quiet" firmware="uefi" luks="linux" luks_version="luks2" luks_pbkdf="pbkdf2" bootpartition="true">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0 rd.kiwi.oem.luks.reencrypt rd.kiwi.oem.luks.reencrypt_randompass quiet" firmware="uefi" luks="random" luks_version="luks2" luks_pbkdf="pbkdf2" bootpartition="true">
             <luksformat>
                 <option name="--cipher" value="aes-xts-plain64"/>
                 <option name="--key-size" value="256"/>

--- a/dracut/modules.d/99kiwi-lib/kiwi-luks-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-luks-lib.sh
@@ -81,8 +81,8 @@ function reencrypt_luks {
             "${device}" 2>&1 | sed -u 's/.* \([0-9]*\)[0-9.]*%.*/\1/'
         ) >"${progress}" &
         run_progress_dialog "${load_text}" "${title_text}"
-        if [ -e "${keyfile}" ];then
-            # re-add keyfile if present
+        if [ -e "${keyfile}" ] && [ ! -e "${new_keyfile}" ];then
+            # re-add keyfile if present and no other keyfile was created
             cryptsetup --key-file "${passphrase_file}" luksAddKey \
                 "${device}" "${keyfile}"
         fi


### PR DESCRIPTION
When kiwi runs the reencryption it also restores an eventual existing keyfile. However if the option rd.kiwi.oem.luks.reencrypt_randompass is specified no former keyfile should be restored. The purpose of reencrypt_randompass is to make sure only this in memory passphrase can access the luks pool such that tooling at boot time gets the opportunity to work with the luks pool for e.g. setting up a TPM key or set a passphrase only known to the user.


