### PR TITLE
reinstall bootstrap packs in image phase for apt

### DIFF
--- a/test/unit/package_manager/apt_test.py
+++ b/test/unit/package_manager/apt_test.py
@@ -258,11 +258,14 @@ class TestPackageManagerApt:
     @patch('kiwi.command.Command.run')
     def test_process_install_requests(self, mock_run, mock_call):
         self.manager.request_package('vim')
+        self.manager.bootstrap_packages = ['?essential', 'some']
         self.manager.process_install_requests()
-        mock_call.assert_called_once_with([
-            'chroot', 'root-dir', 'apt-get',
-            '-c', 'apt.conf', '-y', 'install', 'vim'],
-            self.env
+        mock_call.assert_called_once_with(
+            [
+                'chroot', 'root-dir', 'apt-get',
+                '-c', 'apt.conf', '-y', 'install',
+                '?essential', 'some', 'vim'
+            ], self.env
         )
 
     @patch('kiwi.command.Command.call')


### PR DESCRIPTION
Due to the special bootstrap process, the packages unpacked during bootstrap are not properly listed in the apt index. Therefore the bootstrap packages are added to the install phase which causes an install of this packages again to fix the apt index and provide a consistent system from an apt perspective. This Fixes #2768

