### PR TITLE
Added <oem-ramdisk-size> element

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-agama/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-agama/appliance.kiwi
@@ -16,7 +16,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" fsmountoptions="compress=zstd:15" firmware="uefi" installiso="true" installpxe="true" installboot="install" kernelcmdline="rd.kiwi.ramdisk ramdisk_size=3145728 rd.kiwi.install.pass.bootparam" volid="agama">
+        <type image="oem" filesystem="btrfs" fsmountoptions="compress=zstd:15" firmware="uefi" installiso="true" installpxe="true" installboot="install" kernelcmdline="rd.kiwi.ramdisk rd.kiwi.install.pass.bootparam" volid="agama">
             <bootloader name="grub2" timeout="1"/>
             <oemconfig>
                 <oem-skip-verify>true</oem-skip-verify>
@@ -24,6 +24,7 @@
                 <oem-unattended-id>/dev/ram1</oem-unattended-id>
                 <oem-swap>false</oem-swap>
                 <oem-multipath-scan>false</oem-multipath-scan>
+                <oem-ramdisk-size>3145728</oem-ramdisk-size>
             </oemconfig>
             <size unit="M">2500</size>
         </type>

--- a/build-tests/x86/tumbleweed/test-image-agama/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-agama/appliance.kiwi
@@ -6,6 +6,10 @@
         <contact>yast2-maintainers@suse.de</contact>
         <specification>Agama RamDisk Installer ISO</specification>
     </description>
+    <profiles>
+        <profile name="PXE" description="Small Agama instance for remote installation"/>
+        <profile name="ISO" description="Standard Agama instance for local installation"/>
+    </profiles>
     <preferences>
         <version>1.0.1</version>
         <packagemanager>zypper</packagemanager>
@@ -16,7 +20,23 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" fsmountoptions="compress=zstd:15" firmware="uefi" installiso="true" installpxe="true" installboot="install" kernelcmdline="rd.kiwi.ramdisk rd.kiwi.install.pass.bootparam" volid="agama">
+    </preferences>
+    <preferences profiles="PXE">
+        <type image="oem" filesystem="btrfs" fsmountoptions="compress=zstd:15" firmware="uefi" installpxe="true" kernelcmdline="rd.kiwi.ramdisk rd.kiwi.install.pass.bootparam">
+            <bootloader name="custom"/>
+            <oemconfig>
+                <oem-skip-verify>true</oem-skip-verify>
+                <oem-unattended>true</oem-unattended>
+                <oem-unattended-id>/dev/ram1</oem-unattended-id>
+                <oem-swap>false</oem-swap>
+                <oem-multipath-scan>false</oem-multipath-scan>
+                <oem-ramdisk-size>3145728</oem-ramdisk-size>
+            </oemconfig>
+            <size unit="M">2500</size>
+        </type>
+    </preferences>
+    <preferences profiles="ISO">
+        <type image="oem" filesystem="btrfs" fsmountoptions="compress=zstd:15" firmware="uefi" installiso="true" installboot="install" kernelcmdline="rd.kiwi.ramdisk rd.kiwi.install.pass.bootparam" volid="agama">
             <bootloader name="grub2" timeout="1"/>
             <oemconfig>
                 <oem-skip-verify>true</oem-skip-verify>
@@ -36,20 +56,28 @@
     <repository type="rpm-md">
         <source path="obsrepositories:/"/>
     </repository>
-    <packages type="image">
-        <package name="avahi"/>
-        <package name="bind-utils"/>
-        <package name="patterns-openSUSE-base"/>
-        <package name="systemd"/>
+    <packages type="image" profiles="PXE">
+        <!-- specific packages for Agama remote install -->
+        <package name="kernel-default"/>
+    </packages>
+    <packages type="image" profiles="ISO">
+        <!-- specific packages for agama ISO workload -->
+        <package name="kernel-default"/>
         <package name="grub2-branding-openSUSE" arch="aarch64,x86_64"/>
-        <package name="iputils"/>
-        <package name="vim"/>
-        <package name="vim-data"/>
         <package name="grub2"/>
         <package name="grub2-arm64-efi" arch="aarch64"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>
         <package name="grub2-i386-pc" arch="x86_64"/>
-        <package name="syslinux" arch="x86_64"/>
+        <package name="shim" arch="aarch64,x86_64"/>
+    </packages>
+    <packages type="image">
+        <!-- general system packages for agama workload -->
+        <package name="avahi"/>
+        <package name="bind-utils"/>
+        <package name="patterns-openSUSE-base"/>
+        <package name="systemd"/>
+        <package name="iputils"/>
+        <package name="vim"/>
         <package name="fontconfig"/>
         <package name="fonts-config"/>
         <package name="adobe-sourcecodepro-fonts"/>
@@ -60,8 +88,6 @@
         <package name="bash-completion"/>
         <package name="dhcp-client"/>
         <package name="which"/>
-        <package name="kernel-default"/>
-        <!-- the firmware files not referenced by any kernel driver are removed from the image -->
         <package name="kernel-firmware"/>
         <package name="adaptec-firmware"/>
         <package name="atmel-firmware"/>
@@ -69,10 +95,8 @@
         <package name="ipw-firmware"/>
         <package name="mpt-firmware"/>
         <package name="zd1211-firmware"/>
-        <package name="systemd-zram-service"/> <!--- needed for zram -->
-        <package name="shim" arch="aarch64,x86_64"/>
+        <package name="systemd-zram-service"/>
         <package name="timezone"/>
-        <package name="dracut-kiwi-live"/>
         <package name="blog" arch="s390x" />
         <package name="libblogger2" arch="s390x" />
         <package name="xauth"/>
@@ -91,7 +115,6 @@
         <package name="icewm-lite"/>
         <package name="xinit"/>
         <package name="psmisc"/>
-        <package name="joe"/>
         <package name="checkmedia"/>
         <package name="spice-vdagent"/>
         <package name="libtss2-tcti-device0"/>
@@ -100,7 +123,6 @@
         <package name="dracut-kiwi-oem-dump"/>
     </packages>
     <packages type="delete">
-        <package name="vim-data"/>
         <package name="alsa"/>
         <package name="alsa-utils"/>
         <package name="alsa-ucm-conf"/>

--- a/doc/source/working_with_images/disk_ramdisk_deployment.rst
+++ b/doc/source/working_with_images/disk_ramdisk_deployment.rst
@@ -20,7 +20,7 @@ oem type definition:
 
 .. code:: xml
 
-    <type image="oem" filesystem="ext4" installiso="true" initrd_system="dracut" installboot="install" kernelcmdline="rd.kiwi.ramdisk ramdisk_size=2048000">
+    <type image="oem" filesystem="ext4" installiso="true" initrd_system="dracut" installboot="install" kernelcmdline="rd.kiwi.ramdisk">
         <bootloader name="grub2" timeout="1"/>
         <oemconfig>
             <oem-skip-verify>true</oem-skip-verify>
@@ -28,6 +28,7 @@ oem type definition:
             <oem-unattended-id>/dev/ram1</oem-unattended-id>
             <oem-swap>false</oem-swap>
             <oem-multipath-scan>false</oem-multipath-scan>
+            <oem-ramdisk-size>2048000</oem-ramdisk-size>
          </oemconfig>
      </type>
 
@@ -39,12 +40,12 @@ without asking any questions. In a ramdisk deployment the
 optional target verification, swap space and multipath targets
 are out of scope and therefore disabled.
 
-The configured size of the ramdisk specifies the size of the
-OS disk and must be at least of the size of the System Image.
-The disk size can be configured with the following value in
-the kernelcmdline attribute:
+The configured size of the ramdisk via `oem-ramdisk-size` specifies
+the kB size of the OS disk and it must be at least of the size of the
+System Image. The disk size can be configured dynamically with the
+following value in the kernelcmdline attribute:
 
-*  ramdisk_size=kbyte-value"
+*  ramdisk_size=kbyte-value
 
 An image built with the above setup can be tested in QEMU as
 follows:

--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -22,6 +22,7 @@ function get_disk_list {
     declare kiwi_install_volid=${kiwi_install_volid}
     declare kiwi_oemunattended=${kiwi_oemunattended}
     declare kiwi_oemunattended_id=${kiwi_oemunattended_id}
+    declare kiwi_oemramdisksize=${kiwi_oemramdisksize}
     local disk_id="by-id"
     local disk_size
     local disk_device
@@ -48,8 +49,14 @@ function get_disk_list {
         # target should be a ramdisk on request. Thus actively
         # load the ramdisk block driver and support custom sizes
         local rd_size
+        local custom_rd_size
         local modfile=/etc/modprobe.d/99-brd.conf
-        rd_size=$(getarg ramdisk_size=)
+        custom_rd_size=$(getarg ramdisk_size=)
+        if [ -n "${custom_rd_size}" ];then
+            rd_size="${custom_rd_size}"
+        elif [ -n "${kiwi_oemramdisksize}" ];then
+            rd_size="${kiwi_oemramdisksize}"
+        fi
         mkdir -p /etc/modprobe.d
         if [ -n "${rd_size}" ];then
             echo "options brd rd_size=${rd_size}" > ${modfile}

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -492,6 +492,23 @@ div {
 }
 
 #==========================================
+# common element <oem-ramdisk-size>
+#
+div {
+    k.oem-ramdisk-size.content = text
+    k.oem-ramdisk-size.attlist = empty
+    k.oem-ramdisk-size =
+        ## For oemboot driven images: specify the size of the ramdisk
+        ## The value is taken into account if the deployment of the
+        ## image happens into a ramdisk. The value can be overwritten
+        ## with the kernel boot parameter: ramdisk_size
+        element oem-ramdisk-size {
+            k.oem-ramdisk-size.attlist,
+            k.oem-ramdisk-size.content
+        }
+}
+
+#==========================================
 # common element <oem-device-filter>
 #
 div {
@@ -3462,6 +3479,7 @@ div {
             k.oem-bootwait? &
             k.oem-resize? &
             k.oem-resize-once? &
+            k.oem-ramdisk-size? &
             k.oem-device-filter? &
             k.oem-nic-filter? &
             k.oem-inplace-recovery? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -808,6 +808,29 @@ operation happens only once and then never again</a:documentation>
   </div>
   <!--
     ==========================================
+    common element <oem-ramdisk-size>
+    
+  -->
+  <div>
+    <define name="k.oem-ramdisk-size.content">
+      <text/>
+    </define>
+    <define name="k.oem-ramdisk-size.attlist">
+      <empty/>
+    </define>
+    <define name="k.oem-ramdisk-size">
+      <element name="oem-ramdisk-size">
+        <a:documentation>For oemboot driven images: specify the size of the ramdisk
+The value is taken into account if the deployment of the
+image happens into a ramdisk. The value can be overwritten
+with the kernel boot parameter: ramdisk_size</a:documentation>
+        <ref name="k.oem-ramdisk-size.attlist"/>
+        <ref name="k.oem-ramdisk-size.content"/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
     common element <oem-device-filter>
     
   -->
@@ -5173,6 +5196,9 @@ and setup the system disk.</a:documentation>
           </optional>
           <optional>
             <ref name="k.oem-resize-once"/>
+          </optional>
+          <optional>
+            <ref name="k.oem-ramdisk-size"/>
           </optional>
           <optional>
             <ref name="k.oem-device-filter"/>

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -134,6 +134,8 @@ class Profile:
                 self._text(oemconfig.get_oem_resize_once())
             self.dot_profile['kiwi_oempartition_install'] = \
                 self._text(oemconfig.get_oem_partition_install())
+            self.dot_profile['kiwi_oemramdisksize'] = \
+                self._text(oemconfig.get_oem_ramdisk_size())
             self.dot_profile['kiwi_oemdevicefilter'] = \
                 self._text(oemconfig.get_oem_device_filter())
             self.dot_profile['kiwi_oemtitle'] = \

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -8001,7 +8001,7 @@ class oemconfig(GeneratedsSuper):
     which are used to repartition and setup the system disk."""
     subclass = None
     superclass = None
-    def __init__(self, oem_boot_title=None, oem_bootwait=None, oem_resize=None, oem_resize_once=None, oem_device_filter=None, oem_nic_filter=None, oem_inplace_recovery=None, oem_kiwi_initrd=None, oem_multipath_scan=None, oem_vmcp_parmfile=None, oem_partition_install=None, oem_reboot=None, oem_reboot_interactive=None, oem_recovery=None, oem_recoveryID=None, oem_recovery_part_size=None, oem_shutdown=None, oem_shutdown_interactive=None, oem_silent_boot=None, oem_silent_install=None, oem_silent_verify=None, oem_skip_verify=None, oem_swap=None, oem_swapsize=None, oem_swapname=None, oem_systemsize=None, oem_unattended=None, oem_unattended_id=None):
+    def __init__(self, oem_boot_title=None, oem_bootwait=None, oem_resize=None, oem_resize_once=None, oem_ramdisk_size=None, oem_device_filter=None, oem_nic_filter=None, oem_inplace_recovery=None, oem_kiwi_initrd=None, oem_multipath_scan=None, oem_vmcp_parmfile=None, oem_partition_install=None, oem_reboot=None, oem_reboot_interactive=None, oem_recovery=None, oem_recoveryID=None, oem_recovery_part_size=None, oem_shutdown=None, oem_shutdown_interactive=None, oem_silent_boot=None, oem_silent_install=None, oem_silent_verify=None, oem_skip_verify=None, oem_swap=None, oem_swapsize=None, oem_swapname=None, oem_systemsize=None, oem_unattended=None, oem_unattended_id=None):
         self.original_tagname_ = None
         if oem_boot_title is None:
             self.oem_boot_title = []
@@ -8019,6 +8019,10 @@ class oemconfig(GeneratedsSuper):
             self.oem_resize_once = []
         else:
             self.oem_resize_once = oem_resize_once
+        if oem_ramdisk_size is None:
+            self.oem_ramdisk_size = []
+        else:
+            self.oem_ramdisk_size = oem_ramdisk_size
         if oem_device_filter is None:
             self.oem_device_filter = []
         else:
@@ -8146,6 +8150,11 @@ class oemconfig(GeneratedsSuper):
     def add_oem_resize_once(self, value): self.oem_resize_once.append(value)
     def insert_oem_resize_once_at(self, index, value): self.oem_resize_once.insert(index, value)
     def replace_oem_resize_once_at(self, index, value): self.oem_resize_once[index] = value
+    def get_oem_ramdisk_size(self): return self.oem_ramdisk_size
+    def set_oem_ramdisk_size(self, oem_ramdisk_size): self.oem_ramdisk_size = oem_ramdisk_size
+    def add_oem_ramdisk_size(self, value): self.oem_ramdisk_size.append(value)
+    def insert_oem_ramdisk_size_at(self, index, value): self.oem_ramdisk_size.insert(index, value)
+    def replace_oem_ramdisk_size_at(self, index, value): self.oem_ramdisk_size[index] = value
     def get_oem_device_filter(self): return self.oem_device_filter
     def set_oem_device_filter(self, oem_device_filter): self.oem_device_filter = oem_device_filter
     def add_oem_device_filter(self, value): self.oem_device_filter.append(value)
@@ -8272,6 +8281,7 @@ class oemconfig(GeneratedsSuper):
             self.oem_bootwait or
             self.oem_resize or
             self.oem_resize_once or
+            self.oem_ramdisk_size or
             self.oem_device_filter or
             self.oem_nic_filter or
             self.oem_inplace_recovery or
@@ -8340,6 +8350,9 @@ class oemconfig(GeneratedsSuper):
         for oem_resize_once_ in self.oem_resize_once:
             showIndent(outfile, level, pretty_print)
             outfile.write('<oem-resize-once>%s</oem-resize-once>%s' % (self.gds_format_boolean(oem_resize_once_, input_name='oem-resize-once'), eol_))
+        for oem_ramdisk_size_ in self.oem_ramdisk_size:
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<oem-ramdisk-size>%s</oem-ramdisk-size>%s' % (self.gds_encode(self.gds_format_string(quote_xml(oem_ramdisk_size_), input_name='oem-ramdisk-size')), eol_))
         for oem_device_filter_ in self.oem_device_filter:
             showIndent(outfile, level, pretty_print)
             outfile.write('<oem-device-filter>%s</oem-device-filter>%s' % (self.gds_encode(self.gds_format_string(quote_xml(oem_device_filter_), input_name='oem-device-filter')), eol_))
@@ -8456,6 +8469,10 @@ class oemconfig(GeneratedsSuper):
                 raise_parse_error(child_, 'requires boolean')
             ival_ = self.gds_validate_boolean(ival_, node, 'oem_resize_once')
             self.oem_resize_once.append(ival_)
+        elif nodeName_ == 'oem-ramdisk-size':
+            oem_ramdisk_size_ = child_.text
+            oem_ramdisk_size_ = self.gds_validate_string(oem_ramdisk_size_, node, 'oem_ramdisk_size')
+            self.oem_ramdisk_size.append(oem_ramdisk_size_)
         elif nodeName_ == 'oem-device-filter':
             oem_device_filter_ = child_.text
             oem_device_filter_ = self.gds_validate_string(oem_device_filter_, node, 'oem_device_filter')

--- a/test/unit/system/profile_test.py
+++ b/test/unit/system/profile_test.py
@@ -110,6 +110,7 @@ class TestProfile:
             'kiwi_lvm': 'true',
             'kiwi_lvmgroup': 'systemVG',
             'kiwi_oembootwait': None,
+            'kiwi_oemramdisksize': None,
             'kiwi_oemdevicefilter': None,
             'kiwi_oemnicfilter': None,
             'kiwi_oemkboot': None,


### PR DESCRIPTION
So far it was only possible to specify the size of the ramdisk via the kernel commandline option: ramdisk_size. In a remote deployment it was therefore required to carry this size as a mandatory information to the deployment server. With this commit we allow to specify the size for the ramdisk to be configured as part of the image configuration which makes this information also available inside of the initrd. If provided the ramdisk_size kernel commandline option still takes precedence over the <oem-ramdisk-size> setting to avoid any behavior change and to still allow dynamic overrides of the ramdisk size.


