### PR TITLE
Prevent loading unused data in oem deployment

### DIFF
--- a/doc/source/building_images/build_expandable_disk.rst
+++ b/doc/source/building_images/build_expandable_disk.rst
@@ -213,6 +213,15 @@ a target system:
          other images are deployed, the file must be modified to match the
          correct root reference.
 
+      .. note::
+
+         If the image gets deployed into a ramdisk which is configured
+         by passing `rd.kiwi.ramdisk` as part of the append setup below,
+         it is not required to copy the above mentioned kernel and initrd
+         file to boot the system because for ramdisk deployments the
+         currently active kernel and initrd will be used as kexec cannot
+         be called with a system in memory.
+
 4. Add/Update the kernel command line parameters.
 
    Edit your PXE configuration (for example :file:`pxelinux.cfg/default`) on

--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -425,15 +425,17 @@ function get_remote_image_source_files {
             "Failed to fetch ${image_sha256_uri}" /tmp/fetch.info
     fi
 
-    if ! fetch_file "${image_kernel_uri}" > "${metadata_dir}/linux";then
-        show_log_and_quit \
-            "Failed to fetch ${image_kernel_uri}" /tmp/fetch.info
-    fi
+    if ! getargbool 0 rd.kiwi.ramdisk; then
+        if ! fetch_file "${image_kernel_uri}" > "${metadata_dir}/linux";then
+            show_log_and_quit \
+                "Failed to fetch ${image_kernel_uri}" /tmp/fetch.info
+        fi
 
-    if ! fetch_file "${image_initrd_uri}" > "${install_dir}/initrd.system_image"
-    then
-        show_log_and_quit \
-            "Failed to fetch ${image_initrd_uri}" /tmp/fetch.info
+        if ! fetch_file "${image_initrd_uri}" > "${install_dir}/initrd.system_image"
+        then
+            show_log_and_quit \
+                "Failed to fetch ${image_initrd_uri}" /tmp/fetch.info
+        fi
     fi
 
     if ! fetch_file "${image_config_uri}" > "/config.bootoptions"


### PR DESCRIPTION
In case rd.kiwi.ramdisk is used as part of a remote deployment setup, it's not needed to load the system kernel and initrd because it's not used as kexec is not called with the system deployed into memory. For ramdisk deployments the system is booted using the currently active kernel and initrd and as such we can avoid loading an extra kernel and initrd for booting the system via kexec.

