### PR TITLE
Update LOADER_TYPE setup for grub

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -624,8 +624,10 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
 
     def _setup_sysconfig_bootloader(self):
         """
-        Create or update etc/sysconfig/bootloader by the following
-        parameters required according to the grub2 bootloader setup
+        Create or update etc/sysconfig/bootloader for the following
+        parameters. Please note this file is consumed by perl-bootloader
+        only and marked for deletion with the next major release of
+        kiwi because not a mainline grub config file.
 
         * LOADER_TYPE
         * LOADER_LOCATION
@@ -640,6 +642,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             'LOADER_LOCATION':
                 'none' if self.firmware.efi_mode() else 'mbr'
         }
+        if self.bls:
+            sysconfig_bootloader_entries['LOADER_TYPE'] = 'grub2-bls'
         if '--set-trusted-boot' in self.config_options:
             sysconfig_bootloader_entries['TRUSTED_BOOT'] = 'yes'
         if self.firmware.efi_mode() == 'uefi':

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -874,6 +874,7 @@ class TestBootLoaderConfigGrub2:
         sysconfig_bootloader = MagicMock()
         mock_sysconfig.return_value = sysconfig_bootloader
         mock_exists.return_value = True
+        self.bootloader.bls = False
         self.bootloader._setup_sysconfig_bootloader()
         mock_sysconfig.assert_called_once_with(
             'root_dir/etc/sysconfig/bootloader'
@@ -914,6 +915,7 @@ class TestBootLoaderConfigGrub2:
         sysconfig_bootloader = MagicMock()
         mock_sysconfig.return_value = sysconfig_bootloader
         mock_exists.return_value = True
+        self.bootloader.bls = False
         self.bootloader._setup_sysconfig_bootloader()
         mock_sysconfig.assert_called_once_with(
             'root_dir/etc/sysconfig/bootloader'
@@ -942,6 +944,20 @@ class TestBootLoaderConfigGrub2:
             ),
             call('LOADER_LOCATION', 'none'),
             call('LOADER_TYPE', 'grub2-efi'),
+            call('SECURE_BOOT', 'no'),
+            call('TRUSTED_BOOT', 'yes')
+        ]
+        sysconfig_bootloader.__setitem__.reset_mock()
+        self.bootloader.bls = True
+        self.bootloader._setup_sysconfig_bootloader()
+        assert sysconfig_bootloader.__setitem__.call_args_list == [
+            call('DEFAULT_APPEND', '"some-cmdline root=UUID=foo"'),
+            call(
+                'FAILSAFE_APPEND',
+                '"some-cmdline root=UUID=foo failsafe-options"'
+            ),
+            call('LOADER_LOCATION', 'none'),
+            call('LOADER_TYPE', 'grub2-bls'),
             call('SECURE_BOOT', 'no'),
             call('TRUSTED_BOOT', 'yes')
         ]


### PR DESCRIPTION
If the bootloader attribute: bls is set to true, make sure the LOADER_TYPE changes to grub-bls. This is related to Issue #2773


