### PR TITLE
Fix bundle extension for container types

### DIFF
--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -286,10 +286,11 @@ class ResultBundleTask(CliTask):
     ) -> str:
         image_version = result.xml_state.get_image_version()
         image_name = result.xml_state.xml_data.get_name()
-        if '.tar.' in result_file.filename:
+        special_exts = ['.oci.tar.', '.docker.tar.', '.vagrant.']
+        if any(special_ext in result_file.filename for special_ext in special_exts):
+            extension = f'{".".join(result_file.filename.split(".")[-3:])}'
+        elif '.tar.' in result_file.filename:
             extension = f'tar.{result_file.filename.split(".").pop()}'
-        elif '.vagrant.' in result_file.filename:
-            extension = f'vagrant.{".".join(result_file.filename.split(".")[-2:])}'
         else:
             extension = result_file.filename.split('.').pop()
         if bundle_file_format_name:

--- a/test/unit/tasks/result_bundle_test.py
+++ b/test/unit/tasks/result_bundle_test.py
@@ -435,6 +435,118 @@ class TestResultBundleTask:
     @patch('os.unlink')
     @patch('os.symlink')
     @patch('os.readlink')
+    def test_process_result_bundle_with_bundle_format_for_oci_types(
+        self, mock_os_readlink, mock_os_symlink, mock_os_unlink,
+        mock_os_path_islink, mock_exists, mock_path_create, mock_command,
+        mock_load
+    ):
+        self.xml_state.profiles = None
+        self.xml_state.host_architecture = 'x86_64'
+        self.xml_state.get_build_type_name = Mock(
+            return_value='oci'
+        )
+        self.xml_state.xml_data.get_name = Mock(
+            return_value='Leap-15.2'
+        )
+
+        result = Result(self.xml_state)
+        result.add_bundle_format('%N-%T:%M')
+        result.add(
+            key='container',
+            filename='/tmp/mytest/Leap-15.2.x86_64-1.15.2.oci.tar.xz',
+            use_for_bundle=True, compress=False, shasum=False
+        )
+
+        mock_exists.return_value = False
+        mock_load.return_value = result
+        self._init_command_args()
+
+        self.task.process()
+
+        assert mock_command.call_args_list == [
+            call(
+                [
+                    'cp',
+                    '/tmp/mytest/Leap-15.2.x86_64-1.15.2.oci.tar.xz',
+                    os.sep.join(
+                        [self.abs_bundle_dir, 'Leap-15.2-oci:1.oci.tar.xz']
+                    )
+                ]
+            ),
+            call(
+                [
+                    'file',
+                    os.sep.join(
+                        [self.abs_bundle_dir, 'Leap-15.2-oci:1.oci.tar.xz']
+                    )
+                ]
+            )
+        ]
+
+    @patch('kiwi.tasks.result_bundle.Result.load')
+    @patch('kiwi.tasks.result_bundle.Command.run')
+    @patch('kiwi.tasks.result_bundle.Path.create')
+    @patch('os.path.exists')
+    @patch('os.path.islink')
+    @patch('os.unlink')
+    @patch('os.symlink')
+    @patch('os.readlink')
+    def test_process_result_bundle_with_bundle_format_for_docker_types(
+        self, mock_os_readlink, mock_os_symlink, mock_os_unlink,
+        mock_os_path_islink, mock_exists, mock_path_create, mock_command,
+        mock_load
+    ):
+        self.xml_state.profiles = None
+        self.xml_state.host_architecture = 'x86_64'
+        self.xml_state.get_build_type_name = Mock(
+            return_value='docker'
+        )
+        self.xml_state.xml_data.get_name = Mock(
+            return_value='Leap-15.2'
+        )
+
+        result = Result(self.xml_state)
+        result.add_bundle_format('%N-%T:%M')
+        result.add(
+            key='container',
+            filename='/tmp/mytest/Leap-15.2.x86_64-1.15.2.docker.tar.xz',
+            use_for_bundle=True, compress=False, shasum=False
+        )
+
+        mock_exists.return_value = False
+        mock_load.return_value = result
+        self._init_command_args()
+
+        self.task.process()
+
+        assert mock_command.call_args_list == [
+            call(
+                [
+                    'cp',
+                    '/tmp/mytest/Leap-15.2.x86_64-1.15.2.docker.tar.xz',
+                    os.sep.join(
+                        [self.abs_bundle_dir, 'Leap-15.2-docker:1.docker.tar.xz']
+                    )
+                ]
+            ),
+            call(
+                [
+                    'file',
+                    os.sep.join(
+                        [self.abs_bundle_dir, 'Leap-15.2-docker:1.docker.tar.xz']
+                    )
+                ]
+            )
+        ]
+
+    @patch('kiwi.tasks.result_bundle.Result.load')
+    @patch('kiwi.tasks.result_bundle.Command.run')
+    @patch('kiwi.tasks.result_bundle.Path.create')
+    @patch('os.path.exists')
+    @patch('os.path.islink')
+    @patch('os.unlink')
+    @patch('os.symlink')
+    @patch('os.readlink')
     def test_process_result_bundle_with_bundle_format_from_commandline(
         self, mock_os_readlink, mock_os_symlink, mock_os_unlink,
         mock_os_path_islink, mock_exists, mock_path_create, mock_command,


### PR DESCRIPTION
When building result files that use container types like oci or docker, kiwi creates them as archive tarballs with an extension prefix to indicate the special nature of the archive. However, the bundler code does not retain the prefix, which results in the wrong file extension for these archives.

This change adds exceptions for these types and refactors the exception handling to unify it with the Vagrant image filename handling, which operates similarly.

Fixes #2628