### PR TITLE
Add support for filtering out files from the ESP image for GRUB

### DIFF
--- a/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
@@ -61,6 +61,8 @@
         <source path="obsrepositories:/"/>
     </repository>
     <packages type="image">
+        <!-- Filter out unwanted EFI files from the embedded ESP -->
+        <file name="iso-esp-excludes.yaml" target="image/exclude_files_efifatimage.yaml"/>
         <package name="grub2"/>
         <package name="grubby"/>
         <package name="kernel"/>

--- a/build-tests/x86/fedora/test-image-live-disk/iso-esp-excludes.yaml
+++ b/build-tests/x86/fedora/test-image-live-disk/iso-esp-excludes.yaml
@@ -1,0 +1,3 @@
+exclude:
+- BOOT/fb*.efi
+- fedora

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -443,19 +443,30 @@ class Defaults:
             return yaml.safe_load(meta)
 
     @staticmethod
-    def get_exclude_list_from_custom_exclude_files(root_dir: str) -> List:
+    def _parse_exclude_file(root_dir: str, exclude_filename: str) -> List:
         """
-        Provides the list of folders that are excluded by the
-        optional metadata file image/exclude_files.yaml
+        Retrieves an exclusion list from the provided metadata file
 
-        :return: list of file and directory names
+        The file should contain a YAML dictionary with a top-level key
+        named 'exclude' and the list of exclusions as its value.
+
+        The list of exclusions may include:
+            * file paths
+            * folder paths
+            * glob patterns
+
+        Paths and patterns should be relative to the filesystem or
+        directory that they're being excluded from.
+
+        :return: list of paths and glob patterns
 
         :param string root_dir: image root directory
+        :param string exclude_filename: file exclusion YAML metadata file
 
         :rtype: list
         """
         exclude_file = os.sep.join(
-            [root_dir, 'image', 'exclude_files.yaml']
+            [root_dir, 'image', exclude_filename]
         )
         exclude_list = []
         if os.path.isfile(exclude_file):
@@ -472,6 +483,36 @@ class Defaults:
                         f'invalid yaml structure in {exclude_file}, ignored'
                     )
         return exclude_list
+
+    @staticmethod
+    def get_exclude_list_from_custom_exclude_files(root_dir: str) -> List:
+        """
+        Gets the list of excluded items for the root filesystem from
+        the optional metadata file image/exclude_files.yaml
+
+        :return: list of paths and glob patterns
+
+        :param string root_dir: image root directory
+
+        :rtype: list
+        """
+        return Defaults._parse_exclude_file(root_dir, 'exclude_files.yaml')
+
+    @staticmethod
+    def get_exclude_list_from_custom_exclude_files_for_efifatimage(root_dir: str) -> List:
+        """
+        Gets the list of excluded items for the ESP's EFI folder from
+        the optional metadata file image/exclude_files_efifatimage.yaml
+
+        Excluded items must be relative to the ESP's /EFI directory.
+
+        :return: list of paths and glob patterns
+
+        :param string root_dir: EFI root directory
+
+        :rtype: list
+        """
+        return Defaults._parse_exclude_file(root_dir, 'exclude_files_efifatimage.yaml')
 
     @staticmethod
     def get_exclude_list_for_non_physical_devices():

--- a/test/data/root-dir/image/exclude_files_efifatimage.yaml
+++ b/test/data/root-dir/image/exclude_files_efifatimage.yaml
@@ -1,0 +1,3 @@
+exclude:
+- BOOT/fbia32.efi
+- BOOT/fbx64.efi

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -326,8 +326,13 @@ class TestBootLoaderConfigGrub2:
                 'some-data'
             )
 
+    @patch('kiwi.bootloader.config.grub2.DataSync.sync_data')
+    @patch('kiwi.bootloader.config.grub2.Temporary.new_dir')
     @patch('kiwi.bootloader.config.grub2.Command.run')
-    def test_create_embedded_fat_efi_image(self, mock_command):
+    def test_create_embedded_fat_efi_image(self, mock_command, mock_tmpdir, mock_syncdata):
+        tmpdir = Mock()
+        tmpdir.name = 'tmpdir'
+        mock_tmpdir.return_value = tmpdir
         self.bootloader._create_embedded_fat_efi_image('tmp-esp-image')
         assert mock_command.call_args_list == [
             call(
@@ -343,7 +348,7 @@ class TestBootLoaderConfigGrub2:
             call(
                 [
                     'mcopy', '-Do', '-s', '-i', 'tmp-esp-image',
-                    'root_dir/EFI', '::'
+                    'tmpdir', '::EFI'
                 ]
             )
         ]

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -107,6 +107,23 @@ class TestDefaults:
         assert Defaults.get_vendor_grubenv('boot/efi') == \
             'boot/efi/EFI/fedora/grubenv'
 
+    def test_parse_exclude_file_is_valid(self):
+        assert Defaults._parse_exclude_file(
+            '../data/root-dir', 'exclude_files.yaml'
+        ) == [
+            'usr/bin/qemu-binfmt',
+            'usr/bin/qemu-x86_64-binfmt',
+            'usr/bin/qemu-x86_64'
+        ]
+
+    @patch('yaml.safe_load')
+    def test_parse_exclude_file_is_invalid(self, mock_yaml_safe_load):
+        mock_yaml_safe_load.return_value = {'invalid': 'artificial'}
+        with self._caplog.at_level(logging.WARNING):
+            assert Defaults._parse_exclude_file(
+                '../data/root-dir', 'exclude_files.yaml'
+            ) == []
+
     def test_get_exclude_list_from_custom_exclude_files(self):
         assert Defaults.get_exclude_list_from_custom_exclude_files(
             '../data/root-dir'
@@ -123,6 +140,24 @@ class TestDefaults:
         mock_yaml_safe_load.return_value = {'invalid': 'artificial'}
         with self._caplog.at_level(logging.WARNING):
             assert Defaults.get_exclude_list_from_custom_exclude_files(
+                '../data/root-dir'
+            ) == []
+
+    def test_get_exclude_list_from_custom_exclude_files_for_efifatimage(self):
+        assert Defaults.get_exclude_list_from_custom_exclude_files_for_efifatimage(
+            '../data/root-dir'
+        ) == [
+            'BOOT/fbia32.efi',
+            'BOOT/fbx64.efi',
+        ]
+
+    @patch('yaml.safe_load')
+    def test_get_exclude_list_from_custom_exclude_files_for_efifatimage_is_invalid(
+        self, mock_yaml_safe_load
+    ):
+        mock_yaml_safe_load.return_value = {'invalid': 'artificial'}
+        with self._caplog.at_level(logging.WARNING):
+            assert Defaults.get_exclude_list_from_custom_exclude_files_for_efifatimage(
                 '../data/root-dir'
             ) == []
 


### PR DESCRIPTION
Prior to this change, KIWI blindly synced the ESP directory into the embedded ESP image. Depending on the distribution and packages included for the created image, this can have undesirable side-effects.

For image builds that need some more fine-grained control over the creation of the embedded ESP image (particularly for ISO images), this change introduces the ability to inject an exclusion list similar to what is used to filter out files for the root filesystem.

Fixes: https://github.com/OSInside/kiwi/issues/2008
Fixes: https://github.com/OSInside/kiwi/issues/2777
