### PR TITLE
Fix key slot selection for luks reencrypt

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-luks/appliance.kiwi
@@ -60,7 +60,7 @@
         </type>
     </preferences>
     <preferences profiles="ReEncryptFullDisk">
-        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0 rd.kiwi.oem.luks.reencrypt" firmware="uefi" luks="linux" luks_version="luks2" luks_pbkdf="pbkdf2" bootpartition="false">
+        <type image="oem" filesystem="ext4" kernelcmdline="console=ttyS0 rd.kiwi.oem.luks.reencrypt rd.kiwi.oem.luks.reencrypt_randompass quiet" firmware="uefi" luks="linux" luks_version="luks2" luks_pbkdf="pbkdf2" bootpartition="false" eficsm="false">
             <luksformat>
                 <option name="--cipher" value="aes-xts-plain64"/>
                 <option name="--key-size" value="256"/>
@@ -68,7 +68,7 @@
             <oemconfig>
                 <oem-resize>true</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="10"/>
+            <bootloader name="grub2" console="serial" timeout="10" use_disk_password="true"/>
         </type>
     </preferences>
     <users>

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1277,15 +1277,19 @@ class DiskBuilder:
         self, luks_root: Optional[LuksDevice]
     ) -> None:
         if luks_root is not None:
-            log.info('Including origin LUKS header checksum')
-            filename = ''.join(
-                [self.root_dir, '/root/.luks.header']
+            log.info(
+                'Including origin LUKS header checksum and key slot number'
             )
-            self.boot_image.include_file(
-                filename=os.sep + os.sep.join(
-                    ['root', os.path.basename(filename)]
-                ), delete_after_include=True
-            )
+            filenames = [
+                ''.join([self.root_dir, '/root/.luks.header']),
+                ''.join([self.root_dir, '/root/.luks.slot'])
+            ]
+            for filename in filenames:
+                self.boot_image.include_file(
+                    filename=os.sep + os.sep.join(
+                        ['root', os.path.basename(filename)]
+                    ), delete_after_include=True
+                )
 
     def _write_generic_fstab_to_system_image(
         self, device_map: Dict,

--- a/kiwi/storage/luks_device.py
+++ b/kiwi/storage/luks_device.py
@@ -94,6 +94,7 @@ class LuksDevice(DeviceProvider):
             to unlock the luks device
         :param string root_dir: root dir path
         """
+        keyslot = '0'
         if not options:
             options = []
         if osname:
@@ -174,6 +175,7 @@ class LuksDevice(DeviceProvider):
                     'luksAddKey', storage_device, keyfile_path
                 ]
             )
+            keyslot = '1'
 
         # Create backup header checksum as reencryption reference
         master_checksum = f'{root_dir}/root/.luks.header'
@@ -189,6 +191,11 @@ class LuksDevice(DeviceProvider):
         checksum = Checksum(master_checksum).sha256()
         with open(master_checksum, 'w') as shasum:
             shasum.write(checksum)
+
+        # Create key slot number as reencryption reference
+        master_slot = f'{root_dir}/root/.luks.slot'
+        with open(master_slot, 'w') as slot:
+            slot.write(keyslot)
 
         # open the pool
         Command.run(

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -1196,7 +1196,8 @@ class TestDiskBuilder:
             call('/root/.root.keyfile'),
             call('/config.partids'),
             call('/etc/crypttab'),
-            call(filename='/root/.luks.header', delete_after_include=True)
+            call(filename='/root/.luks.header', delete_after_include=True),
+            call(filename='/root/.luks.slot', delete_after_include=True)
         ]
         self.boot_image_task.write_system_config_file.assert_called_once_with(
             config={'install_items': ['/root/.root.keyfile']},
@@ -1251,7 +1252,8 @@ class TestDiskBuilder:
             call('/root/.root.keyfile'),
             call('/config.partids'),
             call('/etc/crypttab'),
-            call(filename='/root/.luks.header', delete_after_include=True)
+            call(filename='/root/.luks.header', delete_after_include=True),
+            call(filename='/root/.luks.slot', delete_after_include=True)
         ]
         self.boot_image_task.write_system_config_file.assert_called_once_with(
             config={'install_items': ['/root/.root.keyfile']},


### PR DESCRIPTION
Depending on the type setup for a luks encrypted image, there might be one or two key slots available. When kiwi is requested to perform the reencryption process at least one key-slot and the proper keyfile/passphrase must be provided. This commit stores the information about the key-slot number for which a decryption information exists in the initrd. In addition to the code change also the corresponding integration test image was updated.

