### PR TITLE
Drop writing /etc/sysconfig/bootloader

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -240,7 +240,6 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         )
 
         self._setup_default_grub()
-        self._setup_sysconfig_bootloader()
         if self.arch.startswith('s390'):
             self._setup_zipl2grub_conf()
 
@@ -658,62 +657,6 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         ):
             return True
         return False
-
-    def _setup_sysconfig_bootloader(self):
-        """
-        Create or update etc/sysconfig/bootloader for the following
-        parameters. Please note this file is consumed by perl-bootloader
-        only and marked for deletion with the next major release of
-        kiwi because not a mainline grub config file.
-
-        * LOADER_TYPE
-        * LOADER_LOCATION
-        * DEFAULT_APPEND
-        * FAILSAFE_APPEND
-        * SECURE_BOOT
-        * TRUSTED_BOOT
-        """
-        sysconfig_bootloader_entries = {
-            'LOADER_TYPE':
-                'grub2-efi' if self.firmware.efi_mode() else 'grub2',
-            'LOADER_LOCATION':
-                'none' if self.firmware.efi_mode() else 'mbr'
-        }
-        if self.bls:
-            sysconfig_bootloader_entries['LOADER_TYPE'] = 'grub2-bls'
-        if '--set-trusted-boot' in self.config_options:
-            sysconfig_bootloader_entries['TRUSTED_BOOT'] = 'yes'
-        if self.firmware.efi_mode() == 'uefi':
-            sysconfig_bootloader_entries['SECURE_BOOT'] = 'yes'
-        elif self.firmware.efi_mode() == 'efi':
-            sysconfig_bootloader_entries['SECURE_BOOT'] = 'no'
-        if self.cmdline:
-            sysconfig_bootloader_entries['DEFAULT_APPEND'] = '"{0}"'.format(
-                self.cmdline
-            )
-        if self.cmdline_failsafe:
-            sysconfig_bootloader_entries['FAILSAFE_APPEND'] = '"{0}"'.format(
-                self.cmdline_failsafe
-            )
-
-        sysconfig_bootloader_location = ''.join(
-            [self.root_dir, '/etc/sysconfig/']
-        )
-        if os.path.exists(sysconfig_bootloader_location):
-            log.info('Writing sysconfig bootloader file')
-            sysconfig_bootloader_file = ''.join(
-                [sysconfig_bootloader_location, 'bootloader']
-            )
-            sysconfig_bootloader = SysConfig(
-                sysconfig_bootloader_file
-            )
-            sysconfig_bootloader_entries_sorted = OrderedDict(
-                sorted(sysconfig_bootloader_entries.items())
-            )
-            for key, value in list(sysconfig_bootloader_entries_sorted.items()):
-                log.info('--> {0}:{1}'.format(key, value))
-                sysconfig_bootloader[key] = value
-            sysconfig_bootloader.write()
 
     def _setup_zipl2grub_conf(self):
         zipl2grub_config_file = ''.join(

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -369,26 +369,21 @@ class TestBootLoaderConfigGrub2:
         assert self.bootloader.xen_guest is True
 
     @patch.object(BootLoaderConfigGrub2, '_setup_default_grub')
-    @patch.object(BootLoaderConfigGrub2, '_setup_sysconfig_bootloader')
     def test_write_meta_data(
-        self, mock_setup_sysconfig_bootloader,
-        mock_setup_default_grub
+        self, mock_setup_default_grub
     ):
         self.bootloader.write_meta_data()
         mock_setup_default_grub.assert_called_once_with()
-        mock_setup_sysconfig_bootloader.assert_called_once_with()
 
     @patch.object(BootLoaderConfigGrub2, '_setup_default_grub')
-    @patch.object(BootLoaderConfigGrub2, '_setup_sysconfig_bootloader')
     @patch.object(BootLoaderConfigGrub2, '_setup_zipl2grub_conf')
     def test_write_meta_data_s390(
-        self, mock_setup_zipl2grub_conf, mock_setup_sysconfig_bootloader,
+        self, mock_setup_zipl2grub_conf,
         mock_setup_default_grub
     ):
         self.bootloader.arch = 's390x'
         self.bootloader.write_meta_data()
         mock_setup_default_grub.assert_called_once_with()
-        mock_setup_sysconfig_bootloader.assert_called_once_with()
         mock_setup_zipl2grub_conf.assert_called_once_with()
 
     @patch('os.path.exists')
@@ -970,100 +965,6 @@ class TestBootLoaderConfigGrub2:
             'SUSE_BTRFS_SNAPSHOT_BOOTING': 'true',
             'GRUB_DEFAULT': 'saved'
         }
-
-    @patch('os.path.exists')
-    @patch('kiwi.bootloader.config.grub2.SysConfig')
-    def test_setup_sysconfig_bootloader(self, mock_sysconfig, mock_exists):
-        sysconfig_bootloader = MagicMock()
-        mock_sysconfig.return_value = sysconfig_bootloader
-        mock_exists.return_value = True
-        self.bootloader.bls = False
-        self.bootloader._setup_sysconfig_bootloader()
-        mock_sysconfig.assert_called_once_with(
-            'root_dir/etc/sysconfig/bootloader'
-        )
-        sysconfig_bootloader.write.assert_called_once_with()
-        assert sysconfig_bootloader.__setitem__.call_args_list == [
-            call('DEFAULT_APPEND', '"some-cmdline root=UUID=foo"'),
-            call(
-                'FAILSAFE_APPEND',
-                '"some-cmdline root=UUID=foo failsafe-options"'
-            ),
-            call('LOADER_LOCATION', 'mbr'),
-            call('LOADER_TYPE', 'grub2'),
-            call('TRUSTED_BOOT', 'yes')
-        ]
-        self.firmware.efi_mode = Mock(
-            return_value='uefi'
-        )
-        sysconfig_bootloader.__setitem__.reset_mock()
-        self.bootloader._setup_sysconfig_bootloader()
-        assert sysconfig_bootloader.__setitem__.call_args_list == [
-            call('DEFAULT_APPEND', '"some-cmdline root=UUID=foo"'),
-            call(
-                'FAILSAFE_APPEND',
-                '"some-cmdline root=UUID=foo failsafe-options"'
-            ),
-            call('LOADER_LOCATION', 'none'),
-            call('LOADER_TYPE', 'grub2-efi'),
-            call('SECURE_BOOT', 'yes'),
-            call('TRUSTED_BOOT', 'yes')
-        ]
-
-    @patch('os.path.exists')
-    @patch('kiwi.bootloader.config.grub2.SysConfig')
-    def test_setup_sysconfig_bootloader_no_secure(
-        self, mock_sysconfig, mock_exists
-    ):
-        sysconfig_bootloader = MagicMock()
-        mock_sysconfig.return_value = sysconfig_bootloader
-        mock_exists.return_value = True
-        self.bootloader.bls = False
-        self.bootloader._setup_sysconfig_bootloader()
-        mock_sysconfig.assert_called_once_with(
-            'root_dir/etc/sysconfig/bootloader'
-        )
-        sysconfig_bootloader.write.assert_called_once_with()
-        assert sysconfig_bootloader.__setitem__.call_args_list == [
-            call('DEFAULT_APPEND', '"some-cmdline root=UUID=foo"'),
-            call(
-                'FAILSAFE_APPEND',
-                '"some-cmdline root=UUID=foo failsafe-options"'
-            ),
-            call('LOADER_LOCATION', 'mbr'),
-            call('LOADER_TYPE', 'grub2'),
-            call('TRUSTED_BOOT', 'yes')
-        ]
-        self.firmware.efi_mode = Mock(
-            return_value='efi'
-        )
-        sysconfig_bootloader.__setitem__.reset_mock()
-        self.bootloader._setup_sysconfig_bootloader()
-        assert sysconfig_bootloader.__setitem__.call_args_list == [
-            call('DEFAULT_APPEND', '"some-cmdline root=UUID=foo"'),
-            call(
-                'FAILSAFE_APPEND',
-                '"some-cmdline root=UUID=foo failsafe-options"'
-            ),
-            call('LOADER_LOCATION', 'none'),
-            call('LOADER_TYPE', 'grub2-efi'),
-            call('SECURE_BOOT', 'no'),
-            call('TRUSTED_BOOT', 'yes')
-        ]
-        sysconfig_bootloader.__setitem__.reset_mock()
-        self.bootloader.bls = True
-        self.bootloader._setup_sysconfig_bootloader()
-        assert sysconfig_bootloader.__setitem__.call_args_list == [
-            call('DEFAULT_APPEND', '"some-cmdline root=UUID=foo"'),
-            call(
-                'FAILSAFE_APPEND',
-                '"some-cmdline root=UUID=foo failsafe-options"'
-            ),
-            call('LOADER_LOCATION', 'none'),
-            call('LOADER_TYPE', 'grub2-bls'),
-            call('SECURE_BOOT', 'no'),
-            call('TRUSTED_BOOT', 'yes')
-        ]
 
     @patch('os.path.exists')
     def test_setup_live_image_config_custom_template(self, mock_exists):


### PR DESCRIPTION
There are several mainline grub configurations which kiwi cares for but /etc/sysconfig/bootloader is for perl-bootloader only and pretty distribution specific which makes it hard to maintain the correct content. We don't have anything for other distro specific grub tools like grubby in kiwi either.

