### PR TITLE
Change suffix for package manager config files

### DIFF
--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -91,7 +91,7 @@ class RepositoryApt(RepositoryBase):
         self.keyring = '{}/trusted.gpg'.format(self.manager_base)
 
         self.runtime_apt_get_config_file = Temporary(
-            path=self.root_dir, prefix='kiwi_apt.conf'
+            path=self.root_dir, prefix='kiwi_apt.config'
         ).unmanaged_file()
 
         self.apt_get_args = [

--- a/kiwi/repository/dnf4.py
+++ b/kiwi/repository/dnf4.py
@@ -98,7 +98,7 @@ class RepositoryDnf4(RepositoryBase):
         }
 
         self.runtime_dnf_config_file = Temporary(
-            path=self.root_dir, prefix='kiwi_dnf4.conf'
+            path=self.root_dir, prefix='kiwi_dnf4.config'
         ).unmanaged_file()
 
         self.dnf_args = [

--- a/kiwi/repository/dnf5.py
+++ b/kiwi/repository/dnf5.py
@@ -98,7 +98,7 @@ class RepositoryDnf5(RepositoryBase):
         }
 
         self.runtime_dnf_config_file = Temporary(
-            path=self.root_dir, prefix='kiwi_dnf5.conf'
+            path=self.root_dir, prefix='kiwi_dnf5.config'
         ).unmanaged_file()
 
         self.dnf_args = [

--- a/kiwi/repository/pacman.py
+++ b/kiwi/repository/pacman.py
@@ -58,7 +58,7 @@ class RepositoryPacman(RepositoryBase):
         self.repo_names: List = []
 
         self.runtime_pacman_config_file = Temporary(
-            path=self.root_dir, prefix='kiwi_pacman.conf'
+            path=self.root_dir, prefix='kiwi_pacman.config'
         ).unmanaged_file()
 
         if 'check_signatures' in self.custom_args:

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -116,10 +116,10 @@ class RepositoryZypper(RepositoryBase):
         }
 
         self.runtime_zypper_config_file = Temporary(
-            path=self.root_dir, prefix='kiwi_zypper.conf'
+            path=self.root_dir, prefix='kiwi_zypper.config'
         ).unmanaged_file()
         self.runtime_zypp_config_file = Temporary(
-            path=self.root_dir, prefix='kiwi_zypp.conf'
+            path=self.root_dir, prefix='kiwi_zypp.config'
         ).unmanaged_file()
 
         self.zypper_args = [


### PR DESCRIPTION
Use .config instead of .conf for the temporary package manager config files. Reason for this change is a bug in dracut which reads and executes all /*.conf files from the system. This Fixes #2780

