### PR TITLE
Fixed root setup for encrypted overlay disk

### DIFF
--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -628,11 +628,18 @@ class BootLoaderConfigBase(ABC):
             if self.xml_state.build_type.get_overlayroot():
                 # In case of an overlay setup the root partition is a squashfs
                 # In this case the root location can only be specified by the
-                # partition uuid because squashfs itself doesn't have one
-                root_location = self._get_location(boot_device, 'by-partuuid')
-                return 'root=overlay:{0}={1}'.format(
-                    root_location['type'], root_location['name']
-                )
+                # partition uuid because squashfs itself doesn't have one.
+                # Exception to this is if the overlay is also encrypted
+                luks = self.xml_state.get_luks_credentials()
+                if luks is not None:
+                    return 'root=overlay:MAPPER=luks'
+                else:
+                    root_location = self._get_location(
+                        boot_device, 'by-partuuid'
+                    )
+                    return 'root=overlay:{0}={1}'.format(
+                        root_location['type'], root_location['name']
+                    )
             else:
                 root_location = self._get_location(boot_device)
                 return 'root={0}={1}'.format(

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -319,10 +319,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         # More details can be found in the individual methods.
         # One fine day the following fix methods can hopefully
         # be deleted...
-        if self.xml_state.build_type.get_overlayroot_write_partition() is not False:
-            self._fix_grub_root_device_reference(config_file, boot_options)
-            self._fix_grub_loader_entries_boot_cmdline()
-            self._fix_grub_loader_entries_linux_and_initrd_paths()
+        self._fix_grub_root_device_reference(config_file, boot_options)
+        self._fix_grub_loader_entries_boot_cmdline()
+        self._fix_grub_loader_entries_linux_and_initrd_paths()
 
         if self.firmware.efi_mode() and self.early_boot_script_efi:
             self._copy_grub_config_to_efi_path(


### PR DESCRIPTION
When building an image with overlayroot set to true and activated luks encryption, the root= parameter must be set to root=overlay:MAPPER=luks instead of the standard overlay:PARTUUID mapping. This Fixes #2776


