### PR TITLE
doc: overview: Add list of supported Linux distributions

### DIFF
--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -93,3 +93,14 @@ To use and run {kiwi}, you need:
 * Git (package ``git``) to clone a repository.
 
 * Any virtualization technology to start the image. We recommend QEMU.
+
+The project officially tests and supports the following distributions:
+
+* `Fedora Linux <https://fedoraproject.org>`_ 40+
+* `CentOS Stream <https://centos.org>`_ 9+
+* `CentOS Stream Hyperscale <https://centos.org/hyperscale>`_ 9+
+* `openSUSE Tumbleweed <https://get.opensuse.org/tumbleweed/>`_ after April 2024
+* `openSUSE Leap 16.0+ <https://get.opensuse.org/leap/16.0/>`_
+* `Canonical Ubuntu Linux <https://ubuntu.com/>`_ 24.04+
+* `Debian GNU/Linux <https://debian.org>`_ 12+
+* `Arch Linux <https://archlinux.org>`_ after April 2024


### PR DESCRIPTION
These are the Linux distributions that are developed and actively tested for with the latest kiwi releases.

This should offer greater clarity about what we're able to support as an upstream project.
