### PR TITLE
Drop copying GRUB2 modules to /boot with Secure Boot UEFI images

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -564,7 +564,6 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             self._setup_efi_image(uuid=boot_uuid, lookup_path=lookup_path)
             self._copy_efi_modules_to_boot_directory(lookup_path)
         elif self.firmware.efi_mode() == 'uefi':
-            self._copy_efi_modules_to_boot_directory(lookup_path)
             if not self._get_shim_install():
                 self._setup_secure_boot_efi_image(
                     lookup_path=lookup_path, uuid=boot_uuid

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -1591,13 +1591,6 @@ class TestBootLoaderConfigGrub2:
                         'root_dir/usr/share/grub2/i386-pc/',
                         'root_dir/boot/grub2/i386-pc'
                     ]
-                ),
-                call(
-                    [
-                        'rsync', '-a', '--exclude', '/*.module',
-                        'root_dir/usr/share/grub2/x86_64-efi/',
-                        'root_dir/boot/grub2/x86_64-efi'
-                    ]
                 )
             ]
 
@@ -1666,13 +1659,6 @@ class TestBootLoaderConfigGrub2:
                             'rsync', '-a', '--exclude', '/*.module',
                             'root_dir/usr/share/grub2/i386-pc/',
                             'root_dir/boot/grub2/i386-pc'
-                        ]
-                    ),
-                    call(
-                        [
-                            'rsync', '-a', '--exclude', '/*.module',
-                            'root_dir/usr/share/grub2/x86_64-efi/',
-                            'root_dir/boot/grub2/x86_64-efi'
                         ]
                     ),
                     call(
@@ -1763,13 +1749,6 @@ class TestBootLoaderConfigGrub2:
                             'rsync', '-a', '--exclude', '/*.module',
                             'root_dir/usr/share/grub2/i386-pc/',
                             'root_dir/boot/grub2/i386-pc'
-                        ]
-                    ),
-                    call(
-                        [
-                            'rsync', '-a', '--exclude', '/*.module',
-                            'root_dir/usr/share/grub2/x86_64-efi/',
-                            'root_dir/boot/grub2/x86_64-efi'
                         ]
                     ),
                     call(


### PR DESCRIPTION
Copying the modules creates a situation where future updates applied to a running system can cause GRUB to crash due to mixed modules and GRUB EFI binaries.

It is not needed anyway since GRUB EFI binaries for Secure Boot have all modules compiled into the binaries.

Fixes #2790.
