### PR TITLE
Fix setup of use_disk_password for random secret

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1805,8 +1805,10 @@ class DiskBuilder:
                 bootloader.install()
             bootloader.secure_boot_install()
 
-            if self.use_disk_password and self.luks:
-                bootloader.set_disk_password(self.luks)
+            if self.use_disk_password and self.storage_map['luks_root']:
+                bootloader.set_disk_password(
+                    self.storage_map['luks_root'].passphrase
+                )
         else:
             log.warning(
                 'No install of bootcode on read-only root possible'

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -167,6 +167,7 @@ class TestDiskBuilder:
             return_value=self.integrity_root
         )
         self.luks_root = Mock()
+        self.luks_root.passphrase = 'passphrase'
         kiwi.builder.disk.LuksDevice = Mock(
             return_value=self.luks_root
         )

--- a/test/unit/storage/luks_device_test.py
+++ b/test/unit/storage/luks_device_test.py
@@ -247,7 +247,7 @@ class TestLuksDevice:
             mock_open.return_value = MagicMock(spec=io.IOBase)
             file_handle = mock_open.return_value.__enter__.return_value
             LuksDevice.create_random_keyfile('some-file')
-            file_handle.write.assert_called_once_with(secret)
+            file_handle.write.assert_called_once_with('736563726574')
             mock_os_chmod.assert_called_once_with('some-file', 0o600)
 
     def test_is_loop(self):


### PR DESCRIPTION
When using luks="random" in combination with use_disk_password="true" the resulting cryptomount call in grub is wrong. This commit fixes it

