### PR TITLE
Fixed default bls value setup

### DIFF
--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1174,7 +1174,7 @@ class XMLState:
         :rtype: bool
         """
         bootloader = self.get_build_type_bootloader_section()
-        if bootloader:
+        if bootloader and bootloader.get_bls() is not None:
             return bootloader.get_bls()
         return True
 

--- a/package/kiwi-revert-bls-default-for-suse.patch
+++ b/package/kiwi-revert-bls-default-for-suse.patch
@@ -1,25 +1,15 @@
-From b0d850842b0c8d4c98f0486f66ffd7c6e8f1a685 Mon Sep 17 00:00:00 2001
-From: Neal Gompa <ngompa@opensuse.org>
-Date: Thu, 2 May 2024 06:23:45 -0400
-Subject: [PATCH] Revert "kiwi/bootloader: restore backward compatibility for
- grub2 with bls"
-
-For the time being, SUSE distributions cannot handle KIWI's default to use
-BLS with GRUB2. Until they catch up, revert this.
-
-This reverts commit 155d969d7752d92c90c69044bdd69be70f0a1c24.
----
- kiwi/xml_state.py                         | 2 +-
- test/unit/bootloader/config/grub2_test.py | 4 ----
- 2 files changed, 1 insertion(+), 5 deletions(-)
+restore backward compatibility for grub2 with bls.
+For the time being, SUSE distributions cannot handle KIWI's
+default (True) to use BLS with GRUB2. Until they catch up, the
+kiwi default is set to: False
 
 diff --git a/kiwi/xml_state.py b/kiwi/xml_state.py
-index eb39163cd..8c3fd45f3 100644
+index 7653be284..1e72cca22 100644
 --- a/kiwi/xml_state.py
 +++ b/kiwi/xml_state.py
-@@ -1009,7 +1009,7 @@ class XMLState:
+@@ -1176,7 +1176,7 @@ class XMLState:
          bootloader = self.get_build_type_bootloader_section()
-         if bootloader:
+         if bootloader and bootloader.get_bls() is not None:
              return bootloader.get_bls()
 -        return True
 +        return False
@@ -27,10 +17,10 @@ index eb39163cd..8c3fd45f3 100644
      def get_build_type_bootloader_console(self) -> List[str]:
          """
 diff --git a/test/unit/bootloader/config/grub2_test.py b/test/unit/bootloader/config/grub2_test.py
-index e9189a609..d81d76ec7 100644
+index b40362941..a2dd3106d 100644
 --- a/test/unit/bootloader/config/grub2_test.py
 +++ b/test/unit/bootloader/config/grub2_test.py
-@@ -600,7 +600,6 @@ class TestBootLoaderConfigGrub2:
+@@ -629,7 +629,6 @@ class TestBootLoaderConfigGrub2:
              'GRUB_BACKGROUND': '/boot/grub2/themes/openSUSE/background.png',
              'GRUB_CMDLINE_LINUX_DEFAULT': '"some-cmdline"',
              'GRUB_DISTRIBUTOR': '"Bob"',
@@ -38,7 +28,15 @@ index e9189a609..d81d76ec7 100644
              'GRUB_ENABLE_CRYPTODISK': 'y',
              'GRUB_GFXMODE': '800x600',
              'GRUB_SERIAL_COMMAND': '"serial --speed=38400"',
-@@ -643,7 +642,6 @@ class TestBootLoaderConfigGrub2:
+@@ -677,7 +676,6 @@ class TestBootLoaderConfigGrub2:
+             'GRUB_BACKGROUND': '/boot/grub2/themes/openSUSE/background.png',
+             'GRUB_CMDLINE_LINUX_DEFAULT': '"some-cmdline"',
+             'GRUB_DISTRIBUTOR': '"Bob"',
+-            'GRUB_ENABLE_BLSCFG': 'true',
+             'GRUB_ENABLE_CRYPTODISK': 'y',
+             'GRUB_GFXMODE': '800x600',
+             'GRUB_SERIAL_COMMAND': '"serial --speed=38400"',
+@@ -720,7 +718,6 @@ class TestBootLoaderConfigGrub2:
              call('GRUB_CMDLINE_LINUX', '"root=LABEL=some-label"'),
              call('GRUB_DISABLE_LINUX_UUID', 'true'),
              call('GRUB_DISTRIBUTOR', '"Bob"'),
@@ -46,7 +44,7 @@ index e9189a609..d81d76ec7 100644
              call('GRUB_ENABLE_CRYPTODISK', 'y'),
              call('GRUB_ENABLE_LINUX_LABEL', 'true'),
              call('GRUB_GFXMODE', '800x600'),
-@@ -688,7 +686,6 @@ class TestBootLoaderConfigGrub2:
+@@ -765,7 +762,6 @@ class TestBootLoaderConfigGrub2:
              call('GRUB_DISABLE_LINUX_PARTUUID', 'false'),
              call('GRUB_DISABLE_LINUX_UUID', 'true'),
              call('GRUB_DISTRIBUTOR', '"Bob"'),
@@ -54,7 +52,7 @@ index e9189a609..d81d76ec7 100644
              call('GRUB_ENABLE_CRYPTODISK', 'y'),
              call('GRUB_GFXMODE', '800x600'),
              call(
-@@ -732,7 +729,6 @@ class TestBootLoaderConfigGrub2:
+@@ -809,7 +805,6 @@ class TestBootLoaderConfigGrub2:
              call('GRUB_CMDLINE_LINUX_DEFAULT', '"abcd console=tty0"'),
              call('GRUB_DISABLE_LINUX_UUID', 'true'),
              call('GRUB_DISTRIBUTOR', '"Bob"'),
@@ -62,6 +60,3 @@ index e9189a609..d81d76ec7 100644
              call('GRUB_ENABLE_CRYPTODISK', 'y'),
              call('GRUB_ENABLE_LINUX_LABEL', 'true'),
              call('GRUB_GFXMODE', '800x600'),
--- 
-2.44.0
-

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1208,7 +1208,12 @@ class TestXMLState:
     @patch('kiwi.xml_parse.type_.get_bootloader')
     def test_get_build_type_bootloader_bls(self, mock_bootloader):
         mock_bootloader.return_value = [self.bootloader]
+        self.bootloader.get_bls.return_value = False
         assert self.state.get_build_type_bootloader_bls() is False
+        self.bootloader.get_bls.return_value = True
+        assert self.state.get_build_type_bootloader_bls() is True
+        self.bootloader.get_bls.return_value = None
+        assert self.state.get_build_type_bootloader_bls() is True
 
     @patch('kiwi.xml_parse.type_.get_bootloader')
     def test_get_build_type_bootloader_console(self, mock_bootloader):


### PR DESCRIPTION
Fixed get_build_type_bootloader_bls behavior in case the bls attribute is not set. In this case get_bls() returns a None value which was returned. However in this case the attribute value should not be taken into account and the method defined default value for bls should be returned. This Fixes #2542

