### PR TITLE
rawhide install shadow-utils for usermod

### DIFF
--- a/build-tests/x86/fedora/test-image-docker/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-docker/appliance.kiwi
@@ -31,6 +31,7 @@
         <package name="vim"/>
         <package name="tzdata"/>
         <package name="NetworkManager"/>
+        <package name="shadow-utils"/>
     </packages>
     <packages type="bootstrap">
         <package name="filesystem"/>


### PR DESCRIPTION
Using `kiwi-ng` version 10.2.18 (EL9)

Currently with:

```
sudo kiwi-ng system build \
   --description kiwi/build-tests/x86/fedora/test-image-docker
   --set-repo http://ftp.fau.de/fedora/linux/development/rawhide/Everything/x86_64/os/ \
   --target-dir /tmp/myimage1
```

This fails with:

```
[ INFO    ]: 09:46:38 | Setting up user root
[ INFO    ]: 09:46:38 | --> Modifying user: root
[ INFO    ]: 09:46:38 | --> Primary group for user root: root
[ ERROR   ]: 09:46:38 | KiwiCommandError: chroot: stderr: /sbin/chroot: failed to run command ‘usermod’: No such file or directory
```

Install the package `shadow-utils` to provide `usermod`.

The majority of rawhide images were updated for this earlier https://github.com/OSInside/kiwi/commit/9c0e0472c56b74c08f02ace3e1356e62fa17633e

Changes proposed in this pull request:
* Install shadow-utils for usermod command on rawhide builds.