### PR TITLE
Rawhide (F43) has removed basesystem package

### DIFF
--- a/build-tests/x86/rawhide/test-image-dnf5/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-dnf5/appliance.kiwi
@@ -48,7 +48,6 @@
     </packages>
     <packages type="bootstrap">
         <package name="filesystem"/>
-        <package name="basesystem"/>
         <package name="shadow-utils"/>
         <package name="grub2-efi-x64-modules"/>
         <package name="grub2-efi-x64"/>

--- a/build-tests/x86/rawhide/test-image-erofs/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-erofs/appliance.kiwi
@@ -35,7 +35,6 @@
     <packages type="bootstrap">
         <package name="filesystem"/>
         <package name="shadow-utils"/>
-        <package name="basesystem"/>
         <package name="fedora-release"/>
     </packages>
 </image>

--- a/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
@@ -87,7 +87,6 @@
     <packages type="bootstrap">
         <package name="filesystem"/>
         <package name="shadow-utils"/>
-        <package name="basesystem"/>
         <package name="grub2-efi-x64-modules"/>
         <package name="grub2-efi-x64"/>
         <package name="shim" arch="x86_64"/>

--- a/build-tests/x86/rawhide/test-image-systemd-boot/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-systemd-boot/appliance.kiwi
@@ -48,7 +48,6 @@
     <packages type="bootstrap">
         <package name="filesystem"/>
         <package name="shadow-utils"/>
-        <package name="basesystem"/>
         <package name="fedora-release"/>
     </packages>
 </image>


### PR DESCRIPTION
The `basesystem` package was retired with rawhide (F43).

https://src.fedoraproject.org/rpms/filesystem/pull-request/20

Changes proposed in this pull request:

* Stop attempting to install `basesystem` package for rawhide(F43) builds.

