### PR TITLE
Add --no-compress option to bundler

### DIFF
--- a/doc/source/commands/result_bundle.rst
+++ b/doc/source/commands/result_bundle.rst
@@ -15,6 +15,7 @@ SYNOPSIS
        [--bundle-format=<format>]
        [--zsync_source=<download_location>]
        [--package-as-rpm]
+       [--no-compress]
    kiwi-ng result bundle help
 
 .. _db_kiwi_result_bundle_desc:
@@ -75,3 +76,8 @@ OPTIONS
 --package-as-rpm
 
   Create an RPM package containing the result files.
+
+--no-compress
+
+  Do not compress the result image file(s). Note: Image files that
+  were already produced as compressed variants stays compressed.

--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -21,6 +21,7 @@ usage: kiwi-ng result bundle -h | --help
            [--bundle-format=<format>]
            [--zsync-source=<download_location>]
            [--package-as-rpm]
+           [--no-compress]
        kiwi-ng result bundle help
 
 commands:
@@ -54,6 +55,8 @@ options:
         If provided this setting will overwrite an eventually
         provided bundle_format attribute from the main
         image description
+    --no-compress
+        Do not compress the result image file(s)
 """
 from collections import OrderedDict
 from textwrap import dedent
@@ -231,7 +234,7 @@ class ResultBundleTask(CliTask):
                 bundle_file = ''.join(
                     [bundle_directory, '/', bundle_file_basename]
                 )
-                if result_file.compress:
+                if result_file.compress and not self.command_args['--no-compress']:
                     log.info('--> Compressing')
                     compress = Compress(bundle_file)
                     bundle_file = compress.xz(self.runtime_config.get_xz_options())

--- a/test/unit/tasks/result_bundle_test.py
+++ b/test/unit/tasks/result_bundle_test.py
@@ -74,6 +74,7 @@ class TestResultBundleTask:
         self.task.command_args['--zsync-source'] = None
         self.task.command_args['--package-as-rpm'] = None
         self.task.command_args['--bundle-format'] = None
+        self.task.command_args['--no-compress'] = None
 
     def test_process_invalid_bundle_directory(self):
         self._init_command_args()


### PR DESCRIPTION
Allow to skip the compression for bundle files marked to become compressed. This Fixes #2736

