### PR TITLE
Add support for GPT targettype on s390

### DIFF
--- a/build-tests/s390/tumbleweed/test-image-disk/appliance.kiwi
+++ b/build-tests/s390/tumbleweed/test-image-disk/appliance.kiwi
@@ -9,7 +9,8 @@
         <specification>Virtual and Physical disk image test</specification>
     </description>
     <profiles>
-        <profile name="Virtual" description="Image for use with kvm"/>
+        <profile name="Virtual" description="Image for use with kvm DOS disk"/>
+        <profile name="Virtual_GPT" description="Image for use with kvm GPT disk"/>
         <profile name="Physical" description="Image for physical storage disk CDL mode"/>
     </profiles>
     <preferences>
@@ -23,6 +24,14 @@
     </preferences>
     <preferences profiles="Virtual">
         <type image="oem" filesystem="xfs" bootpartition="false" kernelcmdline="console=ttyS0" format="qcow2">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+            <bootloader name="grub2_s390x_emu" console="serial" timeout="10"/>
+        </type>
+    </preferences>
+    <preferences profiles="Virtual_GPT">
+        <type image="oem" filesystem="xfs" bootpartition="false" kernelcmdline="console=ttyS0" format="qcow2" targettype="GPT">
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -1181,11 +1181,11 @@ timeout_style="countdown|hidden":
   an indication of the remaining time is displayed. The attribute is
   available for the grub loader only.
 
-targettype="CDL|LDL|FBA|SCSI":
+targettype="CDL|LDL|FBA|SCSI|GPT":
   Specifies the device type of the disk zipl should boot.
-  On zFCP devices, use `SCSI`; on DASD devices, use `CDL` or `LDL`; on
-  emulated DASD devices, use `FBA`. The attribute is available for the
-  zipl loader only.
+  On zFCP and/or KVM devices, use `SCSI` or `GPT`; on DASD devices,
+  use `CDL` or `LDL`; on emulated DASD devices, use `FBA`.
+  The attribute is available for the zipl loader only.
 
 <preferences><type><bootloader><securelinux>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/kiwi/firmware.py
+++ b/kiwi/firmware.py
@@ -68,6 +68,8 @@ class FirmWare:
         if 's390' in self.arch:
             if self.zipl_target_type and 'CDL' in self.zipl_target_type:
                 return 'dasd'
+            elif self.zipl_target_type and 'GPT' in self.zipl_target_type:
+                return 'gpt'
             else:
                 return 'msdos'
         elif 'ppc64' in self.arch:

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2967,7 +2967,7 @@ div {
         ## devices use SCSI, for  emulated DASD devices use FBA,
         ## for 4k DASD devices use CDL
         attribute targettype {
-            "FBA" | "SCSI" | "CDL"
+            "FBA" | "SCSI" | "CDL" | "GPT"
         }
         >> sch:pattern [ id = "targettype" is-a = "bootloader_name_type"
             sch:param [ name = "attr" value = "targettype" ]

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -4467,6 +4467,7 @@ for 4k DASD devices use CDL</a:documentation>
           <value>FBA</value>
           <value>SCSI</value>
           <value>CDL</value>
+          <value>GPT</value>
         </choice>
       </attribute>
       <sch:pattern id="targettype" is-a="bootloader_name_type">

--- a/test/unit/firmware_test.py
+++ b/test/unit/firmware_test.py
@@ -38,6 +38,9 @@ class TestFirmWare:
         xml_state.get_build_type_bootloader_targettype.return_value = 'CDL'
         self.firmware_s390_cdl = FirmWare(xml_state)
 
+        xml_state.get_build_type_bootloader_targettype.return_value = 'GPT'
+        self.firmware_s390_gpt = FirmWare(xml_state)
+
         xml_state.get_build_type_bootloader_targettype.return_value = 'SCSI'
         self.firmware_s390_scsi = FirmWare(xml_state)
 
@@ -67,6 +70,7 @@ class TestFirmWare:
         assert self.firmware_efi_mbr.get_partition_table_type() == 'msdos'
         assert self.firmware_s390_cdl.get_partition_table_type() == 'dasd'
         assert self.firmware_s390_scsi.get_partition_table_type() == 'msdos'
+        assert self.firmware_s390_gpt.get_partition_table_type() == 'gpt'
 
     def test_get_partition_table_type_ppc_ofw_mode(self):
         assert self.firmware_ofw.get_partition_table_type() == 'gpt'


### PR DESCRIPTION
Allow to build s390 images using GPT instead of the old DOS partition table. zipl has added support to read from GPT. This Fixes #2694

