### PR TITLE
Fix root clone size setup

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1168,7 +1168,8 @@ class DiskBuilder:
                     clone_rootfs_mbsize = int(
                         (disksize_mbytes - disksize_used_mbytes) / (root_clone_count + 1)
                     ) + Defaults.get_min_partition_mbytes()
-                    rootfs_mbsize = f'clone:all_free:{clone_rootfs_mbsize}'
+                    rootfs_mbsize = \
+                        f'clone:{clone_rootfs_mbsize}:{clone_rootfs_mbsize}'
                 else:
                     rootfs_mbsize = f'clone:{rootfs_mbsize}:{rootfs_mbsize}'
             if self.volume_manager_name and self.volume_manager_name == 'lvm':

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -568,7 +568,7 @@ class TestDiskBuilder:
             self.disk_setup.boot_partition_size(), 1
         )
         disk.create_root_partition.assert_called_once_with(
-            'clone:all_free:458', 1
+            'clone:458:458', 1
         )
         disk.create_custom_partitions.assert_called_once_with(
             self.disk_builder.custom_partitions


### PR DESCRIPTION
If the root_clone attribute is specified without providing a fixed size for the system, kiwi estimates the size needed for the root part and assigns the rest to the clone. This leads to different partition sizes for the root clones. As per definition of a clone the expectation is that the size is the same, this commit changes the behavior such that the calculated size for the system is applied to the origin root and all its clones. As a consequence this can leave unpartitioned space free in the image. This Fixes #2463


