### PR TITLE
Support erofs overlaydisk

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
@@ -47,6 +47,7 @@
     </repository>
     <packages type="image" profiles="verity">
         <package name="cryptsetup"/>
+        <package name="dracut-kiwi-verity"/>
     </packages>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>

--- a/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
@@ -7,8 +7,9 @@
         <specification>Overlayroot Disk test build</specification>
     </description>
     <profiles>
-        <profile name="standard" description="Standard overlay disk using erofs"/>
-        <profile name="verity" description="Verity baked overlay disk using erofs"/>
+        <profile name="sdboot_erofs" description="systemd boot overlay disk using erofs"/>
+        <profile name="sdboot_verity_erofs" description="systemd boot verity baked overlay disk using erofs"/>
+        <profile name="grub_verity_erofs" description="grub verity baked overlay disk using erofs"/>
     </profiles>
     <preferences>
         <version>1.42.1</version>
@@ -19,7 +20,7 @@
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
     </preferences>
-    <preferences profiles="standard">
+    <preferences profiles="sdboot_erofs">
         <type
             image="oem"
             filesystem="xfs"
@@ -28,7 +29,7 @@
             format="vmdk"
             overlayroot="true"
             overlayroot_readonly_filesystem="erofs"
-            overlayroot_readonly_partsize="900"
+            overlayroot_readonly_partsize="915"
             erofscompression="zstd,level=9"
             eficsm="false"
             bootpartition="false"
@@ -41,7 +42,7 @@
             <size unit="G">4</size>
         </type>
     </preferences>
-    <preferences profiles="verity">
+    <preferences profiles="sdboot_verity_erofs">
         <type
             image="oem"
             filesystem="xfs"
@@ -50,7 +51,7 @@
             format="vmdk"
             overlayroot="true"
             overlayroot_readonly_filesystem="erofs"
-            overlayroot_readonly_partsize="900"
+            overlayroot_readonly_partsize="915"
             erofscompression="zstd,level=9"
             eficsm="false"
             verity_blocks="all"
@@ -64,19 +65,42 @@
             <size unit="G">4</size>
         </type>
     </preferences>
+    <preferences profiles="grub_verity_erofs">
+        <type
+            image="oem"
+            filesystem="btrfs"
+            kernelcmdline="console=ttyS0 rd.systemd.verity=1"
+            firmware="efi"
+            format="vmdk"
+            overlayroot="true"
+            overlayroot_readonly_filesystem="erofs"
+            overlayroot_readonly_partsize="915"
+            erofscompression="zstd,level=9"
+            eficsm="false"
+            verity_blocks="all"
+        >
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+            <bootloader name="grub2" console="serial" timeout="10"/>
+            <size unit="G">4</size>
+        </type>
+    </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
     <repository type="rpm-md">
         <source path="obsrepositories:/"/>
     </repository>
-    <packages type="image" profiles="verity">
+    <packages type="image" profiles="sdboot_verity_erofs,grub_verity_erofs">
         <package name="cryptsetup"/>
         <package name="dracut-kiwi-verity"/>
     </packages>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>
         <package name="systemd-boot"/>
+        <package name="grub2"/>
+        <package name="grub2-x86_64-efi" arch="x86_64"/>
         <package name="shim"/>
         <package name="procps"/>
         <package name="bind-utils"/>

--- a/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-
+<!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 <image schemaversion="7.5" name="kiwi-test-image-overlayroot">
     <description type="system">
         <author>Marcus Schäfer</author>
-        <contact>ms@suse.com</contact>
+        <contact>marcus.schaefer@suse.com</contact>
         <specification>Overlayroot Disk test build</specification>
     </description>
+    <profiles>
+        <profile name="standard" description="Standard overlay disk using erofs"/>
+        <profile name="verity" description="Verity baked overlay disk using erofs"/>
+    </profiles>
     <preferences>
         <version>1.42.1</version>
         <packagemanager>zypper</packagemanager>
@@ -16,7 +20,18 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>breeze</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext3" kernelcmdline="console=ttyS0" firmware="efi" format="vmdk" overlayroot="true">
+    </preferences>
+    <preferences profiles="standard">
+        <type image="oem" filesystem="ext3" kernelcmdline="console=ttyS0" firmware="efi" format="vmdk" overlayroot="true" overlayroot_readonly_filesystem="erofs" erofscompression="zstd,level=9" eficsm="false">
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+            <bootloader name="grub2" console="serial" timeout="10"/>
+            <size unit="G">4</size>
+        </type>
+    </preferences>
+    <preferences profiles="verity">
+        <type image="oem" filesystem="ext3" kernelcmdline="console=ttyS0 rd.systemd.verity=1" firmware="efi" format="vmdk" overlayroot="true" overlayroot_readonly_filesystem="erofs" erofscompression="zstd,level=9" eficsm="false" verity_blocks="all">
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
@@ -30,6 +45,9 @@
     <repository type="rpm-md">
         <source path="obsrepositories:/"/>
     </repository>
+    <packages type="image" profiles="verity">
+        <package name="cryptsetup"/>
+    </packages>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>
         <package name="procps"/>

--- a/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
@@ -18,24 +18,49 @@
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
-        <bootsplash-theme>breeze</bootsplash-theme>
-        <bootloader-theme>openSUSE</bootloader-theme>
     </preferences>
     <preferences profiles="standard">
-        <type image="oem" filesystem="ext3" kernelcmdline="console=ttyS0" firmware="efi" format="vmdk" overlayroot="true" overlayroot_readonly_filesystem="erofs" erofscompression="zstd,level=9" eficsm="false">
+        <type
+            image="oem"
+            filesystem="xfs"
+            kernelcmdline="console=ttyS0"
+            firmware="uefi"
+            format="vmdk"
+            overlayroot="true"
+            overlayroot_readonly_filesystem="erofs"
+            overlayroot_readonly_partsize="900"
+            erofscompression="zstd,level=9"
+            eficsm="false"
+            bootpartition="false"
+            efipartsize="200"
+        >
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="10"/>
+            <bootloader name="systemd_boot" timeout="10"/>
             <size unit="G">4</size>
         </type>
     </preferences>
     <preferences profiles="verity">
-        <type image="oem" filesystem="ext3" kernelcmdline="console=ttyS0 rd.systemd.verity=1" firmware="efi" format="vmdk" overlayroot="true" overlayroot_readonly_filesystem="erofs" erofscompression="zstd,level=9" eficsm="false" verity_blocks="all">
+        <type
+            image="oem"
+            filesystem="xfs"
+            kernelcmdline="console=ttyS0 rd.systemd.verity=1"
+            firmware="uefi"
+            format="vmdk"
+            overlayroot="true"
+            overlayroot_readonly_filesystem="erofs"
+            overlayroot_readonly_partsize="900"
+            erofscompression="zstd,level=9"
+            eficsm="false"
+            verity_blocks="all"
+            bootpartition="false"
+            efipartsize="200"
+        >
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <bootloader name="grub2" console="serial" timeout="10"/>
+            <bootloader name="systemd_boot" timeout="10"/>
             <size unit="G">4</size>
         </type>
     </preferences>
@@ -51,17 +76,15 @@
     </packages>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>
+        <package name="systemd-boot"/>
+        <package name="shim"/>
         <package name="procps"/>
         <package name="bind-utils"/>
         <package name="systemd"/>
         <package name="plymouth-theme-breeze"/>
         <package name="plymouth-plugin-script"/>
-        <package name="grub2-branding-openSUSE"/>
         <package name="iputils"/>
         <package name="vim"/>
-        <package name="grub2"/>
-        <package name="grub2-x86_64-efi" arch="x86_64"/>
-        <package name="grub2-i386-pc"/>
         <package name="lvm2"/>
         <package name="plymouth"/>
         <package name="fontconfig"/>

--- a/build-tests/x86/tumbleweed/test-image-overlayroot/config.sh
+++ b/build-tests/x86/tumbleweed/test-image-overlayroot/config.sh
@@ -15,13 +15,35 @@ echo "Configure image: [$kiwi_iname]..."
 systemctl enable sshd
 
 #======================================
-# bootctl writes to read-only area
+# kernel links
 #--------------------------------------
-# systemd bootctl writes to /etc/kernel which is not
-# possible on a read-only device. Thus we relink this
-# into the ESP
-rm -rf /etc/kernel
-ln -s /boot/efi /etc/kernel
+for profile in ${kiwi_profiles//,/ }; do
+    if [ "${profile}" = "grub_verity_erofs" ]; then
+        # For image tests with an extra boot partition the
+        # kernel must not be a symlink to another area of
+        # the filesystem. Latest changes on SUSE changed the
+        # layout of the kernel which breaks every image with
+        # an extra boot partition
+        #
+        # All of the following is more than a hack and I
+        # don't like it all
+        #
+        # Complains and discussions about this please with
+        # the SUSE kernel team as we in kiwi can just live
+        # with the consequences of this change
+        #
+        pushd /
+
+        for file in /boot/* /boot/.*; do
+            if [ -L ${file} ];then
+                link_target=$(readlink ${file})
+                if [[ ${link_target} =~ usr/lib/modules ]];then
+                    mv ${link_target} ${file}
+                fi
+            fi
+        done
+    fi
+done
 
 #======================================
 # Include erofs module

--- a/build-tests/x86/tumbleweed/test-image-overlayroot/config.sh
+++ b/build-tests/x86/tumbleweed/test-image-overlayroot/config.sh
@@ -43,19 +43,3 @@ done
 #--------------------------------------
 # remove from blacklist
 rm -f /usr/lib/modprobe.d/60-blacklist_fs-erofs.conf
-
-#======================================
-# Include systemd-verity to initrd
-#--------------------------------------
-# for some reason dracut doesn't automatically pick up
-# the needed systemd veritysetup generator and tools
-# and also the kiwi written /etc/veritytab is not added
-# automatically. Thus we do this programatically here.
-for profile in ${kiwi_profiles//,/ }; do
-    if [ "${profile}" = "verity" ]; then
-        cat >/etc/dracut.conf.d/verity.conf <<- EOF
-			dracutmodules+=" systemd-veritysetup "
-			install_items+=" /etc/veritytab "
-		EOF
-    fi
-done

--- a/build-tests/x86/tumbleweed/test-image-overlayroot/config.sh
+++ b/build-tests/x86/tumbleweed/test-image-overlayroot/config.sh
@@ -14,29 +14,14 @@ echo "Configure image: [$kiwi_iname]..."
 #--------------------------------------
 systemctl enable sshd
 
-# For image tests with an extra boot partition the
-# kernel must not be a symlink to another area of
-# the filesystem. Latest changes on SUSE changed the
-# layout of the kernel which breaks every image with
-# an extra boot partition
-#
-# All of the following is more than a hack and I
-# don't like it all
-#
-# Complains and discussions about this please with
-# the SUSE kernel team as we in kiwi can just live
-# with the consequences of this change
-#
-pushd /
-
-for file in /boot/* /boot/.*; do
-    if [ -L "${file}" ];then
-        link_target=$(readlink "${file}")
-        if [[ ${link_target} =~ usr/lib/modules ]];then
-            mv "${link_target}" "${file}"
-        fi
-    fi
-done
+#======================================
+# bootctl writes to read-only area
+#--------------------------------------
+# systemd bootctl writes to /etc/kernel which is not
+# possible on a read-only device. Thus we relink this
+# into the ESP
+rm -rf /etc/kernel
+ln -s /boot/efi /etc/kernel
 
 #======================================
 # Include erofs module

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -825,6 +825,11 @@ overlayroot="true|false":
   the squashfs root filesystem. In fact this mode is the same
   as not installing the `kiwi-overlay` dracut module.
 
+overlayroot_readonly_filesystem="squashfs|erofs":
+  For the `oem` type only, specifies the filesystem type to use
+  as read-only filesystem in an `overlayroot` setup. By default
+  `squashfs` is used
+
 overlayroot_write_partition="true|false":
   For the `oem` type only, allows to specify if the extra read-write
   partition in an `overlayroot` setup should be created or not.

--- a/dracut/modules.d/80kiwi-verity/Makefile
+++ b/dracut/modules.d/80kiwi-verity/Makefile
@@ -11,7 +11,8 @@ all: build
 
 .PHONY: install
 install: build
-	install -Dm0755 kiwi-verity-setup.sh module-setup.sh \
+	install -Dm0755 \
+		kiwi-verity-setup.sh kiwi-veritytab-setup.sh module-setup.sh \
 		-t ${buildroot}usr/lib/dracut/modules.d/80kiwi-verity
 	install -Dm0755 $(BINARY) ${buildroot}usr/bin/$(BINARY)
 

--- a/dracut/modules.d/80kiwi-verity/kiwi-veritytab-setup.sh
+++ b/dracut/modules.d/80kiwi-verity/kiwi-veritytab-setup.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+# shellcheck disable=SC1091
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if [ ! -e "/etc/veritytab" ];then
+    return
+fi
+
+read -r name data_device hash_device root_hash options < /etc/veritytab
+
+if [ "$(echo "${data_device}" | cut -f1 -d=)" = "UUID" ];then
+    data_device=/dev/disk/by-uuid/$(echo "${data_device}" | cut -f2 -d=)
+fi
+if [ "$(echo "${hash_device}" | cut -f1 -d=)" = "UUID" ];then
+    hash_device=/dev/disk/by-uuid/$(echo "${hash_device}" | cut -f2 -d=)
+fi
+
+veritysetup="veritysetup open "
+veritysetup="${veritysetup} ${data_device} ${name} ${hash_device} ${root_hash}"
+
+for option in $(echo "${options}" | tr , " ");do
+    veritysetup="${veritysetup} --${option}"
+done
+
+eval "${veritysetup}"

--- a/dracut/modules.d/80kiwi-verity/module-setup.sh
+++ b/dracut/modules.d/80kiwi-verity/module-setup.sh
@@ -30,6 +30,11 @@ depends() {
 }
 
 install() {
-    inst_multiple /usr/bin/kiwi-parse-verity /usr/sbin/veritysetup
+    inst_multiple \
+        /usr/bin/kiwi-parse-verity \
+        /usr/sbin/veritysetup \
+        cut \
+        tr
     inst_hook initqueue/settled 70 "$moddir/kiwi-verity-setup.sh"
+    inst_hook initqueue/settled 71 "$moddir/kiwi-veritytab-setup.sh"
 }

--- a/kiwi.yml
+++ b/kiwi.yml
@@ -101,9 +101,6 @@
 #      # verify that the URL for imageinclude repos is accessable
 #      - check_image_include_repos_publicly_resolvable
 
-#      # verify secure boot setup disabled for overlay configured disk images
-#      - check_efi_mode_for_disk_overlay_correctly_setup
-
 #      # verify for legacy kiwi boot images that they exist on the host
 #      - check_boot_description_exists
 

--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -626,13 +626,17 @@ class BootLoaderConfigBase(ABC):
                 return root_search.group(1)
         if boot_device:
             if self.xml_state.build_type.get_overlayroot():
-                # In case of an overlay setup the root partition is a squashfs
-                # In this case the root location can only be specified by the
-                # partition uuid because squashfs itself doesn't have one.
+                # In case of an overlay setup the root partition is read-only
+                # In this case the root location will be specified by the
+                # partition uuid because not all read-only filesystems have one.
                 # Exception to this is if the overlay is also encrypted
+                # Exception to this is if the overlay is on verity
+                verity = self.xml_state.build_type.get_verity_blocks()
                 luks = self.xml_state.get_luks_credentials()
                 if luks is not None:
                     return 'root=overlay:MAPPER=luks'
+                elif verity:
+                    return 'root=overlay:MAPPER=verityroot'
                 else:
                     root_location = self._get_location(
                         boot_device, 'by-partuuid'

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1348,6 +1348,11 @@ class DiskBuilder:
                     os.linesep
                 )
             )
+            self.boot_image.include_file(
+                filename=os.sep + os.sep.join(
+                    ['etc', os.path.basename(veritytab_filename)]
+                ), delete_after_include=True
+            )
 
     def _write_generic_fstab_to_boot_image(
         self, device_map: Dict,

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -887,7 +887,7 @@ class DiskBuilder:
                     ):
                         # run post sync script hook and security context
                         disk_system.call_disk_script()
-                    else:
+                    elif not self.root_filesystem_is_overlay:
                         # setup security context
                         disk_system.setup_selinux_file_contexts()
 
@@ -1793,11 +1793,12 @@ class DiskBuilder:
         root_device = device_map['root']
         boot_device = root_device
         readonly_device = None
-        if 'boot' in device_map:
-            boot_device = device_map['boot']
-
         if 'readonly' in device_map:
             readonly_device = device_map['readonly']
+            boot_device = readonly_device
+
+        if 'boot' in device_map:
+            boot_device = device_map['boot']
 
         custom_install_arguments = {
             'boot_device': boot_device.get_device(),

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -838,35 +838,6 @@ class RuntimeChecker:
                     message.format(required_dracut_packages)
                 )
 
-    def check_efi_mode_for_disk_overlay_correctly_setup(self) -> None:
-        """
-        Disk images configured to use a root filesystem overlay
-        only supports the standard EFI mode and not secure boot.
-        That's because the shim setup performs changes to the
-        root filesystem which can not be applied during the
-        bootloader setup at build time because at that point
-        the root filesystem is a read-only squashfs source.
-        """
-        message = dedent('''\n
-            Secure Boot not supported with overlay disk image
-
-            Disk images configured to use a root filesystem overlay
-            only supports the standard EFI mode and not secure boot.
-            That's because the shim setup performs changes to the
-            root filesystem which can not be applied during the
-            bootloader setup at build time because at that point
-            the root filesystem is a read-only squashfs source
-
-            Thus please change the firmware attribute in the <type>
-            section of the system XML description as follows:
-
-            <type ... firmware="efi"/>
-        ''')
-        overlayroot = self.xml_state.build_type.get_overlayroot()
-        firmware = self.xml_state.build_type.get_firmware()
-        if overlayroot and firmware == 'uefi':
-            raise KiwiRuntimeError(message)
-
     def check_xen_uniquely_setup_as_server_or_guest(self) -> None:
         """
         If the image is classified to be used as Xen image, it can

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1867,7 +1867,7 @@ div {
         ]
     k.type.overlayroot.attribute =
         ## Specifies to use an overlay root system consisting
-        ## out of a squashfs compressed read-only root system
+        ## out of a squashfs or erofs compressed read-only root system
         ## overlayed using the overlayfs filesystem into an
         ## extra read-write partition. Available for the disk
         ## image type oem
@@ -1876,6 +1876,18 @@ div {
             sch:param [ name = "attr" value = "overlayroot" ]
             sch:param [ name = "types" value = "oem" ]
         ]
+    k.type.overlayroot_readonly_filesystem.attribute =
+        ## Specifies the filesystem type to use as read-only
+        ## filesystem in an overlayroot setup. By default
+        ## squashfs is used
+        attribute overlayroot_readonly_filesystem {
+            "squashfs" | "erofs"
+        }
+        >> sch:pattern [ id = "overlayroot_readonly_filesystem" is-a = "image_type"
+            sch:param [ name = "attr" value = "overlayroot_readonly_filesystem" ]
+            sch:param [ name = "types" value = "oem" ]
+        ]
+
     k.type.overlayroot_write_partition.attribute =
         ## Specifies to create an extra read-write partition
         ## in combination with the overlayroot attribute on the
@@ -2413,6 +2425,7 @@ div {
         k.type.mdraid.attribute? &
         k.type.overlayroot.attribute? &
         k.type.overlayroot_write_partition.attribute? &
+        k.type.overlayroot_readonly_filesystem.attribute? &
         k.type.overlayroot_readonly_partsize.attribute? &
         k.type.verity_blocks.attribute? &
         k.type.embed_verity_metadata.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2706,7 +2706,7 @@ The format of this key argument is:
     <define name="k.type.overlayroot.attribute">
       <attribute name="overlayroot">
         <a:documentation>Specifies to use an overlay root system consisting
-out of a squashfs compressed read-only root system
+out of a squashfs or erofs compressed read-only root system
 overlayed using the overlayfs filesystem into an
 extra read-write partition. Available for the disk
 image type oem</a:documentation>
@@ -2714,6 +2714,21 @@ image type oem</a:documentation>
       </attribute>
       <sch:pattern id="overlayroot" is-a="image_type">
         <sch:param name="attr" value="overlayroot"/>
+        <sch:param name="types" value="oem"/>
+      </sch:pattern>
+    </define>
+    <define name="k.type.overlayroot_readonly_filesystem.attribute">
+      <attribute name="overlayroot_readonly_filesystem">
+        <a:documentation>Specifies the filesystem type to use as read-only
+filesystem in an overlayroot setup. By default
+squashfs is used</a:documentation>
+        <choice>
+          <value>squashfs</value>
+          <value>erofs</value>
+        </choice>
+      </attribute>
+      <sch:pattern id="overlayroot_readonly_filesystem" is-a="image_type">
+        <sch:param name="attr" value="overlayroot_readonly_filesystem"/>
         <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
@@ -3550,6 +3565,9 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.overlayroot_write_partition.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.overlayroot_readonly_filesystem.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.overlayroot_readonly_partsize.attribute"/>

--- a/kiwi/system/mount.py
+++ b/kiwi/system/mount.py
@@ -103,7 +103,7 @@ class ImageSystem:
                     self.root_mount_mountpoint, 'boot', 'efi'
                 )
             )
-        if not f'{root_device}' == f'{boot_device}':
+        if root_device != boot_device:
             self.mount_list.append(boot_mount)
             boot_mount.mount()
 
@@ -175,11 +175,12 @@ class ImageSystem:
     def _setup_device_names(self) -> tuple:
         root_device = self.device_map['root'].get_device()
         boot_device = root_device
-        efi_device = None
-        if 'boot' in self.device_map:
-            boot_device = self.device_map['boot'].get_device()
+        efi_device = ''
         if 'readonly' in self.device_map:
             root_device = self.device_map['readonly'].get_device()
+            boot_device = root_device
+        if 'boot' in self.device_map:
+            boot_device = self.device_map['boot'].get_device()
         if 'efi' in self.device_map:
             efi_device = self.device_map['efi'].get_device()
         return (root_device, boot_device, efi_device)

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -71,7 +71,6 @@ class CliTask:
         # initialize generic runtime check dicts
         self.checks_before_command_args: Dict[str, List[str]] = {
             'check_image_version_provided': [],
-            'check_efi_mode_for_disk_overlay_correctly_setup': [],
             'check_initrd_selection_required': [],
             'check_boot_description_exists': [],
             'check_consistent_kernel_in_boot_and_system_image': [],

--- a/kiwi/utils/veritysetup.py
+++ b/kiwi/utils/veritysetup.py
@@ -73,7 +73,6 @@ class VeritySetup:
             [
                 'veritysetup', 'format',
                 self.image_filepath, self.image_filepath,
-                '--no-superblock',
                 f'--hash-offset={self.verity_hash_offset}',
                 f'--hash-block-size={defaults.VERITY_HASH_BLOCKSIZE}'
             ] + (
@@ -109,7 +108,6 @@ class VeritySetup:
             [
                 'veritysetup', 'format',
                 self.image_filepath, temp_file.name,
-                '--no-superblock',
                 f'--hash-block-size={defaults.VERITY_HASH_BLOCKSIZE}'
             ] + (
                 [
@@ -240,5 +238,5 @@ class VeritySetup:
                 verity.write(
                     f'Root hashoffset: {self.verity_hash_offset}')
                 verity.write(os.linesep)
-                verity.write('Superblock: --no-superblock')
+                verity.write('Superblock:')
                 verity.write(os.linesep)

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3363,7 +3363,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, eficsm=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapper_snapshot=None, btrfs_root_is_subvolume=None, btrfs_set_default_volume=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, enclave_format=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, erofscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, application_id=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, provide_system_files=None, require_system_files=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, eficsm=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapper_snapshot=None, btrfs_root_is_subvolume=None, btrfs_set_default_volume=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, enclave_format=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, erofscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_filesystem=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, application_id=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, provide_system_files=None, require_system_files=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -3419,6 +3419,7 @@ class type_(GeneratedsSuper):
         self.mdraid = _cast(None, mdraid)
         self.overlayroot = _cast(bool, overlayroot)
         self.overlayroot_write_partition = _cast(bool, overlayroot_write_partition)
+        self.overlayroot_readonly_filesystem = _cast(None, overlayroot_readonly_filesystem)
         self.overlayroot_readonly_partsize = _cast(int, overlayroot_readonly_partsize)
         self.verity_blocks = _cast(None, verity_blocks)
         self.embed_verity_metadata = _cast(bool, embed_verity_metadata)
@@ -3663,6 +3664,8 @@ class type_(GeneratedsSuper):
     def set_overlayroot(self, overlayroot): self.overlayroot = overlayroot
     def get_overlayroot_write_partition(self): return self.overlayroot_write_partition
     def set_overlayroot_write_partition(self, overlayroot_write_partition): self.overlayroot_write_partition = overlayroot_write_partition
+    def get_overlayroot_readonly_filesystem(self): return self.overlayroot_readonly_filesystem
+    def set_overlayroot_readonly_filesystem(self, overlayroot_readonly_filesystem): self.overlayroot_readonly_filesystem = overlayroot_readonly_filesystem
     def get_overlayroot_readonly_partsize(self): return self.overlayroot_readonly_partsize
     def set_overlayroot_readonly_partsize(self, overlayroot_readonly_partsize): self.overlayroot_readonly_partsize = overlayroot_readonly_partsize
     def get_verity_blocks(self): return self.verity_blocks
@@ -3982,6 +3985,9 @@ class type_(GeneratedsSuper):
         if self.overlayroot_write_partition is not None and 'overlayroot_write_partition' not in already_processed:
             already_processed.add('overlayroot_write_partition')
             outfile.write(' overlayroot_write_partition="%s"' % self.gds_format_boolean(self.overlayroot_write_partition, input_name='overlayroot_write_partition'))
+        if self.overlayroot_readonly_filesystem is not None and 'overlayroot_readonly_filesystem' not in already_processed:
+            already_processed.add('overlayroot_readonly_filesystem')
+            outfile.write(' overlayroot_readonly_filesystem=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.overlayroot_readonly_filesystem), input_name='overlayroot_readonly_filesystem')), ))
         if self.overlayroot_readonly_partsize is not None and 'overlayroot_readonly_partsize' not in already_processed:
             already_processed.add('overlayroot_readonly_partsize')
             outfile.write(' overlayroot_readonly_partsize="%s"' % self.gds_format_integer(self.overlayroot_readonly_partsize, input_name='overlayroot_readonly_partsize'))
@@ -4473,6 +4479,11 @@ class type_(GeneratedsSuper):
                 self.overlayroot_write_partition = False
             else:
                 raise_parse_error(node, 'Bad boolean attribute')
+        value = find_attr_value_('overlayroot_readonly_filesystem', node)
+        if value is not None and 'overlayroot_readonly_filesystem' not in already_processed:
+            already_processed.add('overlayroot_readonly_filesystem')
+            self.overlayroot_readonly_filesystem = value
+            self.overlayroot_readonly_filesystem = ' '.join(self.overlayroot_readonly_filesystem.split())
         value = find_attr_value_('overlayroot_readonly_partsize', node)
         if value is not None and 'overlayroot_readonly_partsize' not in already_processed:
             already_processed.add('overlayroot_readonly_partsize')

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -2110,7 +2110,7 @@ class XMLState:
         if selected_system_disk and selected_system_disk.get_preferlvm():
             # LVM volume management is preferred, use it
             volume_management = 'lvm'
-        elif selected_filesystem in volume_filesystems:
+        elif selected_filesystem in volume_filesystems and selected_system_disk:
             # specified filesystem has its own volume management system
             volume_management = selected_filesystem
         elif selected_system_disk:

--- a/test/unit/bootloader/config/base_test.py
+++ b/test/unit/bootloader/config/base_test.py
@@ -145,6 +145,22 @@ class TestBootLoaderConfigBase:
             '/dev/myroot'
         ) == 'root=overlay:MAPPER=luks'
 
+    @patch('kiwi.xml_parse.type_.get_kernelcmdline')
+    def test_get_boot_cmdline_root_overlay_verity(self, mock_cmdline):
+        mock_cmdline.return_value = ''
+        self.state.build_type.get_overlayroot = Mock(
+            return_value=True
+        )
+        self.state.build_type.get_verity_blocks = Mock(
+            return_value=42
+        )
+        self.state.get_luks_credentials = Mock(
+            return_value=None
+        )
+        assert self.bootloader.get_boot_cmdline(
+            '/dev/myroot'
+        ) == 'root=overlay:MAPPER=verityroot'
+
     @patch('kiwi.xml_parse.type_.get_initrd_system')
     @patch('kiwi.bootloader.config.base.BlockID')
     def test_get_boot_cmdline_initrd_system_is_dracut(

--- a/test/unit/bootloader/config/base_test.py
+++ b/test/unit/bootloader/config/base_test.py
@@ -355,6 +355,7 @@ class TestBootLoaderConfigBase:
     @patch('kiwi.bootloader.config.base.MountManager')
     def test_mount_system_s390(self, mock_MountManager):
         tmp_mount = MagicMock()
+        etc_kernel_mount = MagicMock()
         proc_mount = MagicMock()
         sys_mount = MagicMock()
         dev_mount = MagicMock()
@@ -365,7 +366,8 @@ class TestBootLoaderConfigBase:
         boot_mount.device = 'bootdev'
 
         mount_managers = [
-            proc_mount, sys_mount, dev_mount, tmp_mount, boot_mount, root_mount
+            proc_mount, sys_mount, dev_mount, tmp_mount,
+            etc_kernel_mount, boot_mount, root_mount
         ]
 
         def mount_managers_effect(**args):
@@ -388,10 +390,15 @@ class TestBootLoaderConfigBase:
 
     @patch('kiwi.bootloader.config.base.MountManager')
     @patch('kiwi.bootloader.config.base.SystemSetup')
-    def test_mount_system(self, mock_SystemSetup, mock_MountManager):
+    @patch('os.path.exists')
+    def test_mount_system(
+        self, mock_os_path_exists, mock_SystemSetup, mock_MountManager
+    ):
+        mock_os_path_exists.return_value = True
         setup = Mock()
         mock_SystemSetup.return_value = setup
         tmp_mount = MagicMock()
+        etc_kernel_mount = MagicMock()
         proc_mount = MagicMock()
         sys_mount = MagicMock()
         dev_mount = MagicMock()
@@ -405,8 +412,8 @@ class TestBootLoaderConfigBase:
         volume_mount = MagicMock()
 
         mount_managers = [
-            proc_mount, sys_mount, dev_mount, tmp_mount, volume_mount,
-            efi_mount, boot_mount, root_mount
+            proc_mount, sys_mount, dev_mount, tmp_mount, etc_kernel_mount,
+            volume_mount, efi_mount, boot_mount, root_mount
         ]
 
         def mount_managers_effect(**args):
@@ -430,6 +437,7 @@ class TestBootLoaderConfigBase:
                 call(device='efidev', mountpoint='root_mount_point/boot/efi'),
                 call(device='device', mountpoint='root_mount_point/boot/grub2'),
                 call(device='/tmp', mountpoint='root_mount_point/tmp'),
+                call(device='efidev', mountpoint='root_mount_point/etc/kernel'),
                 call(device='/dev', mountpoint='root_mount_point/dev'),
                 call(device='/proc', mountpoint='root_mount_point/proc'),
                 call(device='/sys', mountpoint='root_mount_point/sys')
@@ -450,6 +458,7 @@ class TestBootLoaderConfigBase:
 
         volume_mount.umount.assert_called_once_with()
         tmp_mount.umount.assert_called_once_with()
+        etc_kernel_mount.umount.assert_called_once_with()
         dev_mount.umount.assert_called_once_with()
         proc_mount.umount.assert_called_once_with()
         sys_mount.umount.assert_called_once_with()

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -693,6 +693,9 @@ class TestDiskBuilder:
         mock_LoopDevice, mock_create_boot_loader_config,
         mock_Disk
     ):
+        system = Mock()
+        system.mountpoint.return_value = 'diskroot'
+        mock_ImageSystem.return_value.__enter__.return_value = system
         disk = self._get_disk_instance()
         mock_Disk.return_value.__enter__.return_value = disk
         bootloader_config = Mock()
@@ -814,20 +817,30 @@ class TestDiskBuilder:
             call('boot_dir/config.partids', 'w'),
             call('root_dir/boot/mbrid', 'w'),
             call('boot_dir/config.bootoptions', 'w'),
-            call('/dev/some-loop', 'wb')
+            call('/dev/some-loop', 'wb'),
+            call('root_dir/etc/veritytab', 'w')
         ]
-        assert m_open.return_value.write.call_args_list == [
-            call('kiwi_BootPart="1"\n'),
-            call('kiwi_RootPart="1"\n'),
-            call('0x0f0f0f0f\n'),
-            call('boot_cmdline\n'),
-            call(bytes(b'\x0f\x0f\x0f\x0f'))
-        ]
+        m_open.return_value.write.assert_has_calls(
+            [
+                call('kiwi_BootPart="1"\n'),
+                call('kiwi_RootPart="1"\n'),
+                call('0x0f0f0f0f\n'),
+                call('boot_cmdline\n'),
+                call(bytes(b'\x0f\x0f\x0f\x0f')),
+            ]
+        )
         assert mock_command.call_args_list == [
             call(['cp', 'root_dir/recovery.partition.size', 'boot_dir']),
             call(['mv', 'initrd', 'root_dir/boot/initramfs-1.2.3.img']),
             call(['blockdev', '--getsize64', '/dev/root-device']),
-            call(['dd', 'if=tempfile', 'of=/dev/root-device'])
+            call(['dd', 'if=tempfile', 'of=/dev/root-device']),
+            call(
+                [
+                    'blkid', '/dev/readonly-root-device',
+                    '-s', 'UUID', '-o', 'value'
+                ]
+            ),
+            call(['mv', 'initrd', 'diskroot/boot/initramfs-1.2.3.img'])
         ]
         self.block_operation.get_blkid.assert_has_calls(
             [call('PARTUUID')]
@@ -902,7 +915,6 @@ class TestDiskBuilder:
     @patch('kiwi.builder.disk.LoopDevice')
     @patch('kiwi.builder.disk.DeviceProvider')
     @patch('kiwi.builder.disk.FileSystem.new')
-    @patch('kiwi.builder.disk.FileSystemSquashFs')
     @patch('kiwi.builder.disk.Command.run')
     @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     @patch('os.path.exists')
@@ -914,7 +926,7 @@ class TestDiskBuilder:
     def test_create_disk_standard_root_is_overlay(
         self, mock_MountManager, mock_BlockID, mock_rand, mock_temp,
         mock_getsize, mock_exists, mock_grub_dir, mock_command,
-        mock_squashfs, mock_fs, mock_DeviceProvider,
+        mock_fs, mock_DeviceProvider,
         mock_LoopDevice, mock_create_boot_loader_config,
         mock_Disk, mock_Path
     ):
@@ -940,8 +952,12 @@ class TestDiskBuilder:
         self.disk_builder.integrity = True
         self.disk_builder.root_filesystem_embed_integrity_metadata = True
         self.disk_builder.volume_manager_name = None
-        squashfs = Mock()
-        mock_squashfs.return_value.__enter__.return_value = squashfs
+        fs = Mock()
+        fs.veritysetup.verity_hash_offset = 'Some'
+        fs.veritysetup.verity_dict = {
+            'Roothash': 'Some'
+        }
+        mock_fs.return_value.__enter__.return_value = fs
         mock_getsize.return_value = 1048576
         tempfile = Mock()
         tempfile.name = 'kiwi-tempname'
@@ -954,27 +970,28 @@ class TestDiskBuilder:
         with patch('builtins.open', m_open, create=True):
             self.disk_builder.create_disk()
 
-        assert mock_squashfs.call_args_list == [
-            call(
-                custom_args={'compression': None},
-                device_provider=mock_DeviceProvider.return_value,
-                root_dir='root_dir'
-            ), call(
-                custom_args={'compression': None},
-                device_provider=mock_DeviceProvider.return_value,
-                root_dir='root_dir'
-            )
-        ]
-        assert squashfs.create_on_file.call_args_list == [
-            call(exclude=['var/cache/kiwi'], filename='kiwi-tempname'),
-            call(exclude=[
-                '.kconfig', 'run/*', 'tmp/*',
-                '.buildenv', 'var/cache/kiwi',
-                'image/*'
-            ], filename='kiwi-tempname')
-        ]
-        squashfs.create_verity_layer.assert_called_once_with(10)
-        squashfs.create_verification_metadata.assert_called_once_with(
+        mock_fs.assert_has_calls(
+            [
+                call(
+                    'squashfs',
+                    custom_args={'compression': None},
+                    device_provider=mock_DeviceProvider.return_value,
+                    root_dir='root_dir'
+                )
+            ]
+        )
+        fs.create_on_file.assert_has_calls(
+            [
+                call(exclude=['var/cache/kiwi'], filename='kiwi-tempname'),
+                call(exclude=[
+                    '.kconfig', 'run/*', 'tmp/*',
+                    '.buildenv', 'var/cache/kiwi',
+                    'image/*'
+                ], filename='kiwi-tempname')
+            ], any_order=True
+        )
+        fs.create_verity_layer.assert_called_once_with(10)
+        fs.create_verification_metadata.assert_called_once_with(
             '/dev/integrityRoot'
         )
         self.integrity_root.create_integrity_metadata.assert_called_once_with()
@@ -989,17 +1006,19 @@ class TestDiskBuilder:
         assert mock_command.call_args_list[3] == call(
             ['dd', 'if=kiwi-tempname', 'of=/dev/integrityRoot']
         )
-        assert m_open.return_value.write.call_args_list == [
-            # config.partids
-            call('kiwi_BootPart="1"\n'),
-            call('kiwi_RootPart="1"\n'),
-            # mbrid
-            call('0x0f0f0f0f\n'),
-            # config.bootoptions
-            call('boot_cmdline\n'),
-            # some-loop
-            call(b'\x0f\x0f\x0f\x0f')
-        ]
+        m_open.return_value.write.assert_has_calls(
+            [
+                # config.partids
+                call('kiwi_BootPart="1"\n'),
+                call('kiwi_RootPart="1"\n'),
+                # mbrid
+                call('0x0f0f0f0f\n'),
+                # config.bootoptions
+                call('boot_cmdline\n'),
+                # some-loop
+                call(b'\x0f\x0f\x0f\x0f')
+            ], any_order=True
+        )
         assert self.boot_image_task.include_module.call_args_list == [
             call('kiwi-overlay'), call('kiwi-repart')
         ]

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -853,7 +853,8 @@ class TestDiskBuilder:
         )
         assert self.boot_image_task.include_file.call_args_list == [
             call('/config.partids'),
-            call('/recovery.partition.size')
+            call('/recovery.partition.size'),
+            call(filename='/etc/veritytab', delete_after_include=True)
         ]
         self.boot_image_task.include_module.assert_called_once_with(
             'kiwi-repart'

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -348,17 +348,6 @@ class TestRuntimeChecker:
             runtime_checker.\
                 check_dracut_module_for_disk_overlay_in_package_list()
 
-    def test_check_efi_mode_for_disk_overlay_correctly_setup(self):
-        self.xml_state.build_type.get_overlayroot = Mock(
-            return_value=True
-        )
-        self.xml_state.build_type.get_firmware = Mock(
-            return_value='uefi'
-        )
-        with raises(KiwiRuntimeError):
-            self.runtime_checker.\
-                check_efi_mode_for_disk_overlay_correctly_setup()
-
     @pytest.mark.parametrize("tool_name, tool_binary", [("isomd5sum", "implantisomd5"), ("checkmedia", "tagmedia")])
     @patch('kiwi.runtime_checker.Path.which')
     @patch('kiwi.runtime_checker.RuntimeConfig')

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -156,9 +156,6 @@ class TestSystemBuildTask:
         self.runtime_checker.\
             check_dracut_module_for_oem_install_in_package_list.\
             assert_called_once_with()
-        self.runtime_checker.\
-            check_efi_mode_for_disk_overlay_correctly_setup.\
-            assert_called_once_with()
         system_prepare.setup_repositories.assert_called_once_with(
             False, ['some_key', 'some_other_key'], None
         )

--- a/test/unit/tasks/system_prepare_test.py
+++ b/test/unit/tasks/system_prepare_test.py
@@ -142,9 +142,6 @@ class TestSystemPrepareTask:
         self.runtime_checker.\
             check_dracut_module_for_oem_install_in_package_list.\
             assert_called_once_with()
-        self.runtime_checker.\
-            check_efi_mode_for_disk_overlay_correctly_setup.\
-            assert_called_once_with()
         system_prepare.setup_repositories.assert_called_once_with(
             True, ['some_key', 'some_other_key'], None
         )

--- a/test/unit/utils/veritysetup_test.py
+++ b/test/unit/utils/veritysetup_test.py
@@ -38,7 +38,7 @@ class TestVeritySetup:
         mock_Command_run.assert_called_once_with(
             [
                 'veritysetup', 'format', 'image_file', 'image_file',
-                '--no-superblock', '--hash-offset=4096',
+                '--hash-offset=4096',
                 '--hash-block-size=4096', '--data-blocks=10',
                 '--data-block-size=4096',
             ]
@@ -58,7 +58,7 @@ class TestVeritySetup:
         mock_Command_run.assert_called_once_with(
             [
                 'veritysetup', 'format', 'image_file', 'tempfile',
-                '--no-superblock', '--hash-block-size=4096', '--data-blocks=10',
+                '--hash-block-size=4096', '--data-blocks=10',
                 '--data-block-size=4096',
             ]
         )
@@ -82,7 +82,7 @@ class TestVeritySetup:
         mock_Command_run.assert_called_once_with(
             [
                 'veritysetup', 'format', 'image_file', 'image_file',
-                '--no-superblock', '--hash-offset=4096',
+                '--hash-offset=4096',
                 '--hash-block-size=4096'
             ]
         )
@@ -109,7 +109,7 @@ class TestVeritySetup:
             call('UUID: \n'),
             call('Root hashoffset: 4096'),
             call('\n'),
-            call('Superblock: --no-superblock'),
+            call('Superblock:'),
             call('\n')
         ]
 


### PR DESCRIPTION
So this change is many fold and split into several commits. The most important changes summarizes into

**Update test-image-overlayroot integration test**
    
Switch to erofs for overlay testing. Additionally split the build into two profiles. The first one just builds a simple overlayroot oem disk based on erofs. The second one adds a veritysetup layer and configures the systemd-veritysetup-generator for use in dracut.

**Add support for selecting the overlay read-only fs**
    
Add new overlayroot_readonly_filesystem attribute which allows to select for either squashfs or erofs as the read-only filesystem  in an OEM overlay disk setup.

**Add documentation for new attribute**
    
Add details how to use the new overlayroot_readonly_filesystem attribute

**Fixed root setup for verity overlay disk**
    
When building an image with overlayroot set to true and activated verity data, the root= parameter must be set to root=overlay:MAPPER=verityroot instead of the standard  overlay:PARTUUID mapping.


This Fixes #2799