### PR TITLE
Add support for new tarball-based WSL format

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-wsl-ng/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-wsl-ng/appliance.kiwi
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="7.5" name="kiwi-test-image-wsl-ng">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>marcus.schaefer@suse.com</contact>
+        <specification>WSL test build for WSL >= 2.4.4 new tar spec</specification>
+    </description>
+    <preferences>
+        <version>2.4.4</version>
+        <packagemanager>zypper</packagemanager>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>false</rpm-check-signatures>
+        <locale>en_US</locale>
+        <keytable>us</keytable>
+        <type image="wsl"/>
+    </preferences>
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
+    </users>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-openSUSE-base"/>
+        <package name="systemd"/>
+        <package name="bash"/>
+        <package name="acl"/>
+        <package name="coreutils"/>
+        <package name="cpio"/>
+        <package name="findutils"/>
+        <package name="dracut"/>
+        <package name="pigz"/>
+        <package name="iputils"/>
+        <package name="tar"/>
+        <package name="psmisc"/>
+        <package name="lvm2"/>
+        <package name="fontconfig"/>
+        <package name="fonts-config"/>
+        <package name="tar"/>
+        <package name="sudo"/>
+        <package name="rsync"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="gawk"/>
+        <package name="grep"/>
+        <package name="gzip"/>
+        <package name="udev"/>
+        <package name="xz"/>
+        <package name="shadow"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+        <package name="cracklib-dict-full"/>
+        <package name="ca-certificates"/>
+        <package name="ca-certificates-mozilla"/>
+        <package name="openSUSE-release"/>
+    </packages>
+</image>

--- a/build-tests/x86/tumbleweed/test-image-wsl-ng/root/etc/wsl-distribution.conf
+++ b/build-tests/x86/tumbleweed/test-image-wsl-ng/root/etc/wsl-distribution.conf
@@ -1,0 +1,3 @@
+[oobe]
+defaultUid = 1000
+defaultName = SUSE

--- a/build-tests/x86/tumbleweed/test-image-wsl-ng/root/etc/wsl.conf
+++ b/build-tests/x86/tumbleweed/test-image-wsl-ng/root/etc/wsl.conf
@@ -1,0 +1,2 @@
+[boot]
+systemd=true

--- a/doc/source/concept_and_workflow/systemdeps.rst
+++ b/doc/source/concept_and_workflow/systemdeps.rst
@@ -29,7 +29,8 @@ following systemdeps packages:
     compliant container images.
 
 `kiwi-systemdeps-containers-wsl`:
-  * Supports building `appx` image types.
+  * Supports building `appx` and `wsl` image types. The `wsl` type
+    is the successor for the former `appx` type
   * Installs the distribution specific tool chain to build
     WSL compliant container images on Windows systems.
 

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -364,6 +364,14 @@ image="appx"
   container engine. The image can be loaded From a Windows System
   that has support for WSL activated.
 
+image="wsl"
+  An archive image suitable for the Windows Subsystem For Linux
+  container engine >= v2.4.4. The image represents a gzip compressed
+  tar file as described in
+  https://learn.microsoft.com/en-us/windows/wsl/build-custom-distro
+  and can be loaded From a Windows System
+  that has support for WSL in that version activated.
+
 image="kis"
   An optional root filesystem image associated with a kernel and initrd.
   The use case for this component image type is highly customizable.

--- a/doc/source/image_types_and_results.rst
+++ b/doc/source/image_types_and_results.rst
@@ -173,6 +173,14 @@ image="appx"
   - **container**:
     :file:`{exc_image_base_name}.x86_64-{exc_image_version}.appx`
 
+image="wsl"
+  An archive image suitable for the Windows Subsystem For Linux
+  container engine >= v2.4.4. The result is a gzip compressed tar
+  archive with the `.wsl` extension:
+
+  - **container**:
+    :file:`{exc_image_base_name}.x86_64-{exc_image_version}.wsl`
+
 image="kis"
   An optional root filesystem image associated with a kernel and initrd.
   All three binaries are packed in a tarball, see :ref:`kis` for further

--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -92,6 +92,7 @@ class ContainerBuilder:
         self.system_setup = SystemSetup(
             xml_state=xml_state, root_dir=self.root_dir
         )
+        self.special_needs = ['appx', 'wsl']
         self.filename = ''.join(
             [
                 target_dir, '/',
@@ -99,7 +100,7 @@ class ContainerBuilder:
                 '.' + Defaults.get_platform_name(),
                 '-' + xml_state.get_image_version(),
                 '.', self.requested_container_type,
-                '.tar' if self.requested_container_type != 'appx' else ''
+                '.tar' if self.requested_container_type not in self.special_needs else ''
             ]
         )
         self.result = Result(xml_state)
@@ -115,6 +116,7 @@ class ContainerBuilder:
         * image="docker"
         * image="oci"
         * image="appx"
+        * image="wsl"
 
         :return: result
 
@@ -148,7 +150,8 @@ class ContainerBuilder:
             self.filename, self.base_image or '', self.ensure_empty_tmpdirs,
             self.runtime_config.get_container_compression()
             # appx containers already contains a compressed root
-            if self.requested_container_type != 'appx' else False
+            # wsl containers recommends gzip and we default to it
+            if self.requested_container_type not in self.special_needs else False
         )
         Result.verify_image_size(
             self.runtime_config.get_max_size_constraint(),

--- a/kiwi/container/__init__.py
+++ b/kiwi/container/__init__.py
@@ -45,12 +45,14 @@ class ContainerImage(metaclass=ABCMeta):
         name_map = {
             'docker': 'OCI',
             'oci': 'OCI',
-            'appx': 'Appx'
+            'appx': 'Appx',
+            'wsl': 'Wsl'
         }
         args_map = {
             'docker': [root_dir, 'docker-archive', custom_args],
             'oci': [root_dir, 'oci-archive', custom_args],
-            'appx': [root_dir, custom_args]
+            'appx': [root_dir, custom_args],
+            'wsl': [root_dir, custom_args]
         }
         try:
             container_image = importlib.import_module(

--- a/kiwi/container/setup/__init__.py
+++ b/kiwi/container/setup/__init__.py
@@ -41,7 +41,8 @@ class ContainerSetup(metaclass=ABCMeta):
         name_map = {
             'docker': 'Docker',
             'oci': 'OCI',
-            'appx': 'Appx'
+            'appx': 'Appx',
+            'wsl': 'Wsl'
         }
         try:
             container_setup = importlib.import_module(

--- a/kiwi/container/setup/wsl.py
+++ b/kiwi/container/setup/wsl.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2025 SUSE LLC.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+
+# project
+from kiwi.container.setup.base import ContainerSetupBase
+from kiwi.exceptions import KiwiContainerSetupError
+
+
+class ContainerSetupWsl(ContainerSetupBase):
+    """
+    WSL new tar setup
+    """
+    def setup(self):
+        """
+        Setup container metadata
+        """
+        # It's expected that the container metadata for the
+        # new WSL format is provided by a package or via overlay
+        # data. Thus this setup routine only checks for the
+        # presence of the data and fails when missing
+        distribution_conf = os.path.normpath(
+            os.sep.join([self.root_dir, 'etc', 'wsl-distribution.conf'])
+        )
+        wsl_conf = os.path.normpath(
+            os.sep.join([self.root_dir, 'etc', 'wsl.conf'])
+        )
+        if not os.path.exists(distribution_conf):
+            raise KiwiContainerSetupError(
+                f'Mandatory WSL {distribution_conf} not found in root tree'
+            )
+        if not os.path.exists(wsl_conf):
+            raise KiwiContainerSetupError(
+                f'Mandatory WSL {wsl_conf} not found in root tree'
+            )

--- a/kiwi/container/wsl.py
+++ b/kiwi/container/wsl.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2025 SUSE LLC.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+from typing import Dict
+
+# project
+from kiwi.archive.tar import ArchiveTar
+from kiwi.defaults import Defaults
+from kiwi.utils.compress import Compress
+from kiwi.command import Command
+from kiwi.container.base import ContainerImageBase
+
+
+class ContainerImageWsl(ContainerImageBase):
+    """
+    Create new WSL root tar
+    WSL(Windows Subsystem Linux >= 2.4.4)
+
+    :param string root_dir: root directory path name
+    :param dict custom_args:
+        Custom processing arguments defined as hash keys
+    """
+    def __init__(self, root_dir: str, custom_args: Dict[str, str] = {}):
+        self.root_dir = root_dir
+        self.wsl_config = custom_args or {}
+
+    def create(
+        self, filename: str, base_image: str = '',
+        ensure_empty_tmpdirs: bool = False, compress_archive: bool = True
+    ) -> str:
+        """
+        Create WSL root tar
+
+        :param string filename: archive file name
+        :param string base_image: not-supported
+        :param bool ensure_empty_tmpdirs: not-supported
+        :param bool compress_archive: not-supported
+        """
+        exclude_list = Defaults.\
+            get_exclude_list_for_root_data_sync() + Defaults.\
+            get_exclude_list_from_custom_exclude_files(self.root_dir)
+        exclude_list.append('boot')
+        exclude_list.append('dev')
+        exclude_list.append('sys')
+        exclude_list.append('proc')
+
+        archive_file_name = filename
+        archive = ArchiveTar(archive_file_name)
+        archive_file_name = archive.create(
+            self.root_dir, exclude=exclude_list,
+            options=['--numeric-owner', '--absolute-names']
+        )
+        compressor = Compress(archive_file_name)
+        archive_file_name = compressor.gzip()
+
+        Command.run(
+            ['mv', archive_file_name, filename]
+        )
+        return filename

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1601,7 +1601,7 @@ class Defaults:
 
         :rtype: list
         """
-        return ['docker', 'oci', 'appx']
+        return ['docker', 'oci', 'appx', 'wsl']
 
     @staticmethod
     def get_filesystem_image_types():

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2060,7 +2060,7 @@ div {
         attribute image {
             "btrfs" | "cpio" | "docker" | "ext2" | "ext3" |
             "ext4" | "iso" | "oem" | "pxe" | "kis" | "squashfs" | "erofs" | "tbz" |
-            "xfs" | "oci" | "appx" | "enclave"
+            "xfs" | "oci" | "appx" | "enclave" | "wsl"
         }
         >> sch:pattern [
             id = "metadata_path_mandatory" is-a = "image_type_requirement"

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2988,6 +2988,7 @@ initrd architecture.</a:documentation>
           <value>oci</value>
           <value>appx</value>
           <value>enclave</value>
+          <value>wsl</value>
         </choice>
       </attribute>
       <sch:pattern id="metadata_path_mandatory" is-a="image_type_requirement">

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -207,6 +207,7 @@ Provides:       kiwi-image-wsl-requires = %{version}-%{release}
 Obsoletes:      kiwi-image-wsl-requires < %{version}-%{release}
 %if "%{_vendor}" != "debbuild"
 Provides:       kiwi-image:appx
+Provides:       kiwi-image:wsl
 %endif
 %if 0%{?suse_version}
 Requires:       fb-util-for-appx

--- a/test/unit/container/init_test.py
+++ b/test/unit/container/init_test.py
@@ -31,3 +31,10 @@ class TestContainerImage:
         mock_appx.assert_called_once_with(
             'root_dir', None
         )
+
+    @patch('kiwi.container.wsl.ContainerImageWsl')
+    def test_container_image_wsl(self, mock_wsl):
+        ContainerImage.new('wsl', 'root_dir')
+        mock_wsl.assert_called_once_with(
+            'root_dir', None
+        )

--- a/test/unit/container/setup/wsl_test.py
+++ b/test/unit/container/setup/wsl_test.py
@@ -1,0 +1,33 @@
+from pytest import raises
+from unittest.mock import patch
+
+from kiwi.container.setup.wsl import ContainerSetupWsl
+from kiwi.exceptions import KiwiContainerSetupError
+
+
+class TestContainerSetupAppx:
+    @patch('os.path.exists')
+    def setup(self, mock_exists):
+        self.wsl = ContainerSetupWsl('root_dir')
+
+    @patch('os.path.exists')
+    def setup_method(self, cls, mock_exists):
+        self.setup()
+
+    @patch('os.path.exists')
+    def test_setup(self, mock_exists):
+
+        def exists(path):
+            if path == path_to_fail:
+                return False
+            return True
+
+        mock_exists.side_effect = exists
+
+        path_to_fail = 'root_dir/etc/wsl-distribution.conf'
+        with raises(KiwiContainerSetupError):
+            self.wsl.setup()
+
+        path_to_fail = 'root_dir/etc/wsl.conf'
+        with raises(KiwiContainerSetupError):
+            self.wsl.setup()

--- a/test/unit/container/wsl_test.py
+++ b/test/unit/container/wsl_test.py
@@ -1,0 +1,48 @@
+from unittest.mock import (
+    patch, Mock
+)
+
+from kiwi.container.wsl import ContainerImageWsl
+
+
+class TestContainerImageWsl:
+    def setup(self):
+        self.wsl = ContainerImageWsl('root_dir')
+
+    def setup_method(self, cls):
+        self.setup()
+
+    @patch('kiwi.container.wsl.ArchiveTar')
+    @patch('kiwi.container.wsl.Compress')
+    @patch('kiwi.container.wsl.Defaults.get_exclude_list_for_root_data_sync')
+    @patch('kiwi.container.wsl.Defaults.get_exclude_list_from_custom_exclude_files')
+    @patch('kiwi.container.wsl.Command.run')
+    def test_create(
+        self, mock_Command_run,
+        mock_get_exclude_list_from_custom_exclude_files,
+        mock_get_exclude_list_for_root_data_sync,
+        mock_Compress, mock_ArchiveTar
+    ):
+        archive = Mock()
+        mock_ArchiveTar.return_value = archive
+        compress = Mock()
+        mock_Compress.return_value = compress
+
+        self.wsl.create('target_dir/image.wsl')
+        mock_ArchiveTar.assert_called_once_with(
+            'target_dir/image.wsl'
+        )
+        archive.create.assert_called_once_with(
+            'root_dir',
+            exclude=mock_get_exclude_list_for_root_data_sync.
+            return_value + mock_get_exclude_list_from_custom_exclude_files.
+            return_value,
+            options=['--numeric-owner', '--absolute-names']
+        )
+        mock_Compress.assert_called_once_with(
+            archive.create.return_value
+        )
+        compress.gzip.assert_called_once_with()
+        mock_Command_run.assert_called_once_with(
+            ['mv', compress.gzip.return_value, 'target_dir/image.wsl']
+        )


### PR DESCRIPTION
With the new image="wsl" type one can build a WSL container image that uses the new tarball format. This Fixes #2678


