### PR TITLE
Added check_target_dir_on_unsupported_filesystem

### DIFF
--- a/kiwi.yml
+++ b/kiwi.yml
@@ -149,6 +149,9 @@
 #      # check kiwi dracut modules compatible with kiwi builder
 #      - check_dracut_module_versions_compatible_to_kiwi
 
+#      # check target_dir and image root on a supported filesystem
+#      - check_target_dir_on_unsupported_filesystem
+
 #      # check for unresolved include statements in the XML description
 #      - check_include_references_unresolvable
 

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -176,6 +176,8 @@ class SystemBuildTask(CliTask):
         build_checks.update(
             {
                 'check_target_directory_not_in_shared_cache':
+                    [abs_target_dir_path],
+                'check_target_dir_on_unsupported_filesystem':
                     [abs_target_dir_path]
             }
         )

--- a/kiwi/tasks/system_create.py
+++ b/kiwi/tasks/system_create.py
@@ -87,6 +87,8 @@ class SystemCreateTask(CliTask):
                 'check_target_directory_not_in_shared_cache':
                     [abs_root_path],
                 'check_dracut_module_versions_compatible_to_kiwi':
+                    [abs_root_path],
+                'check_target_dir_on_unsupported_filesystem':
                     [abs_root_path]
             }
         )

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -160,7 +160,8 @@ class SystemPrepareTask(CliTask):
         prepare_checks = self.checks_before_command_args
         prepare_checks.update(
             {
-                'check_target_directory_not_in_shared_cache': [abs_root_path]
+                'check_target_directory_not_in_shared_cache': [abs_root_path],
+                'check_target_dir_on_unsupported_filesystem': [abs_root_path]
             }
         )
         self.run_checks(prepare_checks)

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -52,6 +52,16 @@ class TestRuntimeChecker:
         with raises(KiwiRuntimeError):
             self.runtime_checker.check_image_include_repos_publicly_resolvable()
 
+    @patch('kiwi.runtime_checker.Command.run')
+    def test_check_target_dir_on_unsupported_filesystem(self, mock_Command_run):
+        stat = Mock()
+        stat.output = 'bogus'
+        mock_Command_run.return_value = stat
+        with raises(KiwiRuntimeError):
+            self.runtime_checker.check_target_dir_on_unsupported_filesystem(
+                '/some/root_dir'
+            )
+
     def test_invalid_target_dir_pointing_to_shared_cache_1(self):
         with raises(KiwiRuntimeError):
             self.runtime_checker.check_target_directory_not_in_shared_cache(


### PR DESCRIPTION
Add runtime check to make sure the selected target directory for the image and/or the image rootfs lives on a filesystem that provides all required features like extended permissions, ACLs or xattrs.

