### PR TITLE
Docs: minor punctuation and grammar fixes

### DIFF
--- a/doc/source/concept_and_workflow/users.rst
+++ b/doc/source/concept_and_workflow/users.rst
@@ -29,7 +29,7 @@ The following attributes are mandatory:
 
 - `password`: The password for the user account. It can be provided either
   in clear-text form (`pwdformat="plain"`) or in encrypted form
-  (`pwdformat="encrypted"`). Using lain passwords is not advisable, as anyone
+  (`pwdformat="encrypted"`). Using plain passwords is not advisable, as anyone
   with access to the image description can see the password. It is
   recommended to generate a hash of your password using `openssl` as
   follows:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -85,16 +85,16 @@ Private and Public Clouds
   service provider. The classic way to install a machine is not
   possible in such an environment because there is no physical access
   to the machine. An appliance is needed to be registered with the
-  cloud
+  cloud.
 
 Custom Linux Distribution
-  Linux distributors provides their distribution based on a collection
+  Linux distributors provide their distribution based on a collection
   of packages and release them on an install media like a DVD or an USB
   stick. Typically a lot more software components exists for the
   distribution which are not part of the default installation media
   or the installation media comes with software and installation
   routines that are not matching your target audience. With an
-  appliance made by {kiwi} you can create provide an installation
+  appliance made by {kiwi} you can create an installation
   media that matches custom criteria as needed by the customer
   and does not require extra post processing steps after the
   default installation method provided by the distributor.
@@ -105,11 +105,11 @@ Live Systems
   system administrators. The creation of such a live system includes
   use of technologies that are not part of a standard installation
   process. An appliance builder is needed to create this sort of
-  system
+  system.
 
 Embedded Systems
-  Embedded Systems like the Raspberry Pi comes with limited hardware
-  components. Their boot sequences often does not allow for classic
+  Embedded Systems like the Raspberry Pi come with limited hardware
+  components. Their boot sequences often do not allow for classic
   installation methods through USB or DVD devices. Instead they boot
   through SD card slots or via the network. SoC (System on Chip) devices
   also tend to implement non standard boot methods which can only

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -53,7 +53,7 @@ Image Description
    Specification to define an appliance. The image description is a
    collection of human readable files in a directory. At least one XML
    file :file:`config.xml` or :file:`.kiwi` is required. In addition
-   there may be as well other files like scripts or configuration data.
+   there may be other files like scripts or configuration data.
    These can be used to customize certain parts either of the {kiwi}
    build process or of the initial start-up behavior of the image.
 

--- a/doc/source/overview/workflow.rst
+++ b/doc/source/overview/workflow.rst
@@ -54,7 +54,7 @@ See :ref:`description_components` section for further details.
 Components of an Image Description
 ----------------------------------
 
-A {kiwi} image description can composed by several parts. The main part is
+A {kiwi} image description can be composed of several parts. The main part is
 the {kiwi} description file itself (named :file:`config.xml` or an arbitrary
 name plus the :file:`*.kiwi` extension). The configuration XML is the
 only required component, others are optional.


### PR DESCRIPTION
Changes proposed in this pull request:
* Adds some missing punctuation and fixes some grammatical mistakes in the index and overview sections of the docs.
