### PR TITLE
Apply security context on writable root only

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
@@ -46,7 +46,7 @@
         <type
             image="oem"
             filesystem="xfs"
-            kernelcmdline="console=ttyS0 rd.systemd.verity=1"
+            kernelcmdline="console=ttyS0 rd.systemd.verity=1 security=selinux selinux=1 enforcing=1"
             firmware="uefi"
             format="vmdk"
             overlayroot="true"
@@ -69,7 +69,7 @@
         <type
             image="oem"
             filesystem="btrfs"
-            kernelcmdline="console=ttyS0 rd.systemd.verity=1"
+            kernelcmdline="console=ttyS0 rd.systemd.verity=1 security=selinux selinux=1 enforcing=1"
             firmware="efi"
             format="vmdk"
             overlayroot="true"
@@ -95,6 +95,12 @@
     <packages type="image" profiles="sdboot_verity_erofs,grub_verity_erofs">
         <package name="cryptsetup"/>
         <package name="dracut-kiwi-verity"/>
+        <package name="restorecond"/>
+        <package name="policycoreutils"/>
+        <package name="setools-console"/>
+        <package name="selinux-policy-targeted"/>
+        <package name="selinux-policy-devel"/>
+        <package name="selinux-autorelabel"/>
     </packages>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -553,6 +553,9 @@ class SystemSetup:
         :param str security_context_file: path file name
         """
         log.info('Processing SELinux file security contexts')
+        if not os.access(self.root_dir, os.W_OK):
+            log.info('System is read-only, security context unchanged')
+            return
         exclude = []
         for devname in Defaults.get_exclude_list_for_non_physical_devices():
             exclude.append('-e')

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -1662,6 +1662,20 @@ class TestSystemSetup:
     @patch('kiwi.system.setup.CommandCapabilities.has_option_in_help')
     @patch('kiwi.system.setup.Command.run')
     @patch('os.scandir')
+    @patch('os.access')
+    def test_set_selinux_file_contexts_read_only_root(
+        self, mock_os_access, mock_os_scandir, mock_command,
+        mock_has_option_in_help
+    ):
+        mock_os_access.return_value = False
+        mock_has_option_in_help.return_value = False
+        mock_os_scandir.return_value = self.selinux_policies
+        self.setup.set_selinux_file_contexts('security_context_file')
+        assert not mock_command.called
+
+    @patch('kiwi.system.setup.CommandCapabilities.has_option_in_help')
+    @patch('kiwi.system.setup.Command.run')
+    @patch('os.scandir')
     def test_set_selinux_file_contexts_old_version(
         self, mock_os_scandir, mock_command, mock_has_option_in_help
     ):


### PR DESCRIPTION
Make sure to perform setfiles only on a writable target. In case of a read-only root it is expected that the security context set by kiwi in an earlier stage is complete. As there is no way to modify data when root is read-only, there is also no way to change the security context of any file such that we skip setfiles in this case. Should there be a read-only system that has writable partitions such as /boot and their content changes while the rest of the root system is read-only it is in the responsibility of the author of the image description to call setfiles only on the affected and still writable files via a custom disk.sh script. Along with the fix the respective integration test was modified to enable selinux such that this change is actually integration tested. This Fixes #2805

