### PR TITLE
Fix systemd-boot loader setup

### DIFF
--- a/kiwi/bootloader/config/systemd_boot.py
+++ b/kiwi/bootloader/config/systemd_boot.py
@@ -178,7 +178,6 @@ class BootLoaderSystemdBoot(BootLoaderSpecBase):
                 '--entry-token', 'os-id'
             ]
         )
-        Path.wipe(f'{root_dir}/boot/loader')
         self._write_kernel_cmdline_file(root_dir)
 
         # copy kernel and initrd


### PR DESCRIPTION
To make sure only loader entries from /boot/efi/loader/entries kiwi deleted eventually existing entry files from /boot/loader. However that is a problem for read-only systems and should actually also not performed by kiwi. This Fixes #2805

