### PR TITLE
Add support for <initrd> section as part of <type>

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
@@ -9,6 +9,7 @@
     <profiles>
         <profile name="sdboot_erofs" description="systemd boot overlay disk using erofs"/>
         <profile name="sdboot_verity_erofs" description="systemd boot verity baked overlay disk using erofs"/>
+        <profile name="sdboot_uki_verity_erofs" description="systemd UKI boot verity baked overlay disk using erofs"/>
         <profile name="grub_verity_erofs" description="grub verity baked overlay disk using erofs"/>
     </profiles>
     <preferences>
@@ -29,7 +30,7 @@
             format="vmdk"
             overlayroot="true"
             overlayroot_readonly_filesystem="erofs"
-            overlayroot_readonly_partsize="1000"
+            overlayroot_readonly_partsize="1500"
             erofscompression="zstd,level=9"
             eficsm="false"
             bootpartition="false"
@@ -51,7 +52,7 @@
             format="vmdk"
             overlayroot="true"
             overlayroot_readonly_filesystem="erofs"
-            overlayroot_readonly_partsize="1000"
+            overlayroot_readonly_partsize="1500"
             erofscompression="zstd,level=9"
             eficsm="false"
             verity_blocks="all"
@@ -65,6 +66,32 @@
             <size unit="G">4</size>
         </type>
     </preferences>
+    <preferences profiles="sdboot_uki_verity_erofs">
+        <type
+            image="oem"
+            filesystem="xfs"
+            kernelcmdline="console=ttyS0 rd.systemd.verity=1 security=selinux selinux=1 enforcing=1"
+            firmware="efi"
+            format="vmdk"
+            overlayroot="true"
+            overlayroot_readonly_filesystem="erofs"
+            overlayroot_readonly_partsize="1500"
+            erofscompression="zstd,level=9"
+            eficsm="false"
+            verity_blocks="all"
+            bootpartition="false"
+            efipartsize="200"
+        >
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+            <bootloader name="systemd_boot" timeout="10"/>
+            <initrd action="setup">
+                <dracut uefi="true"/>
+            </initrd>
+            <size unit="G">4</size>
+        </type>
+    </preferences>
     <preferences profiles="grub_verity_erofs">
         <type
             image="oem"
@@ -74,7 +101,7 @@
             format="vmdk"
             overlayroot="true"
             overlayroot_readonly_filesystem="erofs"
-            overlayroot_readonly_partsize="1000"
+            overlayroot_readonly_partsize="1500"
             erofscompression="zstd,level=9"
             eficsm="false"
             verity_blocks="all"
@@ -92,8 +119,9 @@
     <repository type="rpm-md">
         <source path="obsrepositories:/"/>
     </repository>
-    <packages type="image" profiles="sdboot_verity_erofs,grub_verity_erofs">
+    <packages type="image" profiles="sdboot_verity_erofs,sdboot_uki_verity_erofs,grub_verity_erofs">
         <package name="cryptsetup"/>
+        <package name="systemd-boot"/>
         <package name="dracut-kiwi-verity"/>
         <package name="restorecond"/>
         <package name="policycoreutils"/>
@@ -102,12 +130,19 @@
         <package name="selinux-policy-devel"/>
         <package name="selinux-autorelabel"/>
     </packages>
-    <packages type="image">
-        <package name="patterns-base-minimal_base"/>
+    <packages type="image" profiles="sdboot_uki_verity_erofs">
+        <package name="binutils"/>
+    </packages>
+    <packages type="image" profiles="sdboot_erofs">
         <package name="systemd-boot"/>
+    </packages>
+    <packages type="image" profiles="grub_verity_erofs">
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>
         <package name="shim"/>
+    </packages>
+    <packages type="image">
+        <package name="patterns-base-minimal_base"/>
         <package name="procps"/>
         <package name="bind-utils"/>
         <package name="systemd"/>

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -1319,6 +1319,27 @@ Used to customize the installation media images created for oem images
 deployment.
 For details see: :ref:`installmedia_customize`
 
+<preferences><type><initrd>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Used to specify custom arguments for the initrd tooling e.g. dracut
+
+.. code:: xml
+
+   <initrd action="setup">
+       <dracut uefi="true"/>
+   </initrd>
+   <initrd action="add|omit">
+       <dracut module="some_a"/>
+       <dracut module="some_b"/>
+   </initrd>
+
+dracut.uefi.true:
+  As part of the `setup` action, enables creating a UKI EFI binary
+
+dracut.module.NAME:
+  As part of the `add` or `omit` action, adds or omits the given
+  module name. The element can be specified multiple times
+
 .. _sec.registry:
 
 <containers>

--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -115,6 +115,15 @@ class BootImageBase:
         """
         return False
 
+    def add_argument(self, option: str, value: str = '') -> None:
+        """
+        Add caller argument to boot image creation tool
+
+        :param str option: argument name
+        :param str value: optional argument value
+        """
+        pass
+
     def include_file(self, filename: str, install_media: bool = False) -> None:
         """
         Include file to boot image
@@ -233,6 +242,14 @@ class BootImageBase:
         """
         Prepare new root system to create initrd from. Implementation
         is only needed if there is no other root system available
+
+        Implementation in specialized boot image class
+        """
+        raise NotImplementedError
+
+    def create_uki(self, cmdline: str) -> str:
+        """
+        Create UKI EFI binary
 
         Implementation in specialized boot image class
         """

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2474,6 +2474,7 @@ div {
             k.partitions? &
             k.vagrantconfig* &
             k.installmedia? &
+            k.initrd* &
             k.luksformat?
         }
 }
@@ -3609,7 +3610,7 @@ div {
         ## Sets weather the dracut modules list are meant to be appended,
         ## omitted or they define the static list of modules for the
         ## installation initrd.
-        attribute action { "omit" | "add" | "set" }
+        attribute action { "omit" | "add" | "set" | "setup" }
     k.initrd.attlist =
         k.initrd.action.attribute
     k.initrd =
@@ -3628,8 +3629,11 @@ div {
     k.dracut.module.attribute =
         ## A module name
         attribute module { text }
+    k.dracut.uefi.attribute =
+        attribute uefi { xsd:boolean }
     k.dracut.attlist =
-        k.dracut.module.attribute
+        k.dracut.module.attribute? &
+        k.dracut.uefi.attribute?
     k.dracut =
         ## A dracut module
         element dracut {

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -3709,6 +3709,9 @@ kiwi-ng result bundle ...</a:documentation>
           <optional>
             <ref name="k.installmedia"/>
           </optional>
+          <zeroOrMore>
+            <ref name="k.initrd"/>
+          </zeroOrMore>
           <optional>
             <ref name="k.luksformat"/>
           </optional>
@@ -5414,6 +5417,7 @@ installation initrd.</a:documentation>
           <value>omit</value>
           <value>add</value>
           <value>set</value>
+          <value>setup</value>
         </choice>
       </attribute>
     </define>
@@ -5444,8 +5448,20 @@ for the installation media.</a:documentation>
         <a:documentation>A module name</a:documentation>
       </attribute>
     </define>
+    <define name="k.dracut.uefi.attribute">
+      <attribute name="uefi">
+        <data type="boolean"/>
+      </attribute>
+    </define>
     <define name="k.dracut.attlist">
-      <ref name="k.dracut.module.attribute"/>
+      <interleave>
+        <optional>
+          <ref name="k.dracut.module.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.dracut.uefi.attribute"/>
+        </optional>
+      </interleave>
     </define>
     <define name="k.dracut">
       <element name="dracut">

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3363,7 +3363,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, eficsm=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapper_snapshot=None, btrfs_root_is_subvolume=None, btrfs_set_default_volume=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, enclave_format=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, erofscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_filesystem=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, application_id=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, provide_system_files=None, require_system_files=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, eficsm=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapper_snapshot=None, btrfs_root_is_subvolume=None, btrfs_set_default_volume=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, enclave_format=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, erofscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_filesystem=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, application_id=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, provide_system_files=None, require_system_files=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, initrd=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -3491,6 +3491,10 @@ class type_(GeneratedsSuper):
             self.installmedia = []
         else:
             self.installmedia = installmedia
+        if initrd is None:
+            self.initrd = []
+        else:
+            self.initrd = initrd
         if luksformat is None:
             self.luksformat = []
         else:
@@ -3551,6 +3555,11 @@ class type_(GeneratedsSuper):
     def add_installmedia(self, value): self.installmedia.append(value)
     def insert_installmedia_at(self, index, value): self.installmedia.insert(index, value)
     def replace_installmedia_at(self, index, value): self.installmedia[index] = value
+    def get_initrd(self): return self.initrd
+    def set_initrd(self, initrd): self.initrd = initrd
+    def add_initrd(self, value): self.initrd.append(value)
+    def insert_initrd_at(self, index, value): self.initrd.insert(index, value)
+    def replace_initrd_at(self, index, value): self.initrd[index] = value
     def get_luksformat(self): return self.luksformat
     def set_luksformat(self, luksformat): self.luksformat = luksformat
     def add_luksformat(self, value): self.luksformat.append(value)
@@ -3796,6 +3805,7 @@ class type_(GeneratedsSuper):
             self.partitions or
             self.vagrantconfig or
             self.installmedia or
+            self.initrd or
             self.luksformat
         ):
             return True
@@ -4116,6 +4126,8 @@ class type_(GeneratedsSuper):
             vagrantconfig_.export(outfile, level, namespaceprefix_, name_='vagrantconfig', pretty_print=pretty_print)
         for installmedia_ in self.installmedia:
             installmedia_.export(outfile, level, namespaceprefix_, name_='installmedia', pretty_print=pretty_print)
+        for initrd_ in self.initrd:
+            initrd_.export(outfile, level, namespaceprefix_, name_='initrd', pretty_print=pretty_print)
         for luksformat_ in self.luksformat:
             luksformat_.export(outfile, level, namespaceprefix_, name_='luksformat', pretty_print=pretty_print)
     def build(self, node):
@@ -4773,6 +4785,11 @@ class type_(GeneratedsSuper):
             obj_.build(child_)
             self.installmedia.append(obj_)
             obj_.original_tagname_ = 'installmedia'
+        elif nodeName_ == 'initrd':
+            obj_ = initrd.factory()
+            obj_.build(child_)
+            self.initrd.append(obj_)
+            obj_.original_tagname_ = 'initrd'
         elif nodeName_ == 'luksformat':
             obj_ = luksformat.factory()
             obj_.build(child_)
@@ -8996,9 +9013,10 @@ class dracut(GeneratedsSuper):
     """A dracut module"""
     subclass = None
     superclass = None
-    def __init__(self, module=None):
+    def __init__(self, module=None, uefi=None):
         self.original_tagname_ = None
         self.module = _cast(None, module)
+        self.uefi = _cast(bool, uefi)
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -9012,6 +9030,8 @@ class dracut(GeneratedsSuper):
     factory = staticmethod(factory)
     def get_module(self): return self.module
     def set_module(self, module): self.module = module
+    def get_uefi(self): return self.uefi
+    def set_uefi(self, uefi): self.uefi = uefi
     def hasContent_(self):
         if (
 
@@ -9043,6 +9063,9 @@ class dracut(GeneratedsSuper):
         if self.module is not None and 'module' not in already_processed:
             already_processed.add('module')
             outfile.write(' module=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.module), input_name='module')), ))
+        if self.uefi is not None and 'uefi' not in already_processed:
+            already_processed.add('uefi')
+            outfile.write(' uefi="%s"' % self.gds_format_boolean(self.uefi, input_name='uefi'))
     def exportChildren(self, outfile, level, namespaceprefix_='', name_='dracut', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node):
@@ -9057,6 +9080,15 @@ class dracut(GeneratedsSuper):
         if value is not None and 'module' not in already_processed:
             already_processed.add('module')
             self.module = value
+        value = find_attr_value_('uefi', node)
+        if value is not None and 'uefi' not in already_processed:
+            already_processed.add('uefi')
+            if value in ('true', '1'):
+                self.uefi = True
+            elif value in ('false', '0'):
+                self.uefi = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class dracut

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -80,6 +80,11 @@ volume_type = NamedTuple(
 )
 
 
+class DracutT(NamedTuple):
+    uefi: bool
+    modules: List[str]
+
+
 class FileT(NamedTuple):
     target: str
     owner: str
@@ -1453,6 +1458,23 @@ class XMLState:
         if container_config_sections:
             return container_config_sections[0]
         return None
+
+    def get_dracut_config(self, action: str) -> DracutT:
+        """
+        Get dracut initrd config for the specified action
+        """
+        uefi = False
+        modules = []
+        initrd_sections = self.build_type.get_initrd()
+        for initrd_section in initrd_sections:
+            if initrd_section.get_action() == action:
+                for dracut in initrd_section.get_dracut():
+                    uefi = bool(dracut.get_uefi())
+                    if dracut.get_module():
+                        modules.append(dracut.get_module())
+        return DracutT(
+            uefi=uefi, modules=modules
+        )
 
     def get_installmedia_initrd_modules(self, action: str) -> List[str]:
         """

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -136,6 +136,12 @@
                 <vmconfig-entry>numvcpus = "4"</vmconfig-entry>
                 <vmconfig-entry>cpuid.coresPerSocket = "2"</vmconfig-entry>
             </machine>
+            <initrd action="setup">
+                <dracut uefi="true"/>
+            </initrd>
+            <initrd action="add">
+                <dracut module="some"/>
+            </initrd>
         </type>
         <type image="iso" mediacheck="true"/>
     </preferences>

--- a/test/unit/boot/image/base_test.py
+++ b/test/unit/boot/image/base_test.py
@@ -68,6 +68,10 @@ class TestBootImageBase:
         with raises(NotImplementedError):
             self.boot_image.create_initrd()
 
+    def test_create_uki(self):
+        with raises(NotImplementedError):
+            self.boot_image.create_uki('some_cmdline')
+
     @patch('os.listdir')
     def test_is_prepared(self, mock_listdir):
         mock_listdir.return_value = []
@@ -208,3 +212,6 @@ class TestBootImageBase:
 
     def test_has_initrd_support(self):
         assert self.boot_image.has_initrd_support() is False
+
+    def test_add_argument(self):
+        assert self.boot_image.add_argument('some') is None

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1252,12 +1252,20 @@ class TestXMLState:
             'some-target'
 
     def test_get_installintrd_modules(self):
-        self.state.get_installmedia_initrd_modules('add') == ['network-legacy']
-        self.state.get_installmedia_initrd_modules('set') == []
-        self.state.get_installmedia_initrd_modules('omit') == []
+        assert self.state.get_installmedia_initrd_modules('add') == \
+            ['network-legacy']
+        assert self.state.get_installmedia_initrd_modules('set') == []
+        assert self.state.get_installmedia_initrd_modules('omit') == []
         xml_data = self.description.load()
         state = XMLState(xml_data, ['vmxSimpleFlavour'], 'oem')
-        state.get_installmedia_initrd_modules('add') == []
+        assert state.get_installmedia_initrd_modules('add') == []
+
+    def test_get_dracut_config(self):
+        assert self.state.get_dracut_config('setup').uefi is False
+        xml_data = self.description.load()
+        state = XMLState(xml_data, ['vmxSimpleFlavour'], 'oem')
+        assert state.get_dracut_config('setup').uefi is True
+        assert state.get_dracut_config('add').modules == ['some']
 
     @patch('kiwi.system.uri.os.path.abspath')
     def test_get_repositories_signing_keys(self, mock_root_path):


### PR DESCRIPTION
Extend scope and content of the ```<initrd>``` section to be allowed as part of the ```<type>``` section. This allows to specify custom call options and modules for the dracut tool. In particular this commit implementes support for passing the uefi option to dracut to enable building an UKI EFI binary as follows:

```xml
<initrd action="setup">
    <dracut uefi="true"/>
</initrd>
```

This Fixes #2809 and Fixes #2408

