### PR TITLE
Add UKI support for the grub bootloader

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
@@ -11,6 +11,7 @@
         <profile name="sdboot_verity_erofs" description="systemd boot verity baked overlay disk using erofs"/>
         <profile name="sdboot_uki_verity_erofs" description="systemd UKI boot verity baked overlay disk using erofs"/>
         <profile name="grub_verity_erofs" description="grub verity baked overlay disk using erofs"/>
+        <profile name="grub_uki_verity_erofs" description="grub UKI chainload and verity baked overlay disk using erofs"/>
     </profiles>
     <preferences>
         <version>1.42.1</version>
@@ -113,15 +114,39 @@
             <size unit="G">4</size>
         </type>
     </preferences>
+    <preferences profiles="grub_uki_verity_erofs">
+        <type
+            image="oem"
+            filesystem="btrfs"
+            kernelcmdline="console=ttyS0 rd.systemd.verity=1 security=selinux selinux=1 enforcing=1"
+            firmware="efi"
+            format="vmdk"
+            overlayroot="true"
+            overlayroot_readonly_filesystem="erofs"
+            overlayroot_readonly_partsize="1500"
+            erofscompression="zstd,level=9"
+            eficsm="false"
+            verity_blocks="all"
+            efipartsize="200"
+        >
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+            <bootloader name="grub2" console="serial" timeout="10"/>
+            <initrd action="setup">
+                <dracut uefi="true"/>
+            </initrd>
+            <size unit="G">4</size>
+        </type>
+    </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
     <repository type="rpm-md">
         <source path="obsrepositories:/"/>
     </repository>
-    <packages type="image" profiles="sdboot_verity_erofs,sdboot_uki_verity_erofs,grub_verity_erofs">
+    <packages type="image" profiles="sdboot_verity_erofs,sdboot_uki_verity_erofs,grub_verity_erofs,grub_uki_verity_erofs">
         <package name="cryptsetup"/>
-        <package name="systemd-boot"/>
         <package name="dracut-kiwi-verity"/>
         <package name="restorecond"/>
         <package name="policycoreutils"/>
@@ -130,19 +155,17 @@
         <package name="selinux-policy-devel"/>
         <package name="selinux-autorelabel"/>
     </packages>
-    <packages type="image" profiles="sdboot_uki_verity_erofs">
+    <packages type="image" profiles="sdboot_uki_verity_erofs,grub_uki_verity_erofs">
         <package name="binutils"/>
     </packages>
-    <packages type="image" profiles="sdboot_erofs">
-        <package name="systemd-boot"/>
-    </packages>
-    <packages type="image" profiles="grub_verity_erofs">
+    <packages type="image" profiles="grub_verity_erofs,grub_uki_verity_erofs">
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>
         <package name="shim"/>
     </packages>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>
+        <package name="systemd-boot"/>
         <package name="procps"/>
         <package name="bind-utils"/>
         <package name="systemd"/>

--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -242,13 +242,13 @@ class BootImageDracut(BootImageBase):
                     os.sep.join(
                         [self.boot_root_directory, uki_base_name]
                     ),
-                    self.target_dir
+                    f'{self.target_dir}/kiwi.efi'
                 ]
             )
             for filename in self.delete_after_include_files:
                 os.unlink(f'{self.boot_root_directory}/{filename}')
             return os.path.normpath(
-                os.sep.join([self.target_dir, uki_base_name])
+                os.sep.join([self.target_dir, 'kiwi.efi'])
             )
         return ''
 

--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -157,7 +157,9 @@ class BootLoaderConfigBase(ABC):
         """
 
     @abstractmethod
-    def setup_disk_boot_images(self, boot_uuid, lookup_path=None):
+    def setup_disk_boot_images(
+        self, boot_uuid, efi_uuid=None, lookup_path=None
+    ):
         """
         Create bootloader images for disk boot
 
@@ -166,6 +168,7 @@ class BootLoaderConfigBase(ABC):
         path on a filesystem.
 
         :param string boot_uuid: boot device UUID
+        :param string efi_uuid: EFI device UUID
         :param string lookup_path: custom module lookup path
 
         Implementation in specialized bootloader class required

--- a/kiwi/bootloader/config/bootloader_spec_base.py
+++ b/kiwi/bootloader/config/bootloader_spec_base.py
@@ -168,12 +168,13 @@ class BootLoaderSpecBase(BootLoaderConfigBase):
         pass
 
     def setup_disk_boot_images(
-        self, boot_uuid: str, lookup_path: str = ''
+        self, boot_uuid: str, efi_uuid: str = '', lookup_path: str = ''
     ) -> None:
         """
         Create bootloader image(s) for disk boot
 
-        :param string mbrid: unused
+        :param string boot_uuid: unused
+        :param string efi_uuid: unused
         :param str lookup_path: unused
 
         Targeted to bootloader spec interface

--- a/kiwi/bootloader/config/custom.py
+++ b/kiwi/bootloader/config/custom.py
@@ -26,7 +26,9 @@ class BootLoaderConfigCustom(BootLoaderConfigBase):
     """
     **custom bootloader configuration.**
     """
-    def setup_disk_boot_images(self, boot_uuid, lookup_path=None) -> None:
+    def setup_disk_boot_images(
+        self, boot_uuid, efi_uuid=None, lookup_path=None
+    ) -> None:
         raise NotImplementedError
 
     def setup_disk_image_config(

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1556,6 +1556,10 @@ class DiskBuilder:
         if 'boot' in device_map:
             boot_device = device_map['boot']
 
+        efi_uuid = disk.get_uuid(
+            device_map['efi'].get_device()
+        ) if device_map.get('efi') else None
+
         boot_uuid = disk.get_uuid(
             boot_device.get_device()
         )
@@ -1563,7 +1567,7 @@ class DiskBuilder:
             device_map['luks_root'].get_device()
         ) if self.luks and self.boot_is_crypto else boot_uuid
         bootloader_config.setup_disk_boot_images(
-            boot_uuid_unmapped
+            boot_uuid_unmapped, efi_uuid
         )
         bootloader_config.write_meta_data(
             root_device=ro_device.

--- a/test/unit/boot/image/dracut_test.py
+++ b/test/unit/boot/image/dracut_test.py
@@ -146,7 +146,7 @@ class TestBootImageKiwi:
         assert self.boot_image.create_uki('some_cmdline') == ''
         mock_prepared.return_value = True
         assert self.boot_image.create_uki('some_cmdline') == \
-            'some-target-dir/vmlinuz-kernel_version.efi'
+            'some-target-dir/kiwi.efi'
         profile.create.assert_called_once_with(
             'system-directory/.profile'
         )
@@ -174,7 +174,7 @@ class TestBootImageKiwi:
             call(
                 [
                     'mv', 'system-directory/vmlinuz-kernel_version.efi',
-                    'some-target-dir'
+                    'some-target-dir/kiwi.efi'
                 ]
             )
         ]

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -334,7 +334,7 @@ class TestDiskBuilder:
         )
         disk.map_partitions.assert_called_once_with()
         bootloader_config.setup_disk_boot_images.assert_called_once_with(
-            '0815'
+            '0815', '0815'
         )
         bootloader_config.write_meta_data.assert_called_once_with(
             root_device='/dev/readonly-root-device',
@@ -843,7 +843,7 @@ class TestDiskBuilder:
         )
         disk.map_partitions.assert_called_once_with()
         bootloader_config.setup_disk_boot_images.assert_called_once_with(
-            '0815'
+            '0815', '0815'
         )
         bootloader_config.write_meta_data.assert_called_once_with(
             root_device='/dev/readonly-root-device',
@@ -1231,7 +1231,7 @@ class TestDiskBuilder:
             self.disk_builder.create_disk()
 
         bootloader_config.setup_disk_boot_images.assert_called_once_with(
-            '0815'
+            '0815', '0815'
         )
 
     @patch('kiwi.builder.disk.Disk')


### PR DESCRIPTION
In addition to systemd_boot also add support for UKI creation when grub is used. This includes the creation of a UKI image via dracut in the same way as it's done for systemd_boot. In addition an earlyboot grub script chainloads the UKI and bypasses any written grub configuration. In Theory this should also allow to use the shim loader for chainloading an UKI. However I haven't done testing in this direction and I also expect security issues with this approach because loading any non signed data by shim is not expected to work. A new profile named grub_uki_verity_erofs has been added to the integration test that experiments with UKIs


