### PR TITLE
Update live boot remote boot features

### DIFF
--- a/doc/source/working_with_images/network_live_iso_boot.rst
+++ b/doc/source/working_with_images/network_live_iso_boot.rst
@@ -28,67 +28,39 @@ the network:
    
    .. code:: bash
 
-       $ mount {exc_image_base_name}.x86_64-{exc_image_version}.iso /mnt
-       $ cp /mnt/boot/x86_64/loader/initrd /srv/tftpboot/boot/initrd
-       $ cp /mnt/boot/x86_64/loader/linux /srv/tftpboot/boot/linux
-       $ umount /mnt
+      $ mount {exc_image_base_name_live}.x86_64-{exc_image_version}.iso /mnt
+      $ cp /mnt/boot/x86_64/loader/initrd /srv/tftpboot/boot/initrd
+      $ cp /mnt/boot/x86_64/loader/linux /srv/tftpboot/boot/linux
+      $ umount /mnt
 
    .. note::
 
-       This step must be repeated with any new build of the live ISO image
+      This step must be repeated with any new build of the live ISO image
 
 2. Export Live ISO To The Network
 
-   Access to the live ISO file is implemented using the AoE protocol
-   in {kiwi}. This requires the export of the live ISO file as remote
-   block device which is typically done with the :command:`vblade`
-   toolkit. Install the following package on the system which is
-   expected to export the live ISO image:
+   Access to the live ISO file must be provided by either `ftp`,
+   `http`, `https` or `dolly`. The most simple method is to setup a FTP server
+   e.g. `vsftpd` and copy the live ISO file to the data directory:
 
    .. code:: bash
 
-       $ zypper in vblade
+       $ mkdir -p /srv/ftp/image
+       $ cp {exc_image_base_name_live}.x86_64-{exc_image_version}.iso /srv/ftp/image
 
    .. note::
 
-       Not all versions of AoE are compatible with any kernel. This
-       means the kernel on the system exporting the live ISO image
-       must provide a compatible aoe kernel module compared to the
-       kernel used in the live ISO image.
-   
-   Once done, export the live ISO image as follows:
-
-   .. code:: bash
-
-       $ vbladed 0 1 INTERFACE {exc_image_base_name}.x86_64-{exc_image_version}.iso
-
-   The above command exports the given ISO file as a block storage
-   device to the network of the given INTERFACE. On any machine
-   except the one exporting the file, it will appear as
-   :file:`/dev/etherd/e0.1` once the :command:`aoe` kernel module
-   was loaded. The two numbers, 0 and 1 in the above example, classifies
-   a major and minor number which is used in the device node name
-   on the reading side, in this case :file:`e0.1`. The numbers given
-   at export time must match the AOEINTERFACE name as described in
-   the next step.
-
-   .. note::
-
-       Only machines in the same network of the given INTERFACE
-       can see the exported live ISO image. If virtual machines
-       are the target to boot the live ISO image they could all
-       be connected through a bridge. In this case INTERFACE
-       is the bridge device. The availability scope of the live
-       ISO image on the network is in general not influenced
-       by {kiwi} and is a task for the network administrators.
+       Check if the image can be downloaded via:
+       `wget ftp://IP/image/{exc_image_base_name_live}.x86_64-{exc_image_version}.iso`
+       before the next step.
 
 3. Setup live ISO boot entry in PXE configuration
 
    .. note::
 
-       The following step assumes that the pxelinux.0 loader
-       has been configured on the boot server to boot up network
-       clients
+      The following step assumes that the pxelinux.0 loader
+      has been configured on the boot server to boot up network
+      clients
 
    Edit the file :file:`/srv/tftpboot/pxelinux.cfg/default` and create
    a boot entry of the form:
@@ -97,22 +69,91 @@ the network:
 
       LABEL Live-Boot
           kernel boot/linux
-          append initrd=boot/initrd rd.kiwi.live.pxe root=live:AOEINTERFACE=e0.1
+          append initrd=boot/initrd ip=dhcp root=live:ftp://IP/image/{exc_image_base_name_live}.x86_64-{exc_image_version}.iso
 
-   * The boot parameter `rd.kiwi.live.pxe` tells the {kiwi} boot process to
-     setup the network and to load the required :mod:`aoe` kernel module.
+   * The `ip=` parameter controls how the dracut network module sets up
+     the network. Several options exists to control how the network
+     interface should be setup. Please consult the dracut manual
+     for further information.
 
-   * The boot parameter `root=live:AOEINTERFACE=e0.1` specifies the
-     interface name as it was exported by the :command:`vbladed` command
-     from the last step. Currently only AoE (Ata Over Ethernet)
-     is supported.
+   * The boot parameter `root=live:PROTOCOL://IP/PATH...` specifies the
+     remote endpoint and protocol to find the live ISO file. So far
+     `ftp`, `http`, `https` and `dolly` are supported.
 
 4. Boot from the Network
 
    Within the network which has access to the PXE server and the
-   exported live ISO image, any network client can now boot the
+   IP in the root= option, any network client can now boot the
    live system. A test based on QEMU is done as follows:
 
    .. code:: bash
 
-      $ sudo qemu -boot n
+      $ qemu -boot n
+
+Available Remote Boot Options
+-----------------------------
+
+There are the following kernel boot options available to control
+the behavior of the remote boot process.
+
+rd.kiwi.live.curl_options=
+  Options passed along to the curl call
+
+rd.kiwi.live.dolly_options=
+  Options passed along to the dolly call
+
+rd.kiwi.live.system=
+  Block device to use for the system. By default this is set to `/dev/ram0`
+
+ramdisk_size=bytes
+  Size of the ramdisk in bytes. By default this is set to 2097152 (2G)
+
+rd.kiwi.live.reset
+  Force reset of the live system. This option only makes sense if
+  the live system device (rd.kiwi.live.system) points to a persistent
+  storage device. In this case {kiwi} loads the system only once
+  and does not overwrite it unless a reset is requested.
+
+Persistent Live System
+----------------------
+
+The remote boot process of a live ISO image, places the ISO file
+into a ramdisk by default. This means all data lives in memory and
+is not persistent. In order to boot up the live system from a remote
+location and keep it on a persistent storage, it's required to
+pass the `rd.kiwi.live.system` boot option with the device name
+pointing to that persistent storage.
+
+.. warning::
+
+    All data on the device given via `rd.kiwi.live.system` will be wiped
+
+A test based on QEMU is done as follows:
+
+Edit the file :file:`/srv/tftpboot/pxelinux.cfg/default` and create
+a boot entry of the form:
+
+.. code:: bash
+
+   LABEL Live-Boot
+       kernel boot/linux
+       append initrd=boot/initrd ip=dhcp root=live:ftp://IP/image/{exc_image_base_name_live}.x86_64-{exc_image_version}.iso ramdisk_size=3545728 rd.kiwi.live.system=/dev/sda rd.live.overlay.persistent rd.live.overlay.cowfs=xfs
+
+* The `rd.live.overlay.persistent` and `rd.live.overlay.cowfs=xfs`
+  options are standard {kiwi} live ISO options to control if and how a
+  persistent write partition should be created. The options only take
+  an effect when booting into a persistent storage device.
+
+Next create a persistent storage disk of 3G and attach it to the
+QEMU instance.
+
+.. code:: bash
+
+   $ qemu-img create mydisk.raw 3G
+   $ qemu -boot n -hda mydisk.raw
+
+The live system will be deployed once to the locally attached disk and
+boots from it. Any subsequent boot process will not modify the local
+disk unless `rd.kiwi.live.reset` is passed on the kernel command line.
+If deployed there is also no need for the network anymore and the
+system could also boot standalone.

--- a/dracut/modules.d/90kiwi-live/kiwi-generator.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-generator.sh
@@ -22,6 +22,10 @@ case "${liveroot}" in
         root="${root//\//\\x2f}"
         root="live:aoe:/dev/etherd/${root#AOEINTERFACE=}"
         rootok=1 ;;
+    live:ftp:*|live:http:*|live:https:*|live:dolly:*) \
+        root="${root#live:}"
+        root="live:net:${root}"
+        rootok=1 ;;
 esac
 
 [ "${rootok}" != "1" ] && exit 0

--- a/dracut/modules.d/90kiwi-live/kiwi-live-root.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-root.sh
@@ -14,8 +14,11 @@ initialize
 # load required kernel modules
 loadKernelModules
 
+# provide ISO when remote
+root=$(ProvideIso "$1")
+
 # device nodes and types
-initGlobalDevices "$1"
+initGlobalDevices "$root"
 
 # live options and their default values
 initGlobalOptions

--- a/dracut/modules.d/90kiwi-live/module-setup.sh
+++ b/dracut/modules.d/90kiwi-live/module-setup.sh
@@ -16,7 +16,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods squashfs loop aoe iso9660 overlay
+    instmods squashfs loop aoe brd iso9660 overlay
 }
 
 # called by dracut
@@ -29,7 +29,7 @@ install() {
     inst_multiple \
         umount dmsetup partx blkid lsblk dd losetup \
         grep cut partprobe find wc fdisk tail mkfs.ext4 mkfs.xfs \
-        dialog cat mountpoint
+        dialog cat mountpoint curl dolly dd
 
     dmsquashdir=$(find "${dracutbasedir}/modules.d" -name "*dmsquash-live")
     if [ -n "${dmsquashdir}" ] && \


### PR DESCRIPTION
Like the upstream module also support the root=live:http://... remote boot options. The kiwi-live dracut module is scheduled to become obsolete, but it's still in use and should support remote boot not only for AoE. As we got more issue reports than working AoE remote boot success, this commit also updates the documentation and switches to the capabilities of this PR.

