### PR TITLE
Fixed rd.root.overlay.readonly overlay mode

### DIFF
--- a/dracut/modules.d/90kiwi-overlay/kiwi-generator.sh
+++ b/dracut/modules.d/90kiwi-overlay/kiwi-generator.sh
@@ -16,37 +16,22 @@ GENERATOR_DIR="$2"
 [ -z "$GENERATOR_DIR" ] && exit 1
 [ -d "$GENERATOR_DIR" ] || mkdir "$GENERATOR_DIR"
 
+OVERLAY_BASE="$(getOverlayBaseDirectory)"
+ROOTFLAGS="$(getarg rootflags)"
+
 if getargbool 0 rd.root.overlay.readonly; then
-    case "${overlayroot}" in
-        overlay:PARTUUID=*|PARTUUID=*) \
-            root="${root#overlay:}"
-            root="${root//\//\\x2f}"
-            root="block:/dev/disk/by-partuuid/${root#PARTUUID=}"
-        ;;
-        overlay:PARTLABEL=*|PARTLABEL=*) \
-            root="${root#overlay:}"
-            root="${root//\//\\x2f}"
-            root="block:/dev/disk/by-partlabel/${root#PARTLABEL=}"
-        ;;
-        overlay:UNIXNODE=*|UNIXNODE=*) \
-            root="${root#overlay:}"
-            root="${root//\//\\x2f}"
-            root="block:/dev/${root#UNIXNODE=}"
-        ;;
-    esac
     {
         echo "[Unit]"
         echo "Before=initrd-root-fs.target"
         echo "DefaultDependencies=no"
         echo "[Mount]"
         echo "Where=/sysroot"
-        echo "What=${root#block:}"
-        echo "Type=squashfs"
+        echo "What=${OVERLAY_BASE}/rootfsbase"
+        echo "Options=bind"
+        echo "Type=none"
         _dev=ReadOnlyOS_rootfs
     } > "$GENERATOR_DIR"/sysroot.mount
 else
-    OVERLAY_BASE="$(getOverlayBaseDirectory)"
-    ROOTFLAGS="$(getarg rootflags)"
     {
         echo "[Unit]"
         echo "Before=initrd-root-fs.target"


### PR DESCRIPTION
When booting an overlayroot image with rd.root.overlay.readonly set, the system will boot with only the read-only root mounted. There was a bug in the dracut code which prevented this mount from succeeding when the read-only rootfs is different from squashfs. This commit changes the mount to be a simple bind mount, independent of the origin filesystem. This works because the read-only mount is performed in the dracut overlay code anyway. This is related to Issue #2815


