### PR TITLE
Update overlay integration test for partial write

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-overlayroot/appliance.kiwi
@@ -71,7 +71,7 @@
         <type
             image="oem"
             filesystem="xfs"
-            kernelcmdline="console=ttyS0 rd.systemd.verity=1 security=selinux selinux=1 enforcing=1"
+            kernelcmdline="console=ttyS0 rd.systemd.verity=1 security=selinux selinux=1 enforcing=1 rd.root.overlay.readonly"
             firmware="efi"
             format="vmdk"
             overlayroot="true"


### PR DESCRIPTION
Update the sdboot_uki_verity_erofs profile of the
test-image-overlayroot integration test with a custom fstab example to overlay only parts of the system
for writing. This is related to Issue #2815

