### PR TITLE
Cleanup build metadata

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -926,6 +926,10 @@ class DiskBuilder:
                             ]
                         )
 
+                    # cleanup build metadata
+                    if os.access(f'{root}/', os.W_OK):
+                        disk_system.cleanup()
+
                     # set root filesystem properties
                     if system:
                         self._setup_property_root_is_readonly_snapshot(system)

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -168,9 +168,20 @@ class SystemSetup:
         Command.run(
             [
                 'chroot', self.root_dir,
-                'rm', '-rf', '.kconfig', defaults.IMAGE_METADATA_DIR
+                'rm', '-f',
+                '.kconfig',
+                '.profile',
+                'config.bootoptions',
+                'config.partids'
             ]
         )
+        meta_dir = f'{self.root_dir}/{defaults.IMAGE_METADATA_DIR}'
+        if os.path.isdir(meta_dir):
+            image_meta = MountManager(
+                device='none', mountpoint=meta_dir
+            )
+            image_meta.umount()
+            Path.wipe(meta_dir)
 
     def import_repositories_marked_as_imageinclude(self) -> None:
         """

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -870,6 +870,7 @@ class TestDiskBuilder:
         ]
         disk_system.call_pre_disk_script.assert_called_once_with()
         disk_system.call_disk_script.assert_called_once_with()
+        disk_system.cleanup.assert_called_once_with()
         self.setup.call_edit_boot_config_script.assert_called_once_with(
             'btrfs', 1
         )

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -373,9 +373,24 @@ class TestSystemSetup:
     @patch('kiwi.command.Command.run')
     def test_cleanup(self, mock_command):
         self.setup.cleanup()
-        mock_command.assert_called_once_with(
-            ['chroot', 'root_dir', 'rm', '-rf', '.kconfig', 'image']
-        )
+        assert mock_command.call_args_list == [
+            call(
+                [
+                    'chroot', 'root_dir', 'rm', '-f',
+                    '.kconfig',
+                    '.profile',
+                    'config.bootoptions',
+                    'config.partids'
+                ]
+            ),
+            call(
+                command=['mountpoint', '-q', 'root_dir/image'],
+                raise_on_error=False
+            ),
+            call(
+                ['rm', '-r', '-f', 'root_dir/image']
+            )
+        ]
 
     @patch('kiwi.system.setup.ArchiveTar')
     @patch('kiwi.system.setup.glob.iglob')


### PR DESCRIPTION
Make sure the final image rootfs does not contain unneeded metadata files used during build time. The respective cleanup call is performed after the root sync and after all initrd/boot processing has been done. This is because up to that point it's still possible that the information is required. This means when building images with a read-only rootfs, it might not be possible that the metadata can be deleted due to a chicken&egg situation. Furthermore the cleanup is applied to the disk builder only as other builders do not really suffer from this data and for the container builder the metadata can also be used for the stackbuild feature when building images derived from containers. This Fixes #2668

