### PR TITLE
Fix disk_type validation for zipl loader

### DIFF
--- a/build-tests/s390/tumbleweed/test-image-MicroOS/appliance.kiwi
+++ b/build-tests/s390/tumbleweed/test-image-MicroOS/appliance.kiwi
@@ -36,7 +36,7 @@
                 <oem-unattended>true</oem-unattended>
                 <oem-resize>true</oem-resize>
             </oemconfig>
-            <bootloader name="zipl" timeout="10"/>
+            <bootloader name="zipl" timeout="10" targettype="GPT"/>
             <systemdisk>
                 <volume name="home"/>
                 <volume name="root"/>
@@ -165,17 +165,20 @@
         <package name="cloud-init"/>
         <package name="cloud-init-config-suse"/>
         <package name="systemd-network"/>
+        <package name="systemd-resolved"/>
     </packages>
     <packages type="image" profiles="IBM-Cloud-Standard">
         <package name="cloud-init"/>
         <package name="cloud-init-config-suse"/>
         <package name="systemd-network"/>
+        <package name="systemd-resolved"/>
     </packages>
     <packages type="image" profiles="SUSE-Infra">
         <package name="ibm-se-certificates"/>
         <package name="ibm-se-revocation-lists"/>
         <package name="suse-se-host-certificates"/>
         <package name="systemd-network"/>
+        <package name="systemd-resolved"/>
     </packages>
     <packages type="image">
         <package name="patterns-base-bootloader"/>
@@ -203,6 +206,7 @@
         <package name="curl"/>
         <package name="cryptsetup"/>
         <package name="procps"/>
+        <package name="zlib-devel"/>
     </packages>
     <packages type="bootstrap">
         <package name="gawk"/>

--- a/build-tests/s390/tumbleweed/test-image-MicroOS/disk.sh
+++ b/build-tests/s390/tumbleweed/test-image-MicroOS/disk.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euxo pipefail
+
+/usr/libexec/setup-etc-subvol

--- a/build-tests/s390/tumbleweed/test-image-MicroOS/root/etc/fstab.script
+++ b/build-tests/s390/tumbleweed/test-image-MicroOS/root/etc/fstab.script
@@ -1,9 +1,0 @@
-#!/bin/sh
-set -eux
-
-/usr/sbin/setup-fstab-for-overlayfs
-# If /var is on a different partition than /...
-if [ "$(findmnt -snT / -o SOURCE)" != "$(findmnt -snT /var -o SOURCE)" ]; then
-    # ... set options for autoexpanding /var
-    gawk -i inplace '$2 == "/var" { $4 = $4",x-growpart.grow,x-systemd.growfs" } { print $0 }' /etc/fstab
-fi

--- a/kiwi/bootloader/config/zipl.py
+++ b/kiwi/bootloader/config/zipl.py
@@ -190,6 +190,7 @@ class BootLoaderZipl(BootLoaderSpecBase):
         self, default_entry: str = ''
     ) -> Dict[str, str]:
         disk_type = self.disk_type or 'SCSI'
+        disk_type = disk_type if disk_type != 'GPT' else 'SCSI'
         blocksize = self.disk_blocksize or 512
         unsupported_for_target_geometry = ['FBA', 'SCSI']
         targetbase = f'targetbase={self.custom_args.get("targetbase")}'
@@ -204,7 +205,7 @@ class BootLoaderZipl(BootLoaderSpecBase):
             'boot_timeout': self.timeout,
             'bootpath': self.get_boot_path(),
             'targetbase': targetbase,
-            'targettype': disk_type if disk_type != 'GPT' else 'SCSI',
+            'targettype': disk_type,
             'targetblocksize': format(blocksize),
             'targetoffset': self._get_partition_start(),
             'targetgeometry': geometry,

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1133,7 +1133,7 @@ class DiskBuilder:
             )
             partition_mbsize = self.disk_setup.boot_partition_size()
             disk.create_boot_partition(
-                partition_mbsize, self.boot_clone_count
+                format(partition_mbsize), self.boot_clone_count
             )
             disksize_used_mbytes += \
                 (self.boot_clone_count + 1) * partition_mbsize if \

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -321,7 +321,7 @@ class TestDiskBuilder:
             self.firmware.get_efi_partition_size()
         )
         disk.create_boot_partition.assert_called_once_with(
-            self.disk_setup.boot_partition_size(), 0
+            format(self.disk_setup.boot_partition_size()), 0
         )
         disk.create_swap_partition.assert_called_once_with(
             '128'
@@ -567,7 +567,7 @@ class TestDiskBuilder:
             self.disk_builder.create_disk()
 
         disk.create_boot_partition.assert_called_once_with(
-            self.disk_setup.boot_partition_size(), 1
+            format(self.disk_setup.boot_partition_size()), 1
         )
         disk.create_root_partition.assert_called_once_with(
             'clone:458:458', 1
@@ -833,7 +833,7 @@ class TestDiskBuilder:
             self.firmware.get_efi_partition_size()
         )
         disk.create_boot_partition.assert_called_once_with(
-            self.disk_setup.boot_partition_size(), 0
+            format(self.disk_setup.boot_partition_size()), 0
         )
         disk.create_prep_partition.assert_called_once_with(
             self.firmware.get_prep_partition_size()


### PR DESCRIPTION
If the targettype is set to GPT in combination with plain zipl as loader, the code to validate the targettype against the targetgeometry was not effective and zipl failed. This Fixes #2821

