### PR TITLE
Allow /boot to be a btrfs subvolume

### DIFF
--- a/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
@@ -30,9 +30,10 @@
         </type>
     </preferences>
     <preferences profiles="Virtual">
-        <type image="oem" filesystem="btrfs" kernelcmdline="console=ttyS0" firmware="uefi" format="qcow2" btrfs_root_is_subvolume="true" btrfs_set_default_volume="false" rootfs_label="fedora" bootpartition="true" bootfilesystem="ext4">
+        <type image="oem" filesystem="btrfs" kernelcmdline="console=ttyS0" firmware="uefi" format="qcow2" btrfs_root_is_subvolume="true" btrfs_set_default_volume="false" rootfs_label="fedora" bootpartition="false">
             <systemdisk name="fedora">
                 <volume name="@root=root"/>
+                <volume name="boot" parent="/"/>
                 <volume name="home" parent="/"/>
                 <volume name="var" parent="/"/>
             </systemdisk>

--- a/test/unit/bootloader/config/base_test.py
+++ b/test/unit/bootloader/config/base_test.py
@@ -249,24 +249,6 @@ class TestBootLoaderConfigBase:
 
     @patch('kiwi.bootloader.config.base.DiskSetup')
     @patch('kiwi.xml_parse.type_.get_filesystem')
-    @patch('kiwi.xml_state.XMLState.get_volumes')
-    def test_get_boot_path_btrfs_boot_is_a_volume_error(
-        self, mock_volumes, mock_fs, mock_disk_setup
-    ):
-        volume = Mock()
-        volume.name = 'boot'
-        mock_volumes.return_value = [volume]
-        mock_fs.return_value = 'btrfs'
-        disk_setup = Mock()
-        disk_setup.need_boot_partition = Mock(
-            return_value=False
-        )
-        mock_disk_setup.return_value = disk_setup
-        with raises(KiwiBootLoaderTargetError):
-            self.bootloader.get_boot_path()
-
-    @patch('kiwi.bootloader.config.base.DiskSetup')
-    @patch('kiwi.xml_parse.type_.get_filesystem')
     @patch('kiwi.xml_parse.type_.get_btrfs_root_is_snapper_snapshot')
     @patch('kiwi.xml_state.XMLState.get_volumes')
     def test_get_boot_path_btrfs_no_snapshot(


### PR DESCRIPTION
In a btrfs based design, allow to put /boot as subvolume. This required a small fix in the mount order in a way that boot/efi gets mounted after the subvolume mounts are done. The respective integration test has been updated to test this functionality. This Fixes #2824

