### PR TITLE
Add dependency for isomd5sum for iso images and set in kiwi-settings

### DIFF
--- a/build-tests/arm/fedora/kiwi-settings/kiwi-settings/kiwi.yml
+++ b/build-tests/arm/fedora/kiwi-settings/kiwi-settings/kiwi.yml
@@ -1,2 +1,4 @@
+iso:
+  - media_tag_tool: isomd5sum
 oci:
   - archive_tool: buildah

--- a/build-tests/x86/fedora/kiwi-settings/kiwi-settings/kiwi.yml
+++ b/build-tests/x86/fedora/kiwi-settings/kiwi-settings/kiwi.yml
@@ -1,2 +1,4 @@
+iso:
+  - media_tag_tool: isomd5sum
 oci:
   - archive_tool: buildah

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -233,6 +233,8 @@ Provides:       kiwi-image:iso
 %endif
 %if 0%{?suse_version}
 Requires:       checkmedia
+%else
+Requires:       isomd5sum
 %endif
 Requires:       xorriso
 Requires:       kiwi-systemdeps-core = %{version}-%{release}


### PR DESCRIPTION
This ensures that isomd5sum is pulled into the environment for ISO image builds, and the updated settings makes it so that kiwi boxes will use it.
