### PR TITLE
Fix logging of stderr data in command calls

### DIFF
--- a/kiwi/command_process.py
+++ b/kiwi/command_process.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import os
 import logging
 from collections import namedtuple
 from kiwi.command import CommandCallT
@@ -112,7 +113,8 @@ class CommandProcess:
         )
         if error_output:
             log.debug('--------------err start-------------')
-            log.debug(error_output)
+            for line in error_output.split(os.linesep):
+                log.debug(line)
             log.debug('--------------err stop--------------')
         return result(
             stderr=error_output, returncode=error_code
@@ -197,6 +199,7 @@ class CommandIterator:
             elif byte_read == bytes(b'\n'):
                 line_stderr = Codec.decode(self.command_error_line)
                 self.command_error_line = bytes(b'')
+                self.command_error_output += byte_read
             else:
                 self.command_error_line += byte_read
                 self.command_error_output += byte_read

--- a/test/unit/command_process_test.py
+++ b/test/unit/command_process_test.py
@@ -140,7 +140,7 @@ class TestCommandProcess:
             assert '--------------out start-------------' in self._caplog.text
             assert 'data' in self._caplog.text
             assert '--------------out stop--------------' in self._caplog.text
-            assert result.stderr == 'error'
+            assert result.stderr == 'error\n'
 
     @patch('kiwi.command.Command')
     def test_create_match_method(self, mock_command):


### PR DESCRIPTION
The stderr data was presented as one blob without line breaks. Hard to read and smells like a bug. This commit fixes the output to become readable

