### PR TITLE
Fixed get_partition_node_name

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -192,7 +192,8 @@ function get_partition_node_name {
     local part
     udev_pending
     for partnode in $(
-        lsblk -p -l -o NAME,TYPE "${disk}" | grep -E "part|md$" | cut -f1 -d ' '
+        lsblk -p -l -o NAME,TYPE,START -x START "${disk}" |\
+        grep -E "part|md$" | cut -f1 -d ' '
     );do
         if [ "${index}" = "${partid}" ];then
             echo "${partnode}"


### PR DESCRIPTION
The function get_partition_node_name takes the disk device and the partition index as arguments to match against the respective device node for this partition index. The partition index is the position of the partition in the partition table according to their start offset. For the code to function properly it is required that the list of partitions provided by lsblk is ordered according to the start address of the partitions in the table. The way lsblk was called did not enforce this ordering. This commit enforces the order to be done against the start offset and fixes bsc#1245190


