### PR TITLE
Fix shim lookup for arm on SUSE

### DIFF
--- a/build-tests/arm/tumbleweed/test-image-live-disk/appliance.kiwi
+++ b/build-tests/arm/tumbleweed/test-image-live-disk/appliance.kiwi
@@ -24,7 +24,7 @@
         <bootloader-theme>openSUSE</bootloader-theme>
     </preferences>
     <preferences profiles="Live">
-        <type image="iso" flags="overlay" firmware="efi" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="ext4" hybridpersistent="true"/>
+        <type image="iso" flags="overlay" firmware="uefi" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="ext4" hybridpersistent="true"/>
     </preferences>
     <preferences profiles="Disk">
         <type image="oem" firmware="efi" kernelcmdline="console=ttyS0" installiso="true" installboot="install" filesystem="ext4">
@@ -69,6 +69,7 @@
         <package name="timezone"/>
     </packages>
     <packages type="image" profiles="Live">
+        <package name="shim"/>
         <package name="dracut-kiwi-live"/>
     </packages>
     <packages type="image" profiles="Disk">

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -933,6 +933,10 @@ class Defaults:
                 'bootx64.efi'
             ),
             shim_pattern_type(
+                '/usr/share/efi/aarch64/shim.efi',
+                'bootaa64.efi'
+            ),
+            shim_pattern_type(
                 '/usr/lib64/efi/shim.efi',
                 'bootx64.efi'
             ),
@@ -1256,6 +1260,11 @@ class Defaults:
                     '/usr/share/efi/x86_64/grub.efi',
                     'grub.efi',
                     'grubx64.efi'
+                ),
+                grub_pattern_type(
+                    '/usr/share/efi/aarch64/grub.efi',
+                    'grub.efi',
+                    'grubaa64.efi'
                 ),
                 grub_pattern_type(
                     '/usr/lib64/efi/grub.efi',

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -82,6 +82,7 @@ class TestBootLoaderConfigGrub2:
             [],
             [],
             [],
+            [],
             ['root_dir/usr/lib64/efi/shim.efi'],
             # get_signed_grub_loader(disk)
             [],
@@ -127,8 +128,10 @@ class TestBootLoaderConfigGrub2:
             [],
             [],
             [],
+            [],
             ['root_dir/usr/lib64/efi/shim.efi'],
             # get_signed_grub_loader(iso)
+            [],
             [],
             [],
             [],


### PR DESCRIPTION
Add missing search path for shim binary on arm based SUSE systems. Also update the tumbleweed/test-image-live-disk integration test for arm to build with secure boot enabled to actually test a secure boot enabled ISO build.
This Fixes #2842


