### PR TITLE
Add kernel parameter support for dm-verity options

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -801,6 +801,26 @@ embed_verity_metadata="true|false":
     * **root_hash**: root hash as returned by `veritysetup`
     * **salt**: salt hash as returned by `veritysetup`
 
+.. note:: dm-verity Runtime Options
+
+  Additional veritysetup options can be provided at boot time using the kernel
+  parameter `rd.kiwi.verity_options=option1,option2`. This allows runtime
+  customization.
+
+  KIWI automatically provides `hash-offset` and `hash-block-size` parameters
+  based on the image configuration. These should not be specified manually
+  via `rd.kiwi.verity_options=`.
+
+  **Common Options:**
+
+  * `panic-on-corruption`: System panics on corruption detection
+  * `restart-on-corruption`: System restarts on corruption (often default)
+  * `ignore-corruption`: Ignore corruption (debugging only)
+  * `ignore-zero-blocks`: Skip verification of zero blocks
+  * `check-at-most-once`: Verify each block only once
+
+  For complete options, see `veritysetup(8) <https://man7.org/linux/man-pages/man8/veritysetup.8.html>`_.
+
 overlayroot="true|false":
   For the `oem` type only, specifies to use an `overlayfs` based root
   filesystem consisting out of a squashfs compressed read-only root

--- a/dracut/modules.d/80kiwi-verity/kiwi-veritytab-setup.sh
+++ b/dracut/modules.d/80kiwi-verity/kiwi-veritytab-setup.sh
@@ -30,6 +30,16 @@ if [ "$(echo "${hash_device}" | cut -f1 -d=)" = "UUID" ];then
     hash_device=/dev/disk/by-uuid/$(echo "${hash_device}" | cut -f2 -d=)
 fi
 
+# Read kernel command line verity options and merge the options
+kiwi_verity_options=$(getarg rd.kiwi.verity_options=)
+if [ -n "${kiwi_verity_options}" ]; then
+    if [ -n "${options}" ]; then
+        options="${options},${kiwi_verity_options}"
+    else
+        options="${kiwi_verity_options}"
+    fi
+fi
+
 veritysetup="veritysetup open "
 veritysetup="${veritysetup} ${data_device} ${name} ${hash_device} ${root_hash}"
 


### PR DESCRIPTION
Implement rd.kiwi.verity_options= parameter to allow runtime customization of veritysetup options

Fixes #2837 .

### Changes proposed in this pull request:
Add kernel command line parsing to [kiwi-veritytab-setup.sh](https://github.com/OSInside/kiwi/blob/main/dracut/modules.d/80kiwi-verity/kiwi-veritytab-setup.sh). The script already sources dracut-lib.sh, which provides access to getarg function.

### Supported Options:
panic-on-corruption - System panics on corruption detection
restart-on-corruption - System restarts on corruption (default)
ignore-corruption - Ignore corruption (debugging only)
ignore-zero-blocks - Ignore zero blocks
check-at-most-once - Verify blocks only once
Veritysetup options as documented in [veritysetup(8)](https://man7.org/linux/man-pages/man8/veritysetup.8.html)

### Usage Example:
```
rd.kiwi.verity_options=panic-on-corruption,check-at-most-once
```

Adding `rd.kiwi.verity_options=panic-on-corruption`
```
[63.380164] dracut-initqueue[893]: ///lib/dracut/hooks/initqueue/settled/71-kiwi-veritytab-setup.sh@50(): veritysetup open /dev/disk/by-uuid/**** verityroot /dev/disk/by-uuid/**** **** --hash-offset=**** --hash-block-size=4096 --panic-on-corruption
```