### PR TITLE
Make mbr-id deterministic

### DIFF
--- a/kiwi/system/identifier.py
+++ b/kiwi/system/identifier.py
@@ -15,11 +15,15 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import logging
+import os
 import random
 import struct
 
 # project
 from kiwi.storage.device_provider import DeviceProvider
+
+log = logging.getLogger('kiwi')
 
 
 class SystemIdentifier:
@@ -32,6 +36,10 @@ class SystemIdentifier:
     """
     def __init__(self):
         self.image_id = None
+        sde = os.environ.get('SOURCE_DATE_EPOCH')
+        if sde:
+            log.info(f'Using SOURCE_DATE_EPOCH as random seed: {sde}')
+            random.seed(int(sde))
 
     def get_id(self) -> str:
         """

--- a/test/unit/system/identifier_test.py
+++ b/test/unit/system/identifier_test.py
@@ -6,10 +6,14 @@ from kiwi.system.identifier import SystemIdentifier
 
 
 class TestSystemIdentifier:
-    def setup(self):
-        self.identifier = SystemIdentifier()
+    @patch('random.seed')
+    def setup(self, mock_random_seed):
+        with patch.dict('os.environ', {'SOURCE_DATE_EPOCH': '123456'}):
+            self.identifier = SystemIdentifier()
+        mock_random_seed.assert_called_once_with(123456)
 
-    def setup_method(self, cls):
+    @patch('random.seed')
+    def setup_method(self, cls, mock_random_seed):
         self.setup()
 
     def test_get_id(self):


### PR DESCRIPTION
helps #2358

Changes proposed in this pull request:
* use `SOURCE_DATE_EPOCH` value to seed the random number generator to ensure mbrid is deterministic
