### PR TITLE
Fix regression in get_partition_node_name

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -191,6 +191,7 @@ function get_partition_node_name {
     local index=1
     local part
     udev_pending
+    # backwards compat for lsblk before 2.38: if START column not supported, fall back to default sort
     for partnode in $(
         { lsblk -p -l -o NAME,TYPE,START -x START "${disk}" 2>/dev/null ||\
         lsblk -p -l -o NAME,TYPE "${disk}"; } |\

--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -192,7 +192,8 @@ function get_partition_node_name {
     local part
     udev_pending
     for partnode in $(
-        lsblk -p -l -o NAME,TYPE,START -x START "${disk}" |\
+        { lsblk -p -l -o NAME,TYPE,START -x START "${disk}" 2>/dev/null ||\
+        lsblk -p -l -o NAME,TYPE "${disk}"; } |\
         grep -E "part|md$" | cut -f1 -d ' '
     );do
         if [ "${index}" = "${partid}" ];then


### PR DESCRIPTION
Fixes part of [this issue](https://groups.google.com/g/kiwi-images/c/-hcVSbMSWaw/m/3906dsdSAwAJ)

Changes proposed in this pull request:
* Fixes regression in get_partition_node_name for targets that do not support the `START` column in `lsblk`.
    * This restores prior behaviour, which may reintroduce [the bug that was intended to fix](https://github.com/OSInside/kiwi/commit/246a478d490e85187366ca5717627fc7601c737a), but that's better than breaking existing functionality.