### PR TITLE
Bind mount /dev/pts during image build time

### DIFF
--- a/kiwi/system/root_bind.py
+++ b/kiwi/system/root_bind.py
@@ -17,6 +17,7 @@
 #
 import os
 import logging
+import pathlib
 import shutil
 import textwrap
 from typing import List
@@ -68,6 +69,7 @@ class RootBind:
         self.bind_locations = [
             '/proc',
             '/dev',
+            '/dev/pts',
             '/var/run/dbus',
             '/sys'
         ]
@@ -95,12 +97,13 @@ class RootBind:
                 self.mount_stack.append(shared_mount)
 
             for location in self.bind_locations:
-                location_mount_target = os.path.normpath(os.sep.join([
-                    self.root_dir, location
-                ]))
-                if os.path.exists(location) and os.path.exists(
-                    location_mount_target
-                ):
+                if os.path.exists(location):
+                    location_mount_target = os.path.normpath(
+                        os.sep.join([self.root_dir, location])
+                    )
+                    pathlib.Path(location_mount_target).mkdir(
+                        parents=True, exist_ok=True
+                    )
                     shared_mount = MountManager(
                         device=location, mountpoint=location_mount_target
                     )

--- a/test/unit/system/root_bind_test.py
+++ b/test/unit/system/root_bind_test.py
@@ -32,6 +32,7 @@ class TestRootBind:
         assert self.bind_root.bind_locations == [
             '/proc',
             '/dev',
+            '/dev/pts',
             '/var/run/dbus',
             '/sys'
         ]
@@ -98,7 +99,10 @@ class TestRootBind:
 
     @patch('kiwi.system.root_bind.os.path.exists')
     @patch('kiwi.system.root_bind.MountManager')
-    def test_mount_kernel_file_systems(self, mock_mount, mock_exists):
+    @patch('kiwi.system.root_bind.pathlib.Path')
+    def test_mount_kernel_file_systems(
+        self, mock_pathlib_Path, mock_mount, mock_exists
+    ):
         mock_exists.return_value = True
         shared_mount = Mock()
         mock_mount.return_value = shared_mount


### PR DESCRIPTION
Make sure to bind mount /dev/pts into the build environment. Tools which allocates a pseudo terminal won't work otherwise. Also apply a small refactor for the bind mounts which will create the target mount point directory if it does not exist

