### PR TITLE
defaults: Add patterns for shim/grub2 on riscv64

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -953,6 +953,10 @@ class Defaults:
                 'bootaa64.efi'
             ),
             shim_pattern_type(
+                '/boot/efi/EFI/*/shimriscv64.efi',
+                'bootriscv64.efi'
+            ),
+            shim_pattern_type(
                 '/boot/efi/EFI/*/shim.efi',
                 'bootx64.efi'
             ),
@@ -1062,6 +1066,11 @@ class Defaults:
                     '/boot/efi/EFI/*/grubaa64.efi',
                     'grubaa64.efi',
                     'bootaa64.efi'
+                ),
+                grub_pattern_type(
+                    '/boot/efi/EFI/*/grubriscv64.efi',
+                    'grubriscv64.efi',
+                    'bootriscv64.efi'
                 )
             ],
             'iso': [
@@ -1094,6 +1103,11 @@ class Defaults:
                     '/boot/efi/EFI/*/grubaa64.efi',
                     'grubaa64.efi',
                     'bootaa64.efi'
+                ),
+                grub_pattern_type(
+                    '/boot/efi/EFI/*/grubriscv64.efi',
+                    'grubriscv64.efi',
+                    'bootriscv64.efi'
                 )
             ]
         }
@@ -1235,6 +1249,11 @@ class Defaults:
                     'bootaa64.efi'
                 ),
                 grub_pattern_type(
+                    '/boot/efi/EFI/*/grubriscv64.efi',
+                    'grubriscv64.efi',
+                    'bootriscv64.efi'
+                ),
+                grub_pattern_type(
                     '/usr/share/grub*/*-efi/grub.efi',
                     'grub.efi',
                     'bootx64.efi'
@@ -1285,6 +1304,11 @@ class Defaults:
                     '/boot/efi/EFI/*/grubaa64.efi',
                     'grubaa64.efi',
                     'bootaa64.efi'
+                ),
+                grub_pattern_type(
+                    '/boot/efi/EFI/*/grubriscv64.efi',
+                    'grubriscv64.efi',
+                    'bootriscv64.efi'
                 ),
                 grub_pattern_type(
                     '/usr/share/grub*/x86_64-efi/grub.efi',

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -83,8 +83,10 @@ class TestBootLoaderConfigGrub2:
             [],
             [],
             [],
+            [],
             ['root_dir/usr/lib64/efi/shim.efi'],
             # get_signed_grub_loader(disk)
+            [],
             [],
             [],
             [],
@@ -102,6 +104,7 @@ class TestBootLoaderConfigGrub2:
             [],
             ['root_dir/usr/lib64/efi/MokManager.efi'],
             # get_signed_grub_loader(disk)
+            [],
             [],
             [],
             [],
@@ -129,8 +132,10 @@ class TestBootLoaderConfigGrub2:
             [],
             [],
             [],
+            [],
             ['root_dir/usr/lib64/efi/shim.efi'],
             # get_signed_grub_loader(iso)
+            [],
             [],
             [],
             [],

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -98,7 +98,8 @@ class TestDefaults:
             call('root/usr/lib/grub*/x86_64-efi/grub.efi'),
             call('root/boot/efi/EFI/*/grubx64.efi'),
             call('root/boot/efi/EFI/*/grubia32.efi'),
-            call('root/boot/efi/EFI/*/grubaa64.efi')
+            call('root/boot/efi/EFI/*/grubaa64.efi'),
+            call('root/boot/efi/EFI/*/grubriscv64.efi')
         ]
         mock_glob.reset_mock()
         mock_glob.return_value = []


### PR DESCRIPTION
A recent commit changed the way these are looked up and accidentally broke image building on riscv64, with

```
KiwiBootLoaderGrubSecureBootError: Signed grub2 efi loader not found
```

now being raised for kiwi recipes that worked just fine before that moment.

Fixes: 197572378cf4f25103934beac2ceca4fbbcfcbc0

**Note**: this currently breaks the test suite, and I couldn't figure out how to make that issue go away. Guidance on the matter would be very welcome.