### PR TITLE
Fix check_target_dir_on_unsupported_filesystem

### DIFF
--- a/kiwi/path.py
+++ b/kiwi/path.py
@@ -227,3 +227,14 @@ class Path:
             lookup_paths = Path.rebase_to_root(root_dir, lookup_paths)
         log.debug(f"Looking for {filename} in {os.pathsep.join(lookup_paths)}")
         return shutil.which(filename, access_mode, path=os.pathsep.join(lookup_paths))
+
+    @staticmethod
+    def first_exists(path: str) -> str:
+        """
+        Lookup first path that exists in the given path hierarchy
+        """
+        p = pathlib.Path(path)
+        if p.exists():
+            return path
+        else:
+            return Path.first_exists(format(p.parent))

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -86,11 +86,12 @@ class RuntimeChecker:
         message = dedent('''\n
             Target root/image directory is lacking filesystem features
 
-            The filesystem {0} for the given image target directory {1}
+            The filesystem {0} in the target path {1}
             does not support important features like extended permissions,
             ACLs or xattrs. The image build may fail or the resulting
             image misbehave.
         ''')
+        target_dir = Path.first_exists(target_dir)
         stat = Command.run(['stat', '-f', '-c', '%T', target_dir])
         if stat:
             target_fs = stat.output.strip()

--- a/test/unit/path_test.py
+++ b/test/unit/path_test.py
@@ -140,3 +140,10 @@ class TestPath:
 
         mock_stat.assert_called_once_with(fname)
         mock_access.assert_called_once_with(fname, mode, effective_ids=True)
+
+    def test_first_exists(self):
+        assert Path.first_exists('/') == '/'
+        assert Path.first_exists('/etc/foo/bar') == '/etc'
+        assert Path.first_exists('artificial') == '.'
+        assert Path.first_exists('foo/bar') == '.'
+        assert Path.first_exists('/x/y/z') == '/'


### PR DESCRIPTION
Find the first existing path in the target path and check the filesystem capabilities for this path.
This Fixes #2858


