### PR TITLE
dracut kiwi-repart fixes

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-lvm/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-lvm/appliance.kiwi
@@ -20,11 +20,10 @@
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>512</oem-swapsize>
-                <oem-resize>false</oem-resize>
             </oemconfig>
             <bootloader name="grub2" console="serial" timeout="10"/>
             <systemdisk>
-                <volume name="home"/>
+                <volume name="home" size="2G"/>
             </systemdisk>
         </type>
     </preferences>
@@ -61,6 +60,7 @@
         <package name="kernel-default"/>
         <package name="shim"/>
         <package name="timezone"/>
+        <package name="dracut-kiwi-oem-repart"/>
     </packages>
     <packages type="bootstrap">
         <package name="gawk"/>

--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -226,38 +226,12 @@ function check_repart_possible {
     return 0
 }
 
-function mask_fsck_root_service {
-    info "disable systemd-fsck-root.service"
-    systemctl mask systemd-fsck-root.service
-}
-
-function unmask_fsck_root_service {
-    info "enabling systemd-fsck-root.service"
-    systemctl unmask systemd-fsck-root.service
-}
-
 #======================================
 # Perform repart/resize operations
 #--------------------------------------
 PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
 setup_debug
-
-# when repartitioning disks, the used tools can trigger re-reads of
-# the partition table, in turn triggering systemd-fsck-root.service
-# repeatedly via udev events, which finally can cause booting to fail with
-# * start request repeated too quickly for systemd-fsck-root.service
-# * Failed to start File System Check on /dev/disk/by-uuid...
-# * Dependency failed for /sysroot.
-# To avoid this, disable the root fsck (is finished at this point anyway
-# *and* the filesystem is brand new ;) by masking it.
-# "systemctl disable" does not work here, because it is event driven
-# More details: https://github.com/SUSE/kiwi/issues/1034
-
-# make sure we unmask the fsck service
-trap unmask_fsck_root_service EXIT
-
-mask_fsck_root_service
 
 # initialize for disk repartition
 initialize

--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -18,11 +18,8 @@ function initialize {
     test -f ${profile} || \
         warn "No profile setup found"
         warn "Settings from the kiwi description will be ignored"
-    test -f ${partition_ids} || \
-        die "No partition id setup found"
 
     test -f ${profile} && import_file ${profile}
-    import_file ${partition_ids}
 
     # Optional env TERM setup
     term=$(getarg "rd.kiwi.term=")
@@ -34,6 +31,15 @@ function initialize {
 
     disk=$(lookup_disk_device_from_root)
     export disk
+
+    if ! test -f ${partition_ids}; then
+        warn "No partition id setup found, rebuilding..."
+        {
+            echo "kiwi_RootPart=\"$(get_last_partition_id "${disk}")\""
+        } > ${partition_ids}
+    fi
+
+    import_file ${partition_ids}
 
     root_device=${root#block:}
     export root_device

--- a/dracut/modules.d/90kiwi-repart/module-setup.sh
+++ b/dracut/modules.d/90kiwi-repart/module-setup.sh
@@ -19,11 +19,8 @@ installkernel() {
 # called by dracut
 install() {
     declare moddir=${moddir}
-    if inst_simple /config.partids; then
-        test -f /.profile && inst_simple /.profile
-        inst_hook pre-mount 20 "${moddir}/kiwi-repart-disk.sh"
-        dracut_need_initqueue
-    else
-        echo "ERROR: kiwi-repart needs /config.partids; not installing module"
-    fi
+    test -f /config.partids && inst_simple /config.partids
+    test -f /.profile && inst_simple /.profile
+    inst_hook pre-mount 20 "${moddir}/kiwi-repart-disk.sh"
+    dracut_need_initqueue
 }

--- a/dracut/modules.d/99kiwi-lib/kiwi-luks-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-luks-lib.sh
@@ -74,7 +74,7 @@ function reencrypt_luks {
         setup_progress_fifo ${progress}
         (
             # reencrypt, this will overwrite all key slots
-            cryptsetup reencrypt \
+            udevadm lock --device "${device}" cryptsetup reencrypt \
                 --progress-frequency 1 \
                 --key-file "${passphrase_file}" \
                 --key-slot "${keyslot}" \
@@ -102,7 +102,7 @@ function activate_luks {
         # but this requires to manually call luksOpen since
         # with systemd-cryptsetup we saw it still asking for
         # a passphrase
-        cryptsetup \
+        udevadm lock --device "${device}" cryptsetup \
             --key-file /dev/zero \
             --keyfile-size 32 \
         luksOpen "${device}" luks

--- a/dracut/modules.d/99kiwi-lib/kiwi-lvm-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lvm-lib.sh
@@ -61,7 +61,9 @@ function get_volume_path_for_volume {
 }
 
 function resize_pyhiscal_volumes {
-    pvresize "$(get_root_map)"
+    local device
+    device=$(get_root_map)
+    udevadm lock --device "${device}" pvresize "${device}"
 }
 
 function resize_lvm_volumes_and_filesystems {

--- a/dracut/modules.d/99kiwi-lib/kiwi-mdraid-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-mdraid-lib.sh
@@ -19,12 +19,14 @@ function deactivate_mdraid {
 
 function activate_mdraid {
     declare kiwi_RaidDev=${kiwi_RaidDev}
-    mdadm --assemble --scan "${kiwi_RaidDev}"
+    udevadm lock --device "${kiwi_RaidDev}" \
+        mdadm --assemble --scan "${kiwi_RaidDev}"
     wait_for_storage_device "${kiwi_RaidDev}"
     set_root_map "${kiwi_RaidDev}"
 }
 
 function resize_mdraid {
     declare kiwi_RaidDev=${kiwi_RaidDev}
-    mdadm --grow --size=max "${kiwi_RaidDev}"
+    udevadm lock --device "${kiwi_RaidDev}" \
+        mdadm --grow --size=max "${kiwi_RaidDev}"
 }

--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -23,9 +23,11 @@ function create_partitions {
         ;;
     esac
     if type partprobe &> /dev/null;then
-        partprobe "${disk_device}"
+        udevadm lock --device "${disk_device}" \
+            partprobe "${disk_device}"
     else
-        partx -u "${disk_device}"
+        udevadm lock --device "${disk_device}" \
+            partx -u "${disk_device}"
     fi
 }
 
@@ -59,21 +61,23 @@ function create_msdos_partitions {
             start_sector_from[$partid]=$(
                 _get_msdos_partition_start_sector "${disk_device}" "${partid}"
             )
-            sfdisk --force --delete "${disk_device}" "${partid}"
+            udevadm lock --device "${disk_device}" \
+                sfdisk --force --delete "${disk_device}" "${partid}"
         ;;
         "n")
             # create a partition...
             partid=${cmd_list[$index + 2]}
             part_size_end=${cmd_list[$index + 4]}
             echo "${start_sector_from[$partid]},${part_size_end}" > /tmp/sfdisk.in
-            sfdisk --force -N "${partid}" "${disk_device}" <  /tmp/sfdisk.in
+            udevadm lock --device "${disk_device}" \
+                sfdisk --force -N "${partid}" "${disk_device}" < /tmp/sfdisk.in
         ;;
         "t")
             # change a partition type...
             part_type=${cmd_list[$index + 2]}
             partid=${cmd_list[$index + 1]}
-            sfdisk --force --change-id "${disk_device}" "${partid}" \
-                "${part_type}"
+            udevadm lock --device "${disk_device}" \
+                sfdisk --force --change-id "${disk_device}" "${partid}" "${part_type}"
         ;;
         esac
         index=$((index + 1))
@@ -108,7 +112,8 @@ function create_gpt_partitions {
         "d")
             # delete a partition...
             partid=${cmd_list[$index + 1]}
-            sgdisk --delete "${partid}" "${disk_device}"
+            udevadm lock --device "${disk_device}" \
+                sgdisk --delete "${partid}" "${disk_device}"
         ;;
         "n")
             # create a partition...
@@ -116,17 +121,17 @@ function create_gpt_partitions {
             partid=${cmd_list[$index + 2]}
             part_size_start=${cmd_list[$index + 3]}
             part_size_end=${cmd_list[$index + 4]}
-            sgdisk --new "${partid}:${part_size_start}:${part_size_end}" \
-                "${disk_device}"
-            sgdisk --change-name "${partid}:${part_name}" \
-                "${disk_device}"
+            udevadm lock --device "${disk_device}" \
+                sgdisk --new "${partid}:${part_size_start}:${part_size_end}" "${disk_device}"
+            udevadm lock --device "${disk_device}" \
+                sgdisk --change-name "${partid}:${part_name}" "${disk_device}"
         ;;
         "t")
             # change a partition type...
             part_type=${cmd_list[$index + 2]}
             partid=${cmd_list[$index + 1]}
-            sgdisk --typecode "${partid}:$(_to_guid "${part_type}")" \
-                "${disk_device}"
+            udevadm lock --device "${disk_device}" \
+                sgdisk --typecode "${partid}:$(_to_guid "${part_type}")" "${disk_device}"
         ;;
         esac
         index=$((index + 1))
@@ -148,7 +153,8 @@ function create_dasd_partitions {
     # partition table updated to the actual disk geometry. This is
     # to circumvent the fdasd limitation of not being capable to
     # expand the partition table up to the disk size bsc#1209247
-    parted --script --machine "${disk_device}" resizepart 1
+    udevadm lock --device "${disk_device}" \
+        parted --script --machine "${disk_device}" resizepart 1
 
     for cmd in ${partition_setup};do
         if [ "${ignore_cmd}" = 1 ] && echo "${cmd}" | grep -qE '[dntwq]';then
@@ -182,7 +188,8 @@ function create_dasd_partitions {
     done
     echo "w" >> ${partition_setup_file}
     echo "q" >> ${partition_setup_file}
-    fdasd "${disk_device}" < ${partition_setup_file} 1>&2
+    udevadm lock --device "${disk_device}" \
+        fdasd "${disk_device}" < ${partition_setup_file} 1>&2
 }
 
 function get_partition_node_name {
@@ -336,7 +343,7 @@ function get_partition_uuid {
 }
 
 function relocate_gpt_at_end_of_disk {
-    if ! sfdisk --relocate gpt-bak-std "$1";then
+    if ! udevadm lock --device "$1" sfdisk --relocate gpt-bak-std "$1";then
         die "Failed to write backup GPT at end of disk"
     fi
 }
@@ -378,7 +385,8 @@ function activate_boot_partition {
     pt_table_type=$(get_partition_table_type "${disk_device}")
     if [[ "$(uname -m)" =~ i.86|x86_64 ]];then
         if [ "${pt_table_type}" = "dos" ];then
-            sfdisk --activate "${disk_device}" "${boot_partition_id}"
+            udevadm lock --device "${disk_device}" \
+                sfdisk --activate "${disk_device}" "${boot_partition_id}"
         fi
     fi
 }
@@ -393,7 +401,9 @@ function create_hybrid_gpt {
         # see man sgdisk for details
         partition_count=3
     fi
-    if ! sgdisk -h "$(seq -s : 1 "${partition_count}")" "${disk_device}";then
+    if ! udevadm lock --device "${disk_device}" \
+        sgdisk -h "$(seq -s : 1 "${partition_count}")" "${disk_device}"
+    then
         die "Failed to create hybrid GPT/MBR !"
     fi
 }

--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -336,7 +336,7 @@ function get_partition_uuid {
 }
 
 function relocate_gpt_at_end_of_disk {
-    if ! sgdisk -e "$1";then
+    if ! sfdisk --relocate gpt-bak-std "$1";then
         die "Failed to write backup GPT at end of disk"
     fi
 }

--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -191,7 +191,8 @@ function get_partition_node_name {
     local index=1
     local part
     udev_pending
-    # backwards compat for lsblk before 2.38: if START column not supported, fall back to default sort
+    # backwards compat for lsblk before 2.38:
+    # if START column not supported, fall back to default sort
     for partnode in $(
         { lsblk -p -l -o NAME,TYPE,START -x START "${disk}" 2>/dev/null ||\
         lsblk -p -l -o NAME,TYPE "${disk}"; } |\
@@ -204,6 +205,20 @@ function get_partition_node_name {
         index=$((index + 1))
     done
     return 1
+}
+
+function get_last_partition_id {
+    # """
+    # Get index of last partition from the current table
+    # """
+    local disk=$1
+    local index=0
+    for partnode in $(lsblk -p -l -o NAME,TYPE "${disk}" |\
+        grep -E "part|md$" | cut -f1 -d ' '
+    );do
+        index=$((index + 1))
+    done
+    echo "${index}"
 }
 
 function wait_for_storage_device {

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -173,8 +173,7 @@ class SystemSetup:
                 'rm', '-f',
                 '.kconfig',
                 '.profile',
-                'config.bootoptions',
-                'config.partids'
+                'config.bootoptions'
             ]
         )
         meta_dir = f'{self.root_dir}/{defaults.IMAGE_METADATA_DIR}'

--- a/test/unit/system/setup_test.py
+++ b/test/unit/system/setup_test.py
@@ -379,8 +379,7 @@ class TestSystemSetup:
                     'chroot', 'root_dir', 'rm', '-f',
                     '.kconfig',
                     '.profile',
-                    'config.bootoptions',
-                    'config.partids'
+                    'config.bootoptions'
                 ]
             ),
             call(


### PR DESCRIPTION
This change is many fold

**extend integration test for testing more of the resize code**

Use the lvm integration test as an example for a bit more complex resize testing

**apply proper udev locking**

Several commands during repart, resize and other actions require a proper lock to be set for udev such that other  events knows about the locked state of a device and do not mess with it until the command for which the lock persists has completed. This commit applies proper udev locks to all commands that requires it. In addition incorrect code that was expected to prevent such race conditions got dropped from the implementation.
This is related to https://bugzilla.suse.com/show_bug.cgi?id=1242987#c124

**relocate GPT at the end of disk using sfdisk**

Using sfdisk for relocation and verification makes this part more consistent. We also want to move away from gdisk. This is related to #2851

**Do not strictly require config.partids in repart**

The kiwi-repart implementation requires a metadata file named config.partids which holds information about  partition ids and more stored at the time the image was built. Depending on the complexity of the image and the resize request some of the information can be rebuilt in case the metadata file is missing. This commit adds  the rebuild of the minimum required information to run a standard resize and therefore allows the kiwi-repart dracut module to work also without config.partids to be present in the system

**Do not drop /config.partids**

The partition id metadata file is used in the kiwi-repart module. If a user wants to use the kiwi repart module permanently, this metadata file needs to stay in the system. Therefore it should not be automatically deleted by the cleanup. A disk.sh hook script can be used to force the deletion of the file though. This is related #2851
