### PR TITLE
Fix dracut code to be POSIX compliant

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -54,8 +54,8 @@ function sort_disk_entries {
         fi
         count=$((count + 1))
     done
-    readarray -td '' list_items_sorted \
-        < <(printf '%s\0' "${device_array[@]}" | sort -z)
+    printf '%s\0' "${device_array[@]}" | sort -z > list_items_sorted.txt
+    readarray -td '' list_items_sorted < list_items_sorted.txt
     echo "${list_items_sorted[*]}"
 }
 


### PR DESCRIPTION
The redirect type "< <(...)" is not POSIX complians and leads to a syntax error in dracut which calls bash as "sh" leading it to be restricted to POSIX only


