### PR TITLE
Fix return from repart stage

### DIFF
--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -256,6 +256,9 @@ if [ "$(get_partition_table_type "${disk}")" = 'gpt' ];then
     relocate_gpt_at_end_of_disk "${disk}"
 fi
 
+# wait for the root device to appear
+wait_for_storage_device "${root_device}"
+
 # resize disk partition table
 if lvm_system;then
     repart_lvm_disk || return
@@ -283,3 +286,6 @@ if lvm_system; then
 else
     resize_filesystem "$(get_root_map)"
 fi
+
+# wait for the root device to appear
+wait_for_storage_device "${root_device}"


### PR DESCRIPTION
If we return from the repart stage it's important to wait for the root device to appear. This is because the device setup from udev might still be held back due to a former lock on the device. This means if we return fast after locking for example when check_repart_possible() quickly finds out that it's not possible, then udev has not yet got the time to create the device nodes.
This Fixes #2863

