### PR TITLE
Fix bug in shell condition

### DIFF
--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -15,9 +15,10 @@ function initialize {
     local profile=/.profile
     local partition_ids=/config.partids
 
-    test -f ${profile} || \
+    if test ! -f ${profile}; then
         warn "No profile setup found"
         warn "Settings from the kiwi description will be ignored"
+    fi
 
     test -f ${profile} && import_file ${profile}
 


### PR DESCRIPTION
The shell code test ... || warn A; warn B will always print the warning for B despite the test result. This lead to the warning message "Settings from the kiwi description will be ignored" to be printed always. This commit fixes it with a clean if/then condition

