### PR TITLE
Consolidate device lock into its own method

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-filesystem-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-filesystem-lib.sh
@@ -37,7 +37,7 @@ function resize_filesystem {
     local mpoint=/fs-resize
     local fstype
     fstype=$(probe_filesystem "${device}")
-    lock="udevadm lock --device ${device}"
+    lock="set_device_lock ${device}"
     case ${fstype} in
     ext2|ext3|ext4)
         resize_fs="${lock} resize2fs -f -p ${device}"
@@ -77,7 +77,7 @@ function check_filesystem {
     local check_fs_return_ok
     local fstype
     fstype=$(probe_filesystem "${device}")
-    lock="udevadm lock --device ${device}"
+    lock="set_device_lock ${device}"
     case ${fstype} in
     ext2|ext3|ext4)
         # The exit code by e2fsck is the sum of the following conditions:

--- a/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
@@ -17,6 +17,19 @@ function get_system_id {
     blkid -s PTUUID -o value "${disk_device}"
 }
 
+function set_device_lock {
+    # """
+    # Set device lock, preferrable via udevadm or via
+    # flock as fallback if systemd/udev does not provide
+    # the command
+    # """
+    if udevadm lock --help &>/dev/null;then
+        udevadm lock --device "$@"
+    else
+        flock -x "$@"
+    fi
+}
+
 function disk_matches_system_identifier {
     local disk_device=$1
     local system_identifier=/system_identifier

--- a/dracut/modules.d/99kiwi-lib/kiwi-luks-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-luks-lib.sh
@@ -74,7 +74,7 @@ function reencrypt_luks {
         setup_progress_fifo ${progress}
         (
             # reencrypt, this will overwrite all key slots
-            udevadm lock --device "${device}" cryptsetup reencrypt \
+            set_device_lock "${device}" cryptsetup reencrypt \
                 --progress-frequency 1 \
                 --key-file "${passphrase_file}" \
                 --key-slot "${keyslot}" \
@@ -102,7 +102,7 @@ function activate_luks {
         # but this requires to manually call luksOpen since
         # with systemd-cryptsetup we saw it still asking for
         # a passphrase
-        udevadm lock --device "${device}" cryptsetup \
+        set_device_lock "${device}" cryptsetup \
             --key-file /dev/zero \
             --keyfile-size 32 \
         luksOpen "${device}" luks

--- a/dracut/modules.d/99kiwi-lib/kiwi-lvm-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lvm-lib.sh
@@ -63,7 +63,7 @@ function get_volume_path_for_volume {
 function resize_pyhiscal_volumes {
     local device
     device=$(get_root_map)
-    udevadm lock --device "${device}" pvresize "${device}"
+    set_device_lock "${device}" pvresize "${device}"
 }
 
 function resize_lvm_volumes_and_filesystems {

--- a/dracut/modules.d/99kiwi-lib/kiwi-mdraid-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-mdraid-lib.sh
@@ -19,7 +19,7 @@ function deactivate_mdraid {
 
 function activate_mdraid {
     declare kiwi_RaidDev=${kiwi_RaidDev}
-    udevadm lock --device "${kiwi_RaidDev}" \
+    set_device_lock "${kiwi_RaidDev}" \
         mdadm --assemble --scan "${kiwi_RaidDev}"
     wait_for_storage_device "${kiwi_RaidDev}"
     set_root_map "${kiwi_RaidDev}"
@@ -27,6 +27,6 @@ function activate_mdraid {
 
 function resize_mdraid {
     declare kiwi_RaidDev=${kiwi_RaidDev}
-    udevadm lock --device "${kiwi_RaidDev}" \
+    set_device_lock "${kiwi_RaidDev}" \
         mdadm --grow --size=max "${kiwi_RaidDev}"
 }

--- a/dracut/modules.d/99kiwi-lib/module-setup.sh
+++ b/dracut/modules.d/99kiwi-lib/module-setup.sh
@@ -23,7 +23,7 @@ install() {
         vgs vgchange lvextend lvcreate lvresize pvresize \
         mdadm cryptsetup dialog \
         pv curl xz sha256sum sed \
-        dmsetup touch chmod
+        dmsetup touch chmod flock
     inst_multiple -o dolly
     if type partx &> /dev/null;then
         inst_multiple partx


### PR DESCRIPTION
Add set_device_lock method which uses udevadm lock preferable but also supports an flock fallback in case there is no lock command provided via systemd/udev

