### PR TITLE
Skip repart when booting install/live iso

### DIFF
--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -234,6 +234,13 @@ PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
 setup_debug
 
+# abort for iso/live mode
+case "${root}" in
+    install:* | live:*)
+        return
+        ;;
+esac
+
 # initialize for disk repartition
 initialize
 


### PR DESCRIPTION
Fixes [error](https://groups.google.com/g/kiwi-images/c/SkpfZcRVTTk/m/hxvMTckqBgAJ).

Changes proposed in this pull request:
* Skips doing anything in the kiwi-repart module if it's installed into the install or live iso images, since repartitioning makes no sense there and the format of "$root" is not supported by later code.

----

Note that this is sufficient to get the install iso booting again, but there is still some blkid errors being logged just prior to the install menu popup which suggests that another module might be unhappy, but I wasn't able to work out which.  I do have only these installed though:

```
        <package name="dracut-kiwi-oem-repart"/>
        <package name="dracut-kiwi-oem-dump"/>
        <package name="dracut-kiwi-live"/>
```