### PR TITLE
Skip kiwi-repart module in install ISOs

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -513,7 +513,7 @@ function get_remote_image_source_files {
 #--------------------------------------
 setup_debug
 
-initialize
+lib_initialize
 
 udev_pending
 

--- a/dracut/modules.d/99kiwi-dump-reboot/kiwi-dump-reboot-system.sh
+++ b/dracut/modules.d/99kiwi-dump-reboot/kiwi-dump-reboot-system.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-type initialize >/dev/null 2>&1 || . /lib/kiwi-lib.sh
+type lib_initialize >/dev/null 2>&1 || . /lib/kiwi-lib.sh
 type report_and_quit >/dev/null 2>&1 || . /lib/kiwi-dump-image.sh
 type get_selected_disk >/dev/null 2>&1 || . /lib/kiwi-dump-image.sh
 type run_dialog >/dev/null 2>&1 || . /lib/kiwi-dialog-lib.sh
@@ -73,7 +73,7 @@ function boot_installed_system {
 #======================================
 # Reboot into system
 #--------------------------------------
-initialize
+lib_initialize
 
 if getargbool 0 rd.kiwi.ramdisk; then
     # For ramdisk deployment a kexec boot is not possible as it

--- a/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
@@ -203,7 +203,7 @@ function bool {
     fi
 }
 
-function initialize {
+function lib_initialize {
     # """
     # Source profile variables into runtime environment
     # The method will exit from the initrd if the profile

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -404,6 +404,7 @@ class InstallImageBuilder:
         if self.initrd_system == 'dracut':
             self.boot_image_task.include_module('kiwi-dump')
             self.boot_image_task.include_module('kiwi-dump-reboot')
+            self.boot_image_task.omit_module('kiwi-repart')
             if self.root_filesystem_is_multipath is False:
                 self.boot_image_task.omit_module('multipath')
             for mod in self.xml_state.get_installmedia_initrd_modules('add'):
@@ -452,6 +453,7 @@ class InstallImageBuilder:
         if self.initrd_system == 'dracut':
             self.boot_image_task.include_module('kiwi-dump')
             self.boot_image_task.include_module('kiwi-dump-reboot')
+            self.boot_image_task.omit_module('kiwi-repart')
             if self.root_filesystem_is_multipath is False:
                 self.boot_image_task.omit_module('multipath')
             for mod in self.xml_state.get_installmedia_initrd_modules('add'):

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -256,7 +256,8 @@ class TestInstallImageBuilder:
         self.boot_image_task.include_driver.assert_any_call('driver1')
         self.boot_image_task.include_driver.assert_any_call('driver2')
         assert self.boot_image_task.omit_module.call_args_list == [
-            call('multipath'), call('module1'), call('module2')
+            call('kiwi-repart'), call('multipath'),
+            call('module1'), call('module2')
         ]
         self.boot_image_task.set_static_modules.assert_called_once_with(
             ['module1', 'module2']
@@ -450,7 +451,7 @@ class TestInstallImageBuilder:
         self.boot_image_task.include_driver.assert_any_call('driver1')
         self.boot_image_task.include_driver.assert_any_call('driver2')
         assert self.boot_image_task.omit_module.call_args_list == [
-            call('multipath'), call('module1'), call('module2')
+            call('kiwi-repart'), call('multipath'), call('module1'), call('module2')
         ]
         self.boot_image_task.set_static_modules.assert_called_once_with(
             ['module1', 'module2']


### PR DESCRIPTION
In case the kiwi-repart module is explicitly requested in a dracut.conf file and the image is also configured to build an install ISO image this leads the install ISO to contain the kiwi-repart module as well which is unwanted. This commit explicitly omits the kiwi-repart when creating the initrd for the install image

