### PR TITLE
fix: resize for raid device, ensure vars like kiwi_RaidDev are loaded…

### DIFF
--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -30,17 +30,22 @@ function initialize {
     # Used in the systemd dialog unit
     env >/dialog_profile
 
-    disk=$(lookup_disk_device_from_root)
-    export disk
-
     if ! test -f ${partition_ids}; then
         warn "No partition id setup found, rebuilding..."
         {
+            disk=$(lookup_disk_device_from_root)
+            export disk
+
             echo "kiwi_RootPart=\"$(get_last_partition_id "${disk}")\""
         } > ${partition_ids}
-    fi
 
-    import_file ${partition_ids}
+        import_file ${partition_ids}
+    else
+        import_file ${partition_ids}
+
+        disk=$(lookup_disk_device_from_root)
+        export disk
+    fi
 
     root_device=${root#block:}
     export root_device


### PR DESCRIPTION
Ensure var kiwi_RaidDev var is loaded before looking up disk.

Fixes # Resize operation with mirroring activated and  oem-systemsize set.
The resize operation currently does not work for mirroring/raid root disks:

/run/initiramfs/log/kiwi.boot :
```
...
++ warn 'Requested OEM systemsize exceeds free space on the disk:'
...
```

Because **$kiwi_RaidDev** is unset for the _lookup_disk_device_from_root_ function:

/run/initiramfs/log/kiwi.boot excerpt during failed resize:
```
...
++++ basename ../../md0
+++ root_device=/dev/md0
++++ lsblk -p -n -r -s -o NAME,TYPE /dev/md0
++++ grep -E 'disk|raid'
++++ cut -f1 -d ' '
+++ for disk_device in $(lsblk -p -n -r -s -o NAME,TYPE "${root_device}" | grep -E "disk|raid" | cut -f1 -d ' ')
+++ '[' false = true ']'
+++ type mdadm
+++ '[' -z '' ']'
+++ mdadm --detail -Y /dev/md0
+++ echo /dev/md0
+++ return
++ disk=/dev/md0
++ export disk
...
```
 $RaidDev is empty in ['-z' ''] <--missing **kiwi_RaidDev** var
 
 /run/initiramfs/log/kiwi.boot excerpt previously working, the disk was evaltued to vda:
```
...
+++ root_device=/dev/md0
++++ lsblk -p -n -r -s -o NAME,TYPE /dev/md0
++++ grep -E 'disk|raid'
++++ cut -f1 -d ' '
+++ for disk_device in $(lsblk -p -n -r -s -o NAME,TYPE "${root_device}" | grep -E "disk|raid" | cut -f1 -d ' ')
+++ '[' false = true ']'
+++ type mdadm
+++ '[' -z /dev/md0 ']'
+++ for disk_device in $(lsblk -p -n -r -s -o NAME,TYPE "${root_device}" | grep -E "disk|raid" | cut -f1 -d ' ')
+++ '[' false = true ']'
+++ type mdadm
+++ '[' -z /dev/md0 ']'
+++ echo /dev/vda
++ disk=/dev/vda
++ export disk
...
```

Changes proposed in this pull request:

Lookup root disk device after loading partition id setup (with var **kiwi_RaidDev**).

This works for me, but I'm not sure if you even want to run _lookup_disk_device_from_root_ without **kiwi_RaidDev** variable set in case  **partition_ids=/config.partids** does not exit. 

Maybe _lookup_disk_device_from_root_ should not use vars from .config.partids.


