### PR TITLE
Fix exclude list for live image builds

### DIFF
--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -320,7 +320,10 @@ class LiveImageBuilder:
             ) as live_container_image:
                 container_image = Temporary().new_file()
                 live_container_image.create_on_file(
-                    container_image.name
+                    filename=container_image.name,
+                    exclude=Defaults.
+                    get_exclude_list_for_root_data_sync() + Defaults.
+                    get_exclude_list_from_custom_exclude_files(self.root_dir)
                 )
                 Path.create(self.media_dir.name + '/LiveOS')
                 os.chmod(container_image.name, 0o644)

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -267,7 +267,13 @@ class TestLiveImageBuilder:
                 )
             ]
 
-            filesystem.create_on_file.assert_called_once_with('kiwi-tmpfile')
+            filesystem.create_on_file.assert_called_once_with(
+                filename='kiwi-tmpfile',
+                exclude=[
+                    'image', '.kconfig', 'run/*', 'tmp/*',
+                    '.buildenv', 'var/cache/kiwi'
+                ]
+            )
 
             assert mock_shutil.copy.call_args_list == [
                 call('kiwi-tmpfile', 'temp_media_dir/LiveOS/squashfs.img')


### PR DESCRIPTION
When specifying a filesystem attribute for a live image build, the rootfs gets build directly into this filesystem instead of being a squashfs wraped ext4 which is the default layout for compatibility reasons. In this direct filesystem mode the exclude list was not passed along to the filesystem creation and causes unwanted metadata to be part of the final image. This Fixes #2873

