### PR TITLE
Fix rawhide integration test

### DIFF
--- a/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
@@ -93,7 +93,6 @@
         <package name="grub2-efi-ia32-modules" arch="x86_64"/>
         <package name="grub2-efi-ia32" arch="x86_64"/>
         <package name="shim-x64" arch="x86_64"/>
-        <package name="shim-ia32" arch="x86_64"/>
         <package name="fedora-release"/>
     </packages>
 </image>


### PR DESCRIPTION
The package shim-ia32 got dropped


