### PR TITLE
Run grub mkconfig with os-prober disabled

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -300,12 +300,15 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 self.boot_directory_name, 'grub.cfg'
             ]
         )
+        # Disable os-prober, it takes information from the host it
+        # runs on which is not necessarily matching with the image
+        os.environ.update({'GRUB_DISABLE_OS_PROBER': 'true'})
         Command.run(
             [
                 'chroot', self.root_mount.mountpoint,
                 os.path.basename(self._get_grub2_mkconfig_tool()), '-o',
                 config_file.replace(self.root_mount.mountpoint, '')
-            ]
+            ], os.environ
         )
         if boot_options.get('root_device') != boot_options.get('boot_device'):
             # Create a boot -> . link on the boot partition.

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -1219,12 +1219,13 @@ class TestBootLoaderConfigGrub2:
             mock_mount_system.assert_called_once_with(
                 'rootdev', 'bootdev', None, None, None
             )
+            os.environ.update({'GRUB_DISABLE_OS_PROBER': 'true'})
             assert mock_Command_run.call_args_list == [
                 call(
                     [
                         'chroot', self.bootloader.root_mount.mountpoint,
                         'grub2-mkconfig', '-o', '/boot/grub2/grub.cfg'
-                    ]
+                    ], os.environ
                 ),
                 call(
                     [


### PR DESCRIPTION
Set GRUB_DISABLE_OS_PROBER=true to the caller environment such that it gets consumed via /etc/grub.d/30_os-prober This Fixes #2883

