### PR TITLE
Support SOURCE_DATE_EPOCH for OCI containers

### DIFF
--- a/kiwi/oci_tools/base.py
+++ b/kiwi/oci_tools/base.py
@@ -16,7 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 # project
 from kiwi.path import Path
@@ -38,9 +38,17 @@ class OCIBase:
     """
     def __init__(self):
         self.oci_root_dir = None
-        self.creation_date = datetime.utcnow().strftime(
-            '%Y-%m-%dT%H:%M:%S+00:00'
-        )
+        sde = os.environ.get('SOURCE_DATE_EPOCH')
+        if sde:
+            self.creation_date = datetime.fromtimestamp(
+                int(sde), tz=timezone.utc
+            ).strftime(
+                '%Y-%m-%dT%H:%M:%S+00:00'
+            )
+        else:
+            self.creation_date = datetime.utcnow().strftime(
+                '%Y-%m-%dT%H:%M:%S+00:00'
+            )
         self.post_init()
 
     def __enter__(self):

--- a/test/unit/oci_tools/base_test.py
+++ b/test/unit/oci_tools/base_test.py
@@ -1,5 +1,5 @@
 from pytest import raises
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from kiwi.oci_tools.base import OCIBase
 
@@ -59,3 +59,20 @@ class TestOCIBase:
         assert self.oci._skopeo_provides_tmpdir_option() is True
         mock_Path_which.return_value = None
         assert self.oci._skopeo_provides_tmpdir_option() is False
+
+    @patch('kiwi.oci_tools.base.datetime')
+    def test_creation_date(self, mock_datetime):
+        strftime = Mock()
+        strftime.strftime = Mock(return_value='current_date')
+        mock_datetime.utcnow = Mock(
+            return_value=strftime
+        )
+
+        with patch.dict('os.environ', {'SOURCE_DATE_EPOCH': ''}):
+            oci = OCIBase()
+            assert oci.creation_date == 'current_date'
+
+    def test_creation_date_from_source_date_epoch(self):
+        with patch.dict('os.environ', {'SOURCE_DATE_EPOCH': '946729830'}):
+            oci = OCIBase()
+            assert oci.creation_date == '2000-01-01T12:30:30+00:00'


### PR DESCRIPTION
If SOURCE_DATE_EPOCH is available, use it for the container creation time and history.
