### PR TITLE
fix: Installation with mdraid mirroring with oem-resize and oem-systemsize set

### DIFF
--- a/dracut/modules.d/55kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/55kiwi-repart/kiwi-repart-disk.sh
@@ -124,8 +124,18 @@ function repart_standard_disk {
         d ${kiwi_RootPart}
         n p:lxroot ${kiwi_RootPart} . ${root_part_size}
     "
+    if mdraid_system; then
+       command_query="
+          d ${kiwi_RootPart}
+          n p:lxraid ${kiwi_RootPart} . ${root_part_size}
+          t ${kiwi_RootPart} fd
+       "
+    fi
     if ! create_partitions "${disk}" "${command_query}";then
         die "Failed to create partition table"
+    fi
+    if mdraid_system; then
+        update_devicesize_mdraid
     fi
     # finalize table changes
     finalize_disk_repart

--- a/dracut/modules.d/59kiwi-lib/kiwi-mdraid-lib.sh
+++ b/dracut/modules.d/59kiwi-lib/kiwi-mdraid-lib.sh
@@ -19,10 +19,16 @@ function deactivate_mdraid {
 
 function activate_mdraid {
     declare kiwi_RaidDev=${kiwi_RaidDev}
-    set_device_lock "${kiwi_RaidDev}" \
-        mdadm --assemble --scan "${kiwi_RaidDev}"
+    mdadm --assemble --scan "${kiwi_RaidDev}"
     wait_for_storage_device "${kiwi_RaidDev}"
     set_root_map "${kiwi_RaidDev}"
+}
+
+function update_devicesize_mdraid {
+    declare kiwi_RaidDev=${kiwi_RaidDev}
+    mdadm --assemble --scan "${kiwi_RaidDev}" --update=devicesize
+    wait_for_storage_device "${kiwi_RaidDev}"
+    deactivate_mdraid
 }
 
 function resize_mdraid {


### PR DESCRIPTION
Fixes # Installation with mdraid mirroring with oem-resize and oem-systemsize set.

Changes proposed in this pull request:
### do not device lock the not yet started $RaidDev:
Otherwise we observe in the boot.kiwi debug log:
```
...
+ declare kiwi_RaidDev=/dev/md0
+ set_device_lock /dev/md0 mdadm --assemble --scan /dev/md0 --update=devicesize
+ udevadm lock --help
+ udevadm lock --device /dev/md0 mdadm --assemble --scan /dev/md0 
Failed to find whole block device for '/dev/md0': No such file or directory
+ wait_for_storage_device /dev/md0
+ declare DEVICE_TIMEOUT=
+ local device=/dev/md
...
```
I removed the _set_device_lock_ for raid activation.


### set partition type to fd for raid:
Not strictly necessary:
If we do not enable oem-resize the partition type would be fd/raid and name p.lxraid as created by the kiwi/storage/disky.py.


### assemble once after repart with devicesize update:
Otherwise the btrfs resize fails, because writing to raid device fails. 
The mdadm --grow succeeds but if we look at the raid status afterwords in _/proc/mdstat_ we observed: 
```
Personalities : [raid1] 
md0 : broken raid1 sda4[0]
      2373568 blocks super 1.2 [2/1] [U_]
```

and with mdadm --examine for the underlying root partition, we still see the old partition size at _"Avail Dev Size"_.
With an additional assemble the Avail Dev Size is reported correctly.  Then the mdadm --grow actually resizes and is in state active and ready for the btrfs resize.

I added a new helper function _update_devicesize_mdraid_ to assemble with --update=devicesize option and stop the array afterwards.  The raid array is then ready for activation/resize.


