### PR TITLE
Change appx util from required to recommended

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -213,10 +213,10 @@ Provides:       kiwi-image:appx
 Provides:       kiwi-image:wsl
 %endif
 %if 0%{?suse_version}
-Requires:       fb-util-for-appx
+Recommends:     fb-util-for-appx
 %endif
 %if 0%{?fedora} || 0%{?rhel}
-Requires:       appx-util
+Recommends:     appx-util
 %endif
 
 %description -n kiwi-systemdeps-containers-wsl


### PR DESCRIPTION
Recently we added support for the new tarball-based WSL format. To my understanding this is the successor for the "old" format produced by the appx utility. Our current kiwi-systemdeps-containers-wsl package has appx as a hard requirement. I believe this can change into a recommended package

