### PR TITLE
Add rd.kiwi.install.systemsize kernel boot option

### DIFF
--- a/doc/source/building_images/build_expandable_disk.rst
+++ b/doc/source/building_images/build_expandable_disk.rst
@@ -379,15 +379,19 @@ oemconfig.oem-swapsize
   This value is represented by the ``kiwi_oemswapMB`` variable in the initrd.
 
 oemconfig.oem-systemsize
-  Specifies the size the operating system is allowed to occupy on the target
+  Specifies the MB size the operating system is allowed to occupy on the target
   disk. The size limit does not include any swap space or recovery partition
   considerations. In a setup *without* the systemdisk element, this value
   specifies the size of the root partition. In a setup that *includes* the
-  systemdisk element, this value specifies the size of the LVM partition that
-  contains all specified volumes. This means that the sum of all specified
-  volume sizes plus the sum of the specified freespace for each volume must be
-  smaller than or equal to the size specified with the `oem-systemsize` element. This
-  value is represented by the variable ``kiwi_oemrootMB`` in the initrd.
+  systemdisk element when using LVM, this value specifies the size of the LVM
+  partition that contains all specified volumes. This means that the sum of all
+  specified volume sizes plus the sum of the specified freespace for each volume
+  must be smaller than or equal to the size specified with the `oem-systemsize`
+  element. This value is represented by the variable ``kiwi_oemrootMB`` in the
+  initrd. The specified value can be dynamically overwritten via the
+  `rd.kiwi.install.systemsize` kernel boot option. If `rd.kiwi.install.systemsize`
+  is set to `all` this will unset the size limit and the maximum possible
+  size applies.
 
 oemconfig.oem-unattended
   The installation of the image to the target system occurs

--- a/dracut/modules.d/55kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/55kiwi-repart/kiwi-repart-disk.sh
@@ -80,6 +80,20 @@ function finalize_disk_repart {
         "$(get_partition_node_name "${disk}" "${kiwi_RootPart}")"
 }
 
+function get_target_rootpart_size {
+    declare kiwi_oemrootMB=${kiwi_oemrootMB}
+    local oemrootMB
+    oemrootMB=$(getarg rd.kiwi.install.install.systemsize=)
+    if [ -n "${oemrootMB}" ]; then
+        if [ "${oemrootMB}" = "all" ];then
+            kiwi_oemrootMB=""
+        else
+            kiwi_oemrootMB="${oemrootMB}"
+        fi
+    fi
+    echo "${kiwi_oemrootMB}"
+}
+
 function repart_standard_disk {
     # """
     # repartition disk with read/write root filesystem
@@ -89,8 +103,9 @@ function repart_standard_disk {
     # pX+1: ( root )  [+luks +raid]
     # -------------------------------------
     # """
-    declare kiwi_oemrootMB=${kiwi_oemrootMB}
     declare kiwi_RootPart=${kiwi_RootPart}
+    local kiwi_oemrootMB
+    kiwi_oemrootMB=$(get_target_rootpart_size)
     if [ -z "${kiwi_oemrootMB}" ];then
         local disk_have_root_system_mbytes=$((
             disk_root_mbytes + disk_free_mbytes
@@ -150,8 +165,9 @@ function repart_lvm_disk {
     # pX+1: ( LVM  )  [+luks +raid]
     # -------------------------------------
     # """
-    declare kiwi_oemrootMB=${kiwi_oemrootMB}
     declare kiwi_RootPart=${kiwi_RootPart}
+    local kiwi_oemrootMB
+    kiwi_oemrootMB=$(get_target_rootpart_size)
     if [ -z "${kiwi_oemrootMB}" ];then
         local disk_have_root_system_mbytes=$((
             disk_root_mbytes + disk_free_mbytes
@@ -198,10 +214,11 @@ function repart_lvm_disk {
 }
 
 function check_repart_possible {
-    declare kiwi_oemrootMB=${kiwi_oemrootMB}
     local disk_root_mbytes=$1
     local disk_free_mbytes=$2
     local min_additional_mbytes=$3
+    local kiwi_oemrootMB
+    kiwi_oemrootMB=$(get_target_rootpart_size)
     if [ -n "${kiwi_oemrootMB}" ];then
         if [ "${kiwi_oemrootMB}" -lt "${disk_root_mbytes}" ];then
             # specified oem-systemsize is smaller than root partition


### PR DESCRIPTION
In a kiwi repart process the <oem-systemsize> element allows to control the size of the partition to hold the rootfs. This commit allows to dynamically overwrite the static value, or set it via a kernel cmdline parameter

