### PR TITLE
Fix repo type setup when set from cmdline

### DIFF
--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -371,6 +371,13 @@ class SystemBuildTask(CliTask):
         parameters = self.eleventuple_token(tokens)
         signing_keys_index = 6
         repo_source_index = 0
+        repo_type_index = 1
+        if not parameters[repo_type_index]:
+            # make sure to pass a None value if an empty string
+            # is provided as repo type. This will cause no type
+            # attribute to be set instead of an empty type which
+            # is not allowed by the schema
+            parameters[repo_type_index] = None
         if not parameters[signing_keys_index]:
             # make sure to pass empty list for signing_keys param
             parameters[signing_keys_index] = []

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -368,7 +368,8 @@ class TestSystemBuildTask:
         self.task.command_args['--add-repo'] = [
             'http://example1.com,yast2,alias,99,false,true',
             'http://example2.com,yast2,alias,99,false,true',
-            'http://example3.com,yast2,alias,99,false,true'
+            'http://example3.com,yast2,alias,99,false,true',
+            'http://example4.com,,alias,99,false,true'
         ]
         self.task.process()
         assert mock_add_repo.call_args_list == [
@@ -382,6 +383,10 @@ class TestSystemBuildTask:
             ),
             call(
                 'http://example3.com', 'yast2', 'alias', '99',
+                False, True, [], None, None, None, None
+            ),
+            call(
+                'http://example4.com', None, 'alias', '99',
                 False, True, [], None, None, None, None
             )
         ]
@@ -402,6 +407,10 @@ class TestSystemBuildTask:
             ),
             call(
                 'http://example3.com', 'yast2', 'alias', '99',
+                False, True, [], None, None, None, None
+            ),
+            call(
+                'http://example4.com', None, 'alias', '99',
                 False, True, [], None, None, None, None
             )
         ]


### PR DESCRIPTION
Using --add-repo/--set-repo options on the commandline allows to skip the repotype setting by passing in an empty value. That empty value however caused the type attribute in a repository section to be set to an empty string which is not allowed by the schema. Instead an empty type should lead to no type attribute set at all. This commit fixes it

