### PR TITLE
Fixed spec file requires

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -354,7 +354,7 @@ Provides:       kiwi-image:vmx
 Requires:       kiwi-systemdeps-filesystems = %{version}-%{release}
 Requires:       kiwi-systemdeps-bootloaders = %{version}-%{release}
 Requires:       kiwi-systemdeps-iso-media = %{version}-%{release}
-%if 0%{?suse_version} >= 1650
+%if 0%{?suse_version} >= 1600
 Requires:       binutils
 Requires:       glibc-gconv-modules-extra
 %endif


### PR DESCRIPTION
The package requirement for binutils was set to TW (>=1650) only but is also required for SLES16/Leap16 which is 1600 This commit fixes the condition to match with all required distributions and fixes bsc#1253637
