### PR TITLE
Add support for encryped live images

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
@@ -11,6 +11,7 @@
         <specification>live iso test build</specification>
     </description>
     <profiles>
+        <profile name="Encrypted" description="Encrypted EFI/BIOS Live Boot"/>
         <profile name="Standard" description="Standard EFI/BIOS Live Boot"/>
         <profile name="Secure" description="SecureBoot EFI Live Boot"/>
         <profile name="SDBoot" description="EFI Boot via systemd-boot"/>
@@ -38,6 +39,11 @@
             <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
+    <preferences profiles="Encrypted">
+        <type image="iso" flags="overlay" firmware="efi" kernelcmdline="console=ttyS0 rd.live.encrypt" hybridpersistent_filesystem="ext4" hybridpersistent="true" luks="linux" filesystem="erofs">
+            <bootloader name="grub2" console="serial" timeout="10"/>
+        </type>
+    </preferences>
     <preferences profiles="Standard">
         <type image="iso" flags="overlay" firmware="efi" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="ext4" hybridpersistent="true">
             <bootloader name="grub2" console="serial" timeout="10"/>
@@ -62,12 +68,15 @@
     <packages type="image" profiles="SDBoot">
         <package name="systemd-boot"/>
     </packages>
-    <packages type="image" profiles="Standard,Secure,EroFS,BIOS">
+    <packages type="image" profiles="Standard,Secure,EroFS,BIOS,Encrypted">
         <package name="grub2-branding-openSUSE"/>
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>
         <package name="grub2-i386-pc"/>
         <package name="shim"/>
+    </packages>
+    <packages type="image" profiles="Encrypted">
+        <package name="cryptsetup"/>
     </packages>
     <packages type="image">
         <package name="curl"/>

--- a/build-tests/x86/tumbleweed/test-image-live/config.sh
+++ b/build-tests/x86/tumbleweed/test-image-live/config.sh
@@ -18,7 +18,7 @@ done
 # Include erofs module
 #--------------------------------------
 for profile in ${kiwi_profiles//,/ }; do
-    if [ "${profile}" = "EroFS" ]; then
+    if [ "${profile}" = "EroFS" ] || [ "${profile}" = "Encrypted" ]; then
         # remove from blacklist
         rm -f /usr/lib/modprobe.d/60-blacklist_fs-erofs.conf
     fi

--- a/doc/source/concept_and_workflow/customize_the_boot_process.rst
+++ b/doc/source/concept_and_workflow/customize_the_boot_process.rst
@@ -313,8 +313,12 @@ the available kernel boot parameters for these modules:
   available RAM space can be used for writing new data.
 
 ``rd.live.overlay.persistent``
-  Instructs a live ISO image to prepare a persistent
-  write partition.
+  Instructs a live ISO image to prepare a persistent write partition.
+
+``rd.live.encrypt``
+  Instructs a live ISO image to encrypt the persistent write partition.
+  The boot process becomes interactive in this case and the user has
+  to specify a passphrase at boot time.
 
 ``rd.live.overlay.cowfs``
   Specifies which filesystem of a live ISO image to use for storing data on the

--- a/dracut/modules.d/55kiwi-live/module-setup.sh
+++ b/dracut/modules.d/55kiwi-live/module-setup.sh
@@ -29,7 +29,7 @@ install() {
     inst_multiple \
         umount dmsetup partx blkid lsblk dd losetup \
         grep cut partprobe find wc fdisk tail mkfs.ext4 mkfs.xfs \
-        dialog cat mountpoint curl dolly dd
+        dialog cat mountpoint curl dolly dd cryptsetup
 
     dmsquashdir=$(find "${dracutbasedir}/modules.d" -name "*dmsquash-live")
     if [ -n "${dmsquashdir}" ] && \


### PR DESCRIPTION
So far setting the luks= attribute on a live image build had no impact to the generated ISO image. This commit adds the encryption capability also for live ISO images. The read-only part of the rootfs gets encrypted using the provided luks passphrase. An eventual persistent storage area gets encrypted at boot time if the rd.live.encrypt kernel cmdline parameters is passed. encryption/decryption requires to interactively set/provide passhphrase information at boot time. Please note due to the read-only restrictions of an ISO image there is no way to apply the standard re-encryption process as it is usually performed by kiwi encrypted systems. As such the specified luks passphrase in the kiwi image descriptions becomes sensitive information that needs to be protected

