### PR TITLE
Fix initrd outputfile format detection

### DIFF
--- a/test/data/dracut_config
+++ b/test/data/dracut_config
@@ -1,0 +1,8 @@
+dracutconfig: dracutmodules=all
+dracutconfig: fileloglvl=0
+dracutconfig: fw_dir=/lib/firmware/updates/6.18.0-2-default /lib/firmware/updates /lib/firmware/6.18.0-2-default /lib/firmware
+dracutconfig: hostonly_cmdline=yes
+dracutconfig: initrdname=initrd-kernel_version
+dracutconfig: kmsgloglvl=0
+dracutconfig: libdirs= /lib64 /usr/lib64 /lib /usr/lib
+dracutconfig: omit_drivers=^i2o_scsi$


### PR DESCRIPTION
With dracut-ng the output file format is a configuration option in the system wide dracut dist config file. The detection mechanics must be extended by also looking at this dist config. This Fixes #2918

