### PR TITLE
Set fixed permissions for image root directory

### DIFF
--- a/kiwi/system/root_init.py
+++ b/kiwi/system/root_init.py
@@ -74,6 +74,7 @@ class RootInit:
         """
         root = Temporary(prefix='kiwi_root.').new_dir()
         Path.create(self.root_dir)
+        os.chmod(self.root_dir, 0o755)
         try:
             self._create_base_directories(root.name)
             self._create_base_links(root.name)

--- a/test/unit/system/root_init_test.py
+++ b/test/unit/system/root_init_test.py
@@ -44,6 +44,7 @@ class TestRootInit:
     @patch('os.chown')
     @patch('os.symlink')
     @patch('os.makedev')
+    @patch('os.chmod')
     @patch('kiwi.path.Path.create')
     @patch('kiwi.system.root_init.copy')
     @patch('kiwi.system.root_init.DataSync')
@@ -51,7 +52,7 @@ class TestRootInit:
     @patch('kiwi.system.root_init.Path.create')
     def test_create(
         self, mock_Path_create, mock_Temporary, mock_data_sync,
-        mock_copy, mock_create, mock_makedev,
+        mock_copy, mock_create, mock_chmod, mock_makedev,
         mock_symlink, mock_chwon, mock_makedirs,
         mock_path
     ):
@@ -107,6 +108,7 @@ class TestRootInit:
             '/.buildenv', 'root_dir'
         )
         mock_create.assert_called_once_with('root_dir')
+        mock_chmod.assert_called_once_with('root_dir', 0o755)
 
     @patch('kiwi.path.Path.wipe')
     @patch('os.path.exists')


### PR DESCRIPTION
The new root directory (/) for an image build is created by taking the current system umask into account. However, if that umask setting is not appropriate for the needs of the image root directory some hard to debug after effects can appear on the later run of the image binary. As such this commit changes the permissions for the root directory explicitly to the expected value.
This Fixes #2920


