### PR TITLE
Fixed ramdisk sysroot generator

### DIFF
--- a/dracut/modules.d/55kiwi-dump/kiwi-ramdisk-deployment-generator.sh
+++ b/dracut/modules.d/55kiwi-dump/kiwi-ramdisk-deployment-generator.sh
@@ -40,7 +40,7 @@ root_uuid=$(
     echo "[Mount]"
     echo "Where=/sysroot"
     echo "What=${root_uuid}"
-    _dev=RamDisk_rootfs
+    _dev=$(systemd-escape -p /dev/disk/by-uuid/"${root_uuid#UUID=}")
 } > "$GENERATOR_DIR"/sysroot.mount
 
 if [ ! -e "$GENERATOR_DIR/initrd-root-fs.target.requires/sysroot.mount" ]; then
@@ -52,5 +52,5 @@ fi
 mkdir -p "$GENERATOR_DIR/$_dev.device.d"
 {
     echo "[Unit]"
-    echo "JobTimeoutSec=60"
+    echo "JobTimeoutSec=infinity"
 } > "$GENERATOR_DIR/$_dev.device.d/timeout.conf"


### PR DESCRIPTION
Do not use a custom _dev name and stick with the UUID representation of the disk image in RAM after deployment. Former versions of udev did not create a by-uuid device representation which now seems to have changed. This then leads to the device name RamDisk_rootfs not being created and the respective .device unit times out. In addition the timer unit for the standard device representation changed to infinity. This fixes bsc#1254116


