### PR TITLE
Set btrfs_relative_path conditional

### DIFF
--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -27,8 +27,6 @@ class BootLoaderTemplateGrub2:
     def __init__(self):
         self.header = dedent('''
             # kiwi generated one time grub2 config file
-            set btrfs_relative_path="y"
-            export btrfs_relative_path
             search ${search_params}
             set default=${default_boot}
             if [ -n "$$extra_cmdline" ]; then
@@ -39,6 +37,11 @@ class BootLoaderTemplateGrub2:
             if [ -n "$${iso_path}" ]; then
                 isoboot="iso-scan/filename=$${iso_path}"
             fi
+        ''').strip() + os.linesep
+
+        self.header_btrfs_relative_path = dedent('''
+            set btrfs_relative_path="y"
+            export btrfs_relative_path
         ''').strip() + os.linesep
 
         self.timeout = dedent('''
@@ -248,8 +251,9 @@ class BootLoaderTemplateGrub2:
         ''').strip() + os.linesep
 
     def get_iso_template(
-        self, failsafe=True,
-        has_graphics=True, has_serial=False, checkiso=False
+        self, failsafe: bool = True,
+        has_graphics: bool = True, has_serial: bool = False,
+        checkiso: bool = False, has_btrfs_relative_path: bool = False
     ):
         """
         Bootloader configuration template for live ISO media
@@ -262,7 +266,11 @@ class BootLoaderTemplateGrub2:
 
         :rtype: Template
         """
-        template_data = self.header
+        if has_btrfs_relative_path:
+            template_data = self.header_btrfs_relative_path
+            template_data += self.header
+        else:
+            template_data = self.header
         template_data += self.timeout
         template_data += self.timeout_style
         if has_graphics:
@@ -283,8 +291,9 @@ class BootLoaderTemplateGrub2:
         return Template(template_data)
 
     def get_multiboot_iso_template(
-        self, failsafe=True,
-        has_graphics=True, has_serial=False, checkiso=False
+        self, failsafe: bool = True,
+        has_graphics: bool = True, has_serial: bool = False,
+        checkiso: bool = False, has_btrfs_relative_path: bool = False
     ):
         """
         Bootloader configuration template for live ISO media with
@@ -298,7 +307,11 @@ class BootLoaderTemplateGrub2:
 
         :rtype: Template
         """
-        template_data = self.header
+        if has_btrfs_relative_path:
+            template_data = self.header_btrfs_relative_path
+            template_data += self.header
+        else:
+            template_data = self.header
         template_data += self.timeout
         template_data += self.timeout_style
         if has_graphics:
@@ -319,8 +332,9 @@ class BootLoaderTemplateGrub2:
         return Template(template_data)
 
     def get_install_template(
-        self, failsafe=True,
-        has_graphics=True, has_serial=False, with_timeout=True
+        self, failsafe: bool = True,
+        has_graphics: bool = True, has_serial: bool = False,
+        with_timeout: bool = True, has_btrfs_relative_path: bool = False
     ):
         """
         Bootloader configuration template for install media
@@ -333,7 +347,11 @@ class BootLoaderTemplateGrub2:
 
         :rtype: Template
         """
-        template_data = self.header
+        if has_btrfs_relative_path:
+            template_data = self.header_btrfs_relative_path
+            template_data += self.header
+        else:
+            template_data = self.header
         if with_timeout:
             template_data += self.timeout
             template_data += self.timeout_style
@@ -353,8 +371,9 @@ class BootLoaderTemplateGrub2:
         return Template(template_data)
 
     def get_multiboot_install_template(
-        self, failsafe=True,
-        has_graphics=True, has_serial=False, with_timeout=True
+        self, failsafe: bool = True,
+        has_graphics: bool = True, has_serial: bool = False,
+        with_timeout: bool = True, has_btrfs_relative_path: bool = False
     ):
         """
         Bootloader configuration template for install media with
@@ -368,7 +387,11 @@ class BootLoaderTemplateGrub2:
 
         :rtype: Template
         """
-        template_data = self.header
+        if has_btrfs_relative_path:
+            template_data = self.header_btrfs_relative_path
+            template_data += self.header
+        else:
+            template_data = self.header
         if with_timeout:
             template_data += self.timeout
             template_data += self.timeout_style

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -1120,9 +1120,15 @@ class TestBootLoaderConfigGrub2:
 
     def test_setup_live_image_config_multiboot(self):
         self.bootloader.multiboot = True
+        self.state.build_type.get_btrfs_set_default_volume = Mock(
+            return_value=False
+        )
+        self.state.build_type.get_btrfs_root_is_snapper_snapshot = Mock(
+            return_value=False
+        )
         self.bootloader.setup_live_image_config(self.mbrid)
         self.grub2.get_multiboot_iso_template.assert_called_once_with(
-            True, True, False, None
+            True, True, False, None, False
         )
 
     @patch.object(BootLoaderConfigGrub2, '_copy_grub_config_to_efi_path')
@@ -1138,7 +1144,7 @@ class TestBootLoaderConfigGrub2:
         self.bootloader.multiboot = False
         self.bootloader.setup_live_image_config(self.mbrid)
         self.grub2.get_iso_template.assert_called_once_with(
-            True, True, True, None
+            True, True, True, None, True
         )
         mock_copy_grub_config_to_efi_path.assert_called_once_with(
             'root_dir', 'earlyboot.cfg', 'iso'
@@ -1150,7 +1156,7 @@ class TestBootLoaderConfigGrub2:
         self.bootloader.multiboot = True
         self.bootloader.setup_install_image_config(self.mbrid)
         self.grub2.get_multiboot_install_template.assert_called_once_with(
-            True, True, True, True
+            True, True, True, True, True
         )
 
     @patch.object(BootLoaderConfigGrub2, '_mount_system')
@@ -1306,7 +1312,7 @@ class TestBootLoaderConfigGrub2:
         self.bootloader.multiboot = False
         self.bootloader.setup_install_image_config(self.mbrid)
         self.grub2.get_install_template.assert_called_once_with(
-            True, True, False, True
+            True, True, False, True, True
         )
         mock_copy_grub_config_to_efi_path.assert_called_once_with(
             'root_dir', 'earlyboot.cfg', 'iso'

--- a/test/unit/bootloader/template/grub2_test.py
+++ b/test/unit/bootloader/template/grub2_test.py
@@ -72,9 +72,53 @@ class TestBootLoaderTemplateGrub2:
             terminal_output='serial'
         )
 
+    def test_get_multiboot_install_template_console_relative_btrfs(self):
+        assert self.grub2.get_multiboot_install_template(
+            has_graphics=False, has_btrfs_relative_path=True
+        ).substitute(
+            search_params='--fs-uuid --set=root 0815',
+            default_boot='0',
+            kernel_file='linux.vmx',
+            initrd_file='initrd.vmx',
+            boot_options='splash',
+            failsafe_boot_options='splash',
+            boot_timeout='10',
+            boot_timeout_style='menu',
+            serial_line_setup='',
+            title='LimeJeOS-SLE12-Community [ VMX ]',
+            bootpath='/boot',
+            hypervisor='xen.gz',
+            efi_image_name='bootx64.efi',
+            terminal_input='console',
+            terminal_output='console'
+        )
+
     def test_get_install_template(self):
         assert self.grub2.get_install_template(
             has_serial=True
+        ).substitute(
+            search_params='--file --set=root /boot/0xd305fb7d',
+            default_boot='0',
+            kernel_file='boot/linux.vmx',
+            initrd_file='boot/initrd.vmx',
+            boot_options='cdinst=1 splash',
+            failsafe_boot_options='cdinst=1 splash',
+            gfxmode='800x600',
+            theme='SLE',
+            boot_timeout='10',
+            boot_timeout_style='menu',
+            serial_line_setup='',
+            title='LimeJeOS-SLE12-Community [ VMX ]',
+            bootpath='/boot',
+            boot_directory_name='grub2',
+            efi_image_name='bootx64.efi',
+            terminal_input='console',
+            terminal_output='console'
+        )
+
+    def test_get_install_template_relative_btrfs(self):
+        assert self.grub2.get_install_template(
+            has_serial=True, has_btrfs_relative_path=True
         ).substitute(
             search_params='--file --set=root /boot/0xd305fb7d',
             default_boot='0',
@@ -120,6 +164,29 @@ class TestBootLoaderTemplateGrub2:
 
     def test_get_iso_template_checkiso(self):
         assert self.grub2.get_iso_template(checkiso=True).substitute(
+            search_params='--file --set=root /boot/0xd305fb7d',
+            default_boot='0',
+            kernel_file='boot/linux.vmx',
+            initrd_file='boot/initrd.vmx',
+            boot_options='splash',
+            failsafe_boot_options='splash',
+            gfxmode='800x600',
+            theme='SLE',
+            boot_timeout='10',
+            boot_timeout_style='menu',
+            serial_line_setup='',
+            title='LimeJeOS-SLE12-Community',
+            bootpath='/boot',
+            boot_directory_name='grub2',
+            efi_image_name='bootx64.efi',
+            terminal_input='console',
+            terminal_output='console'
+        )
+
+    def test_get_iso_template_checkiso_relative_btrfs(self):
+        assert self.grub2.get_iso_template(
+            checkiso=True, has_btrfs_relative_path=True
+        ).substitute(
             search_params='--file --set=root /boot/0xd305fb7d',
             default_boot='0',
             kernel_file='boot/linux.vmx',
@@ -206,6 +273,30 @@ class TestBootLoaderTemplateGrub2:
 
     def test_get_multiboot_iso_template_checkiso(self):
         assert self.grub2.get_multiboot_iso_template(checkiso=True).substitute(
+            search_params='--fs-uuid --set=root 0815',
+            default_boot='0',
+            kernel_file='linux.vmx',
+            initrd_file='initrd.vmx',
+            boot_options='splash',
+            failsafe_boot_options='splash',
+            gfxmode='800x600',
+            theme='SLE',
+            boot_timeout='10',
+            boot_timeout_style='menu',
+            serial_line_setup='',
+            title='LimeJeOS-SLE12-Community',
+            bootpath='/boot',
+            boot_directory_name='grub2',
+            hypervisor='xen.gz',
+            efi_image_name='bootx64.efi',
+            terminal_input='console',
+            terminal_output='console'
+        )
+
+    def test_get_multiboot_iso_template_checkiso_relative_btrfs(self):
+        assert self.grub2.get_multiboot_iso_template(
+            checkiso=True, has_btrfs_relative_path=True
+        ).substitute(
             search_params='--fs-uuid --set=root 0815',
             default_boot='0',
             kernel_file='linux.vmx',


### PR DESCRIPTION
The early boot script and also the ISO template should only set this option if the conditions to set it are met. Conditions for this option are if btrfs is in use and a default subvolume and/or a snapper based snapshot is requested by the image description. This Fixes #2919

