### PR TITLE
Move OVA support to open-vmdk

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-disk-simple/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-disk-simple/appliance.kiwi
@@ -16,10 +16,11 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>breeze</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="ext3" kernelcmdline="console=ttyS0" firmware="uefi" eficsm="false" format="vmdk">
+        <type image="oem" filesystem="ext3" kernelcmdline="console=ttyS0" firmware="uefi" eficsm="false" format="ova">
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
+            <machine memory="4096"/>
             <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1527,7 +1527,7 @@ class Defaults:
         :rtype: list
         """
         return [
-            'gce', 'qcow2', 'vmdk', 'ova', 'vmx', 'vhd', 'vhdx',
+            'gce', 'qcow2', 'vmdk', 'ova', 'meta', 'vmx', 'vhd', 'vhdx',
             'vhdfixed', 'vdi', 'vagrant.libvirt.box', 'vagrant.virtualbox.box'
         ]
 

--- a/kiwi/storage/subformat/base.py
+++ b/kiwi/storage/subformat/base.py
@@ -46,8 +46,8 @@ class DiskFormatBase:
     :param dict custom_args: custom format options dictionary
     """
     def __init__(
-            self, xml_state: XMLState, root_dir: str, target_dir: str,
-            custom_args: dict = None
+        self, xml_state: XMLState, root_dir: str, target_dir: str,
+        custom_args: dict = None
     ):
         self.xml_state = xml_state
         self.root_dir = root_dir

--- a/kiwi/storage/subformat/ova.py
+++ b/kiwi/storage/subformat/ova.py
@@ -16,20 +16,24 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
-import stat
+import pathlib
 from textwrap import dedent
 
 # project
+from kiwi.firmware import FirmWare
 from kiwi.storage.subformat.vmdk import DiskFormatVmdk
 from kiwi.storage.subformat.base import DiskFormatBase
 from kiwi.command import Command
-from kiwi.utils.command_capabilities import CommandCapabilities
 from kiwi.path import Path
 from kiwi.system.result import Result
+from kiwi.storage.subformat.template.ova_compose import (
+    OvaComposeTemplate
+)
 
 from kiwi.exceptions import (
     KiwiFormatSetupError,
-    KiwiCommandNotFound
+    KiwiCommandNotFound,
+    KiwiTemplateError
 )
 
 
@@ -45,11 +49,20 @@ class DiskFormatOva(DiskFormatBase):
 
         :param dict custom_args: custom qemu arguments dictionary
         """
-        ovftype = self.xml_state.get_build_type_machine_section().get_ovftype()
+        ovftype = 'vmware'  # default OVA target infrastructure
+        self.machine_setup = self.xml_state.get_build_type_machine_section()
+        if self.machine_setup and self.machine_setup.get_ovftype():
+            ovftype = self.machine_setup.get_ovftype()
         if ovftype != 'vmware':
             raise KiwiFormatSetupError(f'Unsupported ovftype {ovftype}')
         self.image_format = 'ova'
-        self.options = self.get_qemu_option_list(custom_args)
+        # ensure streamOptimized format is enabled
+        custom_args.update(
+            {'subformat=streamOptimized': None}
+        )
+        self.firmware = FirmWare(
+            self.xml_state
+        )
         self.vmdk = DiskFormatVmdk(
             self.xml_state, self.root_dir, self.target_dir, custom_args
         )
@@ -59,16 +72,14 @@ class DiskFormatOva(DiskFormatBase):
         Create ova disk format using ovftool from
         https://www.vmware.com/support/developer/ovf
         """
-        # Check for required ovftool
-        ovftool = Path.which(filename='ovftool', access_mode=os.X_OK)
-        if not ovftool:
+        # Check for required mkova tool
+        ova_compose = Path.which(filename='ova-compose', access_mode=os.X_OK)
+        if not ova_compose:
             tool_not_found_message = dedent('''\n
-                Required ovftool not found in PATH on the build host
+                Required ova-compose not found in PATH on the build host
 
-                Building OVA images requires VMware's ovftool tool which
-                can be installed from the following location
-
-                https://developer.vmware.com/web/tool/ovf
+                Building OVA images requires the ova-compose tool which
+                is usually provided by the open-vmdk package.
             ''')
             raise KiwiCommandNotFound(
                 tool_not_found_message
@@ -77,35 +88,22 @@ class DiskFormatOva(DiskFormatBase):
         # Create the vmdk disk image and vmx config
         self.vmdk.create_image_format()
 
-        # Convert to ova using ovftool
-        vmx = self.get_target_file_path_for_format('vmx')
+        compose_meta = self.get_target_file_path_for_format('meta')
         ova = self.get_target_file_path_for_format('ova')
-        try:
-            os.unlink(ova)
-        except OSError:
-            pass
-        ovftool_options = []
-        if CommandCapabilities.has_option_in_help(
-            ovftool, '--shaAlgorithm', raise_on_error=False
-        ):
-            ovftool_options.append('--shaAlgorithm=SHA1')
-        if CommandCapabilities.has_option_in_help(
-            ovftool, '--allowExtraConfig', raise_on_error=False
-        ):
-            ovftool_options.append('--allowExtraConfig')
-        if CommandCapabilities.has_option_in_help(
-            ovftool, '--exportFlags', raise_on_error=False
-        ):
-            ovftool_options.append('--exportFlags=extraconfig')
 
+        # Create ova composer meta file
+        self._create_ova_compose_meta_file()
+
+        pathlib.Path(ova).unlink(missing_ok=True)
+        os.chdir(self.target_dir)
         Command.run(
-            [ovftool] + ovftool_options + [vmx, ova]
+            [
+                ova_compose,
+                '--input-file', compose_meta,
+                '--output-file', ova,
+                '--format', 'ova'
+            ]
         )
-        # ovftool ignores the umask and creates files with 0600
-        # apply file permission bits set in the vmx file to the
-        # ova file
-        st = os.stat(vmx)
-        os.chmod(ova, stat.S_IMODE(st.st_mode))
 
     def store_to_result(self, result: Result) -> None:
         """
@@ -122,3 +120,47 @@ class DiskFormatOva(DiskFormatBase):
             ),
             shasum=True
         )
+
+    def _create_ova_compose_meta_file(self) -> None:
+        """
+        Create the ova-compose meta file used to create the final ova file
+        """
+        displayname = self.xml_state.xml_data.get_displayname()
+        efi_mode = self.firmware.efi_mode()
+        template_record = {
+            'display_name':
+                displayname or self.xml_state.xml_data.get_name(),
+            'vmdk_file':
+                os.path.basename(self.get_target_file_path_for_format('vmdk')),
+            'guest_os': 'other4xLinux64Guest',
+            'memory_size': 4096,
+            'number_of_cpus': 2,
+            'firmware': 'efi' if efi_mode else 'bios',
+            'secure_boot': 'true' if efi_mode == 'uefi' else 'false'
+        }
+
+        # Basic setup
+        machine_setup = self.xml_state.get_build_type_machine_section()
+        if machine_setup:
+            memory_setup = machine_setup.get_memory()
+            guest_os = machine_setup.get_guestOS()
+            cpu_setup = machine_setup.get_ncpus()
+            if guest_os:
+                template_record['guest_os'] = guest_os
+            if memory_setup:
+                template_record['memory_size'] = memory_setup
+            if cpu_setup:
+                template_record['number_of_cpus'] = cpu_setup
+
+        # Build settings template and write settings file
+        settings_template = OvaComposeTemplate().get_template(
+            bool(machine_setup)
+        )
+        try:
+            settings_file = self.get_target_file_path_for_format('meta')
+            with open(settings_file, 'w') as config:
+                config.write(settings_template.substitute(template_record))
+        except Exception as issue:
+            raise KiwiTemplateError(
+                f'{type(issue).__name__}: {format(issue)}'
+            )

--- a/kiwi/storage/subformat/template/ova_compose.py
+++ b/kiwi/storage/subformat/template/ova_compose.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026 SUSE LLC.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+from string import Template
+from textwrap import dedent
+
+
+class OvaComposeTemplate:
+    """
+    OVA compose settings template
+    """
+    def __init__(self):
+        self.cr = '\n'
+
+        self.header = dedent('''
+            system:
+                name: "${display_name}"
+                type: vmx-20
+                os_vmw: "${guest_os}"
+                firmware: "${firmware}"
+                secure_boot: ${secure_boot}
+        ''').strip() + self.cr
+
+        self.hardware = dedent('''
+            hardware:
+                cpus: ${number_of_cpus}
+                memory: ${memory_size}
+                sata1:
+                    type: sata_controller
+                scsi1:
+                    type: scsi_controller
+                nvme1:
+                    type: nvme_controller
+                cdrom1:
+                    type: cd_drive
+                    parent: sata1
+                rootdisk:
+                    type: hard_disk
+                    parent: nvme1
+                    disk_image: "${vmdk_file}"
+                usb2:
+                    type: usb_controller
+                usb3:
+                    type: usb3_controller
+                ethernet1:
+                    type: ethernet
+                    subtype: VmxNet3
+                    network: vm_network
+                videocard1:
+                    type: video_card
+                vmci1:
+                    type: vmci
+        ''').strip() + self.cr
+
+        self.network = dedent('''
+            networks:
+                vm_network:
+                    name: "VM Network"
+                    description: "The VM Network network"
+        ''').strip() + self.cr
+
+    def get_template(self, hardware_setup: bool = False):
+        """
+        Set data for the ova-compose template
+
+        :param hardware_setup: if True, include hardware section
+
+        :rtype: Template
+        """
+        template_data = self.header
+        template_data += self.network
+        if hardware_setup:
+            template_data += self.hardware
+
+        return Template(template_data)

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -369,6 +369,9 @@ Requires:       kpartx
 Requires:       cryptsetup
 Requires:       mdadm
 Requires:       util-linux
+%if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version}
+Requires:       open-vmdk
+%endif
 # lsblk is part of util-linux-systemd on openSUSE
 %if 0%{?suse_version}
 Requires:       util-linux-systemd

--- a/test/unit/storage/subformat/ova_test.py
+++ b/test/unit/storage/subformat/ova_test.py
@@ -10,12 +10,19 @@ import kiwi
 
 from kiwi.exceptions import (
     KiwiCommandNotFound,
-    KiwiFormatSetupError
+    KiwiFormatSetupError,
+    KiwiTemplateError
 )
 
 
 class TestDiskFormatOva:
-    def setup(self):
+    @patch('kiwi.storage.subformat.ova.FirmWare')
+    def setup(self, mock_FirmWare):
+        self.firmware = Mock()
+        self.firmware.efi_mode = Mock(
+            return_value='uefi'
+        )
+        mock_FirmWare.return_value = self.firmware
         Defaults.set_platform_name('x86_64')
         self.context_manager_mock = Mock()
         self.file_mock = Mock()
@@ -54,6 +61,48 @@ class TestDiskFormatOva:
             return_value='2'
         )
 
+        self.iso_setup = Mock()
+        self.xml_state.get_build_type_vmdvd_section = Mock(
+            return_value=self.iso_setup
+        )
+        self.xml_state.get_luks_credentials = Mock(
+            return_value=None
+        )
+        self.iso_setup.get_controller = Mock(
+            return_value='ide'
+        )
+        self.iso_setup.get_id = Mock(
+            return_value='0'
+        )
+
+        self.network_setup = [Mock()]
+        self.xml_state.get_build_type_vmnic_entries = Mock(
+            return_value=self.network_setup
+        )
+        self.network_setup[0].get_interface = Mock(
+            return_value='0'
+        )
+        self.network_setup[0].get_mac = Mock(
+            return_value='98:90:96:a0:3c:58'
+        )
+        self.network_setup[0].get_mode = Mock(
+            return_value='bridged'
+        )
+        self.network_setup[0].get_driver = Mock(
+            return_value='e1000'
+        )
+
+        self.disk_setup = Mock()
+        self.xml_state.get_build_type_vmdisk_section = Mock(
+            return_value=self.disk_setup
+        )
+        self.disk_setup.get_controller = Mock(
+            return_value='lsilogic'
+        )
+        self.disk_setup.get_id = Mock(
+            return_value='0'
+        )
+
         self.machine_setup.get_ovftype = Mock(
             return_value='vmware'
         )
@@ -71,7 +120,8 @@ class TestDiskFormatOva:
     def setup_method(self, cls):
         self.setup()
 
-    def test_post_init(self):
+    @patch('kiwi.storage.subformat.ova.FirmWare')
+    def test_post_init(self, mock_FirmWare):
         self.disk_format.post_init({})
 
     def test_post_init_bad_ovftype(self):
@@ -94,29 +144,53 @@ class TestDiskFormatOva:
 
     @patch('kiwi.storage.subformat.ova.Path.which')
     @patch('kiwi.storage.subformat.ova.Command.run')
-    @patch('kiwi.storage.subformat.vmdk.DiskFormatVmdk.create_image_format')
-    @patch('kiwi.storage.subformat.ova.CommandCapabilities.has_option_in_help')
-    @patch('os.stat')
-    @patch('os.chmod')
+    @patch('kiwi.storage.subformat.ova.DiskFormatVmdk.create_image_format')
+    @patch('os.chdir')
     def test_create_image_format(
-        self, mock_chmod, mock_stat, mock_has_option_in_help,
-        mock_create_image_format, mock_command, mock_which
+        self,
+        mock_chdir,
+        mock_create_image_format,
+        mock_command,
+        mock_which
     ):
-        mock_has_option_in_help.return_value = True
-        mock_which.return_value = 'ovftool'
-        mock_stat.return_value = Mock(st_mode=0o644)
-        self.disk_format.create_image_format()
-        mock_command.assert_called_once_with(
-            [
-                'ovftool', '--shaAlgorithm=SHA1',
-                '--allowExtraConfig', '--exportFlags=extraconfig',
-                'target_dir/some-disk-image.x86_64-1.2.3.vmx',
-                'target_dir/some-disk-image.x86_64-1.2.3.ova'
-            ]
-        )
+        mock_which.return_value = 'ova-compose'
+        with patch('builtins.open', create=True) as mock_open:
+            self.disk_format.create_image_format()
+            mock_open.assert_called_once_with(
+                'target_dir/some-disk-image.x86_64-1.2.3.meta', 'w'
+            )
+            mock_command.assert_called_once_with(
+                [
+                    'ova-compose',
+                    '--input-file',
+                    'target_dir/some-disk-image.x86_64-1.2.3.meta',
+                    '--output-file',
+                    'target_dir/some-disk-image.x86_64-1.2.3.ova',
+                    '--format', 'ova'
+                ]
+            )
+
+    @patch('kiwi.storage.subformat.ova.DiskFormatVmdk.create_image_format')
+    @patch('kiwi.storage.subformat.ova.OvaComposeTemplate.get_template')
+    @patch('kiwi.storage.subformat.ova.Command.run')
+    @patch('kiwi.storage.subformat.ova.Path.which')
+    def test_create_image_format_template_error(
+        self,
+        mock_Path_which,
+        mock_Command_run,
+        mock_OvaComposeTemplate_get_template,
+        mock_DiskFormatVmdk_create_image_format
+    ):
+        template = Mock()
+        mock_Path_which.return_value = 'ova-compose'
+        mock_OvaComposeTemplate_get_template.return_value = template
+        template.substitute.side_effect = Exception
+        with patch('builtins.open'):
+            with raises(KiwiTemplateError):
+                self.disk_format.create_image_format()
 
     @patch('kiwi.storage.subformat.ova.Path.which')
-    def test_create_image_format_no_ovftool(self, mock_which):
-        mock_which.return_value = None
+    def test_create_image_format_no_ova_compose(self, mock_Path_which):
+        mock_Path_which.return_value = None
         with raises(KiwiCommandNotFound):
             self.disk_format.create_image_format()


### PR DESCRIPTION
Finally this commit drops the use of the VMware ovftool and moves to the real opensource alternative open-vmdk This Fixes #2292


