### PR TITLE
Add plymouth_msg

### DIFF
--- a/dracut/modules.d/55kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/55kiwi-repart/kiwi-repart-disk.sh
@@ -117,6 +117,12 @@ function get_target_rootpart_size {
     echo "${kiwi_oemrootMB}"
 }
 
+function plymouth_msg {
+    if command -v plymouth >/dev/null 2>&1; then
+        plymouth display-message --text="$1"
+    fi
+}
+
 function repart_standard_disk {
     # """
     # repartition disk with read/write root filesystem
@@ -322,6 +328,8 @@ if ! resize_wanted "${last_device}" "${disk}"; then
     return
 fi
 
+plymouth_msg "Expanding disk..."
+
 # prepare disk for repartition
 if [ "$(get_partition_table_type "${disk}")" = 'gpt' ];then
     relocate_gpt_at_end_of_disk "${disk}"
@@ -357,6 +365,8 @@ if lvm_system; then
 else
     resize_filesystem "$(get_root_map)"
 fi
+
+plymouth_msg ""
 
 # wait for the root device to appear
 wait_for_storage_device "${last_device}"

--- a/dracut/modules.d/55kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/55kiwi-repart/kiwi-repart-disk.sh
@@ -118,6 +118,7 @@ function get_target_rootpart_size {
 }
 
 function plymouth_msg {
+    [ -z "$1" ] || info "$1"
     if command -v plymouth &>/dev/null; then
         plymouth display-message --text="$1"
     fi

--- a/dracut/modules.d/55kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/55kiwi-repart/kiwi-repart-disk.sh
@@ -118,7 +118,7 @@ function get_target_rootpart_size {
 }
 
 function plymouth_msg {
-    if command -v plymouth >/dev/null 2>&1; then
+    if command -v plymouth &>/dev/null; then
         plymouth display-message --text="$1"
     fi
 }


### PR DESCRIPTION
Changes proposed in this pull request:
* Adds `plymouth_msg` to kiwi-repart

----
This is mostly a minimal proof of concept; it can be merged as is but I expect you might want to move `plymouth_msg` to the library and then use it in other places too.

The core idea is that I noticed on large disks the first-boot repartitioning could take long enough that people might wonder what's going on, especially on systems running plymouth.  This adds a simple message that displays on plymouth to let people know what it's doing (and implicitly that subsequent boots should be faster).

One caveat is that at least on current versions of OpenSUSE (tested in 15.6 but at time of writing it hasn't been fixed in later versions) there's a bug in `plymouth-dracut` which means that `label-pango.so` is not installed to the initrd and thus no text will display.  This can either be fixed by patching `/usr/lib/plymouth/plymouth-populate-initrd` to install `label-pango.so` instead of `label.so`, or by adding an equivalent entry to any dracut module, e.g. `install_optional_items+=" /usr/lib64/plymouth/label-pango.so "`.