### PR TITLE
Fix checked for extended attributes

### DIFF
--- a/kiwi/utils/sync.py
+++ b/kiwi/utils/sync.py
@@ -97,8 +97,9 @@ class DataSync:
                 warn_me = True
             if warn_me:
                 log.warning(
-                    'Extended attributes not supported for target: %s',
-                    self.target_dir
+                    'Extended attributes not supported for target: {}'.format(
+                        self.target_dir
+                    )
                 )
         if exclude:
             for item in exclude:
@@ -135,10 +136,10 @@ class DataSync:
         """
         try:
             os.getxattr(self.target_dir, 'user.mime_type')
-        except OSError as e:
-            log.debug(
-                f'Check for extended attributes on {self.target_dir} said: {e}'
-            )
-            if e.errno == errno.ENOTSUP:
+        except OSError as issue:
+            if issue.errno == errno.ENOTSUP:
                 return False
+        except Exception:
+            # ignore any other exception here
+            pass
         return True

--- a/test/unit/utils/sync_test.py
+++ b/test/unit/utils/sync_test.py
@@ -71,3 +71,6 @@ class TestDataSync:
         effect.errno = errno.ENOTSUP
         mock_getxattr.side_effect = effect
         assert self.sync.target_supports_extended_attributes() is False
+        effect = NotImplemented
+        mock_getxattr.side_effect = effect
+        assert self.sync.target_supports_extended_attributes() is True


### PR DESCRIPTION
Make sure the check only issues a warning message if the call for the extended attributes really states that the target doesn't support extended attributes. In any other case do not warn as it causes misleading error information which is not an error we care for in this scope

