### PR TITLE
Make error logged/raised from has_option_in_help more accurate

### DIFF
--- a/kiwi/utils/command_capabilities.py
+++ b/kiwi/utils/command_capabilities.py
@@ -69,7 +69,7 @@ class CommandCapabilities:
         for line in command.error.splitlines():
             if flag in line:
                 return True
-        message = 'Could not parse {} output'.format(call)
+        message = 'Could not find flag {} in {} output'.format(flag, call)
         if raise_on_error:
             raise KiwiCommandCapabilitiesError(message)
         if not silent:


### PR DESCRIPTION
If I'm following this code correctly, we're not raising here because we "could not parse" the output. We're raising because we parsed it and it did not have the flag we were looking for.