### PR TITLE
Added cpio to archlinux integration test

### DIFF
--- a/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
+++ b/build-tests/x86/archlinux/test-image-live-disk-kis/appliance.kiwi
@@ -84,6 +84,7 @@
         <package name="linux-firmware"/>
         <package name="netctl"/>
         <package name="dracut-hooks"/>
+        <package name="cpio"/>
     <!--
         dracut-hooks provide some packman hooks
         to ensure dracut recreates the initrd on kernel


### PR DESCRIPTION
dracut requires cpio to be installed

