### PR TITLE
Add support for arch attribute in profile requires

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -1980,15 +1980,27 @@ Manage image namespace(s).
 .. code:: xml
 
    <profiles>
-     <profile name="name" description="text"/>
+     <profile name="profile_name" description="text" arch="arch_name"/>
    </profiles>
 
 The optional profiles section lets you maintain one image description
 while allowing for variation of other sections that are included. A
 separate profile element must be specified for each variation. The
-profile child element, which has name and description attributes,
+profile child element, which has name, description and arch attributes,
 specifies an alias name used to mark sections as belonging to a profile
 and a short description explaining what this profile does.
+
+A profile can require other profiles, and the required profiles will
+be evaluated in the order of their declaration. The optional arch
+attribute can be used to limit the profile and required profiles
+it to a certain architecture. For example:
+
+.. code:: xml
+
+   <profile name="A" description="Some A" arch="x86_64,s390x">
+     <requires profile="B"/>
+     <requires profile="C" arch="s390x"/>
+   </profile>
 
 For example, to mark a set of packages as belonging to a profile, simply
 annotate them with the profiles attribute, as shown below:

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1052,12 +1052,14 @@ div {
 # common element <requires>
 #
 div {
+    k.requires.arch.attribute = k.arch.attribute
     k.requires.profile.attribute =
         ## The profile name required as part of the current profile
         ## definition.
         attribute profile {text}
     k.requires.attlist =
-        k.requires.profile.attribute
+        k.requires.profile.attribute &
+        k.requires.arch.attribute?
     k.requires =
         ## Requires is used to set profiles dependencies, with it a profile
         ## definition can be composed by other existing profiles.

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1618,6 +1618,9 @@ packages.</a:documentation>
     
   -->
   <div>
+    <define name="k.requires.arch.attribute">
+      <ref name="k.arch.attribute"/>
+    </define>
     <define name="k.requires.profile.attribute">
       <attribute name="profile">
         <a:documentation>The profile name required as part of the current profile
@@ -1625,7 +1628,12 @@ definition.</a:documentation>
       </attribute>
     </define>
     <define name="k.requires.attlist">
-      <ref name="k.requires.profile.attribute"/>
+      <interleave>
+        <ref name="k.requires.profile.attribute"/>
+        <optional>
+          <ref name="k.requires.arch.attribute"/>
+        </optional>
+      </interleave>
     </define>
     <define name="k.requires">
       <element name="requires">

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2407,9 +2407,10 @@ class requires(GeneratedsSuper):
     definition can be composed by other existing profiles."""
     subclass = None
     superclass = None
-    def __init__(self, profile=None):
+    def __init__(self, profile=None, arch=None):
         self.original_tagname_ = None
         self.profile = _cast(None, profile)
+        self.arch = _cast(None, arch)
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -2423,6 +2424,15 @@ class requires(GeneratedsSuper):
     factory = staticmethod(factory)
     def get_profile(self): return self.profile
     def set_profile(self, profile): self.profile = profile
+    def get_arch(self): return self.arch
+    def set_arch(self, arch): self.arch = arch
+    def validate_arch_name(self, value):
+        # Validate type arch-name, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_arch_name_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_arch_name_patterns_, ))
+    validate_arch_name_patterns_ = [['^.*$']]
     def hasContent_(self):
         if (
 
@@ -2454,6 +2464,9 @@ class requires(GeneratedsSuper):
         if self.profile is not None and 'profile' not in already_processed:
             already_processed.add('profile')
             outfile.write(' profile=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.profile), input_name='profile')), ))
+        if self.arch is not None and 'arch' not in already_processed:
+            already_processed.add('arch')
+            outfile.write(' arch=%s' % (quote_attrib(self.arch), ))
     def exportChildren(self, outfile, level, namespaceprefix_='', name_='requires', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node):
@@ -2468,6 +2481,12 @@ class requires(GeneratedsSuper):
         if value is not None and 'profile' not in already_processed:
             already_processed.add('profile')
             self.profile = value
+        value = find_attr_value_('arch', node)
+        if value is not None and 'arch' not in already_processed:
+            already_processed.add('arch')
+            self.arch = value
+            self.arch = ' '.join(self.arch.split())
+            self.validate_arch_name(self.arch)    # validate type arch-name
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class requires
@@ -7853,7 +7872,7 @@ class hkd_revocation_list(GeneratedsSuper):
 
 class environment(GeneratedsSuper):
     """Provides details about the container/bootloader environment
-    variables At least one environment variable must be configured"""
+    variables. At least one environment variable must be configured"""
     subclass = None
     superclass = None
     def __init__(self, env=None):

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -383,6 +383,22 @@ class XMLState:
                 result.append(packages)
         return result
 
+    def requires_matches_host_architecture(self, requires: Any) -> bool:
+        """
+        Tests if the given profile requires section is applicable for
+        the current host architecture. If no architecture is specified
+        within the section it is considered as a match returning True.
+
+        Note: The XML section pointer must provide an arch attribute
+
+        :param section: XML section object
+
+        :return: True or False
+
+        :rtype: bool
+        """
+        return self._section_matches_host_architecture(requires)
+
     def volume_matches_host_architecture(self, volume: Any) -> bool:
         """
         Tests if the given volume section is applicable for the current host
@@ -3256,11 +3272,12 @@ class XMLState:
         if profile not in current_profiles:
             profiles_to_add.append(profile)
             for required in available_profiles[profile].get_requires():
-                if required.get_profile() not in current_profiles:
-                    profiles_to_add += self._solve_profile_dependencies(
-                        required.get_profile(), available_profiles,
-                        current_profiles + profiles_to_add
-                    )
+                if self.requires_matches_host_architecture(required):
+                    if required.get_profile() not in current_profiles:
+                        profiles_to_add += self._solve_profile_dependencies(
+                            required.get_profile(), available_profiles,
+                            current_profiles + profiles_to_add
+                        )
         return profiles_to_add
 
     def _build_type_section(self, build_type=None):

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -38,7 +38,7 @@
         <profile name="derivedContainer" description="Container from a base"/>
         <profile name="composedProfile" description="Composed profile">
             <requires profile="vmxSimpleFlavour"/>
-            <requires profile="xenDomUFlavour"/>
+            <requires profile="xenDomUFlavour" arch="x86_64"/>
         </profile>
     </profiles>
     <preferences>

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -405,10 +405,17 @@ class TestXMLState:
             XMLState(xml_data, ['foo'])
 
     def test_profile_requires(self):
+        Defaults.set_platform_name('x86_64')
         xml_data = self.description.load()
         xml_state = XMLState(xml_data, ['composedProfile'])
         assert xml_state.profiles == [
             'composedProfile', 'vmxSimpleFlavour', 'xenDomUFlavour'
+        ]
+        Defaults.set_platform_name('aarch64')
+        xml_data = self.description.load()
+        xml_state = XMLState(xml_data, ['composedProfile'])
+        assert xml_state.profiles == [
+            'composedProfile', 'vmxSimpleFlavour'
         ]
 
     def test_get_partitions(self):


### PR DESCRIPTION
Allow to specify the arch attribute in the <requires> sub section of a <profile> definition.
This Fixes #2948


