### PR TITLE
Fix RepositoryApt and RepositoryPacman instances

### DIFF
--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -61,6 +61,14 @@ class RepositoryApt(RepositoryBase):
         self.exclude_docs = False
         self.signing_keys: List = []
 
+        # delete custom arguments not used for apt
+        for argument in self.custom_args:
+            if '_install_langs' in argument or '_target_arch' in argument:
+                log.warning(
+                    f'Custom argument {argument} will be ignored for apt'
+                )
+                self.custom_args.remove(argument)
+
         # extract custom arguments used for apt config only
         if 'exclude_docs' in self.custom_args:
             self.custom_args.remove('exclude_docs')

--- a/kiwi/repository/pacman.py
+++ b/kiwi/repository/pacman.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import logging
 from configparser import ConfigParser
 from typing import (
     List, Dict
@@ -30,6 +31,8 @@ from kiwi.repository.base import RepositoryBase
 from kiwi.path import Path
 from kiwi.command import Command
 from kiwi.utils.toenv import ToEnv
+
+log = logging.getLogger('kiwi')
 
 
 class RepositoryPacman(RepositoryBase):
@@ -56,6 +59,16 @@ class RepositoryPacman(RepositoryBase):
         self.custom_args = custom_args
         self.check_signatures = False
         self.repo_names: List = []
+
+        # delete custom arguments not used for pacman
+        for argument in self.custom_args:
+            if '_install_langs' in argument or \
+               '_target_arch' in argument or \
+               'exclude_docs' in argument:
+                log.warning(
+                    f'Custom argument {argument} will be ignored for pacman'
+                )
+                self.custom_args.remove(argument)
 
         self.runtime_pacman_config_file = Temporary(
             path=self.root_dir, prefix='kiwi_pacman.config'

--- a/test/unit/repository/apt_test.py
+++ b/test/unit/repository/apt_test.py
@@ -41,7 +41,7 @@ class TestRepositoryApt:
                 }
             )
             repo = RepositoryApt(
-                root_bind, custom_args=['check_signatures']
+                root_bind, custom_args=['check_signatures', '_target_arch%amd64']
             )
             assert repo.custom_args == []
             assert repo.unauthenticated == 'false'

--- a/test/unit/repository/pacman_test.py
+++ b/test/unit/repository/pacman_test.py
@@ -38,7 +38,7 @@ class TestRepositorPacman(object):
             runtime_pacman_config.reset_mock()
 
             RepositoryPacman(
-                root_bind, custom_args=['check_signatures']
+                root_bind, custom_args=['check_signatures', '_target_arch%x86_64']
             )
 
             assert runtime_pacman_config.set.call_args_list == [


### PR DESCRIPTION
Some arguments are not supported/implemented with these repository classes. Make sure to sort them out and log a warning that their use has no effect.
This Fixes #2953


