### PR TITLE
Refactor use of kiwi settings file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,11 @@ install:
 	$(python) helper/completion_generator.py \
 		> ${buildroot}usr/share/bash-completion/completions/kiwi-ng
 	# kiwi default configuration
-	install -d -m 755 ${buildroot}etc
-	install -m 644 kiwi.yml ${buildroot}etc/kiwi.yml
-	# kiwi old XSL stylesheets for upgrade
 	install -d -m 755 ${buildroot}usr/share/kiwi
+	install -d -m 755 ${buildroot}usr/share/kiwi/kiwi.yml.d
+	install -d -m 755 ${buildroot}etc/kiwi.yml.d
+	install -m 644 kiwi.yml ${buildroot}usr/share/kiwi/kiwi.yml.example
+	# kiwi old XSL stylesheets for upgrade
 	cp -a helper/xsl_to_v74 ${buildroot}usr/share/kiwi/
 
 kiwi/schema/kiwi.rng: kiwi/schema/kiwi.rnc

--- a/doc/source/commands/kiwi.rst
+++ b/doc/source/commands/kiwi.rst
@@ -97,8 +97,14 @@ GLOBAL OPTIONS
 --config=<configfile>
 
   Use the specified runtime configuration file. If not specified, the
-  runtime configuration is expected to be in the :file:`~/.config/kiwi/config.yml`
-  or :file:`/etc/kiwi.yml` files.
+  runtime configuration is looked up at :file:`~/.config/kiwi/config.yml`
+  or :file:`/etc/kiwi.yml` or :file:`/usr/share/kiwi/kiwi.yml`.
+  If the runtime configuration file is located at :file:`/etc/kiwi.yml`,
+  the system will also check for extra configuration files in
+  :file:`/etc/kiwi.yml.d/`. Similarly, if the main file is at
+  :file:`/usr/share/kiwi/kiwi.yml`, it will look for additional files in
+  :file:`/usr/share/kiwi/kiwi.yml.d/`. All `.yml` files in these directories are
+  loaded in alphabetical order and combined into the final configuration.
 
 --debug
 

--- a/doc/source/concept_and_workflow/runtime_configuration.rst
+++ b/doc/source/concept_and_workflow/runtime_configuration.rst
@@ -16,6 +16,18 @@ configuration file in the following locations:
 
 2. :file:`/etc/kiwi.yml`
 
-A default runtime config file in :file:`/etc/kiwi.yml` is provided with
-the `python3-kiwi` package. The file contains all settings as comments,
-including a short description of each setting.
+3. :file:`/usr/share/kiwi/kiwi.yml`
+
+A default runtime config file in :file:`/usr/etc/kiwi.yml.example` is
+provided with the `python3-kiwi` main package. The file contains all
+possible settings as comments, including a short description of each
+setting.
+
+If the runtime configuration file is located at :file:`/etc/kiwi.yml`,
+the system will also check for extra configuration files in
+:file:`/etc/kiwi.yml.d/`. Similarly, if the main file is at
+:file:`/usr/share/kiwi/kiwi.yml`, it will look for additional files in
+:file:`/usr/share/kiwi/kiwi.yml.d/`. All `.yml` files in these directories are
+loaded in alphabetical order and combined into the final configuration.
+This allows for modular configuration management, where different
+aspects of the configuration can be separated into different files.

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -94,6 +94,10 @@ RUNTIME_CHECKER_METADATA = '{}/runtime_checker_metadata.yml'.format(
 TEMP_DIR = '/var/tmp'
 LOCAL_CONTAINERS = '/var/tmp/kiwi_containers'
 CUSTOM_RUNTIME_CONFIG_FILE = None
+ETC_RUNTIME_CONFIG_FILE = '/etc/kiwi.yml'
+ETC_RUNTIME_CONFIG_DIR = '/etc/kiwi.yml.d'
+USR_RUNTIME_CONFIG_FILE = '/usr/share/kiwi/kiwi.yml'
+USR_RUNTIME_CONFIG_DIR = '/usr/share/kiwi/kiwi.yml.d'
 PLATFORM_MACHINE = platform.machine()
 EFI_FAT_IMAGE_SIZE = 20
 

--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -43,11 +43,12 @@ class RuntimeConfig:
 
     1. Check for --config provided from the CLI
     2. ~/.config/kiwi/config.yml
-    3. /etc/kiwi.yml
+    3. /etc/kiwi.yml + /etc/kiwi.yml.d/*.yml
+    4. /usr/share/kiwi/kiwi.yml + /usr/share/kiwi/kiwi.yml.d/*.yml
 
     The KIWI runtime configuration file is a yaml formatted file
     containing information to control the behavior of the tools
-    used by KIWI.
+    used by KIWI on the build host.
 
     :param bool reread: reread runtime config
     """
@@ -56,6 +57,7 @@ class RuntimeConfig:
 
         if RUNTIME_CONFIG is None or reread:
             config_file = None
+            config_dir = None
             custom_config_file = defaults.CUSTOM_RUNTIME_CONFIG_FILE
 
             if custom_config_file:
@@ -69,13 +71,33 @@ class RuntimeConfig:
                     [self._home_path(), '.config', 'kiwi', 'config.yml']
                 )
             if not config_file or not os.path.exists(config_file):
-                config_file = '/etc/kiwi.yml'
+                config_file = defaults.ETC_RUNTIME_CONFIG_FILE
+                if not os.path.exists(config_file):
+                    config_file = defaults.USR_RUNTIME_CONFIG_FILE
             if os.path.exists(config_file):
                 log.info(
                     f'Reading runtime config file: {config_file!r}'
                 )
                 with open(config_file, 'r') as config:
                     RUNTIME_CONFIG = yaml.safe_load(config) or {}
+
+                if config_file == defaults.ETC_RUNTIME_CONFIG_FILE:
+                    config_dir = defaults.ETC_RUNTIME_CONFIG_DIR
+                elif config_file == defaults.USR_RUNTIME_CONFIG_FILE:
+                    config_dir = defaults.USR_RUNTIME_CONFIG_DIR
+
+                if config_dir and os.path.isdir(config_dir):
+                    for config_file in sorted(os.listdir(config_dir)):
+                        if config_file.endswith('.yml'):
+                            config_file_path = os.path.normpath(
+                                os.sep.join([config_dir, config_file])
+                            )
+                            log.info(
+                                f'--> Reading addon runtime config file: {config_file_path!r}'
+                            )
+                            with open(config_file_path, 'r') as config:
+                                additional_config = yaml.safe_load(config) or {}
+                                RUNTIME_CONFIG.update(additional_config)
 
     def get_credentials_verification_metadata_signing_key_file(self) -> str:
         """

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -803,6 +803,9 @@ fi
 %files -n python%{python3_pkgversion}-kiwi
 %dir %{_defaultdocdir}/python-kiwi
 %dir %{_usr}/share/kiwi
+%dir %{_usr}/share/kiwi/kiwi.yml.d
+%dir %_sysconfdir/kiwi.yml.d
+%doc %{_usr}/share/kiwi/kiwi.yml.example
 %{_bindir}/kiwi
 %{_bindir}/kiwi-ng
 %{_bindir}/kiwi-ng-3*
@@ -815,7 +818,6 @@ fi
 %{_usr}/share/bash-completion/completions/kiwi-ng
 
 %files -n kiwi-man-pages
-%config %_sysconfdir/kiwi.yml
 %doc %{_mandir}/man8/*
 
 %files -n dracut-kiwi-lib

--- a/test/data/kiwi.yml
+++ b/test/data/kiwi.yml
@@ -1,0 +1,2 @@
+xz:
+  - options: -a -b xxx

--- a/test/data/kiwi.yml.d/mapper.yml
+++ b/test/data/kiwi.yml.d/mapper.yml
@@ -1,0 +1,2 @@
+mapper:
+  - part_mapper: partx

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -123,6 +123,10 @@ class TestDiskBuilder:
         kiwi.builder.disk.DiskSetup = MagicMock(
             return_value=self.disk_setup
         )
+        self.runtime_config = Mock()
+        kiwi.builder.disk.RuntimeConfig = MagicMock(
+            return_value=self.runtime_config
+        )
         self.boot_image_task = Mock()
         self.boot_image_task.boot_root_directory = 'boot_dir'
         self.boot_image_task.kernel_filename = 'kernel'

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -1,5 +1,7 @@
 import logging
-from unittest.mock import patch
+from unittest.mock import (
+    patch, call
+)
 from pytest import (
     raises, fixture
 )
@@ -38,18 +40,83 @@ class TestRuntimeConfig:
 
     @patch('os.path.exists')
     @patch('yaml.safe_load')
-    def test_reading_system_wide_config_file(
-        self, mock_yaml, mock_exists
+    @patch('os.path.isdir')
+    @patch('os.listdir')
+    def test_reading_system_wide_config_file_from_etc(
+        self,
+        mock_os_listdir,
+        mock_os_path_isdir,
+        mock_yaml,
+        mock_exists
     ):
-        exists_call_results = [True, False]
+        mock_os_path_isdir.return_value = True
+        mock_os_listdir.return_value = ['some.yml']
 
         def os_path_exists(config):
-            return exists_call_results.pop()
+            if config == '/etc/kiwi.yml':
+                return True
+            return False
 
         mock_exists.side_effect = os_path_exists
         with patch('builtins.open') as m_open:
             RuntimeConfig(reread=True)
-            m_open.assert_called_once_with('/etc/kiwi.yml', 'r')
+            assert m_open.call_args_list == [
+                call('/etc/kiwi.yml', 'r'),
+                call('/etc/kiwi.yml.d/some.yml', 'r')
+            ]
+
+    @patch('os.path.exists')
+    @patch('yaml.safe_load')
+    @patch('os.path.isdir')
+    @patch('os.listdir')
+    def test_reading_system_wide_config_file_from_usr(
+        self,
+        mock_os_listdir,
+        mock_os_path_isdir,
+        mock_yaml,
+        mock_exists
+    ):
+        mock_os_path_isdir.return_value = True
+        mock_os_listdir.return_value = ['some.yml']
+
+        def os_path_exists(config):
+            if config == '/usr/share/kiwi/kiwi.yml':
+                return True
+            return False
+
+        mock_exists.side_effect = os_path_exists
+        with patch('builtins.open') as m_open:
+            RuntimeConfig(reread=True)
+            assert m_open.call_args_list == [
+                call('/usr/share/kiwi/kiwi.yml', 'r'),
+                call('/usr/share/kiwi/kiwi.yml.d/some.yml', 'r')
+            ]
+
+    @patch('kiwi.defaults.ETC_RUNTIME_CONFIG_FILE', '../data/kiwi.yml')
+    @patch('kiwi.defaults.ETC_RUNTIME_CONFIG_DIR', '../data/kiwi.yml.d')
+    @patch('kiwi.runtime_checker.Defaults.is_buildservice_worker')
+    def test_config_sections_from_system_wide_etc_config(
+        self,
+        mock_is_buildservice_worker
+    ):
+        mock_is_buildservice_worker.return_value = False
+        runtime_config = RuntimeConfig(reread=True)
+        assert runtime_config.get_xz_options() == ['-a', '-b', 'xxx']
+        assert runtime_config.get_mapper_tool() == 'partx'
+
+    @patch('kiwi.defaults.ETC_RUNTIME_CONFIG_FILE', '')
+    @patch('kiwi.defaults.ETC_RUNTIME_CONFIG_DIR', '')
+    @patch('kiwi.defaults.USR_RUNTIME_CONFIG_FILE', '../data/kiwi.yml')
+    @patch('kiwi.defaults.USR_RUNTIME_CONFIG_DIR', '../data/kiwi.yml.d')
+    @patch('kiwi.runtime_checker.Defaults.is_buildservice_worker')
+    def test_config_sections_from_system_wide_usr_config(
+        self,
+        mock_is_buildservice_worker
+    ):
+        mock_is_buildservice_worker.return_value = False
+        runtime_config = RuntimeConfig(reread=True)
+        assert runtime_config.get_xz_options() == ['-a', '-b', 'xxx']
+        assert runtime_config.get_mapper_tool() == 'partx'
 
     @patch('kiwi.runtime_checker.Defaults.is_buildservice_worker')
     def test_config_sections_from_home_base_config(self, mock_is_buildservice_worker):


### PR DESCRIPTION
KIWI supports an optional runtime configuration file for settings to control the behavior of the tools used by    KIWI on the build host. So far this config file could be specified via --config or is searched in the user's HOME    or looked up as /etc/kiwi.yml. With this commit the  following changes to this heuristic are made:
    
1. Support reading of `/etc/kiwi.yml.d/*.yml`
2. Support reading of `/usr/share/kiwi/kiwi.yml` and `/usr/share/kiwi/kiwi.yml.d/*.yml`
3. Install default settings file as `/usr/share/kiwi/kiwi.yml.example` from the main package and drop it from kiwi-man-pages which  was considered a weird place.