### PR TITLE
Update Red Hat distribution CA certificate tool

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -141,7 +141,7 @@ settings apply:
 +==============+===========================================+========================+
 | SUSE         | /etc/pki/trust/anchors                    | update-ca-certificates |
 +--------------+-------------------------------------------+------------------------+
-| Red Hat      | /etc/pki/ca-trust/source/anchors          | update-ca-certificates |
+| Red Hat      | /etc/pki/ca-trust/source/anchors          | update-ca-trust        |
 +--------------+-------------------------------------------+------------------------+
 | Debian Based | /usr/local/share/ca-certificates          | update-ca-certificates |
 +--------------+-------------------------------------------+------------------------+

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -111,7 +111,7 @@ CA_UPDATE_MAP = {
         'destination_path': '/etc/pki/trust/anchors'
     },
     'redhat': {
-        'tool': 'update-ca-certificates',
+        'tool': 'update-ca-trust',
         'destination_path': '/etc/pki/ca-trust/source/anchors/'
     },
     'debian': {


### PR DESCRIPTION
In the original commit, we used `update-ca-certificates` for Red Hat based distributions. This was a mistake, as since earlier versions of RHEL it has used `update-ca-trust` instead. This commit fixes that earlier mistake.

Fixes #2980

Changes proposed in this pull request:
* Replaces `update-ca-certificates` with `update-ca-trust` for Red Hat (or derived) distributions in CA cert workflow
