### PR TITLE
Set default grub terminal output type to: console

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -120,11 +120,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         if self.custom_args and 'config_options' in self.custom_args:
             self.config_options = self.custom_args['config_options']
 
-        # This default output terminal type will change to console
-        # with the next major kiwi version update. Also see:
-        # https://github.com/OSInside/kiwi/issues/2494
         self.terminal_output = \
-            self.xml_state.get_build_type_bootloader_console()[0] or 'gfxterm'
+            self.xml_state.get_build_type_bootloader_console()[0] or 'console'
 
         self.terminal_input = \
             self.xml_state.get_build_type_bootloader_console()[1] or 'console'

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -121,11 +121,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         if self.custom_args and 'config_options' in self.custom_args:
             self.config_options = self.custom_args['config_options']
 
-        # This default output terminal type will change to console
-        # with the next major kiwi version update. Also see:
-        # https://github.com/OSInside/kiwi/issues/2494
         self.terminal_output = \
-            self.xml_state.get_build_type_bootloader_console()[0] or 'gfxterm'
+            self.xml_state.get_build_type_bootloader_console()[0] or 'console'
 
         self.terminal_input = \
             self.xml_state.get_build_type_bootloader_console()[1] or 'console'

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -1133,7 +1133,7 @@ class TestBootLoaderConfigGrub2:
         )
         self.bootloader.setup_live_image_config(self.mbrid)
         self.grub2.get_multiboot_iso_template.assert_called_once_with(
-            True, True, False, None, False
+            True, False, False, None, False
         )
 
     @patch.object(BootLoaderConfigGrub2, '_copy_grub_config_to_efi_path')
@@ -1326,7 +1326,7 @@ class TestBootLoaderConfigGrub2:
         self.bootloader.multiboot = False
         self.bootloader.setup_install_image_config(self.mbrid)
         self.grub2.get_install_template.assert_called_once_with(
-            True, True, False, True, True
+            True, False, False, True, True
         )
         mock_copy_grub_config_to_efi_path.assert_called_once_with(
             'root_dir', 'earlyboot.cfg', 'iso'

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -1133,7 +1133,7 @@ class TestBootLoaderConfigGrub2:
         )
         self.bootloader.setup_live_image_config(self.mbrid)
         self.grub2.get_multiboot_iso_template.assert_called_once_with(
-            True, True, False, None, False
+            True, False, False, None, False
         )
 
     @patch.object(BootLoaderConfigGrub2, '_copy_grub_config_to_efi_path')
@@ -1322,7 +1322,7 @@ class TestBootLoaderConfigGrub2:
         self.bootloader.multiboot = False
         self.bootloader.setup_install_image_config(self.mbrid)
         self.grub2.get_install_template.assert_called_once_with(
-            True, True, False, True, True
+            True, False, False, True, True
         )
         mock_copy_grub_config_to_efi_path.assert_called_once_with(
             'root_dir', 'earlyboot.cfg', 'iso'


### PR DESCRIPTION
Instead of gfxterm the default console should be text based. This Fixes #2494

