### PR TITLE
Let udev settle after partition resize

### DIFF
--- a/dracut/modules.d/59kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/59kiwi-lib/kiwi-partitions-lib.sh
@@ -22,6 +22,7 @@ function create_partitions {
             create_dasd_partitions "${disk_device}" "${partition_setup}"
         ;;
     esac
+    # notify the kernel about partition table changes
     if type partprobe &> /dev/null;then
         set_device_lock "${disk_device}" \
             partprobe "${disk_device}"
@@ -29,6 +30,9 @@ function create_partitions {
         set_device_lock "${disk_device}" \
             partx -u "${disk_device}"
     fi
+    # the changes cause udev to remove and recreate links in /dev,
+    # wait until that has settled
+    udev_pending
 }
 
 function create_msdos_partitions {


### PR DESCRIPTION
The partition resize (resp. recreation) causes udev to remove the partition from /dev temporarily. Make sure it's back before attempting to resize the filesystem.

This fixes failures such as:

```
[    7.532589] dracut-pre-mount[1178]: BUG: specified free space extent for dele
ting doesn't match free space currently shown in FMT7 DSCB!                     
[    7.532608] dracut-pre-mount[1178]: exiting...                               
[    7.536185] dracut-pre-mount[1184]: Device '/dev/dasda' is currently locked, 
waiting                                                                         
 M  [K[ [0;1;31m* [0m [0;31m*     [0m] (1 of 2) A start job is running for Combu
stion (4s / no limit)                                                           
 M  [K[ [0;31m* [0;1;31m* [0m [0;31m*    [0m] (1 of 2) A start job is running fo
r Combustion (4s / no limit)                                                    
 M  [K[  [0;31m* [0;1;31m* [0m [0;31m*   [0m] (2 of 2) A start job is running f 
r   cut pre-mount hook (4s / no limit)                                          
 M  [K[   [0;31m* [0;1;31m* [0m [0;31m*  [0m] (2 of 2) A start job is running fo
r   cut pre-mount hook (5s / no limit)                                          
[    9.412347] dracut-pre-mount[1248]: [1/8] checking log skipped (none written)
                                                                                
[    9.412444] dracut-pre-mount[1248]: [2/8] checking root items                
[    9.438680] dracut-pre-mount[1248]: [3/8] checking extents                   
[    9.687367] dracut-pre-mount[1248]: [4/8] checking free space tree           
[    9.688981] dracut-pre-mount[1248]: [5/8] checking fs roots                  
[    9.714742] dracut-pre-mount[1248]: [6/8] checking only csums items (without 
verifying data)                                                                 
[    9.715029] dracut-pre-mount[1248]: [7/8] checking root refs                 
[    9.715064] dracut-pre-mount[1248]: [8/8] checking quota groups              
[    9.728617] dracut-pre-mount[1251]: mount: /fs-resize: special device /dev/da
sda2 does not exist.                                                            
[    9.728662] dracut-pre-mount[1251]:        dmesg(1) may have more information
 after failed mount system call.                                                
[    9.729481][  T885] dracut: FATAL: Failed to resize filesystem               
[    9.729490][  T885] dracut: Refusing to continue                             
[    9.729873] dracut-pre-mount[1252]: umount: /fs-resize: not mounted.         
```

When booting with `rd.udev.log_level=debug`, this is visible in the log as:

```
Apr 17 16:56:30 fvogt.prg2.suse.org systemd-udevd[485]: dasda2: Device is queued (SEQNUM=1055, ACTION=remove)
Apr 17 16:56:30 fvogt.prg2.suse.org systemd-udevd[485]: dasda: Device is queued (SEQNUM=1056, ACTION=change)
Apr 17 16:56:30 fvogt.prg2.suse.org systemd-udevd[485]: dasda1: Device is queued (SEQNUM=1057, ACTION=add)
Apr 17 16:56:30 fvogt.prg2.suse.org systemd-udevd[485]: dasda2: Device is queued (SEQNUM=1058, ACTION=add)
```

