### PR TITLE
Recreate VTOC with fdasd before recreating partitions

### DIFF
--- a/dracut/modules.d/59kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/59kiwi-lib/kiwi-partitions-lib.sh
@@ -159,6 +159,11 @@ function create_dasd_partitions {
     # expand the partition table up to the disk size bsc#1209247
     parted --script --machine "${disk_device}" resizepart 1
 
+    # Trigger recreation of the VTOC to work around
+    # https://github.com/ibm-s390-linux/s390-tools/issues/166
+    echo "u" >> ${partition_setup_file}
+    echo "y" >> ${partition_setup_file}
+
     for cmd in ${partition_setup};do
         if [ "${ignore_cmd}" = 1 ] && echo "${cmd}" | grep -qE '[dntwq]';then
             ignore_cmd=0


### PR DESCRIPTION
Changing partitions with fdasd after a parted resize leads to an internal error because some internal structures mismatch. Work around that by recreating the partition table initially.

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1247316