### PR TITLE
Fix inconsistent comments regarding OVA creation

### DIFF
--- a/kiwi/storage/subformat/ova.py
+++ b/kiwi/storage/subformat/ova.py
@@ -69,8 +69,8 @@ class DiskFormatOva(DiskFormatBase):
 
     def create_image_format(self) -> None:
         """
-        Create ova disk format using ovftool from
-        https://www.vmware.com/support/developer/ovf
+        Create ova disk format using ova-compose
+        https://github.com/vmware/open-vmdk
         """
         # Check for required mkova tool
         ova_compose = Path.which(filename='ova-compose', access_mode=os.X_OK)

--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -90,9 +90,8 @@ class DiskFormatVmdk(DiskFormatBase):
 
     def _create_vmware_settings_file(self):
         """
-        In order to run a vmdk image in VMware products a settings file is
-        needed or the possibility to convert machine settings into an ovf
-        via VMware's proprietary ovftool
+        In order to run a vmdk image in VMware products a settings
+        file is needed
         """
         displayname = self.xml_state.xml_data.get_displayname()
         template_record = {


### PR DESCRIPTION
Prior open-vmdk the ovftool was used to create OVA images. There are some left over misleading comments in code which gets fixed by this commit. This is related to Issue #2292

