### PR TITLE
Do not hardcode dracut omit module in live builder

### DIFF
--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -473,11 +473,9 @@ class LiveImageBuilder:
         ) + modules
         for dracut_module in live_dracut_modules:
             self.boot_image.include_module(dracut_module)
-        self.boot_image.omit_module('multipath')
         self.boot_image.write_system_config_file(
             config={
-                'modules': live_dracut_modules,
-                'omit_modules': ['multipath']
+                'modules': live_dracut_modules
             },
             config_file=self.root_dir + '/etc/dracut.conf.d/02-livecd.conf'
         )

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -565,11 +565,9 @@ class TestLiveImageBuilder:
         assert self.boot_image_task.include_module.call_args_list == [
             call('kiwi-live'), call('pollcdrom')
         ]
-        self.boot_image_task.omit_module.assert_called_once_with('multipath')
         self.boot_image_task.write_system_config_file.assert_called_once_with(
             config={
-                'modules': ['kiwi-live', 'pollcdrom'],
-                'omit_modules': ['multipath']
+                'modules': ['kiwi-live', 'pollcdrom']
             },
             config_file='root_dir/etc/dracut.conf.d/02-livecd.conf'
         )


### PR DESCRIPTION
This is a relict from the old days when the pure presence of multipath in a live ISO caused issues at boot time. kiwi should not maintain a hardcoded list of dracut modules except for those that are mandatory for live boot, if there should be any special setting needed it should come from an overlay setup in /etc/dracut.conf.d/*.conf as part of the image description. This is related to bsc#1260340