### PR TITLE
Relax check_checkmedia_used_with_msdos_table

### DIFF
--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -934,11 +934,11 @@ class RuntimeChecker:
 
     def check_checkmedia_used_with_msdos_table(self) -> None:
         """
-        The checkmedia/tagmedia tools only supports plain
-        MBR partition tables.
+        The checkmedia/tagmedia tools in versions < v6.6 only
+        supports plain MBR partition tables.
         """
         message = dedent('''\n
-            ISO media tag tool tagmedia does not support {table} partition tables
+            ISO media tag tool tagmedia < v6.6 does not support {table} partition tables
 
             The attribute 'mediacheck' is set to 'true' and the selected
             media tag tool only supports plain MBR (msdos) partition tables.
@@ -951,9 +951,16 @@ class RuntimeChecker:
             firmware = FirmWare(self.xml_state)
             table_type = firmware.get_partition_table_type()
             if media_tagger == 'checkmedia' and table_type != 'msdos':
-                raise KiwiRuntimeError(
-                    message.format(tool=media_tagger, table=table_type)
-                )
+                self.check_mediacheck_installed()
+                # checkmedia in versions >= 6.6 supports GPT, only for
+                # older versions the runtime check applies
+                expected_version = (6, 6)
+                if not CommandCapabilities.check_version(
+                    media_tagger, expected_version, raise_on_error=False
+                ):
+                    raise KiwiRuntimeError(
+                        message.format(tool=media_tagger, table=table_type)
+                    )
 
     def check_image_version_provided(self) -> None:
         """

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -381,16 +381,22 @@ class TestRuntimeChecker:
     @patch('kiwi.runtime_checker.Path.which')
     @patch('kiwi.runtime_checker.RuntimeConfig')
     @patch('kiwi.runtime_checker.FirmWare')
+    @patch('kiwi.runtime_checker.CommandCapabilities.check_version')
     def test_check_checkmedia_used_with_msdos_table(
-        self, mock_FirmWare, mock_RuntimeConfig, mock_which
+        self,
+        mock_CommandCapabilities_check_version,
+        mock_FirmWare,
+        mock_RuntimeConfig,
+        mock_which
     ):
+        mock_CommandCapabilities_check_version.return_value = False
         firmware = Mock()
         firmware.get_partition_table_type.return_value = 'gpt'
         mock_FirmWare.return_value = firmware
         runtime_config = Mock()
         runtime_config.get_iso_media_tag_tool.return_value = 'checkmedia'
         mock_RuntimeConfig.return_value = runtime_config
-        mock_which.return_value = False
+        mock_which.return_value = True
         xml_state = XMLState(
             self.description.load(), ['vmxFlavour'], 'iso'
         )
@@ -398,7 +404,7 @@ class TestRuntimeChecker:
         with raises(KiwiRuntimeError) as runtime_context:
             runtime_checker.check_checkmedia_used_with_msdos_table()
 
-        assert 'ISO media tag tool tagmedia does not support gpt' in \
+        assert 'ISO media tag tool tagmedia < v6.6 does not support gpt' in \
             format(runtime_context)
 
     def test_check_dracut_module_for_live_iso_in_package_list(self):


### PR DESCRIPTION
Relax this runtime check to only apply for tagmedia/checkmedia versions < v6.6. Newer versions also supports GPT. This Fixes bsc#1262229.