### PR TITLE
Add support for credentials handling for apt repos

### DIFF
--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -94,6 +94,7 @@ class RepositoryApt(RepositoryBase):
 
         self.shared_apt_get_dir = {
             'sources-dir': self.manager_base + '/sources.list.d',
+            'netrcparts-dir': self.manager_base + '/auth.conf.d',
             'preferences-dir': self.manager_base + '/preferences.d'
         }
         self.keyring = '{}/trusted.gpg'.format(self.manager_base)
@@ -130,6 +131,8 @@ class RepositoryApt(RepositoryBase):
             os.sep.join([self.manager_base, 'sources.list.d'])
         self.shared_apt_get_dir['preferences-dir'] = \
             os.sep.join([self.manager_base, 'preferences.d'])
+        self.shared_apt_get_dir['netrcparts-dir'] = \
+            os.sep.join([self.manager_base, 'auth.conf.d'])
         self._write_runtime_config(system_default=True)
 
     def runtime_config(self) -> Dict:
@@ -160,8 +163,8 @@ class RepositoryApt(RepositoryBase):
         :param int prio: unused
         :param str dist: distribution name for non flat deb repos
         :param str components: distribution categories
-        :param str user: unused
-        :param str secret: unused
+        :param str user: username
+        :param str secret: password_or_token
         :param str credentials_file: unused
         :param bool repo_gpgcheck: enable repository signature validation
         :param bool pkg_gpgcheck: unused
@@ -173,6 +176,9 @@ class RepositoryApt(RepositoryBase):
         """
         sources_file = '/'.join(
             [self.shared_apt_get_dir['sources-dir'], name + '.sources']
+        )
+        auth_file = '/'.join(
+            [self.shared_apt_get_dir['netrcparts-dir'], name + '.conf']
         )
         pref_file = '/'.join(
             [self.shared_apt_get_dir['preferences-dir'], name + '.pref']
@@ -211,6 +217,20 @@ class RepositoryApt(RepositoryBase):
                 repo_details += 'trusted: yes' + os.linesep
                 repo_details += 'check-valid-until: no' + os.linesep
             repo.write(repo_details)
+        if secret:
+            with open(auth_file, 'w') as auth:
+                if user:
+                    auth.write(
+                        'machine {} login {} password {}{}'.format(
+                            uri, user, secret, os.linesep
+                        )
+                    )
+                else:
+                    auth.write(
+                        'machine {} login {}{}'.format(
+                            uri, secret, os.linesep
+                        )
+                    )
         if customization_script:
             self.run_repo_customize(customization_script, sources_file)
         if prio:
@@ -271,13 +291,20 @@ class RepositoryApt(RepositoryBase):
         Path.wipe(
             self.shared_apt_get_dir['sources-dir'] + '/' + name + '.sources'
         )
+        Path.wipe(
+            self.shared_apt_get_dir['netrcparts-dir'] + '/' + name + '.conf'
+        )
+        Path.wipe(
+            self.shared_apt_get_dir['preferences-dir'] + '/' + name + '.pref'
+        )
 
     def delete_all_repos(self) -> None:
         """
         Delete all apt-get repositories
         """
-        Path.wipe(self.shared_apt_get_dir['sources-dir'])
-        Path.create(self.shared_apt_get_dir['sources-dir'])
+        for dirname in ['sources-dir', 'netrcparts-dir', 'preferences-dir']:
+            Path.wipe(self.shared_apt_get_dir[dirname])
+            Path.create(self.shared_apt_get_dir[dirname])
 
     def delete_repo_cache(self, name: str) -> None:
         """

--- a/test/unit/repository/apt_test.py
+++ b/test/unit/repository/apt_test.py
@@ -66,6 +66,8 @@ class TestRepositoryApt:
             '../data/etc/apt/sources.list.d'
         assert self.repo.shared_apt_get_dir['preferences-dir'] == \
             '../data/etc/apt/preferences.d'
+        assert self.repo.shared_apt_get_dir['netrcparts-dir'] == \
+            '../data/etc/apt/auth.conf.d'
         self.apt_conf.get_image_template.assert_called_once_with(
             self.exclude_docs
         )
@@ -166,6 +168,54 @@ class TestRepositoryApt:
             )
 
     @patch('os.path.exists')
+    def test_add_repo_private_with_authentication(self, mock_exists):
+        mock_exists.return_value = False
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            self.repo.add_repo(
+                'foo', 'https://example.org/debian', 'deb', None, 'xenial', 'a b',
+                user='some-user', secret='some-secret',
+                architectures='amd64,arm64'
+            )
+            assert mock_open.call_args_list == [
+                call('/shared-dir/apt-get/sources.list.d/foo.sources', 'w'),
+                call('/shared-dir/apt-get/auth.conf.d/foo.conf', 'w')
+            ]
+            assert file_handle.write.call_args_list == [
+                call(
+                    'Types: deb\n'
+                    'URIs: https://example.org/debian\n'
+                    'Architectures: amd64 arm64\n'
+                    'Suites: xenial\n'
+                    'Components: a b\n'
+                ),
+                call(
+                    'machine https://example.org/debian login '
+                    'some-user password some-secret\n'
+                )
+            ]
+            file_handle.reset_mock()
+            self.repo.add_repo(
+                'foo', 'https://example.org/debian', 'deb', None, 'xenial', 'a b',
+                secret='some-token',
+                architectures='amd64,arm64'
+            )
+            assert file_handle.write.call_args_list == [
+                call(
+                    'Types: deb\n'
+                    'URIs: https://example.org/debian\n'
+                    'Architectures: amd64 arm64\n'
+                    'Suites: xenial\n'
+                    'Components: a b\n'
+                ),
+                call(
+                    'machine https://example.org/debian login '
+                    'some-token\n'
+                )
+            ]
+
+    @patch('os.path.exists')
     def test_add_repo_distribution_without_gpgchecks(self, mock_exists):
         mock_exists.return_value = True
         with patch('builtins.open', create=True) as mock_open:
@@ -253,9 +303,11 @@ class TestRepositoryApt:
     @patch('kiwi.path.Path.wipe')
     def test_delete_repo(self, mock_wipe):
         self.repo.delete_repo('foo')
-        mock_wipe.assert_called_once_with(
-            '/shared-dir/apt-get/sources.list.d/foo.sources'
-        )
+        assert mock_wipe.call_args_list == [
+            call('/shared-dir/apt-get/sources.list.d/foo.sources'),
+            call('/shared-dir/apt-get/auth.conf.d/foo.conf'),
+            call('/shared-dir/apt-get/preferences.d/foo.pref')
+        ]
 
     @patch('kiwi.path.Path.wipe')
     @patch('os.walk')
@@ -273,12 +325,16 @@ class TestRepositoryApt:
     @patch('kiwi.path.Path.create')
     def test_delete_all_repos(self, mock_create, mock_wipe):
         self.repo.delete_all_repos()
-        mock_wipe.assert_called_once_with(
-            '/shared-dir/apt-get/sources.list.d'
-        )
-        mock_create.assert_called_once_with(
-            '/shared-dir/apt-get/sources.list.d'
-        )
+        assert mock_wipe.call_args_list == [
+            call('/shared-dir/apt-get/sources.list.d'),
+            call('/shared-dir/apt-get/auth.conf.d'),
+            call('/shared-dir/apt-get/preferences.d')
+        ]
+        assert mock_create.call_args_list == [
+            call('/shared-dir/apt-get/sources.list.d'),
+            call('/shared-dir/apt-get/auth.conf.d'),
+            call('/shared-dir/apt-get/preferences.d')
+        ]
 
     @patch('kiwi.path.Path.wipe')
     def test_delete_repo_cache(self, mock_wipe):


### PR DESCRIPTION
If credentials information in form of user and password attributes or only password (token), is passed as part of a <repository> element, create the respective auth.conf.d/xxx.conf file for debian based repositories such that this information can be used by apt.