### PR TITLE
Return integer byte values from StringToSize.to_bytes()

### DIFF
--- a/kiwi/utils/size.py
+++ b/kiwi/utils/size.py
@@ -16,7 +16,6 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import re
-import math
 
 from kiwi.exceptions import KiwiSizeError
 
@@ -26,7 +25,7 @@ class StringToSize:
     **Performs size convertions from strings to numbers**
     """
     @staticmethod
-    def to_bytes(size_value):
+    def to_bytes(size_value: str) -> int:
         """
         Convert the given string representig a size into the appropriate
         number of bytes.
@@ -46,5 +45,5 @@ class StringToSize:
             )
         size_base = int(size.group(1))
         size_unit = {'g': 3, 'm': 2}.get(size.group(2).lower())
-        return size_base * math.pow(1024, size_unit) if size_unit \
+        return size_base * (1024 ** size_unit) if size_unit \
             else size_base

--- a/test/unit/utils/size_test.py
+++ b/test/unit/utils/size_test.py
@@ -11,6 +11,17 @@ class TestStringToSize:
         assert StringToSize.to_bytes('1M') == 1048576
         assert StringToSize.to_bytes('1g') == 1073741824
         assert StringToSize.to_bytes('1G') == 1073741824
+        assert StringToSize.to_bytes('1234') == 1234
+
+    def test_to_bytes_returns_int(self):
+        # The byte value must be returned as int. Returning a float
+        # leads to ugly format output like '1073741824.0' when the
+        # value is interpolated into shell commands or log messages
+        assert isinstance(StringToSize.to_bytes('1'), int)
+        assert isinstance(StringToSize.to_bytes('1m'), int)
+        assert isinstance(StringToSize.to_bytes('1M'), int)
+        assert isinstance(StringToSize.to_bytes('1g'), int)
+        assert isinstance(StringToSize.to_bytes('1G'), int)
 
     def test_to_bytes_wrong_format(self):
         with raises(KiwiSizeError):


### PR DESCRIPTION
## Summary

- `kiwi.utils.size.StringToSize.to_bytes()` was documented to return an `int`, but used `math.pow(1024, n)` to scale the unit suffix, which always returns a `float`. Every call with an `m`/`g` suffix returned a `float` and that float propagated to callers whose return type was annotated `-> int` (e.g. `XMLState.get_build_type_unpartitioned_bytes`).
- The float value reached `DiskFormatBase.resize_raw_disk(..., append=True)`, which formats the value directly into the `qemu-img resize` argument (`'+{0}'.format(size_bytes)`), producing arguments with a trailing `.0` (e.g. `+104857600.0`). The log output of `image_resize` had the same issue.
- Replaces `math.pow(1024, n)` with the integer expression `1024 ** n`, adds proper type annotations (`size_value: str` -> `int`), and asserts `isinstance(..., int)` in the unit tests for both unitless and unit-suffixed inputs.

Fixes Issue#2996

## Test plan

- [x] `pytest test/unit/utils/size_test.py` &rarr; 3 passed
- [x] `pytest test/unit/xml_state_test.py test/unit/tasks/image_resize_test.py test/unit/builder/disk_test.py test/unit/runtime_config_test.py test/unit/filesystem/setup_test.py` &rarr; 205 passed
- [x] `mypy kiwi` &rarr; no issues found in 213 source files
- [x] Manual sanity check confirms `StringToSize.to_bytes('100m')` now returns `104857600` (`int`) and the formatted append argument is `+104857600` rather than `+104857600.0`