### PR TITLE
Fix rereading partition table with partprobe

### DIFF
--- a/dracut/modules.d/55kiwi-live/kiwi-live-lib.sh
+++ b/dracut/modules.d/55kiwi-live/kiwi-live-lib.sh
@@ -405,14 +405,8 @@ function preparePersistentOverlayDiskBoot {
     if ! mount -L cow "${overlay_mount_point}"; then
         partitions_before_cow_part=$(_partition_count)
         echo -e "n\np\n\n\n\nw\nq" | fdisk "${isodiskdev}"
-        if type partprobe &> /dev/null;then
-            if ! partprobe "${isodiskdev}"; then
-                return 1
-            fi
-        else
-            if ! partx -u "${isodiskdev}"; then
-                return 1
-            fi
+        if ! set_device_lock "${isodiskdev}" partx -u "${isodiskdev}"; then
+            return 1
         fi
         udev_pending
         if [ "$(_partition_count)" -le "${partitions_before_cow_part}" ];then

--- a/dracut/modules.d/55kiwi-live/module-setup.sh
+++ b/dracut/modules.d/55kiwi-live/module-setup.sh
@@ -28,7 +28,7 @@ install() {
     inst_multiple -o checkmedia
     inst_multiple \
         umount dmsetup partx blkid lsblk dd losetup \
-        grep cut partprobe find wc fdisk tail mkfs.ext4 mkfs.xfs \
+        grep cut find wc fdisk tail mkfs.ext4 mkfs.xfs \
         dialog cat mountpoint curl dolly dd cryptsetup veritysetup \
         flock udevadm sed
 

--- a/dracut/modules.d/59kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/59kiwi-lib/kiwi-partitions-lib.sh
@@ -23,9 +23,9 @@ function create_partitions {
         ;;
     esac
     # notify the kernel about partition table changes
-    if type partprobe &> /dev/null;then
-        set_device_lock "${disk_device}" \
-            partprobe "${disk_device}"
+    if [ "${pt_table_type}" = "dasd" ];then
+        # partx doesn't work for DASD disk, so on s390 partprobe is used
+        partprobe "${disk_device}"
     else
         set_device_lock "${disk_device}" \
             partx -u "${disk_device}"
@@ -349,20 +349,12 @@ function get_free_disk_bytes {
 function get_partition_table_type {
     local disk_device="$1"
     local table_type
-
-    # blkid doesn't work for dasd partitions, so on s390 parted is used
+    # blkid doesn't work for dasd partitions, so on s390 fdasd is used
+    # checking if it can read the partition table of the device and if it
+    # can set dasd as table_type. In any other case use blkid
     # to detect the partition type (bsc#1209247)
-    if [[ "$(uname -m)" =~ s390 ]];then
-        table_type=$(
-            parted --script --machine "${disk_device}" print |\
-                grep "^${disk_device}" | cut -d":" -f6
-        )
-        if [ "${table_type}" = "msdos" ];then
-            # make sure to set a consistent table name for the
-            # DOS table type. In the initrd code we use 'dos'
-            # as identifier but parted reports msdos
-            table_type="dos"
-        fi
+    if [[ "$(uname -m)" =~ s390 ]] && fdasd -p "${disk_device}" &>/dev/null;then
+        table_type="dasd"
         echo "${table_type}"
     else
         blkid -s PTTYPE -o value "$disk_device"

--- a/dracut/modules.d/59kiwi-lib/module-setup.sh
+++ b/dracut/modules.d/59kiwi-lib/module-setup.sh
@@ -23,16 +23,8 @@ install() {
         vgs vgchange lvextend lvcreate lvresize pvresize \
         mdadm cryptsetup dialog \
         pv curl xz sha256sum sed \
-        dmsetup touch chmod flock
+        dmsetup touch chmod flock partx
     inst_multiple -o dolly
-    if type partx &> /dev/null;then
-        inst_multiple partx
-    elif type partprobe &> /dev/null;then
-        inst_multiple partprobe
-    else
-        dfatal "Either partx or partprobe is required"
-        exit 1
-    fi
     if [[ "$(uname -m)" =~ s390 ]];then
         inst_multiple fdasd parted partprobe
     fi


### PR DESCRIPTION
partprobe does locking itself already. Wrapping it in udevadm lock results in a deadlock, breaking boot.
This Fixes bsc#1263973