### PR TITLE
Fixed partition name validation

### DIFF
--- a/dracut/modules.d/59kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/59kiwi-lib/kiwi-partitions-lib.sh
@@ -231,7 +231,7 @@ function get_partition_name {
     if [ "${table_type}" = "gpt" ];then
         part_name=$(sfdisk --part-label "${disk}" "${part_id}")
     else
-        part_name=unsupported
+        part_name=p:unsupported
     fi
     echo "${part_name}"
 }


### PR DESCRIPTION
The method get_partition_name returns a default name value in case a partition name cannot be retrieved, for example if the partition table does not support this value. In this case the default name was 'unsupported'. However there is a naming policy in kiwi for partition names to match 'p:name' This policy is expected to be true and applied at some places for example in create_dasd_partitions. If the default name is in use which is the case on DASD devices because no partition names exists, then the non policy conform default name causes the method create_dasd_partitions to create an invalid partition setup instructions file. This results in the partition resize to fail. This commit fixes the default name to match the policy as 'p:unsupported'