### PR TITLE
Drop parted requirement for msdos partitioner

### DIFF
--- a/kiwi/partitioner/msdos.py
+++ b/kiwi/partitioner/msdos.py
@@ -108,12 +108,11 @@ class PartitionerMsDos(PartitionerBase):
             if flag_name == 'f.active':
                 Command.run(
                     [
-                        'parted', self.disk_device,
-                        'set', format(partition_id), 'boot', 'on'
+                        'sfdisk', '--activate', self.disk_device,
+                        format(partition_id)
                     ]
                 )
-            else:
-                assert isinstance(flag_val, str), f"flag {flag_name} must be a string but got a {type(flag_val)}"
+            elif isinstance(flag_val, str):
                 Command.run(
                     [
                         'sfdisk', '-c', self.disk_device,

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -365,7 +365,6 @@ Requires:       gptfdisk
 Requires:       gdisk
 %endif
 Requires:       lvm2
-Requires:       parted
 Requires:       kpartx
 Requires:       cryptsetup
 Requires:       mdadm

--- a/test/unit/partitioner/msdos_test.py
+++ b/test/unit/partitioner/msdos_test.py
@@ -182,7 +182,7 @@ class TestPartitionerMsDos:
     def test_set_active(self, mock_command):
         self.partitioner.set_flag(1, 'f.active')
         mock_command.assert_called_once_with(
-            ['parted', '/dev/loop0', 'set', '1', 'boot', 'on']
+            ['sfdisk', '--activate', '/dev/loop0', '1']
         )
 
     def test_set_flag_ignored(self):


### PR DESCRIPTION
parted was used in kiwi at one place to set the active flag on a partition in the DOS table. This action can also be done via sfdisk and drops the parted requirement from the kiwi builder code