### PR TITLE
Fixed grub vendor directory lookup

### DIFF
--- a/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/fedora/test-image-live-disk/appliance.kiwi
@@ -13,7 +13,7 @@
     <profiles>
         <profile name="Live" description="Live image of Fedora"/>
         <profile name="Virtual" description="Virtual image of Fedora"/>
-        <profile name="Virtual_bootpart" description="Virtual image of Fedora with extra boot partition"/>
+        <profile name="Virtual_bootpart" description="Virtual image of Fedora with extra boot partition and no shim"/>
         <profile name="Disk" description="OEM image of Fedora"/>
     </profiles>
     <preferences>
@@ -126,12 +126,14 @@
         <package name="dracut-kiwi-oem-repart"/>
         <package name="dracut-kiwi-oem-dump"/>
     </packages>
+    <packages type="bootstrap" profiles="Live,Disk,Virtual">
+        <package name="shim" arch="x86_64"/>
+    </packages>
     <packages type="bootstrap">
         <package name="filesystem"/>
         <package name="basesystem"/>
         <package name="grub2-efi-x64-modules"/>
         <package name="grub2-efi-x64"/>
-        <package name="shim" arch="x86_64"/>
         <package name="fedora-release"/>
         <package name="shadow"/>
     </packages>

--- a/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-live-disk/appliance.kiwi
@@ -12,7 +12,7 @@
     <profiles>
         <profile name="Live" description="Live image of Fedora Rawhide"/>
         <profile name="LiveEroFS" description="Live Root via EroFS"/>
-        <profile name="Virtual" description="Virtual image of Fedora Rawhide"/>
+        <profile name="Virtual" description="Virtual image of Fedora Rawhide and no shim"/>
         <profile name="Virtual_btrfs" description="Virtual image of Fedora Rawhide with btrfs layout"/>
         <profile name="Disk" description="OEM image of Fedora Rawhide"/>
     </profiles>
@@ -124,6 +124,9 @@
         <package name="dracut-kiwi-oem-repart"/>
         <package name="dracut-kiwi-oem-dump"/>
     </packages>
+    <packages type="bootstrap" profiles="Live,LiveEroFS,Virtual_btrfs,Disk">
+        <package name="shim-x64" arch="x86_64"/>
+    </packages>
     <packages type="bootstrap">
         <package name="filesystem"/>
         <package name="shadow-utils"/>
@@ -131,7 +134,6 @@
         <package name="grub2-efi-x64" arch="x86_64"/>
         <package name="grub2-efi-ia32-modules" arch="x86_64"/>
         <package name="grub2-efi-ia32" arch="x86_64"/>
-        <package name="shim-x64" arch="x86_64"/>
         <package name="fedora-release"/>
     </packages>
 </image>

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -596,12 +596,12 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             self._copy_xen_modules_to_boot_directory(lookup_path)
 
     def _copy_grub_config_to_efi_path(
-        self, root_path, config_file, target_type='disk'
-    ):
-        efi_boot_path = Defaults.get_shim_vendor_directory(
+        self, root_path: str, config_file: str, target_type: str = 'disk'
+    ) -> None:
+        efi_boot_paths = Defaults.get_shim_vendor_directories(
             root_path
         )
-        if not efi_boot_path:
+        if not efi_boot_paths:
             # not all distributors installs a vendor directory but
             # have them in their encoded early boot script. Thus
             # the following code tries to look up the vendor string
@@ -622,31 +622,35 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                         strings_abspath,
                         grub_image.filename, '|', 'grep', r'EFI\/'
                     ]
-                    efi_boot_path = Command.run(
+                    vendor_paths = Command.run(
                         ['bash', '-c', ' '.join(bash_command)],
                         raise_on_error=False, raise_on_command_not_found=True
-                    ).output
-                    if efi_boot_path:
-                        efi_boot_path = os.path.normpath(
-                            os.sep.join([root_path, efi_boot_path.strip()])
-                        )
-        if not efi_boot_path:
-            efi_boot_path = os.path.normpath(
-                os.sep.join([root_path, 'EFI/BOOT'])
+                    )
+                    if vendor_paths and vendor_paths.output:
+                        for path in vendor_paths.output.strip().split(os.linesep):
+                            efi_boot_paths.append(
+                                os.path.normpath(
+                                    os.sep.join([root_path, path.strip()])
+                                )
+                            )
+        if not efi_boot_paths:
+            efi_boot_paths = [
+                os.path.normpath(os.sep.join([root_path, 'EFI/BOOT']))
+            ]
+        for efi_boot_path in efi_boot_paths:
+            Path.create(efi_boot_path)
+            grub_config_file_for_efi_boot = os.sep.join(
+                [efi_boot_path, 'grub.cfg']
             )
-        Path.create(efi_boot_path)
-        grub_config_file_for_efi_boot = os.sep.join(
-            [efi_boot_path, 'grub.cfg']
-        )
-        if config_file != grub_config_file_for_efi_boot:
-            log.info(
-                'Copying {0} -> {1} to be found by EFI'.format(
+            if config_file != grub_config_file_for_efi_boot:
+                log.info(
+                    'Copying {0} -> {1} to be found by EFI'.format(
+                        config_file, grub_config_file_for_efi_boot
+                    )
+                )
+                shutil.copy2(
                     config_file, grub_config_file_for_efi_boot
                 )
-            )
-            shutil.copy2(
-                config_file, grub_config_file_for_efi_boot
-            )
 
     def _supports_platform_modules(self):
         if self.efi_csm and (

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1337,27 +1337,31 @@ class Defaults:
                 return grubenv
 
     @staticmethod
-    def get_shim_vendor_directory(root_path):
+    def get_shim_vendor_directories(root_path: str) -> List[str]:
         """
-        Provides shim vendor directory
+        Provides list of shim vendor directories
 
         Searches distribution specific locations to find shim.efi
-        below the given root path and return the directory name
+        below the given root path and return the directory names
         to the file found
 
         :param string root_path: image root path
 
-        :return: directory path or None
+        :return: list of directory names or empty list
 
-        :rtype: str
+        :rtype: list
         """
         shim_vendor_patterns = [
             '/boot/efi/EFI/*/shim*.efi',
             '/EFI/*/shim*.efi'
         ]
+        vendor_paths = []
         for shim_vendor_pattern in shim_vendor_patterns:
             for shim_file in glob.iglob(root_path + shim_vendor_pattern):
-                return os.path.dirname(shim_file)
+                shim_path = os.path.dirname(shim_file)
+                if shim_path not in vendor_paths:
+                    vendor_paths.append(shim_path)
+        return vendor_paths
 
     @staticmethod
     def get_default_volume_group_name():


### PR DESCRIPTION
If the grub vendor directory cannot be found by the static list of directories used to lookup the shim binary, kiwi also checks the encoded boot paths from the distribution provided grub binary. This information can be a multiline string holding more than one path. With this commit we support multiple vendor directories. This Fixes #3003