### PR TITLE
Fix dnf5 handling for patternType attribute

### DIFF
--- a/build-tests/x86/rawhide/test-image-dnf5/appliance.kiwi
+++ b/build-tests/x86/rawhide/test-image-dnf5/appliance.kiwi
@@ -30,7 +30,7 @@
     <repository type="rpm-md">
         <source path="obsrepositories:/"/>
     </repository>
-    <packages type="image">
+    <packages type="image" patternType="plusRecommended">
         <package name="grub2"/>
         <package name="grubby"/>
         <package name="kernel"/>

--- a/kiwi/package_manager/dnf5.py
+++ b/kiwi/package_manager/dnf5.py
@@ -280,7 +280,7 @@ class PackageManagerDnf5(PackageManagerBase):
         """
         self.__clean_pattern_type()
         self.custom_args.append('--setopt=install_weak_deps=False')
-        self.custom_args.append('--setopt=group_package_types=default,mandatory')
+        self.custom_args.append('--setopt=group_package_types=mandatory')
 
     def process_plus_recommended(self) -> None:
         """
@@ -288,7 +288,7 @@ class PackageManagerDnf5(PackageManagerBase):
         """
         self.__clean_pattern_type()
         self.custom_args.append('--setopt=install_weak_deps=True')
-        self.custom_args.append('--setopt=group_package_types=default,mandatory,optional')
+        self.custom_args.append('--setopt=group_package_types=default,mandatory,conditional')
 
     def match_package_installed(
         self, package_name: str, package_manager_output: str
@@ -367,7 +367,7 @@ class PackageManagerDnf5(PackageManagerBase):
             self.custom_args.remove('--setopt=install_weak_deps=True')
         if '--setopt=install_weak_deps=False' in self.custom_args:
             self.custom_args.remove('--setopt=install_weak_deps=False')
-        if '--setopt=group_package_types=default,mandatory,optional' in self.custom_args:
-            self.custom_args.remove('--setopt=group_package_types=default,mandatory,optional')
-        if '--setopt=group_package_types=default,mandatory' in self.custom_args:
-            self.custom_args.remove('--setopt=group_package_types=default,mandatory')
+        if '--setopt=group_package_types=default,mandatory,conditional' in self.custom_args:
+            self.custom_args.remove('--setopt=group_package_types=default,mandatory,conditional')
+        if '--setopt=group_package_types=mandatory' in self.custom_args:
+            self.custom_args.remove('--setopt=group_package_types=mandatory')

--- a/kiwi/package_manager/dnf5.py
+++ b/kiwi/package_manager/dnf5.py
@@ -278,15 +278,17 @@ class PackageManagerDnf5(PackageManagerBase):
         """
         Setup package processing only for required packages
         """
-        if '--setopt=install_weak_deps=False' not in self.custom_args:
-            self.custom_args.append('--setopt=install_weak_deps=False')
+        self.__clean_pattern_type()
+        self.custom_args.append('--setopt=install_weak_deps=False')
+        self.custom_args.append('--setopt=group_package_types=default,mandatory')
 
     def process_plus_recommended(self) -> None:
         """
         Setup package processing to also include recommended dependencies.
         """
-        if '--setopt=install_weak_deps=False' in self.custom_args:
-            self.custom_args.remove('--setopt=install_weak_deps=False')
+        self.__clean_pattern_type()
+        self.custom_args.append('--setopt=install_weak_deps=True')
+        self.custom_args.append('--setopt=group_package_types=default,mandatory,optional')
 
     def match_package_installed(
         self, package_name: str, package_manager_output: str
@@ -356,3 +358,16 @@ class PackageManagerDnf5(PackageManagerBase):
         Rpm(
             self.root_dir, Defaults.get_custom_rpm_image_macro_name()
         ).wipe_config()
+
+    def __clean_pattern_type(self) -> None:
+        """
+        Setup package processing only for required packages
+        """
+        if '--setopt=install_weak_deps=True' in self.custom_args:
+            self.custom_args.remove('--setopt=install_weak_deps=True')
+        if '--setopt=install_weak_deps=False' in self.custom_args:
+            self.custom_args.remove('--setopt=install_weak_deps=False')
+        if '--setopt=group_package_types=default,mandatory,optional' in self.custom_args:
+            self.custom_args.remove('--setopt=group_package_types=default,mandatory,optional')
+        if '--setopt=group_package_types=default,mandatory' in self.custom_args:
+            self.custom_args.remove('--setopt=group_package_types=default,mandatory')

--- a/test/unit/package_manager/dnf5_test.py
+++ b/test/unit/package_manager/dnf5_test.py
@@ -175,7 +175,7 @@ class TestPackageManagerDnf5:
         self.manager.process_only_required()
         assert self.manager.custom_args == [
             '--setopt=install_weak_deps=False',
-            '--setopt=group_package_types=default,mandatory'
+            '--setopt=group_package_types=mandatory'
         ]
 
     def test_process_plus_recommended(self):
@@ -183,12 +183,12 @@ class TestPackageManagerDnf5:
         self.manager.process_plus_recommended()
         assert self.manager.custom_args == [
             '--setopt=install_weak_deps=True',
-            '--setopt=group_package_types=default,mandatory,optional'
+            '--setopt=group_package_types=default,mandatory,conditional'
         ]
         self.manager.process_only_required()
         assert self.manager.custom_args == [
             '--setopt=install_weak_deps=False',
-            '--setopt=group_package_types=default,mandatory'
+            '--setopt=group_package_types=mandatory'
         ]
 
     def test_match_package_installed(self):

--- a/test/unit/package_manager/dnf5_test.py
+++ b/test/unit/package_manager/dnf5_test.py
@@ -173,14 +173,23 @@ class TestPackageManagerDnf5:
 
     def test_process_only_required(self):
         self.manager.process_only_required()
-        assert self.manager.custom_args == ['--setopt=install_weak_deps=False']
+        assert self.manager.custom_args == [
+            '--setopt=install_weak_deps=False',
+            '--setopt=group_package_types=default,mandatory'
+        ]
 
     def test_process_plus_recommended(self):
         self.manager.process_only_required()
-        assert self.manager.custom_args == ['--setopt=install_weak_deps=False']
         self.manager.process_plus_recommended()
-        assert \
-            '--setopt=install_weak_deps=False' not in self.manager.custom_args
+        assert self.manager.custom_args == [
+            '--setopt=install_weak_deps=True',
+            '--setopt=group_package_types=default,mandatory,optional'
+        ]
+        self.manager.process_only_required()
+        assert self.manager.custom_args == [
+            '--setopt=install_weak_deps=False',
+            '--setopt=group_package_types=default,mandatory'
+        ]
 
     def test_match_package_installed(self):
         assert self.manager.match_package_installed('foo', 'Installing  : foo')


### PR DESCRIPTION
The patternType attribute is used to control the mandatory vs. optional installation for the concept of patterns,groups aka collections for the respective package manager. In dnf5 this is also controlled by the group_package_types option which is used now in combination with install_weak_deps. This Fixes #3008