### PR TITLE
Add support for sha512sum

### DIFF
--- a/build-tests/x86/fedora/kiwi-settings/kiwi-settings/kiwi.yml
+++ b/build-tests/x86/fedora/kiwi-settings/kiwi-settings/kiwi.yml
@@ -2,3 +2,5 @@ iso:
   - media_tag_tool: isomd5sum
 oci:
   - archive_tool: buildah
+bundle:
+  - shasum_size: "512"

--- a/doc/source/concept_and_workflow/customize_the_boot_process.rst
+++ b/doc/source/concept_and_workflow/customize_the_boot_process.rst
@@ -62,7 +62,7 @@ of {kiwi}, the following dracut modules are used:
    .. code:: none
 
       <type ... boot="{exc_netboot}"/>
-    
+
    While {kiwi} supports this approach, it is recommended to use dracut instead.
    Keep also in mind that although {kiwi} supports the creation of custom boot
    images, {kiwi} does not include any official boot image descriptions. You
@@ -300,13 +300,18 @@ the available kernel boot parameters for these modules:
   `oem-unattended-id`, or `rd.kiwi.oem.maxdisk`, and continues the installation on
   the given device. The device must exist and must be a block special.
 
+``rd.kiwi.oem.sha512``
+  Expect sha512 checksums and use the respective `sha512sum` tool and
+  the `.sha512` extension for filename match and checksum calculation.
+  By default sha256 is used.
+
 .. note:: Non-interactive mode activated by rd.kiwi.oem.installdevice
 
    When setting `rd.kiwi.oem.installdevice` explicitly through the kernel command line,
    {kiwi} uses the device without prompting for confirmation.
 
 ``rd.kiwi.oem.smallest_disk``
-  Alters the logic that chooses the destination device during non-interactive mode 
+  Alters the logic that chooses the destination device during non-interactive mode
   deployments. The device with the smallest capacity gets selected instead of the drive
   with the alphabetical first device name. USB flash drives are filtered out.
   For big JBOD setups this parameter is an alternative to `rd.kiwi.oem.maxdisk`.

--- a/dracut/modules.d/55kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/55kiwi-dump/kiwi-dump-image.sh
@@ -571,9 +571,14 @@ function check_image_integrity {
     local progress=/dev/install_verify_progress
     local verify_text="Verifying ${image_target}"
     local title_text="Installation..."
-    local verify_result=/dumped_image.sha256
+    local verify_result
+    local shasum
+    local sha_extension
     kiwi_oemskipverify=$(bool "${kiwi_oemskipverify}")
     kiwi_oemsilentverify=$(bool "${kiwi_oemsilentverify}")
+    shasum=$(shasum_tool)
+    sha_extension=$(shasum_extension)
+    verify_result=/dumped_image."${sha_extension}"
     if [ "${kiwi_oemskipverify}" = "true" ];then
         # no verification wanted
         return
@@ -591,17 +596,17 @@ function check_image_integrity {
         setup_progress_fifo ${progress}
         (
             pv --size $((blocks * blocksize)) --stop-at-size \
-            -n "${image_target}" | sha256sum - > ${verify_result}
+            -n "${image_target}" | "${shasum}" - > "${verify_result}"
         ) 2>${progress} &
         run_progress_dialog "${verify_text}" "${title_text}"
     else
         # verify with silently blocked console
         head --bytes=$((blocks * blocksize)) "${image_target}" |\
-        sha256sum - > ${verify_result}
+        "${shasum}" - > "${verify_result}"
     fi
     local checksum_dumped_image
     local checksum_fileref
-    read -r checksum_dumped_image checksum_fileref < ${verify_result}
+    read -r checksum_dumped_image checksum_fileref < "${verify_result}"
     echo "Dumped Image checksum: ${checksum_dumped_image}/${checksum_fileref}"
     if [ "${checksum}" != "${checksum_dumped_image}" ];then
         report_and_quit "Image checksum test failed"
@@ -613,8 +618,10 @@ function get_local_image_source_files {
     local iso_device="${root#install:}"
     local iso_mount_point=/run/install
     local image_mount_point=/run/image
+    local sha_extension
     local image_source
-    local image_sha256
+    local image_sha
+    sha_extension=$(shasum_extension)
     mkdir -m 0755 -p "${iso_mount_point}"
     if ! mount -n "${iso_device}" "${iso_mount_point}"; then
         report_and_quit "Failed to mount install ISO device"
@@ -624,15 +631,20 @@ function get_local_image_source_files {
         report_and_quit "Failed to mount install image squashfs filesystem"
     fi
     image_source="$(echo "${image_mount_point}"/*.raw)"
-    image_sha256="$(echo "${image_mount_point}"/*.sha256)"
-    echo "${image_source}|${image_sha256}"
+    image_sha="$(echo "${image_mount_point}"/*."${sha_extension}")"
+    echo "${image_source}|${image_sha}"
 }
 
 function get_remote_image_source_files {
     local image_uri
+    local sha_extension
+    local image_sha
     local install_dir=/run/install
-    local image_sha256="${install_dir}/image.sha256"
     local metadata_dir="${install_dir}/boot/remote/loader"
+
+    sha_extension=$(shasum_extension)
+
+    local image_sha="${install_dir}/image.${sha_extension}"
 
     mkdir -p "${metadata_dir}"
 
@@ -640,8 +652,8 @@ function get_remote_image_source_files {
     # make sure the protocol type is tftp for metadata files. There is no need for
     # complex protocol types on small files and for standard PXE boot operations
     # only tftp can be guaranteed
-    image_sha256_uri=$(
-        echo "${image_uri}" | awk '{ gsub("\\.xz",".sha256", $1); gsub("dolly:","tftp:", $1); print $1 }'
+    image_sha_uri=$(
+        echo "${image_uri}" | awk '{ gsub("\\.xz",".'"${sha_extension}"'", $1); gsub("dolly:","tftp:", $1); print $1 }'
     )
     image_initrd_uri=$(
         echo "${image_uri}" | awk '{ gsub("\\.xz",".initrd", $1); gsub("dolly:","tftp:", $1); print $1 }'
@@ -654,15 +666,15 @@ function get_remote_image_source_files {
         awk '{ gsub("\\.xz",".config.bootoptions", $1); gsub("dolly:","tftp:", $1); print $1 }'
     )
 
-    # if we can not access image_sha256_uri, maybe network setup
+    # if we can not access image_sha_uri, maybe network setup
     # by dracut did fail, so collect some additional info
-    if ! fetch_file "${image_sha256_uri}" > "${image_sha256}";then
+    if ! fetch_file "${image_sha_uri}" > "${image_sha}";then
         {
             echo "--- ip a ---"; ip a
             echo "--- ip r ---"; ip r
         } >> /tmp/fetch.info 2>&1
         show_log_and_quit \
-            "Failed to fetch ${image_sha256_uri}" /tmp/fetch.info
+            "Failed to fetch ${image_sha_uri}" /tmp/fetch.info
     fi
 
     if ! getargbool 0 rd.kiwi.ramdisk; then
@@ -684,7 +696,7 @@ function get_remote_image_source_files {
             "Failed to fetch ${image_config_uri}" /tmp/fetch.info
     fi
 
-    echo "${image_uri}|${image_sha256}"
+    echo "${image_uri}|${image_sha}"
 }
 
 #======================================

--- a/dracut/modules.d/55kiwi-dump/module-setup.sh
+++ b/dracut/modules.d/55kiwi-dump/module-setup.sh
@@ -21,7 +21,7 @@ install() {
     declare moddir=${moddir}
     declare systemdutildir=${systemdutildir}
     inst_multiple \
-        tr lsblk dd sha256sum head pv kexec basename awk kpartx sort
+        tr lsblk dd sha256sum sha512sum head pv kexec basename awk kpartx sort
 
     inst_hook pre-udev 30 "${moddir}/kiwi-installer-genrules.sh"
 

--- a/dracut/modules.d/59kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/59kiwi-lib/kiwi-lib.sh
@@ -116,6 +116,28 @@ function lookup_disk_device_from_root {
     echo "${disk_device}"
 }
 
+function shasum_tool {
+    declare kiwi_shasum_suffix=${kiwi_shasum_suffix}
+    if getargbool 0 rd.kiwi.oem.sha512; then
+        echo sha512sum
+    elif [ "${kiwi_shasum_suffix}" = ".sha512" ]; then
+        echo sha512sum
+    else
+        echo sha256sum
+    fi
+}
+
+function shasum_extension {
+    declare kiwi_shasum_suffix=${kiwi_shasum_suffix}
+    if getargbool 0 rd.kiwi.oem.sha512; then
+        echo sha512
+    elif [ "${kiwi_shasum_suffix}" = ".sha512" ]; then
+        echo sha512
+    else
+        echo sha256
+    fi
+}
+
 function udev_pending {
     declare DEVICE_TIMEOUT=${DEVICE_TIMEOUT}
     local limit=30

--- a/dracut/modules.d/59kiwi-lib/kiwi-luks-lib.sh
+++ b/dracut/modules.d/59kiwi-lib/kiwi-luks-lib.sh
@@ -34,16 +34,18 @@ function reencrypt_luks {
     local progress=/dev/install_progress
     local load_text="Reencrypting..."
     local title_text="LUKS"
+    local shasum
     local device
     device=$(get_partition_node_name "${disk}" "${kiwi_RootPart}")
     read -r header_checksum_origin < "${header_checksum_origin}"
     read -r keyslot < "${keyslot}"
 
     # Checksum test if luks header is still the image origin header
+    shasum=$(shasum_tool)
     cryptsetup luksHeaderBackup \
         "${device}" --header-backup-file "${header_checksum_cur}"
     header_checksum_cur=$(
-        sha256sum "${header_checksum_cur}" |\
+        "${shasum}" "${header_checksum_cur}" |\
         cut -f1 -d" "; rm -f "${header_checksum_cur}"
     )
     if [ "${header_checksum_origin}" == "${header_checksum_cur}" ];then

--- a/dracut/modules.d/59kiwi-lib/module-setup.sh
+++ b/dracut/modules.d/59kiwi-lib/module-setup.sh
@@ -22,7 +22,7 @@ install() {
         e2fsck btrfsck xfs_repair \
         vgs vgchange lvextend lvcreate lvresize pvresize \
         mdadm cryptsetup dialog \
-        pv curl xz sha256sum sed \
+        pv curl xz sha256sum sha512sum sed \
         dmsetup touch chmod flock partx
     inst_multiple -o dolly
     if [[ "$(uname -m)" =~ s390 ]];then

--- a/kiwi.yml
+++ b/kiwi.yml
@@ -40,6 +40,11 @@
 #  # a .changes file. The .changes file contains the package changelog
 #  # information from all packages installed into the image.
 #  - has_package_changes: false
+#  # Specify shasum size for the bundle creation. Supported values
+#  # are "256" (default) and "512". This value takes precedence
+#  # over the global shasum size specified in the shasum section.
+#  # If not specified, the global shasum size or the default is used.
+#  - shasum_size: "256"
 
 
 # Setup behaviour of XZ compressor
@@ -72,6 +77,14 @@
 #  # Possible values are umoci and buildah
 #  - archive_tool: umoci
 
+# Setup shasum size
+# shasum:
+#  # Specify shasum size, supported are "256" (default) and "512"
+#  # Setting the size in this section globally applies to all
+#  # shasum operations performed by KIWI. Please also see the
+#  # bundle section for shasum size configuration specific to the
+#  # result bundle creation.
+#  - size: "256"
 
 # Specify build constraints that applies during the image build
 # process. If one or more constraints are violated the build exits

--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -47,6 +47,7 @@ class ContainerBuilder:
         self, xml_state: XMLState, target_dir: str,
         root_dir: str, custom_args: Dict = None
     ):
+        self.runtime_config = RuntimeConfig()
         self.custom_args = custom_args or {}
         self.root_dir = root_dir
         self.target_dir = target_dir
@@ -55,7 +56,7 @@ class ContainerBuilder:
         self.requested_container_type = xml_state.get_build_type_name()
         self.delta_root = xml_state.build_type.get_delta_root()
         self.base_image = None
-        self.base_image_sha256 = None
+        self.base_image_sha = None
         self.ensure_empty_tmpdirs = True
 
         self.container_config['xz_options'] = \
@@ -67,22 +68,24 @@ class ContainerBuilder:
         if xml_state.get_derived_from_image_uri() and not self.delta_root:
             # The base image(all derived imports) is expected to be unpacked
             # by the kiwi prepare step and stored inside of the root_dir/image
-            # directory. In addition a sha256 file of the image is expected too
+            # directory. In addition a sha file of the image is expected too
             self.base_image = Defaults.get_imported_root_image(
                 self.root_dir
             )
-            self.base_image_sha256 = ''.join([self.base_image, '.sha256'])
-
+            self.base_image_sha = '{}{}'.format(
+                self.base_image,
+                self.runtime_config.get_checksum_handler(self.base_image).suffix
+            )
             if not os.path.exists(self.base_image):
                 raise KiwiContainerBuilderError(
                     'Unpacked Base image {0} not found'.format(
                         self.base_image
                     )
                 )
-            if not os.path.exists(self.base_image_sha256):
+            if not os.path.exists(self.base_image_sha):
                 raise KiwiContainerBuilderError(
-                    'Base image SHA256 sum {0} not found at'.format(
-                        self.base_image_sha256
+                    'Base image shasum file {0} not found'.format(
+                        self.base_image_sha
                     )
                 )
 
@@ -104,7 +107,6 @@ class ContainerBuilder:
             ]
         )
         self.result = Result(xml_state)
-        self.runtime_config = RuntimeConfig()
 
     def create(self) -> Result:
         """
@@ -132,8 +134,11 @@ class ContainerBuilder:
             )
             container_setup.setup()
         else:
+            shasum = self.runtime_config.get_checksum_handler(
+                source_filename=self.base_image
+            )
             checksum = Checksum(self.base_image)
-            if not checksum.matches(checksum.sha256(), self.base_image_sha256):
+            if not checksum.matches(shasum.digest(), self.base_image_sha):
                 raise KiwiContainerBuilderError(
                     'base image file {0} checksum validation failed'.format(
                         self.base_image

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -23,6 +23,7 @@ from typing import (
 import shutil
 
 # project
+from kiwi.runtime_config import RuntimeConfig
 from kiwi.utils.temporary import Temporary
 from kiwi.command import Command
 from kiwi.storage.device_provider import DeviceProvider
@@ -36,7 +37,6 @@ from kiwi.system.identifier import SystemIdentifier
 from kiwi.path import Path
 from kiwi.utils.block import BlockID
 from kiwi.defaults import Defaults
-from kiwi.utils.checksum import Checksum
 from kiwi.system.kernel import Kernel
 from kiwi.utils.compress import Compress
 from kiwi.archive.tar import ArchiveTar
@@ -68,6 +68,7 @@ class InstallImageBuilder:
         boot_image_task: Optional[BootImageBase],
         custom_args: Dict = None
     ) -> None:
+        self.runtime_config = RuntimeConfig()
         self.arch = Defaults.get_platform_name()
         self.bootloader = xml_state.get_build_type_bootloader_name()
         if self.bootloader != 'systemd_boot':
@@ -120,9 +121,6 @@ class InstallImageBuilder:
         self.squashed_diskname = ''.join(
             [xml_state.xml_data.get_name(), '.raw']
         )
-        self.sha256name = ''.join(
-            [xml_state.xml_data.get_name(), '.sha256']
-        )
         self.xz_options = custom_args['xz_options'] if custom_args \
             and 'xz_options' in custom_args else None
 
@@ -170,12 +168,19 @@ class InstallImageBuilder:
         }
 
         # the system image transfer is checked against a checksum
-        log.info('Creating disk image checksum')
         self.squashed_contents = Temporary(
             prefix='kiwi_install_squashfs.', path=self.target_dir
         ).new_dir()
-        checksum = Checksum(self.diskname)
-        checksum.sha256(self.squashed_contents.name + '/' + self.sha256name)
+        shasum = self.runtime_config.get_checksum_handler(
+            source_filename=self.diskname,
+            target_filename='{}/{}{}'.format(
+                self.squashed_contents.name,
+                self.xml_state.xml_data.get_name(),
+                self.runtime_config.get_checksum_handler(self.diskname).suffix
+            )
+        )
+        log.info(f'Creating disk image {shasum.suffix} checksum')
+        shasum.digest()
 
         # the system image name is stored in a config file
         self._write_install_image_info_to_iso_image()
@@ -291,15 +296,16 @@ class InstallImageBuilder:
         )
 
         # the system image transfer is checked against a checksum
-        log.info('Creating disk image checksum')
-        pxe_sha256_filename = ''.join(
-            [
-                self.pxe_dir.name, '/',
-                self.pxename, '.sha256'
-            ]
+        shasum = self.runtime_config.get_checksum_handler(
+            source_filename=self.diskname,
+            target_filename='{}/{}{}'.format(
+                self.pxe_dir.name,
+                self.pxename,
+                self.runtime_config.get_checksum_handler(self.diskname).suffix
+            )
         )
-        checksum = Checksum(self.diskname)
-        checksum.sha256(pxe_sha256_filename)
+        log.info(f'Creating disk image {shasum.suffix} checksum')
+        shasum.digest()
 
         # the install image name is stored in a config file
         if self.initrd_system == 'kiwi':

--- a/kiwi/builder/kis.py
+++ b/kiwi/builder/kis.py
@@ -24,7 +24,6 @@ from kiwi.defaults import Defaults
 from kiwi.boot.image import BootImage
 from kiwi.builder.filesystem import FileSystemBuilder
 from kiwi.utils.compress import Compress
-from kiwi.utils.checksum import Checksum
 from kiwi.system.setup import SystemSetup
 from kiwi.system.kernel import Kernel
 from kiwi.system.result import Result
@@ -54,6 +53,7 @@ class KisBuilder:
         self, xml_state: XMLState, target_dir: str,
         root_dir: str, custom_args: Dict = None
     ):
+        self.runtime_config = RuntimeConfig()
         self.target_dir = target_dir
         self.compressed = xml_state.build_type.get_compressed()
         self.xen_server = xml_state.is_xen_server()
@@ -88,11 +88,15 @@ class KisBuilder:
         self.image: str = ''
         self.append_file = ''.join([self.image_name, '.append'])
         self.archive_name = ''.join([self.image_name, '.tar'])
-        self.checksum_name = ''.join([self.image_name, '.sha256'])
+        self.checksum_name = ''.join(
+            [
+                self.image_name,
+                self.runtime_config.get_checksum_handler(self.image_name).suffix
+            ]
+        )
         self.kernel_filename: str = ''
         self.hypervisor_filename: str = ''
         self.result = Result(xml_state)
-        self.runtime_config = RuntimeConfig()
 
         if not self.boot_image_task.has_initrd_support():
             log.warning('Building without initrd support !')
@@ -126,9 +130,12 @@ class KisBuilder:
                 compress = Compress(self.image)
                 self.image = compress.xz(self.xz_options)
 
-            log.info('Creating root filesystem SHA256 checksum')
-            checksum = Checksum(self.image)
-            checksum.sha256(self.checksum_name)
+            shasum = self.runtime_config.get_checksum_handler(
+                source_filename=self.image,
+                target_filename=self.checksum_name
+            )
+            log.info(f'Creating root filesystem {shasum.suffix} checksum')
+            shasum.digest()
 
         # prepare initrd
         if self.boot_image_task.has_initrd_support():

--- a/kiwi/config/strip.xml
+++ b/kiwi/config/strip.xml
@@ -261,6 +261,7 @@
         <file name="sg_inq"/>
         <file name="sh"/>
         <file name="sha256sum"/>
+        <file name="sha512sum"/>
         <file name="showconsole"/>
         <file name="shutdown"/>
         <file name="sleep"/>

--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -17,8 +17,9 @@
 #
 import os
 import logging
+import functools
 from typing import (
-    Literal, List, Optional
+    Literal, List, Optional, NamedTuple, Callable
 )
 import yaml
 
@@ -27,6 +28,7 @@ import kiwi.defaults as defaults
 
 from kiwi.defaults import Defaults
 from kiwi.utils.size import StringToSize
+from kiwi.utils.checksum import Checksum
 from kiwi.exceptions import (
     KiwiRuntimeConfigFormatError,
     KiwiRuntimeConfigFileError
@@ -35,6 +37,11 @@ from kiwi.exceptions import (
 log = logging.getLogger('kiwi')
 
 RUNTIME_CONFIG = None
+
+
+class ShasumT(NamedTuple):
+    suffix: str
+    digest: Callable
 
 
 class RuntimeConfig:
@@ -251,6 +258,66 @@ class RuntimeConfig:
         if bundle_compress is None:
             bundle_compress = default
         return bool(bundle_compress)
+
+    def get_checksum_handler(
+        self,
+        source_filename: str,
+        target_filename: Optional[str] = None,
+        default: str = '256',
+        bundle_lookup: bool = False
+    ) -> ShasumT:
+        """
+        Return a ShasumT with information about the configured
+        shasum suffix name and the digest(Checksum) callable. The
+        following configuration setting allows to configure the
+        size of the checksum:
+
+        shasum:
+          - size: 256
+
+        bundle:
+          - shasum_size: "256"
+
+        Instructs kiwi to use the provided shasum size. Supported
+        values are 256 (default) and 512. In case of an unsupported
+        value the default is used. A value from the bundle section
+        takes precedence over the global shasum size specified
+        in the shasum section for creating bundle results. If no
+        information for bundle results is specified, the global
+        shasum size or the default applies.
+
+        :param str source_filename: filename to calculate checksum for
+        :param str target_filename: filename to write checksum to
+        :param str default: default size set to 256
+
+        :rtype: ShasumT
+        """
+        supported_shasums = {
+            '256': ShasumT(
+                suffix='.sha256',
+                digest=functools.partial(
+                    Checksum(source_filename).sha256, target_filename
+                )
+            ),
+            '512': ShasumT(
+                suffix='.sha512',
+                digest=functools.partial(
+                    Checksum(source_filename).sha512, target_filename
+                )
+            )
+        }
+        shasum_size = self._get_attribute(
+            element='shasum', attribute='size'
+        )
+        if bundle_lookup:
+            bundle_shasum_size = self._get_attribute(
+                element='bundle', attribute='shasum_size'
+            )
+            if bundle_shasum_size:
+                shasum_size = bundle_shasum_size
+        if supported_shasums.get(shasum_size):
+            return supported_shasums[shasum_size]
+        return supported_shasums['256']
 
     def get_xz_options(self) -> Optional[List[str]]:
         """

--- a/kiwi/storage/luks_device.py
+++ b/kiwi/storage/luks_device.py
@@ -21,8 +21,8 @@ import binascii
 from typing import Optional
 
 # project
+from kiwi.runtime_config import RuntimeConfig
 from kiwi.utils.temporary import Temporary
-from kiwi.utils.checksum import Checksum
 from kiwi.path import Path
 from kiwi.command import Command
 from kiwi.defaults import Defaults
@@ -43,7 +43,7 @@ class LuksDevice(DeviceProvider):
     :param object storage_provider: Instance of class based on DeviceProvider
     """
     def __init__(self, storage_provider: DeviceProvider) -> None:
-        #: the underlaying device provider
+        self.runtime_config = RuntimeConfig()
         self.storage_provider = storage_provider
 
         self.luks_device: Optional[str] = None
@@ -191,9 +191,11 @@ class LuksDevice(DeviceProvider):
                 '--header-backup-file', master_checksum
             ]
         )
-        checksum = Checksum(master_checksum).sha256()
-        with open(master_checksum, 'w') as shasum:
-            shasum.write(checksum)
+        shasum = self.runtime_config.get_checksum_handler(
+            source_filename=master_checksum
+        )
+        with open(master_checksum, 'w') as sha_file:
+            sha_file.write(shasum.digest())
 
         # Create key slot number as reencryption reference
         master_slot = f'{root_dir}/root/.luks.slot'

--- a/kiwi/storage/subformat/oci.py
+++ b/kiwi/storage/subformat/oci.py
@@ -89,7 +89,6 @@ class DiskFormatOci(DiskFormatBase):
             base_image = Defaults.get_imported_root_image(
                 container_root
             )
-            base_image_sha256 = ''.join([base_image, '.sha256'])
 
         # Create disk format and copy this format or the raw
         # disk to the imported container root dir.
@@ -133,8 +132,12 @@ class DiskFormatOci(DiskFormatBase):
 
         # build the container
         if base_image:
+            shasum = self.runtime_config.get_checksum_handler(
+                source_filename=base_image
+            )
             checksum = Checksum(base_image)
-            if not checksum.matches(checksum.sha256(), base_image_sha256):
+            base_image_sha = ''.join([base_image, shasum.suffix])
+            if not checksum.matches(shasum.digest(), base_image_sha):
                 raise KiwiContainerBuilderError(
                     f'base image file {base_image} checksum validation failed'
                 )

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -21,6 +21,7 @@ import collections
 from typing import Dict
 
 # project
+from kiwi.runtime_config import RuntimeConfig
 from kiwi.utils.temporary import Temporary
 from kiwi.xml_state import XMLState
 from kiwi.system.shell import Shell
@@ -50,6 +51,7 @@ class Profile:
         self._oemconfig_to_profile()
         self._drivers_to_profile()
         self._root_partition_uuid_to_profile()
+        self._runtime_settings_to_profile()
 
     def get_settings(self) -> Dict:
         """
@@ -346,6 +348,13 @@ class Profile:
             self.xml_state.get_disk_start_sector()
         self.dot_profile['kiwi_luks_empty_passphrase'] = \
             self.xml_state.get_luks_credentials() == ''
+
+    def _runtime_settings_to_profile(self):
+        # kiwi_shasum_suffix
+        temp_file = Temporary().new_file()
+        runtime_config = RuntimeConfig()
+        self.dot_profile['kiwi_shasum_suffix'] = \
+            runtime_config.get_checksum_handler(temp_file.name).suffix
 
     def _profile_names_to_profile(self):
         # kiwi_profiles

--- a/kiwi/system/root_bind.py
+++ b/kiwi/system/root_bind.py
@@ -22,6 +22,7 @@ import textwrap
 from typing import List
 
 # project
+from kiwi.runtime_config import RuntimeConfig
 from kiwi.command import Command
 from kiwi.defaults import Defaults
 from kiwi.path import Path
@@ -53,6 +54,7 @@ class RootBind:
         build system root
     """
     def __init__(self, root_init: RootInit):
+        self.runtime_config = RuntimeConfig()
         self.root_dir = root_init.root_dir
         self.cleanup_files: List[str] = []
         self.mount_stack: List[MountManager] = []
@@ -181,9 +183,11 @@ class RootBind:
                     Command.run(
                         ['ln', '-s', '-f', link_target, self.root_dir + config]
                     )
-                    checksum = Checksum(config)
-                    with open(self.root_dir + config + '.sha', 'w') as shasum:
-                        shasum.write(checksum.sha256())
+                    shasum = self.runtime_config.get_checksum_handler(
+                        source_filename=config
+                    )
+                    with open(f'{self.root_dir}{config}.sha', 'w') as sha_file:
+                        sha_file.write(shasum.digest())
         except Exception as e:
             self.cleanup()
             raise KiwiSetupIntermediateConfigError(
@@ -204,13 +208,16 @@ class RootBind:
 
         for config in self.cleanup_files:
             config_file = self.root_dir + config
-            shasum_file = config_file.replace('.kiwi', '.sha')
+            sha_file = config_file.replace('.kiwi', '.sha')
 
             config_files_to_delete.append(config_file)
-            config_files_to_delete.append(shasum_file)
+            config_files_to_delete.append(sha_file)
 
+            shasum = self.runtime_config.get_checksum_handler(
+                source_filename=config_file
+            )
             checksum = Checksum(config_file)
-            if not checksum.matches(checksum.sha256(), shasum_file):
+            if not checksum.matches(shasum.digest(), sha_file):
                 message = textwrap.dedent('''\n
                     Modifications to intermediate config file detected
 

--- a/kiwi/system/root_import/base.py
+++ b/kiwi/system/root_import/base.py
@@ -23,6 +23,7 @@ from typing import (
 )
 
 # project
+from kiwi.runtime_config import RuntimeConfig
 from kiwi.xml_state import XMLState
 from kiwi.defaults import Defaults
 from kiwi.system.setup import SystemSetup
@@ -30,7 +31,6 @@ from kiwi.path import Path
 from kiwi.system.uri import Uri
 from kiwi.command import Command
 from kiwi.mount_manager import MountManager
-from kiwi.utils.checksum import Checksum
 from kiwi.exceptions import (
     KiwiRootImportError,
     KiwiUriTypeUnknown
@@ -56,6 +56,7 @@ class RootImportBase:
         self, root_dir: str, image_uris: List[Uri],
         custom_args: Dict[str, str] = {}
     ):
+        self.runtime_config = RuntimeConfig()
         self.raw_urls: List[str] = []
         self.image_files: List[str] = []
         self.overlay: Optional[MountManager] = None
@@ -185,5 +186,10 @@ class RootImportBase:
         raise NotImplementedError
 
     def _make_checksum(self, image):
-        checksum = Checksum(image)
-        checksum.sha256(''.join([image, '.sha256']))
+        shasum = self.runtime_config.get_checksum_handler(
+            source_filename=image,
+            target_filename='{}{}'.format(
+                image, self.runtime_config.get_checksum_handler(image).suffix
+            )
+        )
+        shasum.digest()

--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -73,7 +73,6 @@ from kiwi.system.result import (
 )
 from kiwi.path import Path
 from kiwi.utils.compress import Compress
-from kiwi.utils.checksum import Checksum
 from kiwi.privileges import Privileges
 from kiwi.command import Command
 
@@ -263,12 +262,14 @@ class ResultBundleTask(CliTask):
                         )
 
                 if result_file.shasum:
-                    log.info('--> Creating SHA 256 sum')
-                    checksum = Checksum(bundle_file)
-                    with open(bundle_file + '.sha256', 'w') as shasum:
+                    checksum = self.runtime_config.get_checksum_handler(
+                        source_filename=bundle_file, bundle_lookup=True
+                    )
+                    log.info(f'--> Creating {checksum.suffix} sum')
+                    with open(f'{bundle_file}{checksum.suffix}', 'w') as shasum:
                         shasum.write(
                             '{0}  {1}{2}'.format(
-                                checksum.sha256(),
+                                checksum.digest(),
                                 os.path.basename(bundle_file),
                                 os.linesep
                             )

--- a/kiwi/utils/checksum.py
+++ b/kiwi/utils/checksum.py
@@ -86,11 +86,26 @@ class Checksum:
         )
         if filename:
             self._create_checksum_file(
-                sha256_checksum, filename
+                sha256_checksum, filename, hashlib.sha256
             )
         return sha256_checksum
 
-    def _create_checksum_file(self, checksum, filename):
+    def sha512(self, filename=None):
+        """
+        Create sha512 checksum
+
+        :param str filename: filename for checksum
+        """
+        sha512_checksum = self._calculate_hash_hexdigest(
+            hashlib.sha512(), self.source_filename
+        )
+        if filename:
+            self._create_checksum_file(
+                sha512_checksum, filename, hashlib.sha512
+            )
+        return sha512_checksum
+
+    def _create_checksum_file(self, checksum, filename, haslib_method):
         """
         Creates the text file that contains the checksum
 
@@ -108,7 +123,7 @@ class Checksum:
                 os.path.getsize(compress.uncompressed_filename)
             )
             checksum = self._calculate_hash_hexdigest(
-                hashlib.sha256(), compress.uncompressed_filename
+                haslib_method(), compress.uncompressed_filename
             )
         else:
             blocks = self._block_list(

--- a/test/data/kiwi.yml
+++ b/test/data/kiwi.yml
@@ -1,2 +1,8 @@
 xz:
   - options: -a -b xxx
+
+shasum:
+  - size: "512"
+
+bundle:
+  - shasum_size: "256"

--- a/test/unit/builder/container_test.py
+++ b/test/unit/builder/container_test.py
@@ -1,5 +1,5 @@
 from unittest.mock import (
-    patch, call, mock_open
+    patch, call, mock_open, Mock
 )
 from pytest import raises
 import unittest.mock as mock
@@ -12,7 +12,10 @@ from kiwi.exceptions import KiwiContainerBuilderError
 
 class TestContainerBuilder:
     @patch('os.path.exists')
-    def setup(self, mock_exists):
+    def setup(
+        self,
+        mock_exists
+    ):
         Defaults.set_platform_name('x86_64')
         self.runtime_config = mock.Mock()
         self.runtime_config.get_max_size_constraint = mock.Mock(
@@ -20,6 +23,12 @@ class TestContainerBuilder:
         )
         self.runtime_config.get_container_compression = mock.Mock(
             return_value=False
+        )
+        self.shasum = Mock()
+        self.shasum.suffix = '.sha256'
+        self.shasum.digest.return_value = 'checksumvalue'
+        self.runtime_config.get_checksum_handler = Mock(
+            return_value=self.shasum
         )
         kiwi.builder.container.RuntimeConfig = mock.Mock(
             return_value=self.runtime_config
@@ -187,7 +196,12 @@ class TestContainerBuilder:
     @patch('kiwi.builder.container.Checksum')
     @patch('kiwi.builder.container.ContainerImage')
     @patch('os.path.exists')
-    def test_create_derived(self, mock_exists, mock_image, mock_checksum):
+    def test_create_derived(
+        self,
+        mock_exists,
+        mock_image,
+        mock_checksum
+    ):
         def side_effect(filename):
             if filename.endswith('.config/kiwi/config.yml'):
                 return False

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -14,7 +14,18 @@ from kiwi.exceptions import KiwiInstallBootImageError
 
 
 class TestInstallImageBuilder:
-    def setup(self):
+    @patch('kiwi.builder.install.RuntimeConfig')
+    def setup(
+        self,
+        mock_RuntimeConfig
+    ):
+        self.runtime_config = Mock()
+        self.shasum = Mock()
+        self.shasum.suffix = '.sha256'
+        self.runtime_config.get_checksum_handler = Mock(
+            return_value=self.shasum
+        )
+        mock_RuntimeConfig.return_value = self.runtime_config
         Defaults.set_platform_name('x86_64')
         boot_names_type = namedtuple(
             'boot_names_type', ['kernel_name', 'initrd_name']
@@ -40,13 +51,10 @@ class TestInstallImageBuilder:
         kiwi.builder.install.Path = mock.Mock()
 
         create_boot_loader_config_mock = mock.Mock(return_value=MagicMock())
-        create_boot_loader_config_mock.return_value.__enter__.return_value = mock.Mock()
-        kiwi.builder.install.create_boot_loader_config = create_boot_loader_config_mock
-
-        self.checksum = mock.Mock()
-        kiwi.builder.install.Checksum = mock.Mock(
-            return_value=self.checksum
-        )
+        create_boot_loader_config_mock.return_value.__enter__.return_value = \
+            mock.Mock()
+        kiwi.builder.install.create_boot_loader_config = \
+            create_boot_loader_config_mock
         self.kernel = mock.Mock()
         self.kernel.get_kernel = mock.Mock()
         self.kernel.get_xen_hypervisor = mock.Mock()
@@ -95,7 +103,13 @@ class TestInstallImageBuilder:
         self.setup()
 
     @patch('kiwi.builder.install.BootImage')
-    def test_init_dracut_based(self, mock_boot_image):
+    @patch('kiwi.builder.install.RuntimeConfig')
+    def test_init_dracut_based(
+        self,
+        mock_RuntimeConfig,
+        mock_boot_image
+    ):
+        mock_RuntimeConfig.return_value = self.runtime_config
         InstallImageBuilder(
             self.xml_state, 'root_dir', 'target_dir', None
         )
@@ -103,8 +117,13 @@ class TestInstallImageBuilder:
             ANY, 'target_dir', 'root_dir'
         )
 
-    def test_setup_ix86(self):
+    @patch('kiwi.builder.install.RuntimeConfig')
+    def test_setup_ix86(
+        self,
+        mock_RuntimeConfig
+    ):
         Defaults.set_platform_name('i686')
+        mock_RuntimeConfig.return_value = self.runtime_config
         xml_state = mock.Mock()
         xml_state.xml_data.get_name = mock.Mock(
             return_value='result-image'
@@ -159,7 +178,8 @@ class TestInstallImageBuilder:
             return tmp_names.pop()
 
         bootloader_config = mock.MagicMock(spec=BootLoaderConfigGrub2)
-        mock_create_boot_loader_config.return_value.__enter__.return_value = bootloader_config
+        mock_create_boot_loader_config.return_value.__enter__.return_value = \
+            bootloader_config
         mock_Temporary.side_effect = side_effect
 
         self.firmware.bios_mode.return_value = False
@@ -169,10 +189,14 @@ class TestInstallImageBuilder:
             self.install_image.create_install_iso()
 
         self.setup.import_cdroot_files.assert_called_once_with('temp_media_dir')
-
-        self.checksum.sha256.assert_called_once_with(
-            'temp-squashfs/result-image.sha256'
-        )
+        assert self.runtime_config.get_checksum_handler.call_args_list == [
+            call('target_dir/result-image.x86_64-1.2.3.raw'),
+            call(
+                source_filename='target_dir/result-image.x86_64-1.2.3.raw',
+                target_filename='temp-squashfs/result-image.sha256'
+            )
+        ]
+        self.shasum.digest.assert_called_once_with()
         mock_copy.assert_called_once_with(
             'root_dir/boot/initrd-kernel_version',
             'temp_media_dir/initrd.system_image'
@@ -306,10 +330,9 @@ class TestInstallImageBuilder:
 
     @patch('kiwi.builder.install.Temporary')
     @patch('kiwi.builder.install.Command.run')
-    @patch('kiwi.builder.install.Checksum')
     @patch('kiwi.builder.install.Compress')
     def test_create_install_pxe_no_kernel_found(
-        self, mock_compress, mock_sha256, mock_command, mock_Temporary
+        self, mock_compress, mock_command, mock_Temporary
     ):
         self.firmware.bios_mode.return_value = False
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
@@ -320,11 +343,10 @@ class TestInstallImageBuilder:
 
     @patch('kiwi.builder.install.Temporary')
     @patch('kiwi.builder.install.Command.run')
-    @patch('kiwi.builder.install.Checksum')
     @patch('kiwi.builder.install.Compress')
     @patch('kiwi.builder.install.os.symlink')
     def test_create_install_pxe_no_hypervisor_found(
-        self, mock_symlink, mock_compress, mock_sha256, mock_command,
+        self, mock_symlink, mock_compress, mock_command,
         mock_Temporary
     ):
         self.firmware.bios_mode.return_value = False
@@ -337,22 +359,18 @@ class TestInstallImageBuilder:
     @patch('kiwi.builder.install.Temporary')
     @patch('kiwi.builder.install.Command.run')
     @patch('kiwi.builder.install.ArchiveTar')
-    @patch('kiwi.builder.install.Checksum')
     @patch('kiwi.builder.install.Compress')
     @patch('kiwi.builder.install.shutil.copy')
     @patch('kiwi.builder.install.os.symlink')
     @patch('kiwi.builder.install.os.chmod')
     def test_create_install_pxe_archive(
         self, mock_chmod, mock_symlink, mock_copy, mock_compress,
-        mock_sha256, mock_archive, mock_command, mock_Temporary
+        mock_archive, mock_command, mock_Temporary
     ):
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
 
         archive = mock.Mock()
         mock_archive.return_value = archive
-
-        checksum = mock.Mock()
-        mock_sha256.return_value = checksum
 
         compress = mock.Mock()
         src = 'target_dir/result-image.x86_64-1.2.3.raw'
@@ -370,12 +388,14 @@ class TestInstallImageBuilder:
         assert mock_command.call_args_list[0] == call(
             ['mv', src, 'tmpdir/result-image.x86_64-1.2.3.xz']
         )
-        mock_sha256.assert_called_once_with(
-            'target_dir/result-image.x86_64-1.2.3.raw'
-        )
-        checksum.sha256.assert_called_once_with(
-            'tmpdir/result-image.x86_64-1.2.3.sha256'
-        )
+        assert self.runtime_config.get_checksum_handler.call_args_list == [
+            call('target_dir/result-image.x86_64-1.2.3.raw'),
+            call(
+                source_filename='target_dir/result-image.x86_64-1.2.3.raw',
+                target_filename='tmpdir/result-image.x86_64-1.2.3.sha256'
+            )
+        ]
+        self.shasum.digest.assert_called_once_with()
         assert m_open.call_args_list == [
             call('initrd_dir/config.vmxsystem', 'w'),
             call('tmpdir/result-image.x86_64-1.2.3.append', 'w')
@@ -451,7 +471,10 @@ class TestInstallImageBuilder:
         self.boot_image_task.include_driver.assert_any_call('driver1')
         self.boot_image_task.include_driver.assert_any_call('driver2')
         assert self.boot_image_task.omit_module.call_args_list == [
-            call('kiwi-repart'), call('multipath'), call('module1'), call('module2')
+            call('kiwi-repart'),
+            call('multipath'),
+            call('module1'),
+            call('module2')
         ]
         self.boot_image_task.set_static_modules.assert_called_once_with(
             ['module1', 'module2']

--- a/test/unit/builder/kis_test.py
+++ b/test/unit/builder/kis_test.py
@@ -1,7 +1,7 @@
 import logging
 from collections import namedtuple
 from unittest.mock import (
-    patch, Mock, MagicMock, mock_open
+    patch, Mock, MagicMock, mock_open, call
 )
 from pytest import (
     raises, fixture
@@ -20,16 +20,26 @@ class TestKisBuilder:
     @patch('kiwi.builder.kis.FileSystemBuilder')
     @patch('kiwi.builder.kis.BootImage')
     @patch('kiwi.builder.kis.Defaults.get_platform_name')
-    def setup(self, mock_get_platform_name, mock_boot, mock_filesystem):
+    @patch('kiwi.builder.kis.RuntimeConfig')
+    def setup(
+        self,
+        mock_RuntimeConfig,
+        mock_get_platform_name,
+        mock_boot,
+        mock_filesystem
+    ):
         mock_get_platform_name.return_value = 'x86_64'
         self.setup = Mock()
         self.runtime_config = Mock()
         self.runtime_config.get_max_size_constraint = Mock(
             return_value=None
         )
-        kiwi.builder.kis.RuntimeConfig = Mock(
-            return_value=self.runtime_config
+        self.shasum = Mock()
+        self.shasum.suffix = '.sha256'
+        self.runtime_config.get_checksum_handler = Mock(
+            return_value=self.shasum
         )
+        mock_RuntimeConfig.return_value = self.runtime_config
         kiwi.builder.kis.SystemSetup = Mock(
             return_value=self.setup
         )
@@ -86,7 +96,15 @@ class TestKisBuilder:
 
     @patch('kiwi.builder.kis.FileSystemBuilder')
     @patch('kiwi.builder.kis.BootImage')
-    def test_setup_warn_no_initrd_support(self, mock_boot, mock_filesystem):
+    @patch('kiwi.builder.kis.RuntimeConfig')
+    def test_setup_warn_no_initrd_support(self, mock_RuntimeConfig, mock_boot, mock_filesystem):
+        self.runtime_config = Mock()
+        self.shasum = Mock()
+        self.shasum.suffix = '.sha256'
+        self.runtime_config.get_checksum_handler = Mock(
+            return_value=self.shasum
+        )
+        mock_RuntimeConfig.return_value = self.runtime_config
         boot_image_task = MagicMock()
         boot_image_task.has_initrd_support = Mock(
             return_value=False
@@ -95,20 +113,17 @@ class TestKisBuilder:
         with self._caplog.at_level(logging.WARNING):
             KisBuilder(self.xml_state, 'target_dir', 'root_dir')
 
-    @patch('kiwi.builder.kis.Checksum')
     @patch('kiwi.builder.kis.Compress')
     @patch('kiwi.builder.kis.ArchiveTar')
     @patch('os.rename')
     def test_create(
-        self, mock_rename, mock_tar, mock_compress, mock_checksum
+        self, mock_rename, mock_tar, mock_compress
     ):
         tar = Mock()
         mock_tar.return_value = tar
         compress = Mock()
         mock_compress.return_value = compress
         compress.xz.return_value = 'compressed-file-name'
-        checksum = Mock()
-        mock_checksum.return_value = checksum
         self.boot_image_task.required = Mock(
             return_value=True
         )
@@ -129,9 +144,14 @@ class TestKisBuilder:
             'myimage.fs', 'myimage'
         )
         compress.xz.assert_called_once_with(None)
-        checksum.sha256.assert_called_once_with(
-            'target_dir/some-image.x86_64-1.2.3.sha256'
-        )
+        assert self.runtime_config.get_checksum_handler.call_args_list == [
+            call('target_dir/some-image.x86_64-1.2.3'),
+            call(
+                source_filename='compressed-file-name',
+                target_filename='target_dir/some-image.x86_64-1.2.3.sha256'
+            )
+        ]
+        self.shasum.digest.assert_called_once_with()
         self.boot_image_task.prepare.assert_called_once_with()
         self.setup.export_modprobe_setup.assert_called_once_with(
             'initrd_dir'
@@ -160,11 +180,10 @@ class TestKisBuilder:
             'target_dir', xz_options=['--threads=0']
         )
 
-    @patch('kiwi.builder.kis.Checksum')
     @patch('kiwi.builder.kis.Compress')
     @patch('os.rename')
     def test_create_no_kernel_found(
-        self, mock_rename, mock_compress, mock_checksum
+        self, mock_rename, mock_compress
     ):
         compress = Mock()
         mock_compress.return_value = compress
@@ -173,11 +192,10 @@ class TestKisBuilder:
         with raises(KiwiKisBootImageError):
             self.kis.create()
 
-    @patch('kiwi.builder.kis.Checksum')
     @patch('kiwi.builder.kis.Compress')
     @patch('os.rename')
     def test_create_no_hypervisor_found(
-        self, mock_rename, mock_compress, mock_checksum
+        self, mock_rename, mock_compress
     ):
         compress = Mock()
         mock_compress.return_value = compress

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -96,13 +96,18 @@ class TestRuntimeConfig:
     @patch('kiwi.defaults.ETC_RUNTIME_CONFIG_DIR', '../data/kiwi.yml.d')
     @patch('kiwi.runtime_checker.Defaults.is_buildservice_worker')
     def test_config_sections_from_system_wide_etc_config(
-        self,
-        mock_is_buildservice_worker
+        self, mock_is_buildservice_worker
     ):
         mock_is_buildservice_worker.return_value = False
         runtime_config = RuntimeConfig(reread=True)
         assert runtime_config.get_xz_options() == ['-a', '-b', 'xxx']
         assert runtime_config.get_mapper_tool() == 'partx'
+        assert runtime_config.get_checksum_handler(
+            '../data/metalink'
+        ).suffix == '.sha512'
+        assert runtime_config.get_checksum_handler(
+            '../data/metalink', bundle_lookup=True
+        ).suffix == '.sha256'
 
     @patch('kiwi.defaults.ETC_RUNTIME_CONFIG_FILE', '')
     @patch('kiwi.defaults.ETC_RUNTIME_CONFIG_DIR', '')
@@ -175,6 +180,9 @@ class TestRuntimeConfig:
         with patch.dict('os.environ', {'HOME': '../data/kiwi_config/defaults'}):
             runtime_config = RuntimeConfig(reread=True)
         assert runtime_config.get_mapper_tool() == 'partx'
+        assert runtime_config.get_checksum_handler(
+            '../data/metalink'
+        ).suffix == '.sha256'
 
     def test_config_sections_invalid(self):
         with patch.dict('os.environ', {'HOME': '../data/kiwi_config/invalid'}):

--- a/test/unit/storage/luks_device_test.py
+++ b/test/unit/storage/luks_device_test.py
@@ -31,6 +31,9 @@ class TestLuksDevice:
             return_value=True
         )
         self.luks = LuksDevice(storage_device)
+        self.runtime_config = Mock()
+        self.shasum = self.runtime_config.get_checksum_handler.return_value
+        self.luks.runtime_config = self.runtime_config
 
     def setup_method(self, cls):
         self.setup()
@@ -53,10 +56,9 @@ class TestLuksDevice:
         assert self.luks.get_device() is None
 
     @patch('kiwi.storage.luks_device.Command.run')
-    @patch('kiwi.storage.luks_device.Checksum')
     @patch('os.chmod')
     def test_create_crypto_luks_empty_passphrase(
-        self, mock_os_chmod, mock_Checksum, mock_command
+        self, mock_os_chmod, mock_command
     ):
         with patch('builtins.open', create=True):
             self.luks.create_crypto_luks(
@@ -102,16 +104,15 @@ class TestLuksDevice:
                     ]
                 )
             ]
-            mock_Checksum.return_value.sha256.assert_called_once_with()
+            self.shasum.digest.assert_called_once_with()
             self.luks.luks_device = None
 
     @patch('kiwi.storage.luks_device.LuksDevice')
     @patch('kiwi.storage.luks_device.Command.run')
     @patch('kiwi.storage.luks_device.Temporary.new_file')
-    @patch('kiwi.storage.luks_device.Checksum')
     @patch('os.chmod')
     def test_create_crypto_luks_random_passphrase(
-        self, mock_os_chmod, mock_Checksum, mock_tmpfile,
+        self, mock_os_chmod, mock_tmpfile,
         mock_command, mock_LuksDevice
     ):
         tmpfile = Mock()
@@ -151,7 +152,7 @@ class TestLuksDevice:
                     ]
                 )
             ]
-            mock_Checksum.return_value.sha256.assert_called_once_with()
+            self.shasum.digest.assert_called_once_with()
             mock_LuksDevice.create_random_keyfile.assert_called_once_with(
                 'root/some-keyfile'
             )
@@ -161,10 +162,9 @@ class TestLuksDevice:
     @patch('kiwi.storage.luks_device.LuksDevice')
     @patch('kiwi.storage.luks_device.Command.run')
     @patch('kiwi.storage.luks_device.Temporary.new_file')
-    @patch('kiwi.storage.luks_device.Checksum')
     @patch('os.chmod')
     def test_create_crypto_luks(
-        self, mock_os_chmod, mock_Checksum, mock_tmpfile,
+        self, mock_os_chmod, mock_tmpfile,
         mock_command, mock_LuksDevice
     ):
         tmpfile = Mock()
@@ -210,7 +210,7 @@ class TestLuksDevice:
                     ]
                 )
             ]
-            mock_Checksum.return_value.sha256.assert_called_once_with()
+            self.shasum.digest.assert_called_once_with()
             mock_LuksDevice.create_random_keyfile.assert_called_once_with(
                 'root/some-keyfile'
             )

--- a/test/unit/storage/subformat/oci_test.py
+++ b/test/unit/storage/subformat/oci_test.py
@@ -3,8 +3,6 @@ from unittest.mock import (
     patch, Mock
 )
 
-import kiwi
-
 from kiwi.defaults import Defaults
 from kiwi.storage.subformat.oci import DiskFormatOci
 from kiwi.exceptions import KiwiContainerBuilderError
@@ -29,14 +27,15 @@ class TestDiskFormatOci:
         self.xml_state.get_image_version = Mock(
             return_value='1.2.3'
         )
-        self.runtime_config = Mock()
-        kiwi.storage.subformat.base.RuntimeConfig = Mock(
-            return_value=self.runtime_config
-        )
         self.disk_format = DiskFormatOci(
             self.xml_state, 'root_dir', 'target_dir'
         )
         self.disk_format.base_format = 'raw'
+        self.runtime_config = Mock()
+        self.runtime_config.get_container_compression.return_value = True
+        self.shasum = self.runtime_config.get_checksum_handler.return_value
+        self.shasum.suffix = '.sha256'
+        self.disk_format.runtime_config = self.runtime_config
 
     def setup_method(self, cls):
         self.setup()
@@ -153,7 +152,7 @@ class TestDiskFormatOci:
             ]
         )
         mock_Checksum.return_value.matches.assert_called_once_with(
-            mock_Checksum.return_value.sha256.return_value, 'some-base.sha256'
+            self.shasum.digest.return_value, 'some-base.sha256'
         )
         mock_ContainerImage.new.assert_called_once_with(
             'docker', 'tmpdir', self.xml_state.get_container_config.return_value

--- a/test/unit/system/profile_test.py
+++ b/test/unit/system/profile_test.py
@@ -70,7 +70,8 @@ class TestProfile:
             'kiwi_strip_tools': '',
             'kiwi_strip_libs': '',
             'kiwi_drivers': '',
-            'kiwi_rootpartuuid': None
+            'kiwi_rootpartuuid': None,
+            'kiwi_shasum_suffix': '.sha256'
         }
 
     @patch('kiwi.path.Path.which')
@@ -155,7 +156,8 @@ class TestProfile:
             'kiwi_luks_empty_passphrase': True,
             'kiwi_wwid_wait_timeout': None,
             'kiwi_xendomain': 'dom0',
-            'kiwi_rootpartuuid': None
+            'kiwi_rootpartuuid': None,
+            'kiwi_shasum_suffix': '.sha256'
         }
 
     @patch('kiwi.path.Path.which')

--- a/test/unit/system/root_bind_test.py
+++ b/test/unit/system/root_bind_test.py
@@ -46,6 +46,10 @@ class TestRootBind:
         self.bind_root.mount_stack = [self.mount_manager]
         self.bind_root.dir_stack = ['/mountpoint']
 
+        self.runtime_config = Mock()
+        self.shasum = self.runtime_config.get_checksum_handler.return_value
+        self.bind_root.runtime_config = self.runtime_config
+
     def setup_method(self, cls):
         self.setup()
 
@@ -167,7 +171,7 @@ class TestRootBind:
                 'ln', '-s', '-f', 'proxy.kiwi', 'root-dir/etc/sysconfig/proxy'
             ])
         ]
-        checksum.sha256.assert_called_once_with()
+        self.shasum.digest.assert_called_once_with()
 
     @patch('textwrap.dedent')
     @patch('kiwi.system.root_bind.Checksum')

--- a/test/unit/system/root_import/oci_test.py
+++ b/test/unit/system/root_import/oci_test.py
@@ -25,6 +25,9 @@ class TestRootImportOCI:
                 'root_dir', [Uri('file:///image.tar')],
                 {'archive_transport': 'oci-archive'}
             )
+            self.runtime_config = Mock()
+            self.shasum = self.runtime_config.get_checksum_handler.return_value
+            self.oci_import.runtime_config = self.runtime_config
         assert self.oci_import.image_files == ['/image.tar']
 
     @patch('os.path.exists')
@@ -41,13 +44,11 @@ class TestRootImportOCI:
             )
 
     @patch('kiwi.system.root_import.oci.Compress')
-    @patch('kiwi.system.root_import.base.Checksum')
     @patch('kiwi.system.root_import.oci.Path.create')
     @patch('kiwi.system.root_import.oci.OCI')
-    def test_sync_data(self, mock_OCI, mock_path, mock_sha256, mock_compress):
+    def test_sync_data(self, mock_OCI, mock_path, mock_compress):
         oci = Mock()
         mock_OCI.new.return_value.__enter__.return_value = oci
-        mock_sha256.return_value = Mock()
 
         uncompress = Mock()
         uncompress.get_format = Mock(return_value=None)
@@ -61,7 +62,7 @@ class TestRootImportOCI:
         oci.import_rootfs.assert_called_once_with(
             'root_dir'
         )
-        mock_sha256.assert_called_once_with('root_dir/image/imported_root')
+        self.shasum.digest.assert_called_once_with()
         uncompress.get_format.assert_called_once_with()
 
     @patch('kiwi.system.root_import.oci.Compress')
@@ -98,15 +99,13 @@ class TestRootImportOCI:
         )
 
     @patch('kiwi.system.root_import.oci.Compress')
-    @patch('kiwi.system.root_import.base.Checksum')
     @patch('kiwi.system.root_import.oci.Path.create')
     @patch('kiwi.system.root_import.oci.OCI')
     def test_sync_data_compressed_image(
-        self, mock_OCI, mock_path, mock_sha256, mock_compress
+        self, mock_OCI, mock_path, mock_compress
     ):
         oci = Mock()
         mock_OCI.new.return_value.__enter__.return_value = oci
-        mock_sha256.return_value = Mock()
 
         uncompress = Mock()
         uncompress.get_format = Mock(return_value='xz')
@@ -120,26 +119,25 @@ class TestRootImportOCI:
         oci.import_rootfs.assert_called_once_with(
             'root_dir'
         )
-        mock_sha256.assert_called_once_with('root_dir/image/imported_root')
+        self.shasum.digest.assert_called_once_with()
         uncompress.get_format.assert_called_once_with()
         uncompress.uncompress.assert_called_once_with(True)
 
     @patch('os.path.exists')
-    @patch('kiwi.system.root_import.base.Checksum')
     @patch('kiwi.system.root_import.oci.Path.create')
     @patch('kiwi.system.root_import.oci.OCI')
     def test_sync_data_unknown_uri(
-        self, mock_OCI, mock_path, mock_sha256, mock_exists
+        self, mock_OCI, mock_path, mock_exists
     ):
         mock_exists.return_value = True
         oci = Mock()
         mock_OCI.new.return_value.__enter__.return_value = oci
-        mock_sha256.return_value = Mock()
         with patch.dict('os.environ', {'HOME': '../data'}):
             oci_import = RootImportOCI(
                 'root_dir', [Uri('docker:image:tag')],
                 {'archive_transport': 'docker-archive'}
             )
+            oci_import.runtime_config = self.runtime_config
 
         with self._caplog.at_level(logging.WARNING):
             oci_import.sync_data()
@@ -151,4 +149,4 @@ class TestRootImportOCI:
             oci.import_rootfs.assert_called_once_with(
                 'root_dir'
             )
-            mock_sha256.assert_called_once_with('root_dir/image/imported_root')
+            self.shasum.digest.assert_called_once_with()

--- a/test/unit/tasks/image_info_test.py
+++ b/test/unit/tasks/image_info_test.py
@@ -178,6 +178,7 @@ class TestImageInfoTask:
                         ('kiwi_revision', '$Format:%H$'),
                         ('kiwi_rootpartuuid', ''),
                         ('kiwi_sectorsize', '512'),
+                        ('kiwi_shasum_suffix', '.sha256'),
                         ('kiwi_showlicense', ''),
                         ('kiwi_splash_theme', 'openSUSE'),
                         ('kiwi_startsector', '2048'),

--- a/test/unit/tasks/result_bundle_test.py
+++ b/test/unit/tasks/result_bundle_test.py
@@ -89,7 +89,6 @@ class TestResultBundleTask:
     @patch('kiwi.tasks.result_bundle.Path.create')
     @patch('kiwi.tasks.result_bundle.Path.which')
     @patch('kiwi.tasks.result_bundle.Compress')
-    @patch('kiwi.tasks.result_bundle.Checksum')
     @patch('os.path.exists')
     @patch('os.path.islink')
     @patch('os.unlink')
@@ -97,7 +96,7 @@ class TestResultBundleTask:
     @patch('os.readlink')
     def test_process_result_bundle(
         self, mock_os_readlink, mock_os_symlink, mock_os_unlink,
-        mock_os_path_islink, mock_exists, mock_checksum, mock_compress,
+        mock_os_path_islink, mock_exists, mock_compress,
         mock_path_which, mock_path_create, mock_command, mock_load
     ):
         # This file won't be copied with build id
@@ -106,12 +105,10 @@ class TestResultBundleTask:
             use_for_bundle=True, compress=False, shasum=False
         )
 
-        checksum = Mock()
         compress = Mock()
         mock_path_which.return_value = 'zsyncmake'
         compress.xz.return_value = 'compressed_filename'
         mock_compress.return_value = compress
-        mock_checksum.return_value = checksum
         mock_exists.return_value = False
         mock_load.return_value = self.result
         self._init_command_args()
@@ -167,13 +164,9 @@ class TestResultBundleTask:
         mock_compress.assert_called_once_with(
             os.sep.join([self.abs_bundle_dir, 'test-image-1.2.3-Build_42'])
         )
-        mock_checksum.assert_called_once_with(
-            'compressed_filename'
-        )
-        checksum.sha256.assert_called_once_with()
         m_open.return_value.write.assert_called_once_with(
             '{0}  compressed_filename{1}'.format(
-                checksum.sha256.return_value, os.linesep
+                self.task.runtime_config.get_checksum_handler.return_value.digest.return_value, os.linesep
             )
         )
 
@@ -184,7 +177,6 @@ class TestResultBundleTask:
     @patch('kiwi.tasks.result_bundle.Path.which')
     @patch('kiwi.tasks.result_bundle.Path.wipe')
     @patch('kiwi.tasks.result_bundle.Compress')
-    @patch('kiwi.tasks.result_bundle.Checksum')
     @patch('os.path.exists')
     @patch('os.chdir')
     @patch('os.unlink')
@@ -197,7 +189,7 @@ class TestResultBundleTask:
     def test_process_result_bundle_as_rpm(
         self, mock_os_path_abspath, mock_os_path_realpath, mock_os_readlink,
         mock_os_symlink, mock_os_path_islink, mock_iglob, mock_unlink,
-        mock_chdir, mock_exists, mock_checksum, mock_compress,
+        mock_chdir, mock_exists, mock_compress,
         mock_path_wipe, mock_path_which, mock_path_create, mock_command,
         mock_load, mock_Privileges_check_for_root_permissions
     ):
@@ -207,14 +199,12 @@ class TestResultBundleTask:
             else:
                 return 'bundle-dir'
 
-        checksum = Mock()
         compress = Mock()
         mock_os_readlink.return_value = 'readlink'
         mock_os_path_abspath.side_effect = abspath
         mock_path_which.return_value = 'zsyncmake'
         compress.xz.return_value = 'compressed_filename'
         mock_compress.return_value = compress
-        mock_checksum.return_value = checksum
         mock_exists.return_value = False
         mock_load.return_value = self.result
         self._init_command_args()
@@ -710,7 +700,6 @@ class TestResultBundleTask:
     @patch('kiwi.tasks.result_bundle.Path.create')
     @patch('kiwi.tasks.result_bundle.Path.which')
     @patch('kiwi.tasks.result_bundle.Compress')
-    @patch('kiwi.tasks.result_bundle.Checksum')
     @patch('os.path.exists')
     @patch('os.path.islink')
     @patch('os.unlink')
@@ -718,15 +707,13 @@ class TestResultBundleTask:
     @patch('os.readlink')
     def test_process_result_bundle_zsyncmake_missing(
         self, mock_os_readlink, mock_os_symlink, mock_os_unlink,
-        mock_os_path_islink, mock_exists, mock_checksum, mock_compress,
+        mock_os_path_islink, mock_exists, mock_compress,
         mock_path_which, mock_path_create, mock_command, mock_load
     ):
-        checksum = Mock()
         compress = Mock()
         mock_path_which.return_value = None
         compress.xz.return_value = 'compressed_filename'
         mock_compress.return_value = compress
-        mock_checksum.return_value = checksum
         mock_exists.return_value = False
         mock_load.return_value = self.result
         self._init_command_args()

--- a/test/unit/utils/checksum_test.py
+++ b/test/unit/utils/checksum_test.py
@@ -92,6 +92,42 @@ class TestChecksum:
 
     @patch('kiwi.path.Path.which')
     @patch('kiwi.utils.checksum.Compress')
+    @patch('hashlib.sha512')
+    @patch('os.path.getsize')
+    def test_sha512_xz(self, mock_size, mock_sha512, mock_compress, mock_which):
+        checksum = Mock
+        checksum.uncompressed_filename = 'some-file-uncompressed'
+        mock_which.return_value = 'factor'
+        compress = Mock()
+        digest = Mock()
+        digest.block_size = 1024
+        digest._calculate_hash_hexdigest = Mock(
+            return_value=checksum
+        )
+        digest.hexdigest = Mock(
+            return_value='sum'
+        )
+        compress.get_format = Mock(
+            return_value='xz'
+        )
+        mock_size.return_value = 1343225856
+        mock_sha512.return_value = digest
+        mock_compress.return_value = compress
+
+        with patch('builtins.open', self.m_open, create=True):
+            self.checksum.sha512('outfile')
+
+        assert self.m_open.call_args_list == [
+            call('some-file', 'rb'),
+            call('some-file-uncompressed', 'rb'),
+            call('outfile', encoding=self.ascii, mode='w')
+        ]
+        self.m_open.return_value.write.assert_called_once_with(
+            'sum 163968 8192 163968 8192\n'
+        )
+
+    @patch('kiwi.path.Path.which')
+    @patch('kiwi.utils.checksum.Compress')
     @patch('hashlib.sha256')
     @patch('os.path.getsize')
     def test_sha256_file(


### PR DESCRIPTION
Allow to select between the default shasum size 256 and 512 via a new runtime config section named: shasum
This Fixes #3004