### PR TITLE
Fix system resize

### DIFF
--- a/dracut/modules.d/59kiwi-lib/kiwi-filesystem-lib.sh
+++ b/dracut/modules.d/59kiwi-lib/kiwi-filesystem-lib.sh
@@ -62,7 +62,14 @@ function resize_filesystem {
     ;;
     esac
     if ! _is_ramdisk_device "${device}"; then
-        check_filesystem "${device}"
+        if [ ! "${fstype}" = "btrfs" ];then
+            # btrfs reports the free space cache to be outdated/corrupt
+            # after kiwi has resized the partition table. This is an
+            # expected condition prior resize of the filesystem and
+            # should not prevent the following resize. As such the
+            # filesystem check is not applied for btrfs prior resize
+            check_filesystem "${device}"
+        fi
     fi
     info "Resizing ${fstype} filesystem on ${device}..."
     if ! eval "${resize_fs}"; then

--- a/dracut/modules.d/59kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/59kiwi-lib/kiwi-partitions-lib.sh
@@ -366,7 +366,7 @@ function get_partition_uuid {
 }
 
 function relocate_gpt_at_end_of_disk {
-    if ! set_device_lock "$1" sfdisk --relocate gpt-bak-std "$1";then
+    if ! sfdisk --relocate gpt-bak-std "$1";then
         die "Failed to write backup GPT at end of disk"
     fi
 }


### PR DESCRIPTION
When resizing the partition table via sfdisk --relocate, the resize failed when the device was locked beforehand. In addition the resize of the actual filesystem failed the prior filesystem check if the btrfs filesystem is used. btrfs reports the free space cache to be outdated/corrupt after kiwi has resized the partition table. This is an expected condition prior resize of the filesystem and should not prevent the following resize. As such the filesystem check is not applied for btrfs prior resize.