### PR TITLE
Flexible runtime config handling

### DIFF
--- a/build-tests/arm/fedora/kiwi-settings/kiwi-settings/kiwi.yml
+++ b/build-tests/arm/fedora/kiwi-settings/kiwi-settings/kiwi.yml
@@ -1,4 +1,4 @@
 iso:
-  - media_tag_tool: isomd5sum
+  media_tag_tool: isomd5sum
 oci:
-  - archive_tool: buildah
+  archive_tool: buildah

--- a/build-tests/s390/tumbleweed/kiwi-settings/kiwi-settings/kiwi.yml
+++ b/build-tests/s390/tumbleweed/kiwi-settings/kiwi-settings/kiwi.yml
@@ -1,2 +1,2 @@
 mapper:
-  - part_mapper: kpartx
+  part_mapper: kpartx

--- a/build-tests/x86/fedora/kiwi-settings/kiwi-settings/kiwi.yml
+++ b/build-tests/x86/fedora/kiwi-settings/kiwi-settings/kiwi.yml
@@ -1,6 +1,6 @@
 iso:
-  - media_tag_tool: isomd5sum
+  media_tag_tool: isomd5sum
 oci:
-  - archive_tool: buildah
+  archive_tool: buildah
 bundle:
-  - shasum_size: "512"
+  shasum_size: "512"

--- a/build-tests/x86/leap/kiwi-settings/kiwi-settings/kiwi.yml
+++ b/build-tests/x86/leap/kiwi-settings/kiwi-settings/kiwi.yml
@@ -1,3 +1,3 @@
 runtime_checks:
-  - disable:
-      - check_dracut_module_for_disk_overlay_in_package_list
+  disable:
+    - check_dracut_module_for_disk_overlay_in_package_list

--- a/kiwi.yml
+++ b/kiwi.yml
@@ -13,16 +13,16 @@
 # Setup access to security keys
 #credentials:
 #  # Specify private key(s) used for signing operations
-#  - verification_metadata_signing_key_file: /path/to/private.pem
+#  verification_metadata_signing_key_file: /path/to/private.pem
 
 # Setup access options for the Open BuildService
 #obs:
 #  # Specify the URL of the Open BuildService download server
-#  - download_url: http://download.opensuse.org/repositories
+#  download_url: http://download.opensuse.org/repositories
 #  # Specify if the BuildService download server is public or private.
 #  # This information is used to verify if the request to populate
 #  # the repositories via the imageinclude attribute is possible
-#  - public: true
+#  public: true
 
 
 # Setup behaviour of the kiwi result bundle command
@@ -35,39 +35,39 @@
 #  # generally grows when an attempt is made to compress the data. This is
 #  # due to the nature of compression algorithms. Therefore this setting is
 #  # ignored when encryption is enabled.
-#  - compress: false
+#  compress: false
 #  # Specify if the image build result and bundle should contain
 #  # a .changes file. The .changes file contains the package changelog
 #  # information from all packages installed into the image.
-#  - has_package_changes: false
+#  has_package_changes: false
 #  # Specify shasum size for the bundle creation. Supported values
 #  # are "256" (default) and "512". This value takes precedence
 #  # over the global shasum size specified in the shasum section.
 #  # If not specified, the global shasum size or the default is used.
-#  - shasum_size: "256"
+#  shasum_size: "256"
 
 
 # Setup behaviour of XZ compressor
 #xz:
 #  # Specify options used in any xz compression call
-#  - options: '--threads=0'
+#  options: '--threads=0'
 
 
 # Setup process parameters for container image creation
 #container:
 #  # Specify compression for container images
 #  # Possible values are true, false, xz or none.
-#  - compress: true
+#  compress: true
 
 
 # Setup process parameters for ISO image creation
 #iso:
 #  # Specify tool category which should be used to build iso images
 #  # Possible values are: xorriso
-#  - tool_category: xorriso
+#  tool_category: xorriso
 #  # Specify media tag tool used to implant iso checksums
 #  # Possible values are checkmedia and isomd5sum
-#  - media_tag_tool: checkmedia
+#  media_tag_tool: checkmedia
 
 
 # Setup process parameters for OCI toolchain
@@ -75,7 +75,7 @@
 #  # Specify OCI archive tool which should be used on creation of
 #  # container archives for OCI compliant images, e.g docker
 #  # Possible values are umoci and buildah
-#  - archive_tool: umoci
+#  archive_tool: umoci
 
 # Setup shasum size
 # shasum:
@@ -84,7 +84,7 @@
 #  # shasum operations performed by KIWI. Please also see the
 #  # bundle section for shasum size configuration specific to the
 #  # result bundle creation.
-#  - size: "256"
+#  size: "256"
 
 # Specify build constraints that applies during the image build
 # process. If one or more constraints are violated the build exits
@@ -93,89 +93,89 @@
 #  # Maximum result image size. The value can be specified in
 #  # bytes or it can be specified with m=MB or g=GB. The constraint
 #  # is checked prior to the result bundle creation
-#  - max_size: 700m
+#  max_size: 700m
 
 # Setup process parameters for partition mapping
 #mapper:
 #  # Specify tool to use for creating partition maps
 #  # Possible values are: kpartx and partx
-#  - part_mapper: partx
+#  part_mapper: partx
 
 # Setup process parameters to handle runtime checks
 #runtime_checks:
 #  # Specify list of runtime checks to disable
-#  - disable:
-#      # verify that the host has the required container tools installed
-#      - check_container_tool_chain_installed
+#  disable:
+#    # verify that the host has the required container tools installed
+#    - check_container_tool_chain_installed
 
-#      # verify that there are repositories configured
-#      - check_repositories_configured
+#    # verify that there are repositories configured
+#    - check_repositories_configured
 
-#      # verify that the URL for imageinclude repos is accessable
-#      - check_image_include_repos_publicly_resolvable
+#    # verify that the URL for imageinclude repos is accessable
+#    - check_image_include_repos_publicly_resolvable
 
-#      # verify for legacy kiwi boot images that they exist on the host
-#      - check_boot_description_exists
+#    # verify for legacy kiwi boot images that they exist on the host
+#    - check_boot_description_exists
 
-#      # verify if kiwi initrd_system was set if a boot attribute exists
-#      - check_initrd_selection_required
+#    # verify if kiwi initrd_system was set if a boot attribute exists
+#    - check_initrd_selection_required
 
-#      # verify for legacy kiwi boot images that the same kernel is used
-#      - check_consistent_kernel_in_boot_and_system_image
+#    # verify for legacy kiwi boot images that the same kernel is used
+#    - check_consistent_kernel_in_boot_and_system_image
 
-#      # check for reserved label names used in LVM setup
-#      - check_volume_setup_defines_reserved_labels
+#    # check for reserved label names used in LVM setup
+#    - check_volume_setup_defines_reserved_labels
 
-#      # verify only one full size volume is specified for LVM images
-#      - check_volume_setup_defines_multiple_fullsize_volumes
+#    # verify only one full size volume is specified for LVM images
+#    - check_volume_setup_defines_multiple_fullsize_volumes
 
-#      # verify no / volume setup is setup but the @root volume is used
-#      - check_volume_setup_has_no_root_definition
+#    # verify no / volume setup is setup but the @root volume is used
+#    - check_volume_setup_has_no_root_definition
 
-#      # verify if volume label is really used with a volume setup
-#      - check_volume_label_used_with_lvm
+#    # verify if volume label is really used with a volume setup
+#    - check_volume_label_used_with_lvm
 
-#      # verify that there is a xen domain setup for xen images
-#      - check_xen_uniquely_setup_as_server_or_guest
+#    # verify that there is a xen domain setup for xen images
+#    - check_xen_uniquely_setup_as_server_or_guest
 
-#      # verify mediacheck is installed for ISO images that requests it
-#      - check_mediacheck_installed
+#    # verify mediacheck is installed for ISO images that requests it
+#    - check_mediacheck_installed
 
-#      # verify that checkmedia/tagmedia is used with an MBR(msdos) partition table
-#      - check_checkmedia_used_with_msdos_table
+#    # verify that checkmedia/tagmedia is used with an MBR(msdos) partition table
+#    - check_checkmedia_used_with_msdos_table
 
-#      # verify dracut-kiwi-live is installed for ISO images
-#      - check_dracut_module_for_live_iso_in_package_list
+#    # verify dracut-kiwi-live is installed for ISO images
+#    - check_dracut_module_for_live_iso_in_package_list
 
-#      # verify dracut-kiwi-overlay is installed for overlay disk images
-#      - check_dracut_module_for_disk_overlay_in_package_list
+#    # verify dracut-kiwi-overlay is installed for overlay disk images
+#    - check_dracut_module_for_disk_overlay_in_package_list
 
-#      # verify dracut-kiwi-repart is installed for OEM disk images
-#      - check_dracut_module_for_disk_oem_in_package_list
+#    # verify dracut-kiwi-repart is installed for OEM disk images
+#    - check_dracut_module_for_disk_oem_in_package_list
 
-#      # verify dracut-kiwi-oem-dump is installed for OEM install images
-#      - check_dracut_module_for_oem_install_in_package_list
+#    # verify dracut-kiwi-oem-dump is installed for OEM install images
+#    - check_dracut_module_for_oem_install_in_package_list
 
-#      # verify configured firmware is compatible with host architecture
-#      - check_architecture_supports_iso_firmware_setup
+#    # verify configured firmware is compatible with host architecture
+#    - check_architecture_supports_iso_firmware_setup
 
-#      # verify WSL naming conventions
-#      - check_appx_naming_conventions_valid
+#    # verify WSL naming conventions
+#    - check_appx_naming_conventions_valid
 
-#      # check kiwi dracut modules compatible with kiwi builder
-#      - check_dracut_module_versions_compatible_to_kiwi
+#    # check kiwi dracut modules compatible with kiwi builder
+#    - check_dracut_module_versions_compatible_to_kiwi
 
-#      # check target_dir and image root on a supported filesystem
-#      - check_target_dir_on_unsupported_filesystem
+#    # check target_dir and image root on a supported filesystem
+#    - check_target_dir_on_unsupported_filesystem
 
-#      # check for unresolved include statements in the XML description
-#      - check_include_references_unresolvable
+#    # check for unresolved include statements in the XML description
+#    - check_include_references_unresolvable
 
-#      # validate options passed to cryptsetup via luksformat element
-#      - check_luksformat_options_valid
+#    # validate options passed to cryptsetup via luksformat element
+#    - check_luksformat_options_valid
 
-#      # check devicepersistency compatible with partition table type
-#      - check_partuuid_persistency_type_used_with_mbr
+#    # check devicepersistency compatible with partition table type
+#    - check_partuuid_persistency_type_used_with_mbr
 
-#      # check efifatimagesize does not exceed the max El Torito load size
-#      - check_efi_fat_image_has_correct_size
+#    # check efifatimagesize does not exceed the max El Torito load size
+#    - check_efi_fat_image_has_correct_size

--- a/kiwi.yml
+++ b/kiwi.yml
@@ -14,21 +14,18 @@
 # Setup access to security keys
 #credentials:
 #  # Specify private key(s) used for signing operations
-#  - verification_metadata_signing_key_file: /path/to/private.pem
+#  verification_metadata_signing_key_file: /path/to/private.pem
 
 # Setup access options for the Open BuildService
 #obs:
 #  # Specify the URL of the Open BuildService download server
-#  - download_url: http://download.opensuse.org/repositories
+#  download_url: http://download.opensuse.org/repositories
 #  # Specify the URL of the Open BuildService API server
-#  - api_url: https://api.opensuse.org
-#  # Specify Open BuildService API credentials, one mapping per user
-#  - user:
-#      - user_name: user_credentials
+#  api_url: https://api.opensuse.org
 #  # Specify if the BuildService download server is public or private.
 #  # This information is used to verify if the request to populate
 #  # the repositories via the imageinclude attribute is possible
-#  - public: true
+#  public: true
 
 
 # Setup behaviour of the kiwi result bundle command
@@ -47,41 +44,41 @@
 #  # filesystem images and for disk subformats derived from the generic base,
 #  # including vhdfixed and vmdk, when a luks setup is present. For raw disks
 #  # the override additionally requires luks_randomize.
-#  - compress: true
+#  compress: true
 #  # Specify if the image build result and bundle should contain
 #  # a .changes file. The .changes file contains the package changelog
 #  # information from all packages installed into the image.
 #  # Default: true. Automatically false when building inside the Open
 #  # Build Service, which provides an equivalent .report file itself.
-#  - has_package_changes: true
+#  has_package_changes: true
 #  # Specify shasum size for the bundle creation. Supported values
 #  # are "256" (default) and "512". This value takes precedence
 #  # over the global shasum size specified in the shasum section.
 #  # If not specified, the global shasum size or the default is used.
-#  - shasum_size: "256"
+#  shasum_size: "256"
 
 
 # Setup behaviour of XZ compressor
 #xz:
 #  # Specify options used in any xz compression call
-#  - options: '--threads=0'
+#  options: '--threads=0'
 
 
 # Setup process parameters for container image creation
 #container:
 #  # Specify compression for container images
 #  # Possible values are true, false, xz or none.
-#  - compress: true
+#  compress: true
 
 
 # Setup process parameters for ISO image creation
 #iso:
 #  # Specify tool category which should be used to build iso images
 #  # Possible values are: xorriso
-#  - tool_category: xorriso
+#  tool_category: xorriso
 #  # Specify media tag tool used to implant iso checksums
 #  # Possible values are checkmedia and isomd5sum
-#  - media_tag_tool: checkmedia
+#  media_tag_tool: checkmedia
 
 
 # Setup process parameters for OCI toolchain
@@ -89,7 +86,7 @@
 #  # Specify OCI archive tool which should be used on creation of
 #  # container archives for OCI compliant images, e.g docker
 #  # Possible values are umoci and buildah
-#  - archive_tool: umoci
+#  archive_tool: umoci
 
 # Setup shasum size
 # shasum:
@@ -98,7 +95,7 @@
 #  # shasum operations performed by KIWI. Please also see the
 #  # bundle section for shasum size configuration specific to the
 #  # result bundle creation.
-#  - size: "256"
+#  size: "256"
 
 # Specify build constraints that applies during the image build
 # process. If one or more constraints are violated the build exits
@@ -107,102 +104,105 @@
 #  # Maximum result image size. The value can be specified in
 #  # bytes or it can be specified with m=MB or g=GB. The constraint
 #  # is checked prior to the result bundle creation
-#  - max_size: 700m
+#  max_size: 700m
 
 # Setup process parameters for partition mapping
 #mapper:
 #  # Specify tool to use for creating partition maps
 #  # Possible values are: kpartx and partx
 #  # Default: partx, except on s390 where the default is kpartx
-#  - part_mapper: partx
+#  part_mapper: partx
 
 # Setup process parameters to handle runtime checks
 #runtime_checks:
 #  # Specify list of runtime checks to disable
-#  - disable:
-#      # verify that the host has the required container tools installed
-#      - check_container_tool_chain_installed
+#  disable:
+#    # verify that the host has the required container tools installed
+#    - check_container_tool_chain_installed
 
-#      # verify that there are repositories configured
-#      - check_repositories_configured
+#    # verify that there are repositories configured
+#    - check_repositories_configured
 
-#      # verify that the URL for imageinclude repos is accessable
-#      - check_image_include_repos_publicly_resolvable
+#    # verify that the URL for imageinclude repos is accessable
+#    - check_image_include_repos_publicly_resolvable
 
-#      # verify for legacy kiwi boot images that they exist on the host
-#      - check_boot_description_exists
+#    # verify for legacy kiwi boot images that they exist on the host
+#    - check_boot_description_exists
 
-#      # verify if kiwi initrd_system was set if a boot attribute exists
-#      - check_initrd_selection_required
+#    # verify if kiwi initrd_system was set if a boot attribute exists
+#    - check_initrd_selection_required
 
-#      # verify for legacy kiwi boot images that the same kernel is used
-#      - check_consistent_kernel_in_boot_and_system_image
+#    # verify for legacy kiwi boot images that the same kernel is used
+#    - check_consistent_kernel_in_boot_and_system_image
 
-#      # check for reserved label names used in LVM setup
-#      - check_volume_setup_defines_reserved_labels
+#    # check for reserved label names used in LVM setup
+#    - check_volume_setup_defines_reserved_labels
 
-#      # verify only one full size volume is specified for LVM images
-#      - check_volume_setup_defines_multiple_fullsize_volumes
+#    # verify only one full size volume is specified for LVM images
+#    - check_volume_setup_defines_multiple_fullsize_volumes
 
-#      # verify no / volume setup is setup but the @root volume is used
-#      - check_volume_setup_has_no_root_definition
+#    # verify no / volume setup is setup but the @root volume is used
+#    - check_volume_setup_has_no_root_definition
 
-#      # verify if volume label is really used with a volume setup
-#      - check_volume_label_used_with_lvm
+#    # verify if volume label is really used with a volume setup
+#    - check_volume_label_used_with_lvm
 
-#      # verify that there is a xen domain setup for xen images
-#      - check_xen_uniquely_setup_as_server_or_guest
+#    # verify that there is a xen domain setup for xen images
+#    - check_xen_uniquely_setup_as_server_or_guest
 
-#      # verify mediacheck is installed for ISO images that requests it
-#      - check_mediacheck_installed
+#    # verify mediacheck is installed for ISO images that requests it
+#    - check_mediacheck_installed
 
-#      # verify that checkmedia/tagmedia is used with an MBR(msdos) partition table
-#      - check_checkmedia_used_with_msdos_table
+#    # verify that checkmedia/tagmedia is used with an MBR(msdos) partition table
+#    - check_checkmedia_used_with_msdos_table
 
-#      # verify dracut-kiwi-live is installed for ISO images
-#      - check_dracut_module_for_live_iso_in_package_list
+#    # verify dracut-kiwi-live is installed for ISO images
+#    - check_dracut_module_for_live_iso_in_package_list
 
-#      # verify dracut-kiwi-overlay is installed for overlay disk images
-#      - check_dracut_module_for_disk_overlay_in_package_list
+#    # verify dracut-kiwi-overlay is installed for overlay disk images
+#    - check_dracut_module_for_disk_overlay_in_package_list
 
-#      # verify dracut-kiwi-repart is installed for OEM disk images
-#      - check_dracut_module_for_disk_oem_in_package_list
+#    # verify dracut-kiwi-repart is installed for OEM disk images
+#    - check_dracut_module_for_disk_oem_in_package_list
 
-#      # verify dracut-kiwi-oem-dump is installed for OEM install images
-#      - check_dracut_module_for_oem_install_in_package_list
+#    # verify dracut-kiwi-oem-dump is installed for OEM install images
+#    - check_dracut_module_for_oem_install_in_package_list
 
-#      # verify WSL naming conventions
-#      - check_appx_naming_conventions_valid
+#    # verify configured firmware is compatible with host architecture
+#    - check_architecture_supports_iso_firmware_setup
 
-#      # check kiwi dracut modules compatible with kiwi builder
-#      - check_dracut_module_versions_compatible_to_kiwi
+#    # verify WSL naming conventions
+#    - check_appx_naming_conventions_valid
 
-#      # check target_dir and image root on a supported filesystem
-#      - check_target_dir_on_unsupported_filesystem
+#    # check kiwi dracut modules compatible with kiwi builder
+#    - check_dracut_module_versions_compatible_to_kiwi
 
-#      # check for unresolved include statements in the XML description
-#      - check_include_references_unresolvable
+#    # check target_dir and image root on a supported filesystem
+#    - check_target_dir_on_unsupported_filesystem
 
-#      # validate options passed to cryptsetup via luksformat element
-#      - check_luksformat_options_valid
+#    # check for unresolved include statements in the XML description
+#    - check_include_references_unresolvable
 
-#      # check devicepersistency compatible with partition table type
-#      - check_partuuid_persistency_type_used_with_mbr
+#    # validate options passed to cryptsetup via luksformat element
+#    - check_luksformat_options_valid
 
-#      # check efifatimagesize does not exceed the max El Torito load size
-#      - check_efi_fat_image_has_correct_size
+#    # check devicepersistency compatible with partition table type
+#    - check_partuuid_persistency_type_used_with_mbr
 
-#      # check the target directory is not inside the shared cache directory
-#      - check_target_directory_not_in_shared_cache
+#    # check efifatimagesize does not exceed the max El Torito load size
+#    - check_efi_fat_image_has_correct_size
 
-#      # check the swap partition name is only used with an LVM setup
-#      - check_swap_name_used_with_lvm
+#    # check the target directory is not inside the shared cache directory
+#    - check_target_directory_not_in_shared_cache
 
-#      # check the image description provides a version
-#      - check_image_version_provided
+#    # check the swap partition name is only used with an LVM setup
+#    - check_swap_name_used_with_lvm
 
-#      # check no two build types with the same image attribute are selected
-#      - check_image_type_unique
+#    # check the image description provides a version
+#    - check_image_version_provided
 
-#      # check the bootloader environment is compatible with the loader
-#      - check_bootloader_env_compatible_with_loader
+#    # check no two build types with the same image attribute are selected
+#    - check_image_type_unique
+
+#    # check the bootloader environment is compatible with the loader
+#    - check_bootloader_env_compatible_with_loader

--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -109,7 +109,7 @@ class RuntimeConfig:
         signature creation of rootfs verification metadata:
 
         credentials:
-          - verification_metadata_signing_key_file: ...
+          verification_metadata_signing_key_file: ...
 
         There is no default value for this setting available
 
@@ -128,7 +128,7 @@ class RuntimeConfig:
         Return URL of buildservice download server in:
 
         obs:
-          - download_url: ...
+          download_url: ...
 
         if no configuration exists the downloadserver from
         the Defaults class is returned
@@ -148,7 +148,7 @@ class RuntimeConfig:
         Return URL of buildservice API server in:
 
         obs:
-          - api_url: ...
+          api_url: ...
 
         if no configuration exists the API server from
         the Defaults class is returned
@@ -163,27 +163,12 @@ class RuntimeConfig:
         return obs_api_server_url if obs_api_server_url else \
             Defaults.get_obs_api_server_url()
 
-    def get_obs_api_credentials(self) -> List[str]:
-        """
-        Return OBS API credentials if configured:
-
-        obs:
-          - user:
-              - user_name: user_credentials
-
-        :return: List of Dicts with credentials per user
-
-        :rtype: list
-        """
-        obs_users = self._get_attribute(element='obs', attribute='user') or []
-        return obs_users
-
     def is_obs_public(self) -> bool:
         """
         Check if the buildservice configuration is public or private in:
 
         obs:
-          - public: true|false
+          public: true|false
 
         if no configuration exists we assume to be public
 
@@ -205,7 +190,7 @@ class RuntimeConfig:
         into the image.
 
         bundle:
-          - has_package_changes: true|false
+          has_package_changes: true|false
 
         By default the creation is switched on.
         When building in the Open Build Service the default is
@@ -234,7 +219,7 @@ class RuntimeConfig:
         contain XZ compressed image results or not.
 
         bundle:
-          - compress: true|false
+          compress: true|false
 
         If compression of image build results is activated the size
         of the bundle is smaller and the download speed increases.
@@ -270,10 +255,10 @@ class RuntimeConfig:
         size of the checksum:
 
         shasum:
-          - size: 256
+          size: 256
 
         bundle:
-          - shasum_size: "256"
+          shasum_size: "256"
 
         Instructs kiwi to use the provided shasum size. Supported
         values are 256 (default) and 512. In case of an unsupported
@@ -321,7 +306,7 @@ class RuntimeConfig:
         Return list of XZ compression options in:
 
         xz:
-          - options: ...
+          options: ...
 
         if no configuration exists None is returned
 
@@ -342,7 +327,7 @@ class RuntimeConfig:
         Return compression for container images
 
         container:
-          - compress: xz|none|true|false
+          compress: xz|none|true|false
 
         if no or invalid configuration data is provided, the default
         compression from the Defaults class is returned
@@ -373,7 +358,7 @@ class RuntimeConfig:
         Return tool category which should be used to build iso images
 
         iso:
-          - tool_category: xorriso
+          tool_category: xorriso
 
         if no or invalid configuration exists the default tool category
         from the Defaults class is returned
@@ -402,7 +387,7 @@ class RuntimeConfig:
         Return media tag tool used to checksum iso images
 
         iso:
-          - media_tag_tool: checkmedia
+          media_tag_tool: checkmedia
 
         if no or invalid configuration exists the default media tagger
         from the Defaults class is returned
@@ -434,7 +419,7 @@ class RuntimeConfig:
         container archives for OCI compliant images, e.g docker
 
         oci:
-          - archive_tool: umoci
+          archive_tool: umoci
 
         if no configuration exists the default tool from the
         Defaults class is returned
@@ -453,7 +438,7 @@ class RuntimeConfig:
         Return partition mapper tool
 
         mapper:
-          - part_mapper: partx
+          part_mapper: partx
 
         if no configuration exists the default tool from the
         Defaults class is returned
@@ -475,7 +460,7 @@ class RuntimeConfig:
         it can be specified with m=MB or g=GB.
 
         build_constraints:
-          - max_size: 700m
+          max_size: 700m
 
         if no configuration exists None is returned
 
@@ -493,7 +478,8 @@ class RuntimeConfig:
         Returns disabled runtime checks. Checks can be disabled with:
 
         runtime_checks:
-            - disable: check_container_tool_chain_installed
+          disable:
+            - check_container_tool_chain_installed
 
         if the provided string does not match any RuntimeChecker method it is
         just ignored.
@@ -508,10 +494,9 @@ class RuntimeConfig:
     def _get_attribute(self, element: str, attribute: str):
         if RUNTIME_CONFIG:
             try:
-                if element in RUNTIME_CONFIG:
-                    for attribute_dict in RUNTIME_CONFIG[element]:
-                        if attribute in attribute_dict:
-                            return attribute_dict[attribute]
+                for key, value in RUNTIME_CONFIG.get(element, {}).items():
+                    if key == attribute:
+                        return value
             except Exception as issue:
                 raise KiwiRuntimeConfigFormatError(
                     f'{type(issue).__name__}: {issue}'

--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -94,14 +94,17 @@ class RuntimeConfig:
                         f'Custom config file {config_file!r} not found'
                     )
                 config_files.append(config_file)
-            # read all config files...
+            # read and merge all config files...
             RUNTIME_CONFIG = {}
             for config_file in config_files:
                 log.info(
                     f'Reading runtime config file: {config_file!r}'
                 )
                 with open(config_file, 'r') as config:
-                    RUNTIME_CONFIG.update(yaml.safe_load(config) or {})
+                    next_config = yaml.safe_load(config) or {}
+                    RUNTIME_CONFIG = RuntimeConfig._merge(
+                        RUNTIME_CONFIG, next_config
+                    )
 
     def get_credentials_verification_metadata_signing_key_file(self) -> str:
         """
@@ -515,3 +518,43 @@ class RuntimeConfig:
                     )
                     config_files.append(config_file_path)
         return config_files
+
+    @staticmethod
+    def _merge(master: Dict, slave: Dict) -> Dict:
+        if slave:
+            if not master or \
+               isinstance(master, str) or \
+               isinstance(master, int) or \
+               isinstance(master, float):
+                # border case for first run or if slave is a
+                # primitive type in the recursive iteration
+                master = slave
+            elif isinstance(master, list):
+                if isinstance(slave, list):
+                    # list on list gets a merged list
+                    master.extend(slave)
+                else:
+                    raise NotImplementedError(
+                        'No strategy for merge non-list into list'
+                    )
+                # no duplicates
+                master = sorted(set(master))
+            elif isinstance(master, dict):
+                # dict on dict gets a merged dict by copy
+                # slave on master recursively
+                if isinstance(slave, dict):
+                    for key in slave:
+                        if key in master:
+                            master[key] = RuntimeConfig._merge(
+                                master[key], slave[key]
+                            )
+                        else:
+                            master[key] = slave[key]
+                else:
+                    raise NotImplementedError(
+                        'No strategy for merge non-dict into dict'
+                    )
+            else:
+                # No merge strategy available
+                pass
+        return master

--- a/test/data/kiwi.yml
+++ b/test/data/kiwi.yml
@@ -1,8 +1,8 @@
 xz:
-  - options: -a -b xxx
+  options: -a -b xxx
 
 shasum:
-  - size: "512"
+  size: "512"
 
 bundle:
-  - shasum_size: "256"
+  shasum_size: "256"

--- a/test/data/kiwi.yml.d/mapper.yml
+++ b/test/data/kiwi.yml.d/mapper.yml
@@ -1,2 +1,2 @@
 mapper:
-  - part_mapper: partx
+  part_mapper: partx

--- a/test/data/kiwi_config/invalid/.config/kiwi/config.yml
+++ b/test/data/kiwi_config/invalid/.config/kiwi/config.yml
@@ -1,6 +1,6 @@
 iso:
-  - tool_category: foo
-  - media_tag_tool: foo
+  tool_category: foo
+  media_tag_tool: foo
 
 container:
-  - compress: foo
+  compress: foo

--- a/test/data/kiwi_config/ok/.config/kiwi/config.yml
+++ b/test/data/kiwi_config/ok/.config/kiwi/config.yml
@@ -1,30 +1,30 @@
 xz:
-  - options: -a -b xxx
+  options: -a -b xxx
 
 bundle:
-  - compress: true
+  compress: true
 
 obs:
-  - download_url: http://example.com
-  - api_url: https://api.example.com
-  - public: true
-  - user:
-      - user_name: user_credentials
+  download_url: http://example.com
+  api_url: https://api.example.com
+  public: true
+  user:
+    user_name: user_credentials
 
 iso:
-  - tool_category: xorriso
-  - media_tag_tool: isomd5sum
+  tool_category: xorriso
+  media_tag_tool: isomd5sum
 
 oci:
-  - archive_tool: umoci
+  archive_tool: umoci
 
 mapper:
-  - part_mapper: partx
+  part_mapper: partx
 
 container:
-  - compress: none
+  compress: none
 
 runtime_checks:
-  - disable:
-      - check_dracut_module_for_oem_install_in_package_list
-      - check_container_tool_chain_installed
+  disable:
+    - check_dracut_module_for_oem_install_in_package_list
+    - check_container_tool_chain_installed

--- a/test/data/kiwi_config/other/.config/kiwi/config.yml
+++ b/test/data/kiwi_config/other/.config/kiwi/config.yml
@@ -1,8 +1,8 @@
 bundle:
-  - has_package_changes: true
+  has_package_changes: true
 
 container:
-  - compress: true
+  compress: true
 
 iso:
-  - media_tag_tool: checkmedia
+  media_tag_tool: checkmedia

--- a/test/data/kiwi_merge_invalid_dict.yml
+++ b/test/data/kiwi_merge_invalid_dict.yml
@@ -1,0 +1,2 @@
+shasum:
+  - size: "512"

--- a/test/data/kiwi_merge_invalid_list.yml
+++ b/test/data/kiwi_merge_invalid_list.yml
@@ -1,0 +1,2 @@
+runtime_checks:
+  disable: check_container_tool_chain_installed

--- a/test/data/kiwi_merge_ok.yml
+++ b/test/data/kiwi_merge_ok.yml
@@ -1,13 +1,14 @@
 xz:
-  options: -a -b xxx
+  options: --foo
 
 shasum:
-  size: "512"
+  size: "256"
 
 bundle:
   shasum_size: "256"
+  compress: false
 
 runtime_checks:
   disable:
     - check_container_tool_chain_installed
-    - check_repositories_configured
+    - check_boot_description_exists

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -1,4 +1,5 @@
 import logging
+import yaml
 from unittest.mock import (
     patch, call
 )
@@ -38,13 +39,50 @@ class TestRuntimeConfig:
             with raises(KiwiRuntimeConfigFileError):
                 RuntimeConfig(reread=True)
 
+    def test_merge_strategy(self):
+        with open('../data/kiwi.yml', 'r') as config:
+            master = yaml.safe_load(config)
+        with open('../data/kiwi_merge_ok.yml', 'r') as config:
+            slave_ok = yaml.safe_load(config)
+        with open('../data/kiwi_merge_invalid_dict.yml', 'r') as config:
+            slave_invalid_dict = yaml.safe_load(config)
+        with open('../data/kiwi_merge_invalid_list.yml', 'r') as config:
+            slave_invalid_list = yaml.safe_load(config)
+        assert RuntimeConfig._merge(master, slave_ok) == {
+            'xz': {
+                'options': '--foo'
+            },
+            'shasum': {
+                'size': '256'
+            },
+            'bundle': {
+                'shasum_size': '256',
+                'compress': False
+            },
+            'runtime_checks': {
+                'disable': [
+                    'check_boot_description_exists',
+                    'check_container_tool_chain_installed',
+                    'check_repositories_configured'
+                ]
+            }
+        }
+        with raises(NotImplementedError):
+            RuntimeConfig._merge(master, slave_invalid_dict)
+        with raises(NotImplementedError):
+            RuntimeConfig._merge(master, slave_invalid_list)
+
     @patch('yaml.safe_load')
     @patch('kiwi.defaults.CUSTOM_RUNTIME_CONFIG_FILE', 'some-custom-file')
     def test_reading_custom_config_file(self, mock_yaml):
         with patch('os.path.isfile', return_value=True):
             with patch('builtins.open') as m_open:
                 RuntimeConfig(reread=True)
-                m_open.assert_called_once_with('some-custom-file', 'r')
+                m_open.assert_has_calls(
+                    [
+                        call('some-custom-file', 'r')
+                    ]
+                )
 
     @patch('os.path.exists')
     @patch('yaml.safe_load')

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -142,7 +142,9 @@ class TestRuntimeConfig:
         assert runtime_config.get_mapper_tool() == 'partx'
 
     @patch('kiwi.runtime_checker.Defaults.is_buildservice_worker')
-    def test_config_sections_from_home_base_config(self, mock_is_buildservice_worker):
+    def test_config_sections_from_home_base_config(
+        self, mock_is_buildservice_worker
+    ):
         mock_is_buildservice_worker.return_value = False
         with patch.dict('os.environ', {'HOME': '../data/kiwi_config/ok'}):
             runtime_config = RuntimeConfig(reread=True)
@@ -163,9 +165,6 @@ class TestRuntimeConfig:
         assert runtime_config.get_disabled_runtime_checks() == [
             'check_dracut_module_for_oem_install_in_package_list',
             'check_container_tool_chain_installed'
-        ]
-        assert runtime_config.get_obs_api_credentials() == [
-            {'user_name': 'user_credentials'}
         ]
 
     @patch('kiwi.runtime_checker.Defaults.is_buildservice_worker')

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -1,4 +1,5 @@
 import logging
+import yaml
 from unittest.mock import (
     patch, call
 )
@@ -38,6 +39,39 @@ class TestRuntimeConfig:
         with patch('os.path.isfile', return_value=False):
             with raises(KiwiRuntimeConfigFileError):
                 RuntimeConfig(reread=True)
+
+    def test_merge_strategy(self):
+        with open('../data/kiwi.yml', 'r') as config:
+            master = yaml.safe_load(config)
+        with open('../data/kiwi_merge_ok.yml', 'r') as config:
+            slave_ok = yaml.safe_load(config)
+        with open('../data/kiwi_merge_invalid_dict.yml', 'r') as config:
+            slave_invalid_dict = yaml.safe_load(config)
+        with open('../data/kiwi_merge_invalid_list.yml', 'r') as config:
+            slave_invalid_list = yaml.safe_load(config)
+        assert RuntimeConfig._merge(master, slave_ok) == {
+            'xz': {
+                'options': '--foo'
+            },
+            'shasum': {
+                'size': '256'
+            },
+            'bundle': {
+                'shasum_size': '256',
+                'compress': False
+            },
+            'runtime_checks': {
+                'disable': [
+                    'check_boot_description_exists',
+                    'check_container_tool_chain_installed',
+                    'check_repositories_configured'
+                ]
+            }
+        }
+        with raises(NotImplementedError):
+            RuntimeConfig._merge(master, slave_invalid_dict)
+        with raises(NotImplementedError):
+            RuntimeConfig._merge(master, slave_invalid_list)
 
     @patch('yaml.safe_load')
     @patch('kiwi.defaults.CUSTOM_RUNTIME_CONFIG_FILE', 'some-custom-file')

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -149,7 +149,9 @@ class TestRuntimeConfig:
         assert runtime_config.get_mapper_tool() == 'partx'
 
     @patch('kiwi.runtime_checker.Defaults.is_buildservice_worker')
-    def test_config_sections_from_home_base_config(self, mock_is_buildservice_worker):
+    def test_config_sections_from_home_base_config(
+        self, mock_is_buildservice_worker
+    ):
         mock_is_buildservice_worker.return_value = False
         with patch.dict('os.environ', {'HOME': '../data/kiwi_config/ok'}):
             runtime_config = RuntimeConfig(reread=True)
@@ -170,9 +172,6 @@ class TestRuntimeConfig:
         assert runtime_config.get_disabled_runtime_checks() == [
             'check_dracut_module_for_oem_install_in_package_list',
             'check_container_tool_chain_installed'
-        ]
-        assert runtime_config.get_obs_api_credentials() == [
-            {'user_name': 'user_credentials'}
         ]
 
     @patch('kiwi.runtime_checker.Defaults.is_buildservice_worker')


### PR DESCRIPTION
This refactor is two fold

**Refactor runtime config layout style**
    
The runtime config file nested key=value settings into lists like this `[{key1=value1}, {key2=value2}]`. This layout style is unnecessary complex and also makes it hard to implement a straight forward merge strategy for standard data types. This commit refactors the layout to the necessary data structure.

**Refactor merge strategy for runtime config files**
    
So far the runtime config dicts after yaml.safe_load were merged together via python's dict.update() method. However, in kiwi the runtime config contains nested dictionaries and lists which always causes an overwrite and does not allow for add-on settings of the same configuration key. This commit adds a recursive merge strategy to make this more flexible. This is related to Issue #3014