### PR TITLE
Add compatibility symlink in live images

### DIFF
--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -562,6 +562,10 @@ class LiveImageBuilder:
         kernel = Kernel(self.boot_image.boot_root_directory)
         if kernel.get_kernel():
             kernel.copy_kernel(boot_path, '/linux')
+            os.symlink(
+                'loader/linux',
+                f'{self.media_dir.name}/boot/{self.arch}/linux'
+            )
         else:
             raise KiwiLiveBootImageError(
                 'No kernel in boot image tree {0} found'.format(
@@ -583,6 +587,10 @@ class LiveImageBuilder:
             os.chmod(self.boot_image.initrd_filename, 0o644)
             shutil.move(
                 self.boot_image.initrd_filename, boot_path + '/initrd'
+            )
+            os.symlink(
+                'loader/initrd',
+                f'{self.media_dir.name}/boot/{self.arch}/initrd'
             )
         else:
             raise KiwiLiveBootImageError(

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -203,10 +203,12 @@ class TestLiveImageBuilder:
     @patch('os.unlink')
     @patch('os.path.exists')
     @patch('os.chmod')
+    @patch('os.symlink')
     @patch('kiwi.builder.live.BlockID')
     def test_create_overlay_structure_boot_verity_baked(
         self,
         mock_BlockID,
+        mock_os_symlink,
         mock_chmod,
         mock_exists,
         mock_unlink,
@@ -293,8 +295,10 @@ class TestLiveImageBuilder:
     @patch('os.path.exists')
     @patch('os.chmod')
     @patch('os.path.getsize')
+    @patch('os.symlink')
     def test_create_overlay_structure_encrypted_embedded_root(
         self,
+        mock_os_symlink,
         mock_os_path_getsize,
         mock_chmod,
         mock_exists,
@@ -362,8 +366,10 @@ class TestLiveImageBuilder:
     @patch('os.path.exists')
     @patch('os.chmod')
     @patch('os.path.getsize')
+    @patch('os.symlink')
     def test_create_overlay_structure_encrypted_direct_root(
         self,
+        mock_os_symlink,
         mock_os_path_getsize,
         mock_chmod,
         mock_exists,
@@ -437,11 +443,26 @@ class TestLiveImageBuilder:
     @patch('os.unlink')
     @patch('os.path.exists')
     @patch('os.chmod')
+    @patch('os.symlink')
     def test_create_overlay_structure_boot_on_grub(
-        self, mock_chmod, mock_exists, mock_unlink, mock_grub_dir, mock_size,
-        mock_filesystem, mock_isofs, mock_Iso, mock_tag, mock_shutil,
-        mock_Temporary, mock_setup_media_loader_directory, mock_DeviceProvider,
-        mock_LoopDevice, mock_create_boot_loader_config, xml_filesystem
+        self,
+        mock_os_symlink,
+        mock_chmod,
+        mock_exists,
+        mock_unlink,
+        mock_grub_dir,
+        mock_size,
+        mock_filesystem,
+        mock_isofs,
+        mock_Iso,
+        mock_tag,
+        mock_shutil,
+        mock_Temporary,
+        mock_setup_media_loader_directory,
+        mock_DeviceProvider,
+        mock_LoopDevice,
+        mock_create_boot_loader_config,
+        xml_filesystem
     ):
         bootloader_config = Mock()
         mock_create_boot_loader_config.return_value.__enter__.return_value = \
@@ -688,9 +709,15 @@ class TestLiveImageBuilder:
     @patch('kiwi.builder.live.Temporary')
     @patch('kiwi.builder.live.shutil')
     @patch('os.unlink')
+    @patch('os.symlink')
     def test_create_no_hypervisor_found(
-        self, mock_unlink, mock_shutil, mock_Temporary,
-        mock_setup_media_loader_directory, mock_create_boot_loader_config
+        self,
+        mock_os_symlink,
+        mock_unlink,
+        mock_shutil,
+        mock_Temporary,
+        mock_setup_media_loader_directory,
+        mock_create_boot_loader_config
     ):
         self.firmware.bios_mode.return_value = False
         mock_Temporary.return_value.new_dir.return_value.name = 'tmpdir'
@@ -704,8 +731,14 @@ class TestLiveImageBuilder:
     @patch('kiwi.builder.live.shutil')
     @patch('os.unlink')
     @patch('os.path.exists')
+    @patch('os.symlink')
     def test_create_no_initrd_found(
-        self, mock_exists, mock_unlink, mock_shutil, mock_Temporary,
+        self,
+        mock_os_symlink,
+        mock_exists,
+        mock_unlink,
+        mock_shutil,
+        mock_Temporary,
         mock_setup_media_loader_directory,
         mock_create_boot_loader_config
     ):


### PR DESCRIPTION
The live image layout places the kernel and initrd files for loading from ISO below the directory structure `boot/ARCH/loader/...` Some PXE infrastructure code also reads from `boot/ARCH/...`. To support this infrastructure code we add a compat symlink such that both locations can be used to lookup the kernel and initrd on the ISO. This Fixes bsc#1240633