### PR TITLE
Allow to build kis image without archiving

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-kis/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-kis/appliance.kiwi
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="7.5" name="kiwi-test-image-kis">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>marcus.schaefer@gmail.com</contact>
+        <specification>KIS test build</specification>
+    </description>
+    <preferences>
+        <version>1.42.1</version>
+        <packagemanager>zypper</packagemanager>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>false</rpm-check-signatures>
+    </preferences>
+    <preferences>
+        <type image="kis" filesystem="ext3" archive="false"/>
+    </preferences>
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
+    </users>
+    <repository type="rpm-md">
+        <source path="obsrepositories:/"/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-openSUSE-base"/>
+        <package name="shadow"/>
+        <package name="systemd"/>
+        <package name="iputils"/>
+        <package name="vim"/>
+        <package name="plymouth"/>
+        <package name="fontconfig"/>
+        <package name="fonts-config"/>
+        <package name="tar"/>
+        <package name="parted"/>
+        <package name="openssh"/>
+        <package name="iproute2"/>
+        <package name="less"/>
+        <package name="bash-completion"/>
+        <package name="dhcp-client"/>
+        <package name="which"/>
+        <package name="kernel-default"/>
+        <package name="timezone"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="gawk"/>
+        <package name="grep"/>
+        <package name="gzip"/>
+        <package name="udev"/>
+        <package name="xz"/>
+        <package name="shadow"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+        <package name="cracklib-dict-full"/>
+        <package name="ca-certificates"/>
+        <package name="ca-certificates-mozilla"/>
+        <package name="openSUSE-release"/>
+    </packages>
+</image>

--- a/doc/source/building_images/build_kis.rst
+++ b/doc/source/building_images/build_kis.rst
@@ -42,6 +42,16 @@ as part of the image description.
 The following attributes of the `type` element are often used when
 building KIS images:
 
+- `archive`: By default the output files of a KIS image will be stored
+  in a tarball archive. If you want to store the output files
+  individually instead, set this attribute to `false`.
+
+- `compressed`: By default the output files of a KIS image will be tar
+  archived and compressed. If you want to store the output files in
+  the archive without compression, set this attribute to `false`.
+  If the `archive` attribute is set to `false`, this attribute has no
+  effect.
+
 - `filesystem`: Specifies the root filesystem and triggers the build
   of an additional filesystem image of that filesystem. The generated
   kernel command-line options file (append file) will then also
@@ -64,7 +74,7 @@ build the image:
 .. code:: bash
 
    $ sudo kiwi-ng --type kis system build \
-       --description kiwi/build-tests/{exc_description_pxe} \
+       --description kiwi/build-tests/{exc_description_kis} \
        --set-repo {exc_repo_tumbleweed} \
        --target-dir /tmp/myimage
 
@@ -78,14 +88,14 @@ tested with QEMU as follows:
        -kernel /tmp/myimage/*.kernel \
        -initrd /tmp/myimage/*.initrd \
        -append "$(cat /tmp/myimage/*.append) rw" \
-       -drive file=/tmp/myimage/{exc_image_base_name_pxe}.*-{exc_image_version},if=virtio,driver=raw \
+       -drive file=/tmp/myimage/{exc_image_base_name_kis}.*.ext3,if=virtio,driver=raw \
        -serial stdio
 
 .. note::
 
    Testing the components of a KIS image normally requires a deployment
-   infrastructure and a deployment process. An example of a deployment
-   infrastructure using PXE is provided by {kiwi} with the `netboot`
-   infrastructure. However, that netboot infrastructure is no longer developed
-   and is only kept for compatibility reasons. For details, see
-   :ref:`build_legacy_pxe`.
+   infrastructure and a deployment process encoded in the initrd. An example
+   of a deployment infrastructure using PXE is provided by {kiwi} with
+   the `netboot` infrastructure. However, that netboot infrastructure is
+   no longer developed and is only kept for compatibility reasons.
+   For details, see :ref:`build_legacy_pxe`.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -86,6 +86,7 @@ def setup(app):
 prolog_replacements = {
     '{exc_image_base_name}': 'kiwi-test-image-some',
     '{exc_image_base_name_pxe}': 'kiwi-test-image-pxe',
+    '{exc_image_base_name_kis}': 'kiwi-test-image-kis',
     '{exc_image_base_name_vagrant}': 'kiwi-test-image-vagrant',
     '{exc_image_base_name_disk}': 'kiwi-test-image-disk',
     '{exc_image_base_name_disk_simple}': 'kiwi-test-image-disk-simple',
@@ -94,6 +95,7 @@ prolog_replacements = {
     '{exc_image_base_name_enclave}': 'kiwi-test-image-nitro-enclave',
     '{exc_netboot}': 'netboot/suse-tumbleweed',
     '{exc_description_pxe}': 'x86/tumbleweed/test-image-pxe',
+    '{exc_description_kis}': 'x86/tumbleweed/test-image-kis',
     '{exc_description_vagrant}': 'x86/leap/test-image-vagrant',
     '{exc_description_disk}': 'x86/leap/test-image-disk',
     '{exc_description_disk_simple}': 'x86/leap/test-image-disk-simple',

--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -517,8 +517,17 @@ bootstrap_package="package_name":
 
 compressed="true|false":
   Specifies whether the image output file should be
-  compressed or not. This option is only used for filesystem-only images or
-  for the `pxe` or `cpio` types.
+  compressed or not. This option is used for filesystem-only images or
+  for the `pxe`, `kis` or `cpio` types. When used with the `pxe` or `kis`
+  types, compression also applies to the tar archive that contains
+  the build results.
+
+archive="true|false":
+  Specifies whether the image output file should be an archive or not.
+  This option is only available for the `kis` type. When set to `true`,
+  all image build results will be placed into an archive file. When set
+  to `false`, the build results will stay as individual files in the
+  build directory. The default is `true`.
 
 editbootconfig="file_path":
   Specifies the path to a script that is called right

--- a/kiwi/builder/kis.py
+++ b/kiwi/builder/kis.py
@@ -61,6 +61,8 @@ class KisBuilder:
         self.filesystem = FileSystemBuilder(
             xml_state, target_dir, root_dir + '/'
         ) if xml_state.build_type.get_filesystem() else None
+        self.archive = xml_state.build_type.get_archive() \
+            if xml_state.build_type.get_archive() is not None else True
         self.system_setup = SystemSetup(
             xml_state=xml_state, root_dir=root_dir
         )
@@ -230,37 +232,66 @@ class KisBuilder:
            and self.initrd_system == 'dracut':
             kis_tarball_files.append(os.path.basename(self.append_file))
 
-        kis_tarball = ArchiveTar(
-            self.archive_name,
-            create_from_file_list=True,
-            file_list=kis_tarball_files
-        )
-
-        if self.compressed:
-            self.archive_name = kis_tarball.create(self.target_dir)
-        else:
-            self.archive_name = kis_tarball.create_xz_compressed(
-                self.target_dir, xz_options=self.xz_options
+        if self.archive:
+            # Put all result files into a tar archive and add this
+            # one file to the result instance
+            kis_tarball = ArchiveTar(
+                self.archive_name,
+                create_from_file_list=True,
+                file_list=kis_tarball_files
             )
 
-        Result.verify_image_size(
-            self.runtime_config.get_max_size_constraint(),
-            self.archive_name
-        )
+            if self.compressed:
+                self.archive_name = kis_tarball.create(self.target_dir)
+            else:
+                self.archive_name = kis_tarball.create_xz_compressed(
+                    self.target_dir, xz_options=self.xz_options
+                )
+
+            Result.verify_image_size(
+                self.runtime_config.get_max_size_constraint(),
+                self.archive_name
+            )
+
+            # store archive file name in result
+            self.result.add(
+                key='kis_archive',
+                filename=self.archive_name,
+                use_for_bundle=True,
+                compress=self.runtime_config.get_bundle_compression(
+                    default=False
+                ),
+                shasum=True
+            )
+        else:
+            # Treat all result files individually and add them to the
+            # result instance. An eventually configured max size constraint
+            # applies to the rootfs image only
+            if self.image:
+                Result.verify_image_size(
+                    self.runtime_config.get_max_size_constraint(),
+                    self.image
+                )
+            for result_file in kis_tarball_files:
+                compress_file = False
+                filename = f'{self.target_dir}/{result_file}'
+                keyname = f'kis_{result_file.split(".").pop()}'
+                if self.image and filename == self.image:
+                    keyname = 'kis_rootfs'
+                    compress_file = self.runtime_config.get_bundle_compression(
+                        default=False
+                    )
+                self.result.add(
+                    key=keyname,
+                    filename=filename,
+                    use_for_bundle=True,
+                    compress=compress_file,
+                    shasum=False
+                )
+
         # store image bundle_format in result
         if self.bundle_format:
             self.result.add_bundle_format(self.bundle_format)
-
-        # # store archive file name in result
-        self.result.add(
-            key='kis_archive',
-            filename=self.archive_name,
-            use_for_bundle=True,
-            compress=self.runtime_config.get_bundle_compression(
-                default=False
-            ),
-            shasum=True
-        )
 
         # create image root metadata
         self.result.add(

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2379,6 +2379,14 @@ div {
             sch:param [ name = "attr" value = "ensure_empty_tmpdirs" ]
             sch:param [ name = "types" value = "docker oci" ]
         ]
+    k.type.archive.attribute =
+        ## Specifies to archive the image result files into a tarball.
+        ## The option is only available for the kis image type
+        attribute archive { xsd:boolean }
+        >> sch:pattern [ id = "archive" is-a = "image_type"
+            sch:param [ name = "attr" value = "archive" ]
+            sch:param [ name = "types" value = "kis" ]
+        ]
     k.type.publisher.attribute =
         ## Specifies the publisher name of the ISO.
         attribute publisher { ecma-119-achar-128-text }
@@ -2463,6 +2471,7 @@ div {
         ]
     k.type.attlist =
         ## Specifies the image type
+        k.type.archive.attribute? &
         k.type.eficsmpart_id.attribute? &
         k.type.efipart_id.attribute? &
         k.type.rootpart_id.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -3414,6 +3414,17 @@ container image created by Kiwi.  Default is true.</a:documentation>
         <sch:param name="types" value="docker oci"/>
       </sch:pattern>
     </define>
+    <define name="k.type.archive.attribute">
+      <attribute name="archive">
+        <a:documentation>Specifies to archive the image result files into a tarball.
+The option is only available for the kis image type</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="archive" is-a="image_type">
+        <sch:param name="attr" value="archive"/>
+        <sch:param name="types" value="kis"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.publisher.attribute">
       <attribute name="publisher">
         <a:documentation>Specifies the publisher name of the ISO.</a:documentation>
@@ -3527,9 +3538,12 @@ partition if present</a:documentation>
     <define name="k.type.attlist">
       <interleave>
         <optional>
-          <ref name="k.type.eficsmpart_id.attribute">
+          <ref name="k.type.archive.attribute">
             <a:documentation>Specifies the image type</a:documentation>
           </ref>
+        </optional>
+        <optional>
+          <ref name="k.type.eficsmpart_id.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.efipart_id.attribute"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3567,8 +3567,9 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, eficsmpart_id=None, efipart_id=None, rootpart_id=None, bootpart_id=None, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, eficsm=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapper_snapshot=None, btrfs_root_is_subvolume=None, btrfs_set_default_volume=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, enclave_format=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, erofscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_filesystem=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vhdfixedtag=None, volid=None, application_id=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, provide_system_files=None, require_system_files=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, initrd=None, luksformat=None):
+    def __init__(self, archive=None, eficsmpart_id=None, efipart_id=None, rootpart_id=None, bootpart_id=None, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, eficsm=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapper_snapshot=None, btrfs_root_is_subvolume=None, btrfs_set_default_volume=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, enclave_format=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, erofscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_filesystem=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vhdfixedtag=None, volid=None, application_id=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, provide_system_files=None, require_system_files=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, initrd=None, luksformat=None):
         self.original_tagname_ = None
+        self.archive = _cast(bool, archive)
         self.eficsmpart_id = _cast(None, eficsmpart_id)
         self.efipart_id = _cast(None, efipart_id)
         self.rootpart_id = _cast(None, rootpart_id)
@@ -3772,6 +3773,8 @@ class type_(GeneratedsSuper):
     def add_luksformat(self, value): self.luksformat.append(value)
     def insert_luksformat_at(self, index, value): self.luksformat.insert(index, value)
     def replace_luksformat_at(self, index, value): self.luksformat[index] = value
+    def get_archive(self): return self.archive
+    def set_archive(self, archive): self.archive = archive
     def get_eficsmpart_id(self): return self.eficsmpart_id
     def set_eficsmpart_id(self, eficsmpart_id): self.eficsmpart_id = eficsmpart_id
     def get_efipart_id(self): return self.efipart_id
@@ -4046,6 +4049,9 @@ class type_(GeneratedsSuper):
         else:
             outfile.write('/>%s' % (eol_, ))
     def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='type'):
+        if self.archive is not None and 'archive' not in already_processed:
+            already_processed.add('archive')
+            outfile.write(' archive="%s"' % self.gds_format_boolean(self.archive, input_name='archive'))
         if self.eficsmpart_id is not None and 'eficsmpart_id' not in already_processed:
             already_processed.add('eficsmpart_id')
             outfile.write(' eficsmpart_id=%s' % (quote_attrib(self.eficsmpart_id), ))
@@ -4360,6 +4366,15 @@ class type_(GeneratedsSuper):
             self.buildChildren(child, node, nodeName_)
         return self
     def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('archive', node)
+        if value is not None and 'archive' not in already_processed:
+            already_processed.add('archive')
+            if value in ('true', '1'):
+                self.archive = True
+            elif value in ('false', '0'):
+                self.archive = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('eficsmpart_id', node)
         if value is not None and 'eficsmpart_id' not in already_processed:
             already_processed.add('eficsmpart_id')

--- a/test/unit/builder/kis_test.py
+++ b/test/unit/builder/kis_test.py
@@ -86,7 +86,7 @@ class TestKisBuilder:
             self.xml_state, 'target_dir', 'root_dir',
             custom_args={'signing_keys': ['key_file_a', 'key_file_b']}
         )
-        self.kis.image_name = 'myimage'
+        self.kis.image_name = 'target_dir/myimage'
         self.kis.compressed = True
 
     @patch('kiwi.builder.kis.FileSystemBuilder')
@@ -113,20 +113,15 @@ class TestKisBuilder:
         with self._caplog.at_level(logging.WARNING):
             KisBuilder(self.xml_state, 'target_dir', 'root_dir')
 
-    @patch('kiwi.builder.kis.Compress')
-    @patch('kiwi.builder.kis.ArchiveTar')
     @patch('os.rename')
-    def test_create(
-        self, mock_rename, mock_tar, mock_compress
+    def test_create_no_archive(
+        self, mock_rename
     ):
-        tar = Mock()
-        mock_tar.return_value = tar
-        compress = Mock()
-        mock_compress.return_value = compress
-        compress.xz.return_value = 'compressed-file-name'
         self.boot_image_task.required = Mock(
             return_value=True
         )
+        self.kis.archive = False
+        self.kis.compressed = False
 
         m_open = mock_open()
         with patch('builtins.open', m_open, create=True):
@@ -141,14 +136,67 @@ class TestKisBuilder:
 
         self.filesystem.create.assert_called_once_with()
         mock_rename.assert_called_once_with(
-            'myimage.fs', 'myimage'
+            'myimage.fs', 'target_dir/myimage'
+        )
+        assert self.runtime_config.get_checksum_handler.call_args_list == [
+            call('target_dir/myimage'),
+            call(
+                source_filename='target_dir/myimage',
+                target_filename='target_dir/myimage.sha256'
+            ),
+            call('target_dir/myimage-42.kernel')
+        ]
+        self.shasum.digest.assert_called_once_with()
+        self.boot_image_task.prepare.assert_called_once_with()
+        self.setup.export_modprobe_setup.assert_called_once_with(
+            'initrd_dir'
+        )
+        self.boot_image_task.create_initrd.assert_called_once_with()
+        self.setup.export_package_list.assert_called_once_with(
+            'target_dir'
+        )
+        self.setup.export_package_verification.assert_called_once_with(
+            'target_dir'
+        )
+
+    @patch('kiwi.builder.kis.Compress')
+    @patch('kiwi.builder.kis.ArchiveTar')
+    @patch('os.rename')
+    def test_create(
+        self, mock_rename, mock_tar, mock_compress
+    ):
+        tar = Mock()
+        mock_tar.return_value = tar
+        compress = Mock()
+        mock_compress.return_value = compress
+        compress.xz.return_value = 'compressed-file-name'
+        self.boot_image_task.required = Mock(
+            return_value=True
+        )
+        self.kis.archive = True
+        self.kis.compressed = True
+
+        m_open = mock_open()
+        with patch('builtins.open', m_open, create=True):
+            self.kis.create()
+
+        m_open.assert_called_once_with(
+            'target_dir/some-image.x86_64-1.2.3.append', 'w'
+        )
+        m_open.return_value.write.assert_called_once_with(
+            'root=UUID=some_uuid console=hvc0'
+        )
+
+        self.filesystem.create.assert_called_once_with()
+        mock_rename.assert_called_once_with(
+            'myimage.fs', 'target_dir/myimage'
         )
         compress.xz.assert_called_once_with(None)
         assert self.runtime_config.get_checksum_handler.call_args_list == [
             call('compressed-file-name'),
             call(
                 source_filename='compressed-file-name',
-                target_filename='myimage.sha256'
+                target_filename='target_dir/myimage.sha256'
             ),
             call('target_dir/myimage-42.kernel')
         ]


### PR DESCRIPTION
By default the files (kernel, initrd, system) plus the metadata information (shasum, append) are all placed into a tar archive and served as one entity. In some cases this archived bundle is unwanted and users want to just handle the files individually. To allow this a new type attribute named: archive="true|false" is introduced which is evaluated for the kis type only at the moment. If set to false no tar archive is produced and the kiwi bundler handles all result files individually. In addition the documentation around the topic has been improved/corrected. This Fixes #3016