### PR TITLE
Refactor credentials handling from the cmdline

### DIFF
--- a/kiwi/tasks/image_info.py
+++ b/kiwi/tasks/image_info.py
@@ -255,9 +255,8 @@ class ImageInfoTask(CliTask):
             parameters[signing_keys_index] = []
         if credentials:
             if os.path.isfile(credentials):
-                credentials_data = open(credentials).readline().strip(os.linesep)
-                os.unlink(credentials)
-                credentials = credentials_data
+                with open(credentials) as credentials_fd:
+                    credentials = credentials_fd.readline().strip(os.linesep)
             repo_source = parameters[repo_source_index]
             repo_scheme = urlparse(repo_source).scheme
             if repo_scheme:

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -430,9 +430,8 @@ class SystemBuildTask(CliTask):
             parameters[signing_keys_index] = []
         if credentials:
             if os.path.isfile(credentials):
-                credentials_data = open(credentials).readline().strip(os.linesep)
-                os.unlink(credentials)
-                credentials = credentials_data
+                with open(credentials) as credentials_fd:
+                    credentials = credentials_fd.readline().strip(os.linesep)
             repo_source = parameters[repo_source_index]
             repo_scheme = urlparse(repo_source).scheme
             if repo_scheme:

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -375,9 +375,8 @@ class SystemPrepareTask(CliTask):
             parameters[signing_keys_index] = []
         if credentials:
             if os.path.isfile(credentials):
-                credentials_data = open(credentials).readline().strip(os.linesep)
-                os.unlink(credentials)
-                credentials = credentials_data
+                with open(credentials) as credentials_fd:
+                    credentials = credentials_fd.readline().strip(os.linesep)
             repo_source = parameters[repo_source_index]
             repo_scheme = urlparse(repo_source).scheme
             if repo_scheme:

--- a/test/unit/tasks/image_info_test.py
+++ b/test/unit/tasks/image_info_test.py
@@ -241,9 +241,8 @@ class TestImageInfoTask:
     @patch('kiwi.xml_state.XMLState.add_repository')
     @patch('kiwi.tasks.image_info.DataOutput')
     @patch('os.path.isfile')
-    @patch('os.unlink')
     def test_process_image_info_add_repo(
-        self, mock_os_unlink, mock_os_path_is_file, mock_out, mock_add_repo
+        self, mock_os_path_is_file, mock_out, mock_add_repo
     ):
         self._init_command_args()
         mock_os_path_is_file.return_value = False

--- a/test/unit/tasks/system_build_test.py
+++ b/test/unit/tasks/system_build_test.py
@@ -337,11 +337,13 @@ class TestSystemBuildTask:
     @patch('kiwi.xml_state.XMLState.set_repository')
     @patch('kiwi.logger.Logger.set_logfile')
     @patch('os.path.isfile')
-    @patch('os.unlink')
     @patch('kiwi.tasks.system_build.SystemPrepare')
     def test_process_system_build_prepare_stage_set_repo(
-        self, mock_SystemPrepare, mock_os_unlink, mock_os_path_is_file,
-        mock_log, mock_set_repo
+        self,
+        mock_SystemPrepare,
+        mock_os_path_is_file,
+        mock_log,
+        mock_set_repo
     ):
         mock_os_path_is_file.return_value = False
         self._init_command_args()
@@ -366,7 +368,6 @@ class TestSystemBuildTask:
             'http://user:pass@example.com', 'yast2', 'alias',
             None, None, None, [], None, None, None, None
         )
-        mock_os_unlink.assert_called_once_with('../data/credentials')
 
     @patch('kiwi.xml_state.XMLState.add_repository')
     @patch('kiwi.logger.Logger.set_logfile')

--- a/test/unit/tasks/system_prepare_test.py
+++ b/test/unit/tasks/system_prepare_test.py
@@ -307,11 +307,12 @@ class TestSystemPrepareTask:
 
     @patch('kiwi.xml_state.XMLState.set_repository')
     @patch('os.path.isfile')
-    @patch('os.unlink')
     @patch('kiwi.tasks.system_prepare.SystemPrepare')
     def test_process_system_prepare_set_repo(
-        self, mock_SystemPrepare, mock_os_unlink,
-        mock_os_path_is_file, mock_set_repo
+        self,
+        mock_SystemPrepare,
+        mock_os_path_is_file,
+        mock_set_repo
     ):
         mock_os_path_is_file.return_value = False
         self._init_command_args()
@@ -342,7 +343,6 @@ class TestSystemPrepareTask:
             'prio', 'imageinclude', 'package_gpgcheck', ['file:///key.asc'],
             'components', 'dist', 'repo_gpgcheck', 'repo_sourcetype'
         )
-        mock_os_unlink.assert_called_once_with('../data/credentials')
 
     @patch('kiwi.xml_state.XMLState.add_repository')
     @patch('kiwi.tasks.system_prepare.SystemPrepare')


### PR DESCRIPTION
When passing a repo definition on the cmdline it is possible to provide the credentials information as file name reference. Doing so deleted that file after reading which is unexpected and should not be done. This Fixes #2992