### PR TITLE
fixed return value for get video_mode

### DIFF
--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1247,8 +1247,8 @@ class XMLState:
         :rtype: str
         """
         bootloader = self.get_build_type_bootloader_section()
-        if bootloader:
-            return bootloader.get_video_mode()
+        if bootloader and (video_mode := bootloader.get_video_mode()):
+            return video_mode
         return 'auto'
 
     def get_build_type_bootloader_timeout(self) -> Optional[str]:

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1274,6 +1274,9 @@ class TestXMLState:
         mock_bootloader.return_value = [self.bootloader]
         assert self.state.get_build_type_bootloader_video_mode() == \
             '800x600'
+        self.bootloader.get_video_mode.return_value = None
+        assert self.state.get_build_type_bootloader_video_mode() == \
+            'auto'
         mock_bootloader.return_value = [None]
         assert self.state.get_build_type_bootloader_video_mode() == \
             'auto'


### PR DESCRIPTION
The method get_build_type_bootloader_video_mode() is expected to return "auto" if no video mode is available. However a bug in that method caused it to return a None value which should not happen. This commit fixes the condition checking. This Fixes #3023 and Fixes bsc#1271164