### PR TITLE
Fix OVA compose to respect machine section configuration

### DIFF
--- a/kiwi/storage/subformat/ova.py
+++ b/kiwi/storage/subformat/ova.py
@@ -123,7 +123,10 @@ class DiskFormatOva(DiskFormatBase):
 
     def _create_ova_compose_meta_file(self) -> None:
         """
-        Create the ova-compose meta file used to create the final ova file
+        Create the ova-compose meta file used to create the final ova file.
+
+        This method mirrors the logic from DiskFormatVmdk._create_vmware_settings_file()
+        to ensure consistent hardware configuration between VMX and Meta files.
         """
         displayname = self.xml_state.xml_data.get_displayname()
         efi_mode = self.firmware.efi_mode()
@@ -132,19 +135,26 @@ class DiskFormatOva(DiskFormatBase):
                 displayname or self.xml_state.xml_data.get_name(),
             'vmdk_file':
                 os.path.basename(self.get_target_file_path_for_format('vmdk')),
-            'guest_os': 'other4xLinux64Guest',
+            'virtual_hardware_version': '9',
+            'guest_os': 'suse-64',
+            'disk_id': '0',
             'memory_size': 4096,
             'number_of_cpus': 2,
             'firmware': 'efi' if efi_mode else 'bios',
             'secure_boot': 'true' if efi_mode == 'uefi' else 'false'
         }
 
-        # Basic setup
+        # Basic setup - extract memory, guest OS, and CPU configuration
         machine_setup = self.xml_state.get_build_type_machine_section()
+        memory_setup = None
+        cpu_setup = None
         if machine_setup:
             memory_setup = machine_setup.get_memory()
+            hardware_version = machine_setup.get_HWversion()
             guest_os = machine_setup.get_guestOS()
             cpu_setup = machine_setup.get_ncpus()
+            if hardware_version:
+                template_record['virtual_hardware_version'] = hardware_version
             if guest_os:
                 template_record['guest_os'] = guest_os
             if memory_setup:
@@ -152,9 +162,43 @@ class DiskFormatOva(DiskFormatBase):
             if cpu_setup:
                 template_record['number_of_cpus'] = cpu_setup
 
+        # CD/DVD setup
+        iso_setup = self.xml_state.get_build_type_vmdvd_section()
+        iso_controller = 'ide'
+        iso_id = '0'
+        if iso_setup:
+            iso_controller = iso_setup.get_controller() or iso_controller
+            iso_id = iso_setup.get_id() or iso_id
+
+        # Disk setup
+        disk_controller = None
+        disk_id = '0'
+        disk_setup = self.xml_state.get_build_type_vmdisk_section()
+        if disk_setup:
+            disk_controller = disk_setup.get_controller()
+            disk_id = disk_setup.get_id() or disk_id
+
+        # Network setup
+        network_entries = self.xml_state.get_build_type_vmnic_entries()
+        network_setup = {}
+        if network_entries:
+            for network_entry in network_entries:
+                network_setup[network_entry.get_interface() or '0'] = {
+                    'driver': network_entry.get_driver(),
+                    'connection_type': network_entry.get_mode(),
+                    'mac': network_entry.get_mac() or 'generated'
+                }
+
         # Build settings template and write settings file
         settings_template = OvaComposeTemplate().get_template(
-            bool(machine_setup)
+            memory_setup,
+            cpu_setup,
+            network_setup,
+            bool(iso_setup),
+            disk_controller=disk_controller,
+            iso_controller=iso_controller,
+            disk_id=disk_id,
+            iso_id=iso_id
         )
         try:
             settings_file = self.get_target_file_path_for_format('meta')

--- a/kiwi/storage/subformat/template/ova_compose.py
+++ b/kiwi/storage/subformat/template/ova_compose.py
@@ -29,61 +29,183 @@ class OvaComposeTemplate:
         self.header = dedent('''
             system:
                 name: "${display_name}"
-                type: vmx-20
+                type: vmx-${virtual_hardware_version}
                 os_vmw: "${guest_os}"
                 firmware: "${firmware}"
                 secure_boot: ${secure_boot}
-        ''').strip() + self.cr
-
-        self.hardware = dedent('''
-            hardware:
-                cpus: ${number_of_cpus}
-                memory: ${memory_size}
-                sata1:
-                    type: sata_controller
-                scsi1:
-                    type: scsi_controller
-                nvme1:
-                    type: nvme_controller
-                cdrom1:
-                    type: cd_drive
-                    parent: sata1
-                rootdisk:
-                    type: hard_disk
-                    parent: nvme1
-                    disk_image: "${vmdk_file}"
-                usb2:
-                    type: usb_controller
-                usb3:
-                    type: usb3_controller
-                ethernet1:
-                    type: ethernet
-                    subtype: VmxNet3
-                    network: vm_network
-                videocard1:
-                    type: video_card
-                vmci1:
-                    type: vmci
         ''').strip() + self.cr
 
         self.network = dedent('''
             networks:
                 vm_network:
                     name: "VM Network"
-                    description: "The VM Network network"
+                    description: "The VM Network"
         ''').strip() + self.cr
 
-    def get_template(self, hardware_setup: bool = False):
+    def _get_controller(self, controller: str | None, device_id: str) -> tuple[str, str, str]:
+        controller_map = {
+            'ide': ('ide', 'ide_controller'),
+            'sata': ('sata', 'sata_controller'),
+            'scsi': ('scsi', 'scsi_controller'),
+            'lsilogic': ('scsi', 'scsi_controller'),
+            'lsisas1068': ('scsi', 'scsi_controller'),
+            'paravirtual': ('scsi', 'scsi_controller'),
+            'nvme': ('nvme', 'nvme_controller')
+        }
+        normalized_controller = (controller or 'nvme').lower()
+        controller_name, controller_type = controller_map.get(
+            normalized_controller, ('nvme', 'nvme_controller')
+        )
+        return f'{controller_name}{device_id}', controller_type, normalized_controller
+
+    def _add_controller(
+            self, hardware_lines: list, controllers_added: set,
+            controller_name: str, controller_type: str,
+            controller_subtype: str | None = None) -> None:
+        if controller_name in controllers_added:
+            return
+        hardware_lines.append(f'    {controller_name}:')
+        hardware_lines.append(f'        type: {controller_type}')
+        if controller_subtype:
+            hardware_lines.append(f'        subtype: {controller_subtype}')
+        controllers_added.add(controller_name)
+
+    def _get_network_setup(self, network_setup: dict = None) -> tuple[list, list]:
+        hardware_lines = []
+        network_lines = [
+            'networks:'
+        ]
+
+        if network_setup:
+            for nic_id, nic_setup in list(network_setup.items()):
+                network_name = f'vm_network_{nic_id}'
+                nic_name = f'ethernet{nic_id}'
+                nic_driver = nic_setup.get('driver') or 'VmxNet3'
+
+                hardware_lines.extend([
+                    f'    {nic_name}:',
+                    '        type: ethernet',
+                    f'        subtype: {nic_driver}',
+                    f'        network: {network_name}'
+                ])
+
+                if nic_setup.get('mac') and nic_setup['mac'] != 'generated':
+                    hardware_lines.append(
+                        f'        mac_address: "{nic_setup["mac"]}"'
+                    )
+
+                if nic_setup.get('connection_type'):
+                    hardware_lines.append(
+                        f'        connection_type: "{nic_setup["connection_type"]}"'
+                    )
+
+                network_lines.extend([
+                    f'    {network_name}:',
+                    f'        name: "VM Network {nic_id}"',
+                    f'        description: "The VM Network {nic_id} network"'
+                ])
+        else:
+            hardware_lines.extend([
+                '    ethernet0:',
+                '        type: ethernet',
+                '        subtype: VmxNet3',
+                '        network: vm_network_0'
+            ])
+            network_lines.extend([
+                '    vm_network_0:',
+                '        name: "VM Network"',
+                '        description: "The VM Network network"'
+            ])
+
+        return hardware_lines, network_lines
+
+    def _get_hardware_template(
+            self, memory_setup: bool = False, cpu_setup: bool = False,
+            network_setup: dict = None, iso_setup: bool = False,
+            disk_controller: str = None, iso_controller: str = 'ide',
+            disk_id: str = '0', iso_id: str = '0') -> str:
+        """
+        Generate hardware template with VMware feature parity.
+
+        :rtype: str
+        """
+        hardware_lines = [
+            'hardware:'
+        ]
+        if cpu_setup:
+            hardware_lines.append('    cpus: ${number_of_cpus}')
+        if memory_setup:
+            hardware_lines.append('    memory: ${memory_size}')
+
+        controllers_added: set[str] = set()
+
+        disk_parent, disk_controller_type, disk_controller_subtype = self._get_controller(
+            disk_controller, str(disk_id)
+        )
+        self._add_controller(
+            hardware_lines, controllers_added,
+            disk_parent, disk_controller_type, disk_controller_subtype
+        )
+
+        if iso_setup:
+            iso_parent, iso_controller_type, iso_controller_subtype = self._get_controller(
+                iso_controller, str(iso_id)
+            )
+            self._add_controller(
+                hardware_lines, controllers_added,
+                iso_parent, iso_controller_type, iso_controller_subtype
+            )
+            hardware_lines.extend([
+                f'    cdrom{iso_id}:',
+                '        type: cd_drive',
+                f'        parent: {iso_parent}'
+            ])
+
+        hardware_lines.extend([
+            '    rootdisk:',
+            '        type: hard_disk',
+            f'        parent: {disk_parent}',
+            '        disk_image: "${vmdk_file}"',
+            '    usb2:',
+            '        type: usb_controller',
+            '    usb3:',
+            '        type: usb3_controller'
+        ])
+
+        nic_hardware, network_lines = self._get_network_setup(network_setup)
+        hardware_lines.extend(nic_hardware)
+
+        return '\n'.join(hardware_lines) + self.cr + '\n'.join(network_lines) + self.cr
+
+    def get_template(
+            self, memory_setup=False, cpu_setup=False, network_setup=False,
+            iso_setup=False, disk_controller='ide', iso_controller='ide',
+            disk_id='0', iso_id='0') -> Template:
         """
         Set data for the ova-compose template
 
-        :param hardware_setup: if True, include hardware section
+        :param bool memory_setup: with main memory setup true|false
+        :param bool cpu_setup: with number of CPU's setup true|false
+        :param dict network_setup: with network emulation setup
+        :param bool iso_setup: with CD/DVD drive emulation true|false
+        :param string disk_controller: add disk controller setup to template
+        :param string iso_controller: add CD/DVD controller setup to template
+        :param string disk_id: disk controller id
+        :param string iso_id: cdrom controller id
 
         :rtype: Template
         """
         template_data = self.header
-        template_data += self.network
-        if hardware_setup:
-            template_data += self.hardware
+        hardware = self._get_hardware_template(
+            memory_setup=memory_setup,
+            cpu_setup=cpu_setup,
+            network_setup=network_setup,
+            iso_setup=iso_setup,
+            disk_controller=disk_controller,
+            iso_controller=iso_controller,
+            disk_id=disk_id,
+            iso_id=iso_id
+        )
+        template_data += hardware
 
         return Template(template_data)

--- a/test/unit/storage/subformat/ova_test.py
+++ b/test/unit/storage/subformat/ova_test.py
@@ -194,3 +194,89 @@ class TestDiskFormatOva:
         mock_Path_which.return_value = None
         with raises(KiwiCommandNotFound):
             self.disk_format.create_image_format()
+
+    @patch('kiwi.storage.subformat.ova.OvaComposeTemplate.get_template')
+    def test_create_ova_compose_meta_file_with_disk_controller(self, mock_get_template):
+        """Test that disk controller and disk id are passed to OvaComposeTemplate"""
+        self.disk_setup.get_controller.return_value = 'lsilogic'
+        self.disk_setup.get_id.return_value = '7'
+        template = Mock()
+        mock_get_template.return_value = template
+        template.substitute.return_value = 'meta_content'
+
+        with patch('builtins.open', create=True):
+            self.disk_format._create_ova_compose_meta_file()
+            # Verify OvaComposeTemplate.get_template was called with disk setup
+            mock_get_template.assert_called_once()
+            call_args = mock_get_template.call_args
+            assert call_args[1]['disk_controller'] == 'lsilogic'
+            assert call_args[1]['disk_id'] == '7'
+
+    @patch('kiwi.storage.subformat.ova.OvaComposeTemplate.get_template')
+    def test_create_ova_compose_meta_file_with_nic_driver(self, mock_get_template):
+        """Test that NIC settings are passed to OvaComposeTemplate"""
+        self.network_setup[0].get_driver.return_value = 'e1000'
+        self.network_setup[0].get_interface.return_value = '2'
+        self.network_setup[0].get_mode.return_value = 'bridged'
+        self.network_setup[0].get_mac.return_value = '00:11:22:33:44:55'
+        template = Mock()
+        mock_get_template.return_value = template
+        template.substitute.return_value = 'meta_content'
+
+        with patch('builtins.open', create=True):
+            self.disk_format._create_ova_compose_meta_file()
+            # Verify OvaComposeTemplate.get_template was called with network setup
+            mock_get_template.assert_called_once()
+            call_args = mock_get_template.call_args
+            assert call_args[0][2] == {
+                '2': {
+                    'driver': 'e1000',
+                    'connection_type': 'bridged',
+                    'mac': '00:11:22:33:44:55'
+                }
+            }
+
+    @patch('kiwi.storage.subformat.ova.OvaComposeTemplate.get_template')
+    def test_create_ova_compose_meta_file_with_no_controllers(self, mock_get_template):
+        """Test that defaults are used when no optional setup is configured"""
+        self.disk_setup.get_controller.return_value = None
+        self.disk_setup.get_id.return_value = None
+        self.iso_setup.get_controller.return_value = None
+        self.iso_setup.get_id.return_value = None
+        self.network_setup = []
+        self.xml_state.get_build_type_vmnic_entries.return_value = self.network_setup
+        template = Mock()
+        mock_get_template.return_value = template
+        template.substitute.return_value = 'meta_content'
+
+        with patch('builtins.open', create=True):
+            self.disk_format._create_ova_compose_meta_file()
+            # Verify OvaComposeTemplate.get_template was called with defaults
+            mock_get_template.assert_called_once()
+            call_args = mock_get_template.call_args
+            assert call_args[1]['disk_controller'] is None
+            assert call_args[1]['disk_id'] == '0'
+            assert call_args[1]['iso_controller'] == 'ide'
+            assert call_args[1]['iso_id'] == '0'
+            assert call_args[0][2] == {}
+
+    @patch('kiwi.storage.subformat.ova.OvaComposeTemplate.get_template')
+    def test_create_ova_compose_meta_file_memory_cpu_extraction(self, mock_get_template):
+        """Test that memory and CPU configuration are correctly extracted"""
+        self.machine_setup.get_memory.return_value = '8192'
+        self.machine_setup.get_ncpus.return_value = '4'
+        self.machine_setup.get_guestOS.return_value = 'ubuntu64Guest'
+        template = Mock()
+        mock_get_template.return_value = template
+        template.substitute.return_value = 'meta_content'
+
+        with patch('builtins.open', create=True) as mock_open:
+            self.disk_format._create_ova_compose_meta_file()
+            # Verify template.substitute was called with correct values
+            template.substitute.assert_called_once()
+            call_args = template.substitute.call_args[0][0]
+            assert call_args['memory_size'] == '8192'
+            assert call_args['number_of_cpus'] == '4'
+            assert call_args['guest_os'] == 'ubuntu64Guest'
+            # Verify meta file was opened for writing
+            mock_open.assert_called_once()

--- a/test/unit/storage/subformat/template/ova_compose_test.py
+++ b/test/unit/storage/subformat/template/ova_compose_test.py
@@ -1,0 +1,254 @@
+from kiwi.storage.subformat.template.ova_compose import OvaComposeTemplate
+
+
+class TestOvaComposeTemplate:
+    """Test OvaComposeTemplate hardware configuration"""
+
+    def test_get_template_with_default_hardware(self):
+        """Test template generation with default hardware (ide + VmxNet3)"""
+        template = OvaComposeTemplate().get_template()
+        rendered = template.substitute({
+            'display_name': 'test-vm',
+            'guest_os': 'other4xLinux64Guest',
+            'firmware': 'bios',
+            'secure_boot': 'false',
+            'number_of_cpus': 2,
+            'memory_size': 4096,
+            'vmdk_file': 'test.vmdk',
+            'virtual_hardware_version': '9'
+        })
+
+        # Verify default hardware configuration (ide controller)
+        assert 'parent: ide0' in rendered
+        assert 'subtype: VmxNet3' in rendered
+        assert 'rootdisk:' in rendered
+        assert 'ethernet0:' in rendered
+
+    def test_get_template_with_lsilogic_controller(self):
+        """Test template generation with SCSI lsilogic controller"""
+        template = OvaComposeTemplate().get_template(
+            disk_controller='lsilogic'
+        )
+        rendered = template.substitute({
+            'display_name': 'test-vm',
+            'guest_os': 'other4xLinux64Guest',
+            'firmware': 'bios',
+            'secure_boot': 'false',
+            'number_of_cpus': 2,
+            'memory_size': 4096,
+            'vmdk_file': 'test.vmdk',
+            'virtual_hardware_version': '9'
+        })
+
+        # Verify lsilogic mapping to scsi0
+        assert 'parent: scsi0' in rendered
+
+    def test_get_template_with_sata_controller(self):
+        """Test template generation with SATA controller"""
+        template = OvaComposeTemplate().get_template(
+            disk_controller='sata'
+        )
+        rendered = template.substitute({
+            'display_name': 'test-vm',
+            'guest_os': 'other4xLinux64Guest',
+            'firmware': 'bios',
+            'secure_boot': 'false',
+            'number_of_cpus': 2,
+            'memory_size': 4096,
+            'vmdk_file': 'test.vmdk',
+            'virtual_hardware_version': '9'
+        })
+
+        # Verify sata mapping
+        assert 'parent: sata0' in rendered
+
+    def test_get_template_with_nvme_controller(self):
+        """Test template generation with NVMe controller"""
+        template = OvaComposeTemplate().get_template(
+            disk_controller='nvme'
+        )
+        rendered = template.substitute({
+            'display_name': 'test-vm',
+            'guest_os': 'other4xLinux64Guest',
+            'firmware': 'bios',
+            'secure_boot': 'false',
+            'number_of_cpus': 2,
+            'memory_size': 4096,
+            'vmdk_file': 'test.vmdk',
+            'virtual_hardware_version': '9'
+        })
+
+        # Verify nvme mapping
+        assert 'parent: nvme0' in rendered
+
+    def test_get_template_with_e1000_nic_driver(self):
+        """Test template generation with e1000 network driver"""
+        template = OvaComposeTemplate().get_template(
+            network_setup={
+                '0': {'driver': 'e1000', 'connection_type': 'bridged', 'mac': 'generated'}
+            }
+        )
+        rendered = template.substitute({
+            'display_name': 'test-vm',
+            'guest_os': 'other4xLinux64Guest',
+            'firmware': 'bios',
+            'secure_boot': 'false',
+            'number_of_cpus': 2,
+            'memory_size': 4096,
+            'vmdk_file': 'test.vmdk',
+            'virtual_hardware_version': '9'
+        })
+
+        # Verify e1000 driver
+        assert 'subtype: e1000' in rendered
+
+    def test_get_template_with_multiple_configurations(self):
+        """Test template generation with both custom disk and nic config"""
+        template = OvaComposeTemplate().get_template(
+            disk_controller='lsilogic',
+            memory_setup=True,
+            cpu_setup=True,
+            network_setup={
+                '0': {'driver': 'e1000', 'connection_type': 'bridged', 'mac': 'generated'}
+            }
+        )
+        rendered = template.substitute({
+            'display_name': 'test-vm',
+            'guest_os': 'suse-64',
+            'firmware': 'efi',
+            'secure_boot': 'true',
+            'number_of_cpus': 4,
+            'memory_size': 8192,
+            'vmdk_file': 'test.vmdk',
+            'virtual_hardware_version': '9'
+        })
+
+        # Verify both configurations are applied
+        assert 'parent: scsi0' in rendered
+        assert 'subtype: e1000' in rendered
+        assert 'cpus: 4' in rendered
+        assert 'memory: 8192' in rendered
+        assert 'os_vmw: "suse-64"' in rendered
+
+    def test_get_template_controller_mapping(self):
+        """Test all supported disk controller mappings"""
+        controller_mappings = {
+            'ide': 'ide0',
+            'sata': 'sata0',
+            'scsi': 'scsi0',
+            'lsilogic': 'scsi0',
+            'lsisas1068': 'scsi0',
+            'nvme': 'nvme0',
+            'paravirtual': 'scsi0'
+        }
+
+        for controller, expected_parent in controller_mappings.items():
+            template = OvaComposeTemplate().get_template(
+                disk_controller=controller
+            )
+            rendered = template.substitute({
+                'display_name': 'test-vm',
+                'guest_os': 'other4xLinux64Guest',
+                'firmware': 'bios',
+                'secure_boot': 'false',
+                'number_of_cpus': 2,
+                'memory_size': 4096,
+                'vmdk_file': 'test.vmdk',
+                'virtual_hardware_version': '9'
+            })
+            assert f'parent: {expected_parent}' in rendered, \
+                f"Controller '{controller}' should map to '{expected_parent}'"
+
+    def test_get_template_controller_subtype_mapping(self):
+        """Test all supported disk controller subtype mappings"""
+        controller_subtypes = {
+            'ide': 'ide',
+            'sata': 'sata',
+            'scsi': 'scsi',
+            'lsilogic': 'lsilogic',
+            'lsisas1068': 'lsisas1068',
+            'nvme': 'nvme',
+            'paravirtual': 'paravirtual'
+        }
+
+        for controller, expected_subtype in controller_subtypes.items():
+            template = OvaComposeTemplate().get_template(
+                disk_controller=controller
+            )
+            rendered = template.substitute({
+                'display_name': 'test-vm',
+                'guest_os': 'other4xLinux64Guest',
+                'firmware': 'bios',
+                'secure_boot': 'false',
+                'number_of_cpus': 2,
+                'memory_size': 4096,
+                'vmdk_file': 'test.vmdk',
+                'virtual_hardware_version': '9'
+            })
+            assert f'subtype: {expected_subtype}' in rendered, \
+                f"Controller '{controller}' should set subtype '{expected_subtype}'"
+
+    def test_get_template_unknown_controller_defaults_to_nvme(self):
+        """Test that unknown disk controllers default to nvme0"""
+        template = OvaComposeTemplate().get_template(
+            disk_controller='unknown_controller'
+        )
+        rendered = template.substitute({
+            'display_name': 'test-vm',
+            'guest_os': 'other4xLinux64Guest',
+            'firmware': 'bios',
+            'secure_boot': 'false',
+            'number_of_cpus': 2,
+            'memory_size': 4096,
+            'vmdk_file': 'test.vmdk',
+            'virtual_hardware_version': '9'
+        })
+
+        # Verify unknown controller defaults to nvme0
+        assert 'parent: nvme0' in rendered
+        assert 'type: nvme_controller' in rendered
+        assert 'subtype: unknown_controller' in rendered
+
+    def test_get_template_with_iso_controller_subtype(self):
+        """Test that ISO controller subtype is rendered"""
+        template = OvaComposeTemplate().get_template(
+            iso_setup=True,
+            iso_controller='lsilogic'
+        )
+        rendered = template.substitute({
+            'display_name': 'test-vm',
+            'guest_os': 'other4xLinux64Guest',
+            'firmware': 'bios',
+            'secure_boot': 'false',
+            'number_of_cpus': 2,
+            'memory_size': 4096,
+            'vmdk_file': 'test.vmdk',
+            'virtual_hardware_version': '9'
+        })
+
+        assert 'cdrom0:' in rendered
+        assert 'parent: scsi0' in rendered
+        assert 'subtype: lsilogic' in rendered
+
+    def test_get_template_with_duplicate_controllers(self):
+        """Test that duplicate controllers are deduplicated"""
+        # Both disk and ISO use IDE controller - should only appear once
+        template = OvaComposeTemplate().get_template(
+            disk_controller='ide',
+            iso_setup=True,
+            iso_controller='ide'
+        )
+        rendered = template.substitute({
+            'display_name': 'test-vm',
+            'guest_os': 'other4xLinux64Guest',
+            'firmware': 'bios',
+            'secure_boot': 'false',
+            'number_of_cpus': 2,
+            'memory_size': 4096,
+            'vmdk_file': 'test.vmdk',
+            'virtual_hardware_version': '9'
+        })
+
+        # Count ide0 controller definitions - should appear only once
+        ide_count = rendered.count('ide0:')
+        assert ide_count == 1, f"IDE0 controller should appear exactly once, but appears {ide_count} times"


### PR DESCRIPTION
- Refactor OvaComposeTemplate for feature parity with VmwareSettingsTemplate
- Extract disk controller, network driver from machine section
- Support multiple NICs with per-interface configuration
- Add virtual hardware version (vmx-${version}) support

Fixes: #3025
Co-authored-by: copilot