### PR TITLE
Fix setup of partition IDs

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-lvm/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-lvm/appliance.kiwi
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-
+<!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 <image schemaversion="7.5" name="kiwi-test-image-lvm">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
         <specification>Disk test build using LVM</specification>
     </description>
+    <profiles>
+        <profile name="DOS" description="MBR(DOS) disk"/>
+        <profile name="GPT" description="GPT disk"/>
+    </profiles>
     <preferences>
         <version>1.42.1</version>
         <packagemanager>zypper</packagemanager>
@@ -16,7 +20,21 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>breeze</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
+    </preferences>
+    <preferences profiles="GPT">
         <type image="oem" filesystem="ext3" kernelcmdline="console=ttyS0" firmware="uefi" format="vmdk">
+            <oemconfig>
+                <oem-swap>true</oem-swap>
+                <oem-swapsize>512</oem-swapsize>
+            </oemconfig>
+            <bootloader name="grub2" console="serial" timeout="10"/>
+            <systemdisk>
+                <volume name="home" size="2G"/>
+            </systemdisk>
+        </type>
+    </preferences>
+    <preferences profiles="DOS">
+        <type image="oem" filesystem="ext3" kernelcmdline="console=ttyS0" firmware="bios" format="vmdk">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>512</oem-swapsize>
@@ -43,7 +61,6 @@
         <package name="iputils"/>
         <package name="vim"/>
         <package name="grub2"/>
-        <package name="grub2-x86_64-efi" arch="x86_64"/>
         <package name="grub2-i386-pc"/>
         <package name="lvm2"/>
         <package name="plymouth"/>
@@ -61,6 +78,9 @@
         <package name="shim"/>
         <package name="timezone"/>
         <package name="dracut-kiwi-oem-repart"/>
+    </packages>
+    <packages type="image" profiles="GPT">
+        <package name="grub2-x86_64-efi" arch="x86_64"/>
     </packages>
     <packages type="bootstrap">
         <package name="gawk"/>

--- a/kiwi/partitioner/dasd.py
+++ b/kiwi/partitioner/dasd.py
@@ -96,6 +96,17 @@ class PartitionerDasd(PartitionerBase):
         """
         pass  # pragma: nocover
 
+    def set_flag(self, partition_id: int, flag_name: str):
+        """
+        Set partition flag
+
+        Nothing to be done here for DASD devices
+
+        :param int partition_id: unused
+        :param string flag_name: unused
+        """
+        pass  # pragma: nocover
+
     def resize_table(self, entries: int = None) -> None:
         """
         Resize partition table

--- a/kiwi/partitioner/msdos.py
+++ b/kiwi/partitioner/msdos.py
@@ -99,6 +99,7 @@ class PartitionerMsDos(PartitionerBase):
         :param int partition_id: partition number
         :param string flag_name: name from flag map
         """
+        partition_id = partition_id if partition_id else self.partition_id
         if flag_name not in self.flag_map:
             raise KiwiPartitionerMsDosFlagError(
                 f'Unknown partition flag {flag_name}'

--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -177,6 +177,9 @@ class Disk(DeviceProvider):
                 self.partitioner.set_uuid(
                     self.partition_id_map[map_name], part_uuid
                 )
+                self.partitioner.set_flag(
+                    entry.partition_id, entry.partition_type
+                )
 
     def create_root_partition(
         self, mbsize: str, clone: int = 0, partition_id: Optional[int] = None
@@ -250,6 +253,7 @@ class Disk(DeviceProvider):
             self.partitioner.set_uuid(
                 self.partition_id_map['root'], root_uuid
             )
+            self.partitioner.set_flag(partition_id, 't.lvm')
 
     def create_root_raid_partition(
         self, mbsize: str, clone: int = 0, partition_id: Optional[int] = None
@@ -287,6 +291,7 @@ class Disk(DeviceProvider):
             self.partitioner.set_uuid(
                 self.partition_id_map['root'], root_uuid
             )
+            self.partitioner.set_flag(partition_id, 't.raid')
 
     def create_root_readonly_partition(
         self, mbsize: str, clone: int = 0, partition_id: Optional[int] = None
@@ -432,6 +437,7 @@ class Disk(DeviceProvider):
             self.partitioner.set_uuid(
                 self.partition_id_map['swap'], swap_uuid
             )
+            self.partitioner.set_flag(partition_id, 't.swap')
 
     def create_efi_csm_partition(
         self, mbsize: str, partition_id: Optional[int] = None
@@ -483,6 +489,7 @@ class Disk(DeviceProvider):
             self.partitioner.set_uuid(
                 self.partition_id_map['efi'], esp_uuid
             )
+            self.partitioner.set_flag(partition_id, 't.efi')
 
     def activate_boot_partition(self):
         """


### PR DESCRIPTION
When setting the partition type code (gUID, UUID) the partition id hex code gets resetted to Linux(83) when it should stay at the value it had before. This causes for example on LVM type(8e) partitions a reset to Linux(83) which is unwanted. With this commit we make sure the partition type hex code gets reset to the correct value. This Fixes #3036