### PR TITLE
Fix system mount list for chroot operations

### DIFF
--- a/kiwi/system/root_bind.py
+++ b/kiwi/system/root_bind.py
@@ -71,7 +71,8 @@ class RootBind:
             '/proc',
             '/dev',
             '/var/run/dbus',
-            '/sys'
+            '/sys',
+            '/sys/fs/cgroup'
         ]
         # share the following directory with the host
         self.shared_location = '/' + Defaults.get_shared_cache_location()

--- a/test/unit/system/root_bind_test.py
+++ b/test/unit/system/root_bind_test.py
@@ -33,7 +33,8 @@ class TestRootBind:
             '/proc',
             '/dev',
             '/var/run/dbus',
-            '/sys'
+            '/sys',
+            '/sys/fs/cgroup'
         ]
 
         # stub config files and bind locations


### PR DESCRIPTION
Add /sys/fs/cgroup to the bind mount list as it is not transported into the chroot when bind mounting only /sys. This fixes problems for applications that runs as part of image scripts or package scripts and required access to the cgroups interface.