### PR TITLE
Erofs overlay patches

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -993,6 +993,15 @@ overlayroot_readonly_filesystem="squashfs|erofs":
   as a read-only filesystem in an `overlayroot` setup. By default,
   `squashfs` is used.
 
+overlayroot_readonly_createoptions="string":
+  For the `oem` type only, specifies additional creation options
+  passed to the tool that builds the read-only filesystem of an
+  `overlayroot` setup (`mkfs.erofs` or `mksquashfs`). The value is a
+  whitespace separated list of options, analogous to `fscreateoptions`
+  for the read-write root filesystem. A typical use is to select a
+  larger EROFS physical cluster for a better compression ratio, for
+  example `overlayroot_readonly_createoptions="-C 1048576"`.
+
 overlayroot_write_partition="true|false":
   For the `oem` type only, this allows you to specify if the extra read-write
   partition in an `overlayroot` setup should be created or not.

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -283,6 +283,22 @@ class DiskBuilder:
         self.append_unpartitioned_space()
         return self.create_disk_format(result)
 
+    def _get_root_readonly_compression(self):
+        """
+        Compression setting for the overlay read-only root filesystem
+
+        The read-only root filesystem type of an overlayroot image is
+        selectable via the overlayroot_readonly_filesystem attribute
+        (squashfs or erofs). Return the compression value that matches
+        that type, so that both squashfscompression and erofscompression
+        are honored. Before this, the overlay code path always read
+        squashfscompression, which silently ignored erofscompression for
+        an erofs overlay root.
+        """
+        if self.root_filesystem_read_only_type == 'erofs':
+            return self.xml_state.build_type.get_erofscompression()
+        return self.xml_state.build_type.get_squashfscompression()
+
     def create_disk(self) -> Result:
         """
         Build a bootable raw disk image
@@ -1235,7 +1251,7 @@ class DiskBuilder:
                     device_provider=DeviceProvider(), root_dir=self.root_dir,
                     custom_args={
                         'compression':
-                            self.xml_state.build_type.get_squashfscompression()
+                            self._get_root_readonly_compression()
                     }
                 ) as squashed_root:
                     squashed_root.create_on_file(
@@ -1751,7 +1767,7 @@ class DiskBuilder:
                 device_provider=DeviceProvider(), root_dir=self.root_dir,
                 custom_args={
                     'compression':
-                        self.xml_state.build_type.get_squashfscompression()
+                        self._get_root_readonly_compression()
                 }
             ) as squashed_root:
                 exclude_list = self._get_exclude_list_for_root_data_sync(

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -138,6 +138,8 @@ class DiskBuilder:
             if xml_state.build_type.get_root_clone() else 0
         self.custom_root_mount_args = xml_state.get_fs_mount_option_list()
         self.custom_root_creation_args = xml_state.get_fs_create_option_list()
+        self.custom_root_readonly_creation_args = \
+            xml_state.get_fs_readonly_create_option_list()
         self.build_type_name = xml_state.get_build_type_name()
         self.image_format = xml_state.build_type.get_format()
         self.install_iso = xml_state.build_type.get_installiso()
@@ -1251,7 +1253,9 @@ class DiskBuilder:
                     device_provider=DeviceProvider(), root_dir=self.root_dir,
                     custom_args={
                         'compression':
-                            self._get_root_readonly_compression()
+                            self._get_root_readonly_compression(),
+                        'create_options':
+                            self.custom_root_readonly_creation_args
                     }
                 ) as squashed_root:
                     squashed_root.create_on_file(
@@ -1767,7 +1771,9 @@ class DiskBuilder:
                 device_provider=DeviceProvider(), root_dir=self.root_dir,
                 custom_args={
                     'compression':
-                        self._get_root_readonly_compression()
+                        self._get_root_readonly_compression(),
+                    'create_options':
+                        self.custom_root_readonly_creation_args
                 }
             ) as squashed_root:
                 exclude_list = self._get_exclude_list_for_root_data_sync(

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2086,6 +2086,11 @@ div {
     k.type.fscreateoptions.attribute =
         ## Specifies options to create the filesystem
         attribute fscreateoptions { text }
+    k.type.overlayroot_readonly_createoptions.attribute =
+        ## Specifies extra creation options passed to the tool that builds
+        ## the overlay read-only root filesystem (e.g. mkfs.erofs -C for a
+        ## larger pcluster). Whitespace separated.
+        attribute overlayroot_readonly_createoptions { text }
     k.type.hybridpersistent.attribute =
         ## Will trigger the creation of a partition for a COW file
         ## to keep data persistent over a reboot
@@ -2532,6 +2537,7 @@ div {
         k.type.overlayroot_write_partition.attribute? &
         k.type.overlayroot_readonly_filesystem.attribute? &
         k.type.overlayroot_readonly_partsize.attribute? &
+        k.type.overlayroot_readonly_createoptions.attribute? &
         k.type.verity_blocks.attribute? &
         k.type.embed_verity_metadata.attribute? &
         k.type.standalone_integrity.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -3005,6 +3005,13 @@ The string given here is passed as value to the -o option of mount</a:documentat
         <a:documentation>Specifies options to create the filesystem</a:documentation>
       </attribute>
     </define>
+    <define name="k.type.overlayroot_readonly_createoptions.attribute">
+      <attribute name="overlayroot_readonly_createoptions">
+        <a:documentation>Specifies extra creation options passed to the tool that builds
+the overlay read-only root filesystem (e.g. mkfs.erofs -C for a
+larger pcluster). Whitespace separated.</a:documentation>
+      </attribute>
+    </define>
     <define name="k.type.hybridpersistent.attribute">
       <attribute name="hybridpersistent">
         <a:documentation>Will trigger the creation of a partition for a COW file
@@ -3719,6 +3726,9 @@ partition if present</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.overlayroot_readonly_partsize.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.overlayroot_readonly_createoptions.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.verity_blocks.attribute"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -3567,7 +3567,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, archive=None, eficsmpart_id=None, efipart_id=None, rootpart_id=None, bootpart_id=None, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, eficsm=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapper_snapshot=None, btrfs_root_is_subvolume=None, btrfs_set_default_volume=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, enclave_format=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, erofscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_filesystem=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vhdfixedtag=None, volid=None, application_id=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, provide_system_files=None, require_system_files=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, initrd=None, luksformat=None):
+    def __init__(self, archive=None, eficsmpart_id=None, efipart_id=None, rootpart_id=None, bootpart_id=None, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efifatimagesize=None, eficsm=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapper_snapshot=None, btrfs_root_is_subvolume=None, btrfs_set_default_volume=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, enclave_format=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, erofscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, luks_randomize=None, luks_pbkdf=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_filesystem=None, overlayroot_readonly_partsize=None, overlayroot_readonly_createoptions=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_legacy_hmac=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vhdfixedtag=None, volid=None, application_id=None, wwid_wait_timeout=None, derived_from=None, delta_root=None, provide_system_files=None, require_system_files=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, initrd=None, luksformat=None):
         self.original_tagname_ = None
         self.archive = _cast(bool, archive)
         self.eficsmpart_id = _cast(None, eficsmpart_id)
@@ -3630,6 +3630,7 @@ class type_(GeneratedsSuper):
         self.overlayroot_write_partition = _cast(bool, overlayroot_write_partition)
         self.overlayroot_readonly_filesystem = _cast(None, overlayroot_readonly_filesystem)
         self.overlayroot_readonly_partsize = _cast(int, overlayroot_readonly_partsize)
+        self.overlayroot_readonly_createoptions = _cast(None, overlayroot_readonly_createoptions)
         self.verity_blocks = _cast(None, verity_blocks)
         self.embed_verity_metadata = _cast(bool, embed_verity_metadata)
         self.standalone_integrity = _cast(bool, standalone_integrity)
@@ -3893,6 +3894,8 @@ class type_(GeneratedsSuper):
     def set_overlayroot_write_partition(self, overlayroot_write_partition): self.overlayroot_write_partition = overlayroot_write_partition
     def get_overlayroot_readonly_filesystem(self): return self.overlayroot_readonly_filesystem
     def set_overlayroot_readonly_filesystem(self, overlayroot_readonly_filesystem): self.overlayroot_readonly_filesystem = overlayroot_readonly_filesystem
+    def get_overlayroot_readonly_createoptions(self): return self.overlayroot_readonly_createoptions
+    def set_overlayroot_readonly_createoptions(self, overlayroot_readonly_createoptions): self.overlayroot_readonly_createoptions = overlayroot_readonly_createoptions
     def get_overlayroot_readonly_partsize(self): return self.overlayroot_readonly_partsize
     def set_overlayroot_readonly_partsize(self, overlayroot_readonly_partsize): self.overlayroot_readonly_partsize = overlayroot_readonly_partsize
     def get_verity_blocks(self): return self.verity_blocks
@@ -4229,6 +4232,9 @@ class type_(GeneratedsSuper):
         if self.overlayroot_readonly_filesystem is not None and 'overlayroot_readonly_filesystem' not in already_processed:
             already_processed.add('overlayroot_readonly_filesystem')
             outfile.write(' overlayroot_readonly_filesystem=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.overlayroot_readonly_filesystem), input_name='overlayroot_readonly_filesystem')), ))
+        if self.overlayroot_readonly_createoptions is not None and 'overlayroot_readonly_createoptions' not in already_processed:
+            already_processed.add('overlayroot_readonly_createoptions')
+            outfile.write(' overlayroot_readonly_createoptions=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.overlayroot_readonly_createoptions), input_name='overlayroot_readonly_createoptions')), ))
         if self.overlayroot_readonly_partsize is not None and 'overlayroot_readonly_partsize' not in already_processed:
             already_processed.add('overlayroot_readonly_partsize')
             outfile.write(' overlayroot_readonly_partsize="%s"' % self.gds_format_integer(self.overlayroot_readonly_partsize, input_name='overlayroot_readonly_partsize'))
@@ -4757,6 +4763,10 @@ class type_(GeneratedsSuper):
             already_processed.add('overlayroot_readonly_filesystem')
             self.overlayroot_readonly_filesystem = value
             self.overlayroot_readonly_filesystem = ' '.join(self.overlayroot_readonly_filesystem.split())
+        value = find_attr_value_('overlayroot_readonly_createoptions', node)
+        if value is not None and 'overlayroot_readonly_createoptions' not in already_processed:
+            already_processed.add('overlayroot_readonly_createoptions')
+            self.overlayroot_readonly_createoptions = value
         value = find_attr_value_('overlayroot_readonly_partsize', node)
         if value is not None and 'overlayroot_readonly_partsize' not in already_processed:
             already_processed.add('overlayroot_readonly_partsize')

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -2915,6 +2915,28 @@ class XMLState:
 
         return option_list
 
+    def get_fs_readonly_create_option_list(self) -> List:
+        """
+        List of overlay read-only root filesystem creation options
+
+        The list contains elements with the information from the
+        overlayroot_readonly_createoptions attribute string that got
+        split into its substring components. These options are passed to
+        the tool that builds the overlay read-only root filesystem
+        (e.g. mkfs.erofs / mksquashfs), for example a larger pcluster
+        via the erofs -C option.
+
+        :return: list with create options
+
+        :rtype: list
+        """
+        option_list = []
+        create_options = self.build_type.get_overlayroot_readonly_createoptions()
+        if create_options:
+            option_list = create_options.split()
+
+        return option_list
+
     def get_luks_credentials(self) -> Optional[str]:
         """
         Return key or passphrase credentials to open the luks pool

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -1192,7 +1192,7 @@ class TestDiskBuilder:
             [
                 call(
                     'squashfs',
-                    custom_args={'compression': None},
+                    custom_args={'compression': None, 'create_options': []},
                     device_provider=mock_DeviceProvider.return_value,
                     root_dir='root_dir'
                 )

--- a/test/unit/builder/disk_test.py
+++ b/test/unit/builder/disk_test.py
@@ -1952,3 +1952,18 @@ class TestDiskBuilder:
         disk.storage_provider = provider
         disk.partitioner = partitioner
         return disk
+
+    def test_get_root_readonly_compression_erofs(self):
+        self.disk_builder.root_filesystem_read_only_type = 'erofs'
+        self.disk_builder.xml_state.build_type.get_erofscompression = Mock(
+            return_value='lz4hc,level=12'
+        )
+        assert self.disk_builder._get_root_readonly_compression() == \
+            'lz4hc,level=12'
+
+    def test_get_root_readonly_compression_squashfs(self):
+        self.disk_builder.root_filesystem_read_only_type = 'squashfs'
+        self.disk_builder.xml_state.build_type.get_squashfscompression = Mock(
+            return_value='gzip'
+        )
+        assert self.disk_builder._get_root_readonly_compression() == 'gzip'

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1001,6 +1001,12 @@ class TestXMLState:
     def test_get_fs_create_option_list(self):
         assert self.state.get_fs_create_option_list() == ['-O', '^has_journal']
 
+    @patch('kiwi.xml_parse.type_.get_overlayroot_readonly_createoptions')
+    def test_get_fs_readonly_create_option_list(self, mock_createopts):
+        mock_createopts.return_value = '-C 1048576'
+        assert self.state.get_fs_readonly_create_option_list() == \
+            ['-C', '1048576']
+
     @patch('kiwi.xml_parse.type_.get_boot')
     def test_get_distribution_name_from_boot_attribute_no_boot(self, mock_boot):
         mock_boot.return_value = None


### PR DESCRIPTION
# disk: honor erofscompression and allow create options for the overlay read-only root fs

Issue#3038
Issue#3039

## What
Two commits fixing/extending compression handling for the `overlayroot`
read-only filesystem:

1. **disk: honor erofscompression for overlay read-only root filesystem**
   The overlay read-only fs can be `squashfs` or `erofs`
   (`overlayroot_readonly_filesystem`), but both overlay code paths in
   `DiskBuilder` hard-coded `get_squashfscompression()`, so
   `erofscompression` was ignored and an erofs overlay base was written
   uncompressed. Routes the read-only compression through a small helper
   (`_get_root_readonly_compression`) that returns `get_erofscompression()`
   for an erofs read-only type and `get_squashfscompression()` otherwise.
   Complements #2648 (which fixed only the standalone erofs builder).

2. **disk: allow extra create options for the overlay read-only root fs**
   Adds a new free-form `overlayroot_readonly_createoptions` attribute
   (whitespace-split, analogous to `fscreateoptions`) passed as
   `create_options` to both overlay read-only `FileSystem` builds. This
   lets a description request e.g.
   `overlayroot_readonly_createoptions="-C 1048576"` for a larger EROFS
   pcluster. Updates schema (rnc + rng), the generated `xml_parse.py`,
   `XMLState.get_fs_readonly_create_option_list()`, `disk.py`, docs and
   tests.

## Why
Building an AL2023 `overlayroot` EROFS image, `erofscompression` had no
effect (uncompressed ~1.4 GB base). With these two changes the recipe can
use `erofscompression="lz4hc,level=12"` +
`overlayroot_readonly_createoptions="-C 1048576"` directly.

## Testing
- `make check` — flake8 clean (shell unchanged)
- `make test` — `mypy kiwi` clean; full unit suite passes at **100%
  coverage** (new code covered; existing overlay test updated)
- `make docs` — sphinx html builds, new attribute documented
- schema regeneration verified: `trang` reproduces `kiwi.rng`
  byte-for-byte from the edited `kiwi.rnc`; the generated `xml_parse.py`
  additions match the generateDS output pattern

Assisted-by: Kiro:claude-opus-4.8