### PR TITLE
Support nbd backend for remote live boot

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
@@ -107,6 +107,9 @@
         <package name="kernel-default"/>
         <package name="kernel-firmware-all"/>
         <package name="timezone"/>
+        <package name="nbd"/>
+        <package name="nbdkit"/>
+        <package name="nbdkit-curl-plugin"/>
         <package name="dracut-kiwi-live"/>
     </packages>
     <packages type="bootstrap">

--- a/doc/source/working_with_images/network_live_iso_boot.rst
+++ b/doc/source/working_with_images/network_live_iso_boot.rst
@@ -78,7 +78,15 @@ the network:
 
    * The boot parameter `root=live:PROTOCOL://IP/PATH...` specifies the
      remote endpoint and protocol to find the live ISO file. So far,
-     `ftp`, `http`, `https`, and `dolly` are supported.
+     `ftp`, `http`, `https`, and `dolly` are supported. In these modes
+     the ISO file is copied into the RAM space of the system.
+
+   * The boot parameter `root=live:nbd:PROTOCOL://IP/PATH...` can be
+     used to remote bind the specified remote file to a local NBD block
+     device. The kiwi-live dracut module is using the nbdkit-curl-plugin
+     to serve the ISO file and opens an nbd-client connection to a local
+     block storage device (/dev/nbd0). In this mode the ISO file is not
+     copied as a whole into the RAM space of the system.
 
 4. Boot from the Network
 

--- a/dracut/modules.d/55kiwi-live/kiwi-live-lib.sh
+++ b/dracut/modules.d/55kiwi-live/kiwi-live-lib.sh
@@ -63,6 +63,14 @@ function ProvideIso {
                 echo "/dev/disk/by-label/CDROM"
             fi
         ;;
+        nbd:*) \
+            {
+                modprobe nbd
+                nbdkit -r curl "$(echo "${iso_url}" | cut -f2- -d:)"
+                nbd-client -N live 127.0.0.1 /dev/nbd0
+            } &>/dev/null
+            echo "/dev/nbd0"
+        ;;
         *) \
             echo "${root}"
         ;;

--- a/dracut/modules.d/55kiwi-live/module-setup.sh
+++ b/dracut/modules.d/55kiwi-live/module-setup.sh
@@ -30,7 +30,9 @@ install() {
         umount dmsetup partx blkid lsblk dd losetup \
         grep cut find wc fdisk tail mkfs.ext4 mkfs.xfs \
         dialog cat mountpoint curl dolly dd cryptsetup veritysetup \
-        flock udevadm sed
+        flock udevadm sed nbdkit nbd-client
+    inst_simple "/usr/lib64/nbdkit/plugins/nbdkit-curl-plugin.so" \
+        "/usr/lib64/nbdkit/plugins/nbdkit-curl-plugin.so"
 
     dmsquashdir=$(find "${dracutbasedir}/modules.d" -name "*dmsquash-live")
     if [ -n "${dmsquashdir}" ] && \

--- a/dracut/modules.d/55kiwi-live/parse-kiwi-live.sh
+++ b/dracut/modules.d/55kiwi-live/parse-kiwi-live.sh
@@ -26,7 +26,7 @@ case "${liveroot}" in
         root="${root//\//\\x2f}"
         root="live:aoe:/dev/etherd/${root#AOEINTERFACE=}"
         rootok=1 ;;
-    live:ftp:*|live:http:*|live:https:*|live:dolly:*) \
+    live:ftp:*|live:http:*|live:https:*|live:nbd:*|live:dolly:*) \
         modprobe -q brd
         root="${root#live:}"
         root="live:net:${root}"

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -613,6 +613,9 @@ Requires:       dialog
 Requires:       xfsprogs
 Requires:       e2fsprogs
 Requires:       util-linux
+Requires:       nbd
+Requires:       nbdkit
+Requires:       nbdkit-curl-plugin
 # lsblk is part of util-linux-systemd on openSUSE
 %if 0%{?suse_version}
 Requires:       util-linux-systemd


### PR DESCRIPTION
In addition to the existing remote live boot options also support the root=live:nbd:PROTOCOL://IP/PATH access method. The nbdkit-curl-plugin is used to serve the ISO file and opens an nbd-client connection to a local block storage device. This mode requires a server enpoind with range support.