### PR TITLE
Use typer shell completion

### DIFF
--- a/completions/bash-completion
+++ b/completions/bash-completion
@@ -1,105 +1,12 @@
-# shellcheck shell=bash
+# NOTE: this file was generated from kiwi-ng --show-completion
 
-#========================================
-# _kiwi
-#----------------------------------------
-function _kiwi_is_flag_option {
-    case "$1" in
-        --allow-existing-root|--clear-cache|--color-output|--debug|\
-        --debug-run-scripts-in-screen|--help|--ignore-repos|\
-        --ignore-repos-used-for-build|--list-profiles|--no-compress|\
-        --package-as-rpm|--print-kiwi-env|--print-toml|--print-xml|\
-        --print-yaml|--resolve-package-list|--version)
-            return 0
-            ;;
-    esac
-    return 1
-}
-
-function setupCompletionLine {
-    local comp_line
-    local result_comp_line
-    local prev_was_option=0
-    comp_line=${COMP_LINE//kiwi-ng/kiwi}
-    for item in $comp_line; do
-        if [ "$prev_was_option" = 1 ]; then
-            prev_was_option=0
-            continue
-        fi
-        if [[ $item =~ -.* ]]; then
-            if ! _kiwi_is_flag_option "$item"; then
-                prev_was_option=1
-            fi
-            continue
-        fi
-        result_comp_line="$result_comp_line $item"
-    done
-    echo "$result_comp_line"
-}
-
-function _kiwi {
-    local cur prev cmd
-    _get_comp_words_by_ref cur prev
-    cmd=$(setupCompletionLine | awk -F ' ' '{ print $NF }')
-    for comp in $prev $cmd; do
-        case "$comp" in
-            "image")
-                __comp_reply "info resize"
-                return 0
-                ;;
-            "result")
-                __comp_reply "bundle list"
-                return 0
-                ;;
-            "system")
-                __comp_reply "build create prepare update"
-                return 0
-                ;;
-            "build")
-                __comp_reply "--add-bootstrap-package --add-container-label --add-package --add-repo --add-repo-credentials --allow-existing-root --ca-cert --ca-target-distribution --clear-cache --delete-package --description --help --ignore-repos --ignore-repos-used-for-build --set-container-derived-from --set-container-tag --set-release-version --set-repo --set-repo-credentials --set-type-attr --signing-key --target-dir help"
-                return 0
-                ;;
-            "bundle")
-                __comp_reply "--bundle-dir --bundle-format --help --id --no-compress --package-as-rpm --target-dir --zsync-source help"
-                return 0
-                ;;
-            "create")
-                __comp_reply "--help --root --signing-key --target-dir help"
-                return 0
-                ;;
-            "info")
-                __comp_reply "--add-repo --add-repo-credentials --description --help --ignore-repos --list-profiles --print-kiwi-env --print-toml --print-xml --print-yaml --resolve-package-list help"
-                return 0
-                ;;
-            "list")
-                __comp_reply "--help --target-dir help"
-                return 0
-                ;;
-            "prepare")
-                __comp_reply "--add-bootstrap-package --add-container-label --add-package --add-repo --add-repo-credentials --allow-existing-root --ca-cert --ca-target-distribution --clear-cache --delete-package --description --help --ignore-repos --ignore-repos-used-for-build --root --set-container-derived-from --set-container-tag --set-release-version --set-repo --set-repo-credentials --set-type-attr --signing-key help"
-                return 0
-                ;;
-            "resize")
-                __comp_reply "--help --root --size --target-dir help"
-                return 0
-                ;;
-            "update")
-                __comp_reply "--add-package --delete-package --help --root help"
-                return 0
-                ;;
-        esac
-    done
-    __comp_reply "--color-output --config --debug --debug-run-scripts-in-screen --help --kiwi-file --logfile --loglevel --logsocket --profile --setenv --shared-cache-dir --target-arch --temp-dir --type --version help image result system"
+_kiwi_ng_completion() {
+    local IFS=$'
+'
+    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
+                   COMP_CWORD=$COMP_CWORD \
+                   _KIWI_NG_COMPLETE=complete_bash $1 ) )
     return 0
 }
-#========================================
-# comp_reply
-#----------------------------------------
-function __comp_reply {
-    local word_list
-    word_list="$*"
-    mapfile -t COMPREPLY < <(compgen -W "$word_list" -- "${cur}")
-}
 
-complete -F _kiwi -o default kiwi
-complete -F _kiwi -o default kiwi-ng
+complete -o default -F _kiwi_ng_completion kiwi-ng

--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -19,7 +19,6 @@ import typer
 import logging
 import sys
 import os
-from unittest.mock import patch
 from importlib.metadata import (
     entry_points, EntryPoint
 )
@@ -98,17 +97,11 @@ class Cli:
                     'obj': Cli
                 }
             )
-        with patch('sys.exit') as sys_exit:
-            # This is unfortunately needed to integrate the
-            # typer interface with the former docopt based
-            # option handling to kiwi in a way that is not
-            # too intrusive. Usually typer quits after the
-            # invocation of the commmand function. But in case
-            # of kiwi we need the result of the typer processing
-            # to be used in the task classes such that typer
-            # should not exit from its operation.
+        try:
             Cli.cli()
-            (exit_code,) = sys_exit.call_args[0]
+        except SystemExit:
+            # avoid standalone mode
+            pass
         if not Cli.cli_ok:
             sys.exit(exit_code)
 


### PR DESCRIPTION
Fix typer standalone mode and allow to use the typer completion mechanics. The standalone completion we provide with the kiwi-bash-completion has changed to the variant provided by typer. Even without a completion installed the new --install-completion option provided by typer allows to install a completion based on the running shell in the user home directory.