### PR TITLE
Fix media check call and display

### DIFF
--- a/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
+++ b/build-tests/x86/tumbleweed/test-image-live/appliance.kiwi
@@ -55,8 +55,8 @@
         </type>
     </preferences>
     <preferences profiles="BIOS">
-        <type image="iso" flags="overlay" firmware="bios" kernelcmdline="console=ttyS0" hybridpersistent_filesystem="ext4" hybridpersistent="true">
-            <bootloader name="grub2" console="serial" timeout="10"/>
+        <type image="iso" flags="overlay" firmware="bios" kernelcmdline="console=ttyS0 console=tty1" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="true">
+            <bootloader name="grub2" console="gfxterm" timeout="10"/>
         </type>
     </preferences>
     <users>
@@ -77,6 +77,9 @@
     </packages>
     <packages type="image" profiles="Encrypted,EroFS">
         <package name="cryptsetup"/>
+    </packages>
+    <packages type="image" profiles="BIOS">
+        <package name="checkmedia"/>
     </packages>
     <packages type="image">
         <package name="curl"/>

--- a/dracut/modules.d/55kiwi-live/kiwi-live-lib.sh
+++ b/dracut/modules.d/55kiwi-live/kiwi-live-lib.sh
@@ -452,7 +452,8 @@ function runMediaCheck {
     local timeout=20
     local check_result
     check_result=/run/initramfs/checkmedia.result
-    checkmedia "${media_check_device}" &>${check_result}
+    set_device_lock "${media_check_device}" \
+        checkmedia --verbose "${media_check_device}" &>${check_result}
     local check_status=$?
     if [ ${check_status} != 0 ];then
         echo "ISO check failed" >> ${check_result}
@@ -460,7 +461,7 @@ function runMediaCheck {
         echo "ISO check passed" >> ${check_result}
     fi
     echo "Press key to continue (waiting ${timeout}sec...)" >> ${check_result}
-    _run_dialog --timeout ${timeout} --textbox ${check_result} 20 70
+    _run_dialog --timeout ${timeout} --tailbox ${check_result} 20 70
     if [ ${check_status} != 0 ];then
         die "Failed to verify system integrity"
     fi
@@ -556,7 +557,6 @@ function _setup_interactive_service {
         echo "StandardError=inherit"
         echo "KillMode=process"
         echo "IgnoreSIGPIPE=no"
-        echo "TaskMax=infinity"
         echo "KillSignal=SIGHUP"
     } > ${service}
 }
@@ -581,6 +581,7 @@ function _run_dialog {
     # output of the dialog call is stored in a file and can be
     # one time read via the get_dialog_result function
     # """
+    stop_plymouth
     local dialog_result=/tmp/dialog_result
     local dialog_exit_code=/tmp/dialog_code
     {
@@ -589,6 +590,14 @@ function _run_dialog {
     } >/run/dracut-interactive
     _run_interactive
     return "$(cat $dialog_exit_code)"
+}
+
+function stop_plymouth {
+    if ! getargbool 0 rd.kiwi.allow_plymouth; then
+        if command -v plymouth &>/dev/null;then
+            plymouth --quit --wait
+        fi
+    fi
 }
 
 function _partition_count {


### PR DESCRIPTION
Make sure the checkmedia call runs with the device locked to avoid race conditions on other parallel actions. Also move from textbox layout to tailbox layout which displays the output of checkmedia correctly. The check tool prints an escape sequence based progress information which the textbox doesn't display correctly. Next to this fixed the interactive service file which was using a wrong task setting. Finally make sure to stop plymouth which in case it's active prevents the dialog based display from being visible. To test the checker on a standard console situation update and enable the mediacheck in the BIOS profile of the test-image-live integration check. This Fixes bsc#1192829