### PR TITLE
Make the luks device mapper name unique per build

### DIFF
--- a/kiwi/storage/luks_device.py
+++ b/kiwi/storage/luks_device.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import uuid
 import logging
 import binascii
 from typing import Optional
@@ -49,7 +50,11 @@ class LuksDevice(DeviceProvider):
         self.luks_device: Optional[str] = None
         self.luks_keyfile: str = ''
         self.passphrase: str = ''
-        self.luks_name = 'luksRoot'
+        # The device mapper name must be unique per build. Device mapper
+        # names are global to the host kernel and are not namespaced by
+        # the build chroot, so a fixed name makes concurrent builds on
+        # one host fail with 'Device luksRoot already exists.'
+        self.luks_name = 'luksRoot_{0}'.format(uuid.uuid4().hex)
 
         self.option_map = {
             'sle12': [

--- a/test/unit/storage/luks_device_test.py
+++ b/test/unit/storage/luks_device_test.py
@@ -42,6 +42,12 @@ class TestLuksDevice:
         with raises(KiwiLuksSetupError):
             self.luks.create_crypto_luks('passphrase', 'some-os')
 
+    def test_luks_name_is_unique_per_instance(self):
+        # Device mapper names are global to the host kernel, so two
+        # concurrent builds must not share the luks map name
+        assert self.luks.luks_name != LuksDevice(Mock()).luks_name
+        assert self.luks.luks_name.startswith('luksRoot_')
+
     @patch('os.path.exists')
     def test_get_device(self, mock_path):
         mock_path.return_value = True
@@ -100,7 +106,7 @@ class TestLuksDevice:
                     [
                         'cryptsetup', '--key-file', '/dev/zero',
                         '--keyfile-size', '32',
-                        'luksOpen', '/dev/some-device', 'luksRoot'
+                        'luksOpen', '/dev/some-device', self.luks.luks_name
                     ]
                 )
             ]
@@ -148,7 +154,7 @@ class TestLuksDevice:
                 call(
                     [
                         'cryptsetup', '--key-file', 'root/some-keyfile', 'luksOpen',
-                        '/dev/some-device', 'luksRoot'
+                        '/dev/some-device', self.luks.luks_name
                     ]
                 )
             ]
@@ -206,7 +212,7 @@ class TestLuksDevice:
                 call(
                     [
                         'cryptsetup', '--key-file', 'tmpfile', 'luksOpen',
-                        '/dev/some-device', 'luksRoot'
+                        '/dev/some-device', self.luks.luks_name
                     ]
                 )
             ]
@@ -260,6 +266,7 @@ class TestLuksDevice:
         with self._caplog.at_level(logging.ERROR):
             with LuksDevice(Mock()) as luks:
                 luks.luks_device = '/dev/mapper/luksRoot'
+                luks_name = luks.luks_name
         mock_command.assert_called_once_with(
-            ['cryptsetup', 'luksClose', 'luksRoot']
+            ['cryptsetup', 'luksClose', luks_name]
         )


### PR DESCRIPTION
## Problem

`LuksDevice.luks_name` is the fixed string `luksRoot`. Device mapper names live in the host kernel and are not namespaced by the build chroot, so two kiwi builds that use `luks=` and run concurrently on one host race on that name. The second one to reach `luksOpen` fails:

```
[ DEBUG   ]: EXEC: [cryptsetup --key-file /dev/zero --keyfile-size 32 luksOpen /dev/mapper/loop2p3 luksRoot]
[ DEBUG   ]: EXEC: Failed with stderr: Device luksRoot already exists.
[ ERROR   ]: KiwiCommandError: cryptsetup: stderr: Device luksRoot already exists.
```

Observed with kiwi 10.3.0 building two disk images from the same description (different distro majors, both with `<type image="oem" luks="" luks_version="luks2">`) in parallel on one build host. The two builds started 7s apart; the loser died at `luksOpen` while the winner still held the map:

| build | start | end |
|---|---|---|
| A | 17:31:22 | 17:39:07 (ok) |
| B | 17:31:29 | 17:36:55 (failed at `luksOpen`) |
| B, retried alone | 17:39:43 | 17:44:02 (ok) |

The window is short, at the very end of the build, so this shows up as an intermittent failure that passes on retry, which makes it easy to misattribute.

## Fix

Generate the map name per instance: `luksRoot_<uuid4 hex>`.

The name is only used to open and close the map during the build (`luksOpen`, `/dev/mapper/<name>`, `luksClose`). It is not written into the produced image: `create_crypttab` emits the mapping name `luks` together with `UUID=` independently of `luks_name`, and `grep -rn luksRoot` over the tree matches only the one assignment. So the built image is unaffected.

kiwi already handles this class of collision the same way in `clone_device.py`, where the LUKS UUID, the LVM volume group name and the RAID superblock UUID are each made unique to avoid conflicts.

## Tests

Added `test_luks_name_is_unique_per_instance`. The existing tests that asserted the literal `luksRoot` passed to cryptsetup now assert against the generated name.

`pytest test/unit/storage/luks_device_test.py` -> 11 passed. The wider `test/unit/storage` suite is unchanged relative to `main` in this environment: 1 pre-existing failure (`disk_test.py::test_get_discoverable_partition_ids`) and 27 pre-existing errors before and after, with one additional passing test from this change.

Happy to open a tracking issue and reference it here if you would prefer that per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)